### PR TITLE
Issue #357 - Y axis is unclear

### DIFF
--- a/src/AllPlot.cpp
+++ b/src/AllPlot.cpp
@@ -228,14 +228,14 @@ AllPlot::AllPlot(AllPlotWindow *parent, MainWindow *mainWindow):
     rideItem(NULL),
     shade_zones(true),
     showPowerState(3),
-    showHrState(Qt::Checked),
-    showSpeedState(Qt::Checked),
-    showCadState(Qt::Checked),
-    showAltState(Qt::Checked),
-    showTempState(Qt::Checked),
-    showWindState(Qt::Checked),
-    showTorqueState(Qt::Checked),
-    showBalanceState(Qt::Checked),
+    showHr(true),
+    showSpeed(true),
+    showCad(true),
+    showAlt(true),
+    showTemp(true),
+    showWind(true),
+    showTorque(true),
+    showBalance(true),
     bydist(false),
     mainWindow(mainWindow),
     parent(parent)
@@ -844,9 +844,26 @@ AllPlot::setYMax()
     if (wattsCurve->isVisible()) {
         double maxY = (referencePlot == NULL) ? (1.05 * wattsCurve->maxYValue()) :
                                              (1.05 * referencePlot->wattsCurve->maxYValue());
-        // grid lines for 100 or 25
+
+        int axisHeight = qRound( plotLayout()->canvasRect().height() );
+        QFontMetrics labelWidthMetric = QFontMetrics( QwtPlot::axisFont(yLeft) );
+        int labelWidth = labelWidthMetric.width( (maxY > 1000) ? "8888 " : "888 " );
+
+        int step = 100;
+        while( ( qCeil(maxY / step) * labelWidth ) > axisHeight )
+        {
+            if( step == 100 || step == 150 )
+            {
+                step += 50;
+            }
+            else
+            {
+                step += 100;
+            }
+        }
+
         QwtValueList xytick[QwtScaleDiv::NTickTypes];
-        for (int i=0;i<maxY;i+=100)
+        for (int i=0;i<maxY;i+=step)
             xytick[QwtScaleDiv::MajorTick]<<i;
 #if 0
         for (int i=0;i<maxY;i+=25)
@@ -1018,15 +1035,15 @@ AllPlot::setDataFromPlot(AllPlot *plot, int startidx, int stopidx)
     balanceRCurve->detach();
 
     wattsCurve->setVisible(rideItem->ride()->areDataPresent()->watts && showPowerState < 2);
-    hrCurve->setVisible(rideItem->ride()->areDataPresent()->hr && showHrState == Qt::Checked);
-    speedCurve->setVisible(rideItem->ride()->areDataPresent()->kph && showSpeedState == Qt::Checked);
-    cadCurve->setVisible(rideItem->ride()->areDataPresent()->cad && showCadState == Qt::Checked);
-    altCurve->setVisible(rideItem->ride()->areDataPresent()->alt && showAltState == Qt::Checked);
-    tempCurve->setVisible(rideItem->ride()->areDataPresent()->temp && showTempState == Qt::Checked);
-    windCurve->setVisible(rideItem->ride()->areDataPresent()->headwind && showWindState == Qt::Checked);
-    torqueCurve->setVisible(rideItem->ride()->areDataPresent()->nm && showTorqueState == Qt::Checked);
-    balanceLCurve->setVisible(rideItem->ride()->areDataPresent()->lrbalance && showBalanceState == Qt::Checked);
-    balanceRCurve->setVisible(rideItem->ride()->areDataPresent()->lrbalance && showBalanceState == Qt::Checked);
+    hrCurve->setVisible(rideItem->ride()->areDataPresent()->hr && showHr);
+    speedCurve->setVisible(rideItem->ride()->areDataPresent()->kph && showSpeed);
+    cadCurve->setVisible(rideItem->ride()->areDataPresent()->cad && showCad);
+    altCurve->setVisible(rideItem->ride()->areDataPresent()->alt && showAlt);
+    tempCurve->setVisible(rideItem->ride()->areDataPresent()->temp && showTemp);
+    windCurve->setVisible(rideItem->ride()->areDataPresent()->headwind && showWind);
+    torqueCurve->setVisible(rideItem->ride()->areDataPresent()->nm && showTorque);
+    balanceLCurve->setVisible(rideItem->ride()->areDataPresent()->lrbalance && showBalance);
+    balanceRCurve->setVisible(rideItem->ride()->areDataPresent()->lrbalance && showBalance);
 
     wattsCurve->setData(xaxis,smoothW,stopidx-startidx);
     hrCurve->setData(xaxis, smoothHR,stopidx-startidx);
@@ -1172,15 +1189,15 @@ AllPlot::setDataFromRide(RideItem *_rideItem)
         }
 
         wattsCurve->setVisible(dataPresent->watts && showPowerState < 2);
-        hrCurve->setVisible(dataPresent->hr && showHrState == Qt::Checked);
-        speedCurve->setVisible(dataPresent->kph && showSpeedState == Qt::Checked);
-        cadCurve->setVisible(dataPresent->cad && showCadState == Qt::Checked);
-        altCurve->setVisible(dataPresent->alt && showAltState == Qt::Checked);
-        tempCurve->setVisible(dataPresent->temp && showTempState == Qt::Checked);
-        windCurve->setVisible(dataPresent->headwind && showWindState == Qt::Checked);
-        torqueCurve->setVisible(dataPresent->nm && showWindState == Qt::Checked);
-        balanceLCurve->setVisible(dataPresent->lrbalance && showBalanceState == Qt::Checked);
-        balanceRCurve->setVisible(dataPresent->lrbalance && showBalanceState == Qt::Checked);
+        hrCurve->setVisible(dataPresent->hr && showHr);
+        speedCurve->setVisible(dataPresent->kph && showSpeed);
+        cadCurve->setVisible(dataPresent->cad && showCad);
+        altCurve->setVisible(dataPresent->alt && showAlt);
+        tempCurve->setVisible(dataPresent->temp && showTemp);
+        windCurve->setVisible(dataPresent->headwind && showWind);
+        torqueCurve->setVisible(dataPresent->nm && showWind);
+        balanceLCurve->setVisible(dataPresent->lrbalance && showBalance);
+        balanceRCurve->setVisible(dataPresent->lrbalance && showBalance);
 
         arrayLength = 0;
         foreach (const RideFilePoint *point, ride->dataPoints()) {
@@ -1261,7 +1278,7 @@ AllPlot::setDataFromRide(RideItem *_rideItem)
 }
 
 void
-AllPlot::showPower(int id)
+AllPlot::setShowPower(int id)
 {
     if (showPowerState == id) return;
 
@@ -1277,91 +1294,82 @@ AllPlot::showPower(int id)
 }
 
 void
-AllPlot::showHr(int state)
+AllPlot::setShowHr(bool show)
 {
-    showHrState = state;
-    assert(state != Qt::PartiallyChecked);
-    hrCurve->setVisible(state == Qt::Checked);
+    showHr = show;
+    hrCurve->setVisible(show);
     setYMax();
     replot();
 }
 
 void
-AllPlot::showSpeed(int state)
+AllPlot::setShowSpeed(bool show)
 {
-    showSpeedState = state;
-    assert(state != Qt::PartiallyChecked);
-    speedCurve->setVisible(state == Qt::Checked);
+    showSpeed = show;
+    speedCurve->setVisible(show);
     setYMax();
     replot();
 }
 
 void
-AllPlot::showCad(int state)
+AllPlot::setShowCad(bool show)
 {
-    showCadState = state;
-    assert(state != Qt::PartiallyChecked);
-    cadCurve->setVisible(state == Qt::Checked);
+    showCad = show;
+    cadCurve->setVisible(show);
     setYMax();
     replot();
 }
 
 void
-AllPlot::showAlt(int state)
+AllPlot::setShowAlt(bool show)
 {
-    showAltState = state;
-    assert(state != Qt::PartiallyChecked);
-    altCurve->setVisible(state == Qt::Checked);
+    showAlt = show;
+    altCurve->setVisible(show);
     setYMax();
     replot();
 }
 
 void
-AllPlot::showTemp(int state)
+AllPlot::setShowTemp(bool show)
 {
-    showTempState = state;
-    assert(state != Qt::PartiallyChecked);
-    tempCurve->setVisible(state == Qt::Checked);
+    showTemp = show;
+    tempCurve->setVisible(show);
     setYMax();
     replot();
 }
 
 void
-AllPlot::showWind(int state)
+AllPlot::setShowWind(bool show)
 {
-    showWindState = state;
-    assert(state != Qt::PartiallyChecked);
-    windCurve->setVisible(state == Qt::Checked);
+    showWind = show;
+    windCurve->setVisible(show);
     setYMax();
     replot();
 }
 
 void
-AllPlot::showTorque(int state)
+AllPlot::setShowTorque(bool show)
 {
-    showTorqueState = state;
-    assert(state != Qt::PartiallyChecked);
-    torqueCurve->setVisible(state == Qt::Checked);
+    showTorque = show;
+    torqueCurve->setVisible(show);
     setYMax();
     replot();
 }
 
 void
-AllPlot::showBalance(int state)
+AllPlot::setShowBalance(bool show)
 {
-    showBalanceState = state;
-    assert(state != Qt::PartiallyChecked);
-    balanceLCurve->setVisible(state == Qt::Checked);
-    balanceRCurve->setVisible(state == Qt::Checked);
+    showBalance = show;
+    balanceLCurve->setVisible(show);
+    balanceRCurve->setVisible(show);
     setYMax();
     replot();
 }
 
 void
-AllPlot::showGrid(int state)
+AllPlot::setShowGrid(bool show)
 {
-    assert(state != Qt::PartiallyChecked);
-    grid->setVisible(state == Qt::Checked);
+    grid->setVisible(show);
     replot();
 }
 

--- a/src/AllPlot.h
+++ b/src/AllPlot.h
@@ -70,16 +70,16 @@ class AllPlot : public QwtPlot
 
     public slots:
 
-        void showPower(int state);
-        void showHr(int state);
-        void showSpeed(int state);
-        void showCad(int state);
-        void showAlt(int state);
-        void showTemp(int state);
-        void showWind(int state);
-        void showTorque(int state);
-        void showBalance(int state);
-        void showGrid(int state);
+        void setShowPower(int id);
+        void setShowHr(bool show);
+        void setShowSpeed(bool show);
+        void setShowCad(bool show);
+        void setShowAlt(bool show);
+        void setShowTemp(bool show);
+        void setShowWind(bool show);
+        void setShowTorque(bool show);
+        void setShowBalance(bool show);
+        void setShowGrid(bool show);
         void setPaintBrush(int state);
         void setShadeZones(bool x) { shade_zones=x; }
         void setSmoothing(int value);
@@ -105,14 +105,14 @@ class AllPlot : public QwtPlot
         // controls
         bool shade_zones;
         int showPowerState;
-        int showHrState;
-        int showSpeedState;
-        int showCadState;
-        int showAltState;
-        int showTempState;
-        int showWindState;
-        int showTorqueState;
-        int showBalanceState;
+        bool showHr;
+        bool showSpeed;
+        bool showCad;
+        bool showAlt;
+        bool showTemp;
+        bool showWind;
+        bool showTorque;
+        bool showBalance;
 
         // plot objects
         QwtPlotGrid *grid;

--- a/src/AllPlotWindow.cpp
+++ b/src/AllPlotWindow.cpp
@@ -439,7 +439,7 @@ AllPlotWindow::redrawFullPlot()
     if (!ride) return;
 
     // hide the usual plot decorations etc
-    fullPlot->showPower(1);
+    fullPlot->setShowPower(1);
     //We now use the window background color
     //fullPlot->setCanvasBackground(GColor(CPLOTTHUMBNAIL));
     fullPlot->setCanvasLineWidth(0);
@@ -728,8 +728,8 @@ AllPlotWindow::setAllPlotWidgets(RideItem *ride)
     else shade = false;
     allPlot->setShadeZones(shade);
     foreach (AllPlot *plot, allPlots) plot->setShadeZones(shade);
-    allPlot->showGrid(showGrid->checkState());
-    foreach (AllPlot *plot, allPlots) plot->showGrid(showGrid->checkState());
+    allPlot->setShowGrid(showGrid->checkState() == Qt::Checked);
+    foreach (AllPlot *plot, allPlots) plot->setShowGrid(showGrid->checkState() == Qt::Checked);
 
     // set the SpanSlider for the ride length, by default
     // show the entire ride (the user can adjust later)
@@ -1079,13 +1079,13 @@ AllPlotWindow::setShowPower(int value)
 
     // we only show the power shading on the
     // allPlot / stack plots, not on the fullPlot
-    allPlot->showPower(value);
+    allPlot->setShowPower(value);
     if (!showStack->isChecked())
         allPlot->replot();
 
     // redraw
     foreach (AllPlot *plot, allPlots)
-        plot->showPower(value);
+        plot->setShowPower(value);
 
     // now replot 'em - to avoid flicker
     if (showStack->isChecked()) {
@@ -1102,10 +1102,11 @@ AllPlotWindow::setShowHr(int value)
     showHr->setChecked(value);
 
     //if (!current) return;
+    bool checked = ( ( value == Qt::Checked ) && showHr->isEnabled()) ? true : false;
 
-    allPlot->showHr(value);
+    allPlot->setShowHr(checked);
     foreach (AllPlot *plot, allPlots)
-        plot->showHr(value);
+        plot->setShowHr(checked);
 }
 
 void
@@ -1114,10 +1115,11 @@ AllPlotWindow::setShowSpeed(int value)
     showSpeed->setChecked(value);
 
     //if (!current) return;
+    bool checked = ( ( value == Qt::Checked ) && showSpeed->isEnabled()) ? true : false;
 
-    allPlot->showSpeed(value);
+    allPlot->setShowSpeed(checked);
     foreach (AllPlot *plot, allPlots)
-        plot->showSpeed(value);
+        plot->setShowSpeed(checked);
 }
 
 void
@@ -1126,10 +1128,11 @@ AllPlotWindow::setShowCad(int value)
     showCad->setChecked(value);
 
     //if (!current) return;
+    bool checked = ( ( value == Qt::Checked ) && showCad->isEnabled()) ? true : false;
 
-    allPlot->showCad(value);
+    allPlot->setShowCad(checked);
     foreach (AllPlot *plot, allPlots)
-        plot->showCad(value);
+        plot->setShowCad(checked);
 }
 
 void
@@ -1138,10 +1141,11 @@ AllPlotWindow::setShowAlt(int value)
     showAlt->setChecked(value);
 
     //if (!current) return;
+    bool checked = ( ( value == Qt::Checked ) && showAlt->isEnabled()) ? true : false;
 
-    allPlot->showAlt(value);
+    allPlot->setShowAlt(checked);
     foreach (AllPlot *plot, allPlots)
-        plot->showAlt(value);
+        plot->setShowAlt(checked);
 }
 
 void
@@ -1150,10 +1154,11 @@ AllPlotWindow::setShowTemp(int value)
     showTemp->setChecked(value);
 
     //if (!current) return;
+    bool checked = ( ( value == Qt::Checked ) && showTemp->isEnabled()) ? true : false;
 
-    allPlot->showTemp(value);
+    allPlot->setShowTemp(checked);
     foreach (AllPlot *plot, allPlots)
-        plot->showTemp(value);
+        plot->setShowTemp(checked);
 }
 
 void
@@ -1162,22 +1167,24 @@ AllPlotWindow::setShowWind(int value)
     showWind->setChecked(value);
 
     //if (!current) return;
+    bool checked = ( ( value == Qt::Checked ) && showWind->isEnabled()) ? true : false;
 
-    allPlot->showWind(value);
+    allPlot->setShowWind(checked);
     foreach (AllPlot *plot, allPlots)
-        plot->showWind(value);
+        plot->setShowWind(checked);
 }
 
 void
 AllPlotWindow::setShowTorque(int value)
 {
     showTorque->setChecked(value);
+    bool checked = ( ( value == Qt::Checked ) && showTorque->isEnabled()) ? true : false;
 
     //if (!current) return;
 
-    allPlot->showTorque(value);
+    allPlot->setShowTorque(checked);
     foreach (AllPlot *plot, allPlots)
-        plot->showTorque(value);
+        plot->setShowTorque(checked);
 }
 
 void
@@ -1185,9 +1192,11 @@ AllPlotWindow::setShowBalance(int value)
 {
     showBalance->setChecked(value);
 
-    allPlot->showBalance(value);
+    bool checked = ( ( value == Qt::Checked ) && showBalance->isEnabled()) ? true : false;
+
+    allPlot->setShowBalance(checked);
     foreach (AllPlot *plot, allPlots)
-        plot->showBalance(value);
+        plot->setShowBalance(checked);
 }
 
 void
@@ -1217,9 +1226,9 @@ AllPlotWindow::setShowGrid(int value)
 
     //if (!current) return;
 
-    allPlot->showGrid(value);
+    allPlot->setShowGrid(value);
     foreach (AllPlot *plot, allPlots)
-        plot->showGrid(value);
+        plot->setShowGrid(value);
 }
 
 void
@@ -1487,14 +1496,14 @@ AllPlotWindow::setupStackPlots()
 
         // controls
         _allPlot->setShadeZones(showPower->currentIndex() == 0);
-        _allPlot->showPower(showPower->currentIndex());
-        _allPlot->showHr(showHr->checkState());
-        _allPlot->showSpeed(showSpeed->checkState());
-        _allPlot->showCad(showCad->checkState());
-        _allPlot->showAlt(showAlt->checkState());
-        _allPlot->showTemp(showTemp->checkState());
-        _allPlot->showTorque(showTorque->checkState());
-        _allPlot->showGrid(showGrid->checkState());
+        _allPlot->setShowPower(showPower->currentIndex());
+        _allPlot->setShowHr( (showHr->isEnabled()) ? ( showHr->checkState() == Qt::Checked ) : false );
+        _allPlot->setShowSpeed((showSpeed->isEnabled()) ? ( showSpeed->checkState() == Qt::Checked ) : false );
+        _allPlot->setShowCad((showCad->isEnabled()) ? ( showCad->checkState() == Qt::Checked ) : false );
+        _allPlot->setShowAlt((showAlt->isEnabled()) ? ( showAlt->checkState() == Qt::Checked ) : false );
+        _allPlot->setShowTemp((showTemp->isEnabled()) ? ( showTemp->checkState() == Qt::Checked ) : false );
+        _allPlot->setShowTorque((showTorque->isEnabled()) ? ( showTorque->checkState() == Qt::Checked ) : false );
+        _allPlot->setShowGrid(showGrid->checkState() == Qt::Checked);
         _allPlot->setPaintBrush(paintBrush->checkState());
         _allPlot->setSmoothing(smoothSlider->value());
         _allPlot->setByDistance(comboDistance->currentIndex());


### PR DESCRIPTION
Axis labels for non-existent datasets could not be turned off if they were checked but greyed out. Changed so that it only displays if the box is checked and it isn't greyed out (the box greys out if the dataset doesn't exist).

Watt value increments were set to always be 100 watts. In variable intensity activities this led to overlapping values. I made the label increment dynamic based on the size of the axis.
