### PR TITLE
Enable metrics translations

### DIFF
--- a/src/AerobicDecoupling.cpp
+++ b/src/AerobicDecoupling.cpp
@@ -17,9 +17,7 @@
  */
 
 #include "RideMetric.h"
-#include <QObject>
-
-#define tr(s) QObject::tr(s)
+#include <QApplication>
 
 // This metric computes aerobic decoupling percentage as described
 // by Joe Friel:
@@ -39,6 +37,7 @@
 // in heart rate to power ratio as described by Friel.
 
 class AerobicDecoupling : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(AerobicDecoupling)
 
     double percent;
 
@@ -47,6 +46,9 @@ class AerobicDecoupling : public RideMetric {
     AerobicDecoupling() : percent(0.0)
     {
         setSymbol("aerobic_decoupling");
+        setInternalName("Aerobic Decoupling");
+    }
+    void initialize() {
         setName(tr("Aerobic Decoupling"));
         setType(RideMetric::Average);
         setMetricUnits(tr("%"));

--- a/src/BasicRideMetrics.cpp
+++ b/src/BasicRideMetrics.cpp
@@ -22,15 +22,18 @@
 #include "math.h"
 #include <algorithm>
 #include <QVector>
-
-#define tr(s) QObject::tr(s)
+#include <QApplication>
 
 class RideCount : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(RideCount)
     public:
 
     RideCount()
     {
         setSymbol("ride_count");
+        setInternalName("Rides");
+    }
+    void initialize() {
         setName(tr("Rides"));
         setMetricUnits(tr(""));
         setImperialUnits(tr(""));
@@ -50,6 +53,7 @@ static bool countAdded =
 
 //////////////////////////////////////////////////////////////////////////////
 class WorkoutTime : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(WorkoutTime)
     double seconds;
 
     public:
@@ -57,6 +61,9 @@ class WorkoutTime : public RideMetric {
     WorkoutTime() : seconds(0.0)
     {
         setSymbol("workout_time");
+        setInternalName("Duration");
+    }
+    void initialize() {
         setName(tr("Duration"));
         setMetricUnits(tr("seconds"));
         setImperialUnits(tr("seconds"));
@@ -84,6 +91,7 @@ static bool workoutTimeAdded =
 //////////////////////////////////////////////////////////////////////////////
 
 class TimeRiding : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(TimeRiding)
     double secsMovingOrPedaling;
 
     public:
@@ -91,6 +99,9 @@ class TimeRiding : public RideMetric {
     TimeRiding() : secsMovingOrPedaling(0.0)
     {
         setSymbol("time_riding");
+        setInternalName("Time Riding");
+    }
+    void initialize() {
         setName(tr("Time Riding"));
         setMetricUnits(tr("seconds"));
         setImperialUnits(tr("seconds"));
@@ -119,6 +130,7 @@ static bool timeRidingAdded =
 //////////////////////////////////////////////////////////////////////////////
 
 class TotalDistance : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(TotalDistance)
     double km;
 
     public:
@@ -126,6 +138,9 @@ class TotalDistance : public RideMetric {
     TotalDistance() : km(0.0)
     {
         setSymbol("total_distance");
+        setInternalName("Distance");
+    }
+    void initialize() {
         setName(tr("Distance"));
         setType(RideMetric::Total);
         setMetricUnits(tr("km"));
@@ -159,6 +174,7 @@ static bool totalDistanceAdded =
 
 
 class ElevationGain : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(ElevationGain)
     double elegain;
     double prevalt;
 
@@ -167,6 +183,9 @@ class ElevationGain : public RideMetric {
     ElevationGain() : elegain(0.0), prevalt(0.0)
     {
         setSymbol("elevation_gain");
+        setInternalName("Elevation Gain");
+    }
+    void initialize() {
         setName(tr("Elevation Gain"));
         setType(RideMetric::Total);
         setMetricUnits(tr("meters"));
@@ -203,6 +222,7 @@ static bool elevationGainAdded =
 //////////////////////////////////////////////////////////////////////////////
 
 class TotalWork : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(TotalWork)
     double joules;
 
     public:
@@ -210,6 +230,9 @@ class TotalWork : public RideMetric {
     TotalWork() : joules(0.0)
     {
         setSymbol("total_work");
+        setInternalName("Work");
+    }
+    void initialize() {
         setName(tr("Work"));
         setMetricUnits(tr("kJ"));
         setImperialUnits(tr("kJ"));
@@ -233,6 +256,7 @@ static bool totalWorkAdded =
 //////////////////////////////////////////////////////////////////////////////
 
 class AvgSpeed : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(AvgSpeed)
     double secsMoving;
     double km;
 
@@ -241,6 +265,9 @@ class AvgSpeed : public RideMetric {
     AvgSpeed() : secsMoving(0.0), km(0.0)
     {
         setSymbol("average_speed");
+        setInternalName("Average Speed");
+    }
+    void initialize() {
         setName(tr("Average Speed"));
         setMetricUnits(tr("kph"));
         setImperialUnits(tr("mph"));
@@ -278,6 +305,7 @@ static bool avgSpeedAdded =
 
 //////////////////////////////////////////////////////////////////////////////
 class Pace : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(Pace)
     double pace;
 
     public:
@@ -285,6 +313,9 @@ class Pace : public RideMetric {
     Pace() : pace(0.0)
     {
         setSymbol("pace");
+        setInternalName("Pace");
+    }
+    void initialize() {
         setName(tr("Pace"));
         setType(RideMetric::Average);
         setMetricUnits(tr("min/km"));
@@ -322,12 +353,18 @@ static bool paceAdded = addPace();
 //////////////////////////////////////////////////////////////////////////////
 
 struct AvgPower : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(AvgPower)
 
     double count, total;
+
+    public:
 
     AvgPower()
     {
         setSymbol("average_power");
+        setInternalName("Average Power");
+    }
+    void initialize() {
         setName(tr("Average Power"));
         setMetricUnits(tr("watts"));
         setImperialUnits(tr("watts"));
@@ -356,12 +393,18 @@ static bool avgPowerAdded =
 //////////////////////////////////////////////////////////////////////////////
 
 struct NonZeroPower : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(NonZeroPower)
 
     double count, total;
+
+    public:
 
     NonZeroPower()
     {
         setSymbol("nonzero_power");
+        setInternalName("Nonzero Average Power");
+    }
+    void initialize() {
         setName(tr("Nonzero Average Power"));
         setMetricUnits(tr("watts"));
         setImperialUnits(tr("watts"));
@@ -390,12 +433,18 @@ static bool nonZeroPowerAdded =
 //////////////////////////////////////////////////////////////////////////////
 
 struct AvgHeartRate : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(AvgHeartRate)
 
     double total, count;
+
+    public:
 
     AvgHeartRate()
     {
         setSymbol("average_hr");
+        setInternalName("Average Heart Rate");
+    }
+    void initialize() {
         setName(tr("Average Heart Rate"));
         setMetricUnits(tr("bpm"));
         setImperialUnits(tr("bpm"));
@@ -424,12 +473,18 @@ static bool avgHeartRateAdded =
 //////////////////////////////////////////////////////////////////////////////
 
 struct AvgCadence : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(AvgCadence)
 
     double total, count;
+
+    public:
 
     AvgCadence()
     {
         setSymbol("average_cad");
+        setInternalName("Average Cadence");
+    }
+    void initialize() {
         setName(tr("Average Cadence"));
         setMetricUnits(tr("rpm"));
         setImperialUnits(tr("rpm"));
@@ -458,12 +513,18 @@ static bool avgCadenceAdded =
 //////////////////////////////////////////////////////////////////////////////
 
 struct AvgTemp : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(AvgTemp)
 
     double total, count;
+
+    public:
 
     AvgTemp()
     {
         setSymbol("average_temp");
+        setInternalName("Average Temp");
+    }
+    void initialize() {
         setName(tr("Average Temp"));
         setMetricUnits(tr("C"));
         setImperialUnits(tr("F"));
@@ -501,11 +562,15 @@ static bool avgTempAdded =
 //////////////////////////////////////////////////////////////////////////////
 
 class MaxPower : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(MaxPower)
     double max;
     public:
     MaxPower() : max(0.0)
     {
         setSymbol("max_power");
+        setInternalName("Max Power");
+    }
+    void initialize() {
         setName(tr("Max Power"));
         setMetricUnits(tr("watts"));
         setImperialUnits(tr("watts"));
@@ -530,11 +595,15 @@ static bool maxPowerAdded =
 //////////////////////////////////////////////////////////////////////////////
 
 class MaxHr : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(MaxHr)
     double max;
     public:
     MaxHr() : max(0.0)
     {
         setSymbol("max_heartrate");
+        setInternalName("Max Heartrate");
+    }
+    void initialize() {
         setName(tr("Max Heartrate"));
         setMetricUnits(tr("bpm"));
         setImperialUnits(tr("bpm"));
@@ -559,11 +628,15 @@ static bool maxHrAdded =
 //////////////////////////////////////////////////////////////////////////////
 
 class MaxSpeed : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(MaxSpeed)
     public:
 
     MaxSpeed()
     {
         setSymbol("max_speed");
+        setInternalName("Max Speed");
+    }
+    void initialize() {
         setName(tr("Max Speed"));
         setMetricUnits(tr("kph"));
         setImperialUnits(tr("mph"));
@@ -598,11 +671,15 @@ static bool maxSpeedAdded =
 //////////////////////////////////////////////////////////////////////////////
 
 class MaxCadence : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(MaxCadence)
     public:
 
     MaxCadence()
     {
         setSymbol("max_cadence");
+        setInternalName("Max Cadence");
+    }
+    void initialize() {
         setName(tr("Max Cadence"));
         setMetricUnits(tr("rpm"));
         setImperialUnits(tr("rpm"));
@@ -635,11 +712,15 @@ static bool maxCadenceAdded =
 //////////////////////////////////////////////////////////////////////////////
 
 class MaxTemp : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(MaxTemp)
     public:
 
     MaxTemp()
     {
         setSymbol("max_temp");
+        setInternalName("Max Temp");
+    }
+    void initialize() {
         setName(tr("Max Temp"));
         setMetricUnits(tr("C"));
         setImperialUnits(tr("F"));
@@ -680,11 +761,15 @@ static bool maxTempAdded =
 //////////////////////////////////////////////////////////////////////////////
 
 class NinetyFivePercentHeartRate : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(NinetyFivePercentHeartRate)
     double hr;
     public:
     NinetyFivePercentHeartRate() : hr(0.0)
     {
         setSymbol("ninety_five_percent_hr");
+        setInternalName("95% Heartrate");
+    }
+    void initialize() {
         setName(tr("95% Heartrate"));
         setMetricUnits(tr("bpm"));
         setImperialUnits(tr("bpm"));
@@ -714,11 +799,15 @@ static bool ninetyFivePercentHeartRateAdded =
 ///////////////////////////////////////////////////////////////////////////////
 
 class VAM : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(VAM)
 
     public:
     VAM()
     {
         setSymbol("vam");
+        setInternalName("VAM");
+    }
+    void initialize() {
         setName(tr("VAM"));
         setImperialUnits("");
         setMetricUnits("");
@@ -750,11 +839,15 @@ static bool vamAdded = addVam();
 ///////////////////////////////////////////////////////////////////////////////
 
 class Gradient : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(Gradient)
 
     public:
     Gradient()
     {
         setSymbol("gradient");
+        setInternalName("Gradient");
+    }
+    void initialize() {
         setName(tr("Gradient"));
         setImperialUnits("%");
         setMetricUnits("%");
@@ -790,6 +883,7 @@ static bool gradientAdded = addGradient();
 ///////////////////////////////////////////////////////////////////////////////
 
 class MeanPowerVariance : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(MeanPowerVariance)
 
     public:
     LTMOutliers *outliers;
@@ -798,6 +892,9 @@ class MeanPowerVariance : public RideMetric {
     {
         outliers = NULL;
         setSymbol("meanpowervariance");
+        setInternalName("Average Power Variance");
+    }
+    void initialize() {
         setName(tr("Average Power Variance"));
         setImperialUnits("watts change");
         setMetricUnits("watts change");
@@ -840,11 +937,15 @@ static bool meanPowerVarianceAdded = addMeanPowerVariance();
 ///////////////////////////////////////////////////////////////////////////////
 
 class MaxPowerVariance : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(MaxPowerVariance)
 
     public:
     MaxPowerVariance()
     {
         setSymbol("maxpowervariance");
+        setInternalName("Max Power Variance");
+    }
+    void initialize() {
         setName(tr("Max Power Variance"));
         setImperialUnits("watts change");
         setMetricUnits("watts change");

--- a/src/BikeScore.cpp
+++ b/src/BikeScore.cpp
@@ -19,8 +19,7 @@
 #include "RideMetric.h"
 #include "Zones.h"
 #include <math.h>
-
-#define tr(s) QObject::tr(s)
+#include <QApplication>
 
 const double  bikeScoreN   = 4.0;
 
@@ -34,6 +33,7 @@ const double  bikeScoreN   = 4.0;
 // a spreadsheet provided by Dr. Skiba.
 
 class XPower : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(XPower)
     double xpower;
     double secs;
 
@@ -42,6 +42,9 @@ class XPower : public RideMetric {
     XPower() : xpower(0.0), secs(0.0)
     {
         setSymbol("skiba_xpower");
+        setInternalName("xPower");
+    }
+    void initialize() {
         setName(tr("xPower"));
         setType(RideMetric::Average);
         setMetricUnits(tr("watts"));
@@ -91,6 +94,7 @@ class XPower : public RideMetric {
 };
 
 class VariabilityIndex : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(VariabilityIndex)
     double vi;
     double secs;
 
@@ -99,6 +103,9 @@ class VariabilityIndex : public RideMetric {
     VariabilityIndex() : vi(0.0), secs(0.0)
     {
         setSymbol("skiba_variability_index");
+        setInternalName("Skiba VI");
+    }
+    void initialize() {
         setName(tr("Skiba VI"));
         setType(RideMetric::Average);
         setMetricUnits(tr(""));
@@ -125,6 +132,7 @@ class VariabilityIndex : public RideMetric {
 };
 
 class RelativeIntensity : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(RelativeIntensity)
     double reli;
     double secs;
 
@@ -133,6 +141,9 @@ class RelativeIntensity : public RideMetric {
     RelativeIntensity() : reli(0.0), secs(0.0)
     {
         setSymbol("skiba_relative_intensity");
+        setInternalName("Relative Intensity");
+    }
+    void initialize() {
         setName(tr("Relative Intensity"));
         setType(RideMetric::Average);
         setMetricUnits(tr(""));
@@ -171,6 +182,7 @@ class RelativeIntensity : public RideMetric {
 };
 
 class BikeScore : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(BikeScore)
     double score;
 
     public:
@@ -178,6 +190,9 @@ class BikeScore : public RideMetric {
     BikeScore() : score(0.0)
     {
         setSymbol("skiba_bike_score");
+        setInternalName("BikeScore&#8482;");
+    }
+    void initialize() {
         setName(tr("BikeScore&#8482;"));
         setMetricUnits("");
         setImperialUnits("");
@@ -208,6 +223,7 @@ class BikeScore : public RideMetric {
 };
 
 class ResponseIndex : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(ResponseIndex)
     double ri;
 
     public:
@@ -215,6 +231,9 @@ class ResponseIndex : public RideMetric {
     ResponseIndex() : ri(0.0)
     {
         setSymbol("skiba_response_index");
+        setInternalName("Response Index");
+    }
+    void initialize() {
         setName(tr("Response Index"));
         setType(RideMetric::Average);
         setMetricUnits(tr(""));

--- a/src/Coggan.cpp
+++ b/src/Coggan.cpp
@@ -19,10 +19,10 @@
 #include "RideMetric.h"
 #include "Zones.h"
 #include <math.h>
-
-#define tr(s) QObject::tr(s)
+#include <QApplication>
 
 class NP : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(NP)
     double np;
     double secs;
 
@@ -31,6 +31,9 @@ class NP : public RideMetric {
     NP() : np(0.0), secs(0.0)
     {
         setSymbol("coggan_np");
+        setInternalName("NP");
+    }
+    void initialize() {
         setName("NP");
         setType(RideMetric::Average);
         setMetricUnits("watts");
@@ -88,6 +91,7 @@ class NP : public RideMetric {
 };
 
 class VI : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(VI)
     double vi;
     double secs;
 
@@ -96,6 +100,9 @@ class VI : public RideMetric {
     VI() : vi(0.0), secs(0.0)
     {
         setSymbol("coggam_variability_index");
+        setInternalName("VI");
+    }
+    void initialize() {
         setName("VI");
         setType(RideMetric::Average);
         setPrecision(3);
@@ -121,6 +128,7 @@ class VI : public RideMetric {
 };
 
 class IntensityFactor : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(IntensityFactor)
     double rif;
     double secs;
 
@@ -129,6 +137,9 @@ class IntensityFactor : public RideMetric {
     IntensityFactor() : rif(0.0), secs(0.0)
     {
         setSymbol("coggan_if");
+        setInternalName("IF");
+    }
+    void initialize() {
         setName("IF");
         setType(RideMetric::Average);
         setPrecision(3);
@@ -154,6 +165,7 @@ class IntensityFactor : public RideMetric {
 };
 
 class TSS : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(TSS)
     double score;
 
     public:
@@ -161,6 +173,9 @@ class TSS : public RideMetric {
     TSS() : score(0.0)
     {
         setSymbol("coggan_tss");
+        setInternalName("TSS");
+    }
+    void initialize() {
         setName("TSS");
         setType(RideMetric::Total);
     }
@@ -188,6 +203,7 @@ class TSS : public RideMetric {
 };
 
 class EfficiencyFactor : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(EfficiencyFactor)
     double ef;
 
     public:
@@ -195,6 +211,9 @@ class EfficiencyFactor : public RideMetric {
     EfficiencyFactor() : ef(0.0)
     {
         setSymbol("friel_efficiency_factor");
+        setInternalName("Efficiency Factor");
+    }
+    void initialize() {
         setName(tr("Efficiency Factor"));
         setType(RideMetric::Average);
         setMetricUnits(tr(""));

--- a/src/DanielsPoints.cpp
+++ b/src/DanielsPoints.cpp
@@ -18,10 +18,8 @@
 
 #include "RideMetric.h"
 #include "Zones.h"
-#include <QObject>
 #include <math.h>
-
-#define tr(s) QObject::tr(s)
+#include <QApplication>
 
 // The idea: Fit a curve to the points system in Table 2.2 of "Daniel's Running
 // Formula", Second Edition, assume that power at VO2Max is 1.2 * FTP, further
@@ -33,6 +31,7 @@
 
 
 class DanielsPoints : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(DanielsPoints)
 
     double score;
     void inc(double secs, double watts, double cp) {
@@ -46,6 +45,9 @@ class DanielsPoints : public RideMetric {
     DanielsPoints() : score(0.0)
     {
         setSymbol("daniels_points");
+        setInternalName("Daniels Points");
+    }
+    void initialize() {
         setName(tr("Daniels Points"));
         setMetricUnits("");
         setImperialUnits("");
@@ -100,6 +102,7 @@ class DanielsPoints : public RideMetric {
 const double DanielsPoints::K = 100.0 / 3600.0;
 
 class DanielsEquivalentPower : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(DanielsEquivalentPower)
     double watts;
 
     public:
@@ -107,6 +110,9 @@ class DanielsEquivalentPower : public RideMetric {
     DanielsEquivalentPower() : watts(0.0)
     {
         setSymbol("daniels_equivalent_power");
+        setInternalName("Daniels EqP");
+    }
+    void initialize() {
         setName(tr("Daniels EqP"));
         setMetricUnits(tr("watts"));
         setImperialUnits(tr("watts"));

--- a/src/HrTimeInZone.cpp
+++ b/src/HrTimeInZone.cpp
@@ -21,10 +21,10 @@
 #include "BestIntervalDialog.h"
 #include "HrZones.h"
 #include <math.h>
-
-#define tr(s) QObject::tr(s)
+#include <QApplication>
 
 class HrZoneTime : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(HrZoneTime)
     int level;
     double seconds;
 
@@ -63,96 +63,136 @@ public:
 };
 
 class HrZoneTime1 : public HrZoneTime {
+    Q_DECLARE_TR_FUNCTIONS(HrZoneTime1)
 
 public:
     HrZoneTime1()
     {
         setLevel(1);
         setSymbol("time_in_zone_H1");
+        setInternalName("H1 Time in Zone");
+    }
+    void initialize ()
+    {
         setName(tr("H1 Time in Zone"));
     }
     RideMetric *clone() const { return new HrZoneTime1(*this); }
 };
 
 class HrZoneTime2 : public HrZoneTime {
+    Q_DECLARE_TR_FUNCTIONS(HrZoneTime2)
 
 public:
     HrZoneTime2()
     {
         setLevel(2);
         setSymbol("time_in_zone_H2");
+        setInternalName("H2 Time in Zone");
+    }
+    void initialize ()
+    {
         setName(tr("H2 Time in Zone"));
     }
     RideMetric *clone() const { return new HrZoneTime2(*this); }
 };
 
 class HrZoneTime3 : public HrZoneTime {
+    Q_DECLARE_TR_FUNCTIONS(HrZoneTime3)
 
 public:
     HrZoneTime3()
     {
         setLevel(3);
         setSymbol("time_in_zone_H3");
+        setInternalName("H3 Time in Zone");
+    }
+    void initialize ()
+    {
         setName(tr("H3 Time in Zone"));
     }
     RideMetric *clone() const { return new HrZoneTime3(*this); }
 };
 
 class HrZoneTime4 : public HrZoneTime {
+    Q_DECLARE_TR_FUNCTIONS(HrZoneTime4)
 
 public:
     HrZoneTime4()
     {
         setLevel(4);
         setSymbol("time_in_zone_H4");
+        setInternalName("H4 Time in Zone");
+    }
+    void initialize ()
+    {
         setName(tr("H4 Time in Zone"));
     }
     RideMetric *clone() const { return new HrZoneTime4(*this); }
 };
 
 class HrZoneTime5 : public HrZoneTime {
+    Q_DECLARE_TR_FUNCTIONS(HrZoneTime5)
 
 public:
     HrZoneTime5()
     {
         setLevel(5);
         setSymbol("time_in_zone_H5");
+        setInternalName("H5 Time in Zone");
+    }
+    void initialize ()
+    {
         setName(tr("H5 Time in Zone"));
     }
     RideMetric *clone() const { return new HrZoneTime5(*this); }
 };
 
 class HrZoneTime6 : public HrZoneTime {
+    Q_DECLARE_TR_FUNCTIONS(HrZoneTime6)
 
 public:
     HrZoneTime6()
     {
         setLevel(6);
         setSymbol("time_in_zone_H6");
+        setInternalName("H6 Time in Zone");
+    }
+    void initialize ()
+    {
         setName(tr("H6 Time in Zone"));
     }
     RideMetric *clone() const { return new HrZoneTime6(*this); }
 };
 
 class HrZoneTime7 : public HrZoneTime {
+    Q_DECLARE_TR_FUNCTIONS(HrZoneTime7)
 
 public:
     HrZoneTime7()
     {
         setLevel(7);
         setSymbol("time_in_zone_H7");
+        setInternalName("H7 Time in Zone");
+    }
+    void initialize ()
+    {
         setName(tr("H7 Time in Zone"));
     }
     RideMetric *clone() const { return new HrZoneTime7(*this); }
 };
 
 class HrZoneTime8 : public HrZoneTime {
+    Q_DECLARE_TR_FUNCTIONS(HrZoneTime8)
 
 public:
     HrZoneTime8()
     {
         setLevel(8);
         setSymbol("time_in_zone_H8");
+        setInternalName("H8 Time in Zone");
+    }
+    void initialize ()
+    {
         setName(tr("H8 Time in Zone"));
     }
     RideMetric *clone() const { return new HrZoneTime8(*this); }

--- a/src/PeakPower.cpp
+++ b/src/PeakPower.cpp
@@ -20,10 +20,10 @@
 #include "BestIntervalDialog.h"
 #include "Zones.h"
 #include <math.h>
-
-#define tr(s) QObject::tr(s)
+#include <QApplication>
 
 class PeakPower : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(PeakPower)
     double watts;
     double secs;
 
@@ -55,138 +55,187 @@ class PeakPower : public RideMetric {
 };
 
 class CriticalPower : public PeakPower {
+    Q_DECLARE_TR_FUNCTIONS(CriticalPower)
     public:
         CriticalPower()
         {
             setSecs(3600);
             setSymbol("60m_critical_power");
+            setInternalName("60 min Peak Power");
+        }
+        void initialize () {
             setName(tr("60 min Peak Power"));
         }
         RideMetric *clone() const { return new CriticalPower(*this); }
 };
 
 class PeakPower1s : public PeakPower {
+    Q_DECLARE_TR_FUNCTIONS(PeakPower1s)
     public:
         PeakPower1s()
         {
             setSecs(1);
             setSymbol("1s_critical_power");
+            setInternalName("1 sec Peak Power");
+        }
+        void initialize () {
             setName(tr("1 sec Peak Power"));
         }
         RideMetric *clone() const { return new PeakPower1s(*this); }
 };
 
 class PeakPower5s : public PeakPower {
+    Q_DECLARE_TR_FUNCTIONS(PeakPower5s)
     public:
         PeakPower5s()
         {
             setSecs(5);
             setSymbol("5s_critical_power");
+            setInternalName("5 sec Peak Power");
+        }
+        void initialize () {
             setName(tr("5 sec Peak Power"));
         }
         RideMetric *clone() const { return new PeakPower5s(*this); }
 };
 
 class PeakPower10s : public PeakPower {
+    Q_DECLARE_TR_FUNCTIONS(PeakPower10s)
     public:
         PeakPower10s()
         {
             setSecs(10);
             setSymbol("10s_critical_power");
+            setInternalName("10 sec Peak Power");
+        }
+        void initialize () {
             setName(tr("10 sec Peak Power"));
         }
         RideMetric *clone() const { return new PeakPower10s(*this); }
 };
 
 class PeakPower15s : public PeakPower {
+    Q_DECLARE_TR_FUNCTIONS(PeakPower15s)
     public:
         PeakPower15s()
         {
             setSecs(15);
             setSymbol("15s_critical_power");
+            setInternalName("15 sec Peak Power");
+        }
+        void initialize () {
             setName(tr("15 sec Peak Power"));
         }
         RideMetric *clone() const { return new PeakPower15s(*this); }
 };
 
 class PeakPower20s : public PeakPower {
+    Q_DECLARE_TR_FUNCTIONS(PeakPower20s)
     public:
         PeakPower20s()
         {
             setSecs(20);
             setSymbol("20s_critical_power");
+            setInternalName("20 sec Peak Power");
+        }
+        void initialize () {
             setName(tr("20 sec Peak Power"));
         }
         RideMetric *clone() const { return new PeakPower20s(*this); }
 };
 
 class PeakPower30s : public PeakPower {
+    Q_DECLARE_TR_FUNCTIONS(PeakPower30s)
     public:
         PeakPower30s()
         {
             setSecs(30);
             setSymbol("30s_critical_power");
+            setInternalName("30 sec Peak Power");
+        }
+        void initialize () {
             setName(tr("30 sec Peak Power"));
         }
         RideMetric *clone() const { return new PeakPower30s(*this); }
 };
 
 class PeakPower1m : public PeakPower {
+    Q_DECLARE_TR_FUNCTIONS(PeakPower1m)
     public:
         PeakPower1m()
         {
             setSecs(60);
             setSymbol("1m_critical_power");
+            setInternalName("1 min Peak Power");
+        }
+        void initialize () {
             setName(tr("1 min Peak Power"));
         }
         RideMetric *clone() const { return new PeakPower1m(*this); }
 };
 
 class PeakPower5m : public PeakPower {
+    Q_DECLARE_TR_FUNCTIONS(PeakPower5m)
     public:
         PeakPower5m()
         {
             setSecs(300);
             setSymbol("5m_critical_power");
+            setInternalName("5 min Peak Power");
+        }
+        void initialize () {
             setName(tr("5 min Peak Power"));
         }
         RideMetric *clone() const { return new PeakPower5m(*this); }
 };
 
 class PeakPower10m : public PeakPower {
+    Q_DECLARE_TR_FUNCTIONS(PeakPower10m)
     public:
         PeakPower10m()
         {
             setSecs(600);
             setSymbol("10m_critical_power");
+            setInternalName("10 min Peak Power");
+        }
+        void initialize () {
             setName(tr("10 min Peak Power"));
         }
         RideMetric *clone() const { return new PeakPower10m(*this); }
 };
 
 class PeakPower20m : public PeakPower {
+    Q_DECLARE_TR_FUNCTIONS(PeakPower20m)
     public:
         PeakPower20m()
         {
             setSecs(1200);
             setSymbol("20m_critical_power");
+            setInternalName("20 min Peak Power");
+        }
+        void initialize () {
             setName(tr("20 min Peak Power"));
         }
         RideMetric *clone() const { return new PeakPower20m(*this); }
 };
 
 class PeakPower30m : public PeakPower {
+    Q_DECLARE_TR_FUNCTIONS(PeakPower30m)
     public:
         PeakPower30m()
         {
             setSecs(1800);
             setSymbol("30m_critical_power");
+            setInternalName("30 min Peak Power");
+        }
+        void initialize () {
             setName(tr("30 min Peak Power"));
         }
         RideMetric *clone() const { return new PeakPower30m(*this); }
 };
 
 class PeakPowerHr : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(PeakPowerHr)
 
     double hr;
     double secs;
@@ -226,12 +275,16 @@ class PeakPowerHr : public RideMetric {
 };
 
 class PeakPowerHr1m : public PeakPowerHr {
+    Q_DECLARE_TR_FUNCTIONS(PeakPowerHr1m)
 
     public:
         PeakPowerHr1m()
         {
             setSecs(60);
             setSymbol("1m_critical_power_hr");
+            setInternalName("1 min Peak Power HR");
+        }
+        void initialize () {
             setName(tr("1 min Peak Power HR"));
             setMetricUnits(tr("bpm"));
             setImperialUnits(tr("bpm"));
@@ -240,12 +293,16 @@ class PeakPowerHr1m : public PeakPowerHr {
 };
 
 class PeakPowerHr5m : public PeakPowerHr {
+    Q_DECLARE_TR_FUNCTIONS(PeakPowerHr5m)
 
     public:
         PeakPowerHr5m()
         {
             setSecs(300);
             setSymbol("5m_critical_power_hr");
+            setInternalName("5 min Peak Power HR");
+        }
+        void initialize () {
             setName(tr("5 min Peak Power HR"));
             setMetricUnits(tr("bpm"));
             setImperialUnits(tr("bpm"));
@@ -254,12 +311,16 @@ class PeakPowerHr5m : public PeakPowerHr {
 };
 
 class PeakPowerHr10m : public PeakPowerHr {
+    Q_DECLARE_TR_FUNCTIONS(PeakPowerHr10m)
 
     public:
         PeakPowerHr10m()
         {
             setSecs(600);
             setSymbol("10m_critical_power_hr");
+            setInternalName("10 min Peak Power HR");
+        }
+        void initialize () {
             setName(tr("10 min Peak Power HR"));
             setMetricUnits(tr("bpm"));
             setImperialUnits(tr("bpm"));
@@ -268,12 +329,16 @@ class PeakPowerHr10m : public PeakPowerHr {
 };
 
 class PeakPowerHr20m : public PeakPowerHr {
+    Q_DECLARE_TR_FUNCTIONS(PeakPowerHr20m)
 
     public:
         PeakPowerHr20m()
         {
             setSecs(1200);
             setSymbol("20m_critical_power_hr");
+            setInternalName("20 min Peak Power HR");
+        }
+        void initialize () {
             setName(tr("20 min Peak Power HR"));
             setMetricUnits(tr("bpm"));
             setImperialUnits(tr("bpm"));
@@ -282,12 +347,16 @@ class PeakPowerHr20m : public PeakPowerHr {
 };
 
 class PeakPowerHr30m : public PeakPowerHr {
+    Q_DECLARE_TR_FUNCTIONS(PeakPowerHr30m)
 
     public:
         PeakPowerHr30m()
         {
             setSecs(1800);
             setSymbol("30m_critical_power_hr");
+            setInternalName("30 min Peak Power HR");
+        }
+        void initialize () {
             setName(tr("30 min Peak Power HR"));
             setMetricUnits(tr("bpm"));
             setImperialUnits(tr("bpm"));
@@ -297,12 +366,16 @@ class PeakPowerHr30m : public PeakPowerHr {
 
 
 class PeakPowerHr60m : public PeakPowerHr {
+    Q_DECLARE_TR_FUNCTIONS(PeakPowerHr60m)
 
     public:
         PeakPowerHr60m()
         {
             setSecs(3600);
             setSymbol("60m_critical_power_hr");
+            setInternalName("60 min Peak Power HR");
+        }
+        void initialize () {
             setName(tr("60 min Peak Power HR"));
             setMetricUnits(tr("bpm"));
             setImperialUnits(tr("bpm"));

--- a/src/RideMetric.h
+++ b/src/RideMetric.h
@@ -54,6 +54,9 @@ struct RideMetric {
     }
     virtual ~RideMetric() {}
 
+    // Initialization moved from constructor to enable translation
+    virtual void initialize() {}
+
     // The string by which we refer to this RideMetric in the code,
     // configuration files, and caches (like stress.cache).  It should
     // not be translated, and it should never be shown to the user.
@@ -63,6 +66,9 @@ struct RideMetric {
     // summaries, configuration dialogs, etc.  It should be translated
     // using QObject::tr().
     virtual QString name() const { return name_; }
+
+    // English name used in metadata.xml for compatibility
+    virtual QString internalName() const { return internalName_; }
 
     // What type of metric is this?
     // Drives the way metrics combined over a day or week in the
@@ -140,6 +146,7 @@ struct RideMetric {
     void setMetricUnits(QString x) { metricUnits_ = x; }
     void setImperialUnits(QString x) { imperialUnits_ = x; }
     void setName(QString x) { name_ = x; }
+    void setInternalName(QString x) { internalName_ = x; }
     void setSymbol(QString x) { symbol_ = x; }
     void setType(MetricType x) { type_ = x; }
     void setAggregate(bool x) { aggregate_ = x; }
@@ -153,7 +160,7 @@ struct RideMetric {
                 precision_;
 
         QString metricUnits_, imperialUnits_;
-        QString name_, symbol_;
+        QString name_, symbol_, internalName_;
         MetricType type_;
 };
 
@@ -190,6 +197,11 @@ class RideMetricFactory {
     }
 
     int metricCount() const { return metricNames.size(); }
+
+    void initialize() {
+        foreach(const QString &metricName, metrics.keys())
+            metrics[metricName]->initialize();
+    }
 
     const QString &metricName(int i) const { return metricNames[i]; }
     const RideMetric::MetricType &metricType(int i) const { return metricTypes[i]; }

--- a/src/TRIMPPoints.cpp
+++ b/src/TRIMPPoints.cpp
@@ -20,11 +20,9 @@
 #include "Settings.h"
 #include "Zones.h"
 #include "HrZones.h"
-#include <QObject>
 #include <math.h>
 #include "MainWindow.h"
-
-#define tr(s) QObject::tr(s)
+#include <QApplication>
 
 // This is Morton/Banister with Green et al coefficient.
 //
@@ -34,6 +32,7 @@
 // RHR = resting heart rate
 //
 class TRIMPPoints : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(TRIMPPoints)
 
     double score;
 
@@ -44,6 +43,9 @@ class TRIMPPoints : public RideMetric {
     TRIMPPoints() : score(0.0)
     {
         setSymbol("trimp_points");
+        setInternalName("TRIMP Points");
+    }
+    void initialize() {
         setName(tr("TRIMP Points"));
         setMetricUnits("");
         setImperialUnits("");
@@ -101,6 +103,7 @@ class TRIMPPoints : public RideMetric {
 
 
 class TRIMP100Points : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(TRIMP100Points)
 
     double score;
 
@@ -111,6 +114,9 @@ public:
     TRIMP100Points() : score(0.0)
     {
         setSymbol("trimp_100_points");
+        setInternalName("TRIMP(100) Points");
+    }
+    void initialize() {
         setName(tr("TRIMP(100) Points"));
         setMetricUnits("");
         setImperialUnits("");
@@ -167,6 +173,7 @@ public:
 // 0.9 (zone 1 0-55%), 1.1 (zone 2 55-66%), 1.2 (zone 3 66-75%), 2 (zone 4 75-84%), and 5 (zone 5 84-100%)
 
 class TRIMPZonalPoints : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(TRIMPZonalPoints)
 
     double score;
 
@@ -177,6 +184,9 @@ public:
     TRIMPZonalPoints() : score(0.0)
     {
         setSymbol("trimp_zonal_points");
+        setInternalName("TRIMP Zonal Points");
+    }
+    void initialize() {
         setName(tr("TRIMP Zonal Points"));
         setMetricUnits("");
         setImperialUnits("");
@@ -291,6 +301,7 @@ public:
 //    - perceived load (session RPE)
 //
 class SessionRPE : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(SessionRPE)
 
     double score;
 
@@ -299,6 +310,9 @@ class SessionRPE : public RideMetric {
     SessionRPE() : score(0.0)
     {
         setSymbol("session_rpe");
+        setInternalName("Session RPE");
+    }
+    void initialize() {
         setName(tr("Session RPE"));
         setMetricUnits("");
         setImperialUnits("");

--- a/src/TimeInZone.cpp
+++ b/src/TimeInZone.cpp
@@ -21,10 +21,10 @@
 #include "BestIntervalDialog.h"
 #include "Zones.h"
 #include <math.h>
-
-#define tr(s) QObject::tr(s)
+#include <QApplication>
 
 class ZoneTime : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(ZoneTime)
     int level;
     double seconds;
 
@@ -65,120 +65,170 @@ class ZoneTime : public RideMetric {
 };
 
 class ZoneTime1 : public ZoneTime {
+    Q_DECLARE_TR_FUNCTIONS(ZoneTime1)
 
     public:
         ZoneTime1()
         {
             setLevel(1);
             setSymbol("time_in_zone_L1");
+            setInternalName("L1 Time in Zone");
+        }
+        void initialize ()
+        {
             setName(tr("L1 Time in Zone"));
         }
         RideMetric *clone() const { return new ZoneTime1(*this); }
 };
 
 class ZoneTime2 : public ZoneTime {
+    Q_DECLARE_TR_FUNCTIONS(ZoneTime2)
 
     public:
         ZoneTime2()
         {
             setLevel(2);
             setSymbol("time_in_zone_L2");
+            setInternalName("L2 Time in Zone");
+        }
+        void initialize ()
+        {
             setName(tr("L2 Time in Zone"));
         }
         RideMetric *clone() const { return new ZoneTime2(*this); }
 };
 
 class ZoneTime3 : public ZoneTime {
+    Q_DECLARE_TR_FUNCTIONS(ZoneTime3)
 
     public:
         ZoneTime3()
         {
             setLevel(3);
             setSymbol("time_in_zone_L3");
+            setInternalName("L3 Time in Zone");
+        }
+        void initialize ()
+        {
             setName(tr("L3 Time in Zone"));
         }
         RideMetric *clone() const { return new ZoneTime3(*this); }
 };
 
 class ZoneTime4 : public ZoneTime {
+    Q_DECLARE_TR_FUNCTIONS(ZoneTime4)
 
     public:
         ZoneTime4()
         {
             setLevel(4);
             setSymbol("time_in_zone_L4");
+            setInternalName("L4 Time in Zone");
+        }
+        void initialize ()
+        {
             setName(tr("L4 Time in Zone"));
         }
         RideMetric *clone() const { return new ZoneTime4(*this); }
 };
 
 class ZoneTime5 : public ZoneTime {
+    Q_DECLARE_TR_FUNCTIONS(ZoneTime5)
 
     public:
         ZoneTime5()
         {
             setLevel(5);
             setSymbol("time_in_zone_L5");
+            setInternalName("L5 Time in Zone");
+        }
+        void initialize ()
+        {
             setName(tr("L5 Time in Zone"));
         }
         RideMetric *clone() const { return new ZoneTime5(*this); }
 };
 
 class ZoneTime6 : public ZoneTime {
+    Q_DECLARE_TR_FUNCTIONS(ZoneTime6)
 
     public:
         ZoneTime6()
         {
             setLevel(6);
             setSymbol("time_in_zone_L6");
+            setInternalName("L6 Time in Zone");
+        }
+        void initialize ()
+        {
             setName(tr("L6 Time in Zone"));
         }
         RideMetric *clone() const { return new ZoneTime6(*this); }
 };
 
 class ZoneTime7 : public ZoneTime {
+    Q_DECLARE_TR_FUNCTIONS(ZoneTime7)
 
     public:
         ZoneTime7()
         {
             setLevel(7);
             setSymbol("time_in_zone_L7");
+            setInternalName("L7 Time in Zone");
+        }
+        void initialize ()
+        {
             setName(tr("L7 Time in Zone"));
         }
         RideMetric *clone() const { return new ZoneTime7(*this); }
 };
 
 class ZoneTime8 : public ZoneTime {
+    Q_DECLARE_TR_FUNCTIONS(ZoneTime8)
 
     public:
         ZoneTime8()
         {
             setLevel(8);
             setSymbol("time_in_zone_L8");
+            setInternalName("L8 Time in Zone");
+        }
+        void initialize ()
+        {
             setName(tr("L8 Time in Zone"));
         }
         RideMetric *clone() const { return new ZoneTime8(*this); }
 };
 
 class ZoneTime9 : public ZoneTime {
+    Q_DECLARE_TR_FUNCTIONS(ZoneTime9)
 
     public:
         ZoneTime9()
         {
             setLevel(9);
             setSymbol("time_in_zone_L9");
+            setInternalName("L9 Time in Zone");
+        }
+        void initialize ()
+        {
             setName(tr("L9 Time in Zone"));
         }
         RideMetric *clone() const { return new ZoneTime9(*this); }
 };
 
 class ZoneTime10 : public ZoneTime {
+    Q_DECLARE_TR_FUNCTIONS(ZoneTime10)
 
     public:
         ZoneTime10()
         {
             setLevel(10);
             setSymbol("time_in_zone_L10");
+            setInternalName("L10 Time in Zone");
+        }
+        void initialize ()
+        {
             setName(tr("L10 Time in Zone"));
         }
         RideMetric *clone() const { return new ZoneTime10(*this); }

--- a/src/WattsPerKilogram.cpp
+++ b/src/WattsPerKilogram.cpp
@@ -22,8 +22,7 @@
 #include "Settings.h"
 #include "MetricAggregator.h"
 #include <math.h>
-
-#define tr(s) QObject::tr(s)
+#include <QApplication>
 
 // first use RideFile::startTime, then Measure then fallback to Global Setting
 static double
@@ -46,12 +45,16 @@ getWeight(const MainWindow *main, const RideFile *ride)
 }
 
 class AverageWPK : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(AverageWPK)
 
     public:
 
     AverageWPK()
     {
         setSymbol("average_wpk");
+        setInternalName("Watts Per Kilogram");
+    }
+    void initialize () {
         setName(tr("Watts Per Kilogram"));
         setType(RideMetric::Average);
         setMetricUnits(tr("wpk"));
@@ -77,6 +80,7 @@ class AverageWPK : public RideMetric {
 };
 
 class PeakWPK : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(PeakWPK)
     double wpk;
     double secs;
     double weight;
@@ -112,143 +116,195 @@ class PeakWPK : public RideMetric {
 };
 
 class CPWPK : public PeakWPK {
+    Q_DECLARE_TR_FUNCTIONS(CPWPK)
     public:
         CPWPK()
         {
             setSecs(3600);
             setSymbol("60m_peak_wpk");
+            setInternalName("60 min Peak WPK");
+        }
+        void initialize () {
             setName(tr("60 min Peak WPK"));
         }
         RideMetric *clone() const { return new CPWPK(*this); }
 };
 
 class PeakWPK1s : public PeakWPK {
+    Q_DECLARE_TR_FUNCTIONS(PeakWPK1s)
     public:
         PeakWPK1s()
         {
             setSecs(1);
             setSymbol("1s_peak_wpk");
+            setInternalName("1 sec Peak WPK");
+        }
+        void initialize () {
             setName(tr("1 sec Peak WPK"));
         }
         RideMetric *clone() const { return new PeakWPK1s(*this); }
 };
 
 class PeakWPK5s : public PeakWPK {
+    Q_DECLARE_TR_FUNCTIONS(PeakWPK5s)
     public:
         PeakWPK5s()
         {
             setSecs(5);
             setSymbol("5s_peak_wpk");
+            setInternalName("5 sec Peak WPK");
+        }
+        void initialize () {
             setName(tr("5 sec Peak WPK"));
         }
         RideMetric *clone() const { return new PeakWPK5s(*this); }
 };
 
 class PeakWPK10s : public PeakWPK {
+    Q_DECLARE_TR_FUNCTIONS(PeakWPK10s)
     public:
         PeakWPK10s()
         {
             setSecs(10);
             setSymbol("10s_peak_wpk");
+            setInternalName("10 sec Peak WPK");
+        }
+        void initialize () {
             setName(tr("10 sec Peak WPK"));
         }
         RideMetric *clone() const { return new PeakWPK10s(*this); }
 };
 
 class PeakWPK15s : public PeakWPK {
+    Q_DECLARE_TR_FUNCTIONS(PeakWPK15s)
     public:
         PeakWPK15s()
         {
             setSecs(15);
             setSymbol("15s_peak_wpk");
+            setInternalName("15 sec Peak WPK");
+        }
+        void initialize () {
             setName(tr("15 sec Peak WPK"));
         }
         RideMetric *clone() const { return new PeakWPK15s(*this); }
 };
 
 class PeakWPK20s : public PeakWPK {
+    Q_DECLARE_TR_FUNCTIONS(PeakWPK20s)
     public:
         PeakWPK20s()
         {
             setSecs(20);
             setSymbol("20s_peak_wpk");
+            setInternalName("20 sec Peak WPK");
+        }
+        void initialize () {
             setName(tr("20 sec Peak WPK"));
         }
         RideMetric *clone() const { return new PeakWPK20s(*this); }
 };
 
 class PeakWPK30s : public PeakWPK {
+    Q_DECLARE_TR_FUNCTIONS(PeakWPK30s)
     public:
         PeakWPK30s()
         {
             setSecs(30);
             setSymbol("30s_peak_wpk");
+            setInternalName("30 sec Peak WPK");
+        }
+        void initialize () {
             setName(tr("30 sec Peak WPK"));
         }
         RideMetric *clone() const { return new PeakWPK30s(*this); }
 };
 
 class PeakWPK1m : public PeakWPK {
+    Q_DECLARE_TR_FUNCTIONS(PeakWPK1m)
     public:
         PeakWPK1m()
         {
             setSecs(60);
             setSymbol("1m_peak_wpk");
+            setInternalName("1 min Peak WPK");
+        }
+        void initialize () {
             setName(tr("1 min Peak WPK"));
         }
         RideMetric *clone() const { return new PeakWPK1m(*this); }
 };
 
 class PeakWPK5m : public PeakWPK {
+    Q_DECLARE_TR_FUNCTIONS(PeakWPK5m)
     public:
         PeakWPK5m()
         {
             setSecs(300);
             setSymbol("5m_peak_wpk");
+            setInternalName("5 min Peak WPK");
+        }
+        void initialize () {
             setName(tr("5 min Peak WPK"));
         }
         RideMetric *clone() const { return new PeakWPK5m(*this); }
 };
 
 class PeakWPK10m : public PeakWPK {
+    Q_DECLARE_TR_FUNCTIONS(PeakWPK10m)
     public:
         PeakWPK10m()
         {
             setSecs(600);
             setSymbol("10m_peak_wpk");
+            setInternalName("10 min Peak WPK");
+        }
+        void initialize () {
             setName(tr("10 min Peak WPK"));
         }
         RideMetric *clone() const { return new PeakWPK10m(*this); }
 };
 
 class PeakWPK20m : public PeakWPK {
+    Q_DECLARE_TR_FUNCTIONS(PeakWPK20m)
     public:
         PeakWPK20m()
         {
             setSecs(1200);
             setSymbol("20m_peak_wpk");
+            setInternalName("20 min Peak WPK");
+        }
+        void initialize () {
             setName(tr("20 min Peak WPK"));
         }
         RideMetric *clone() const { return new PeakWPK20m(*this); }
 };
 
 class PeakWPK30m : public PeakWPK {
+    Q_DECLARE_TR_FUNCTIONS(PeakWPK30m)
     public:
         PeakWPK30m()
         {
             setSecs(1800);
             setSymbol("30m_peak_wpk");
+            setInternalName("30 min Peak WPK");
+        }
+        void initialize () {
             setName(tr("30 min Peak WPK"));
         }
         RideMetric *clone() const { return new PeakWPK30m(*this); }
 };
 
 class Vo2max : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(Vo2max)
     public:
 
     Vo2max()
     {
         setSymbol("vo2max");
+        setInternalName("Estimated VO2MAX");
+    }
+    void initialize () {
         setName(tr("Estimated VO2MAX"));
         setType(RideMetric::Average);
         setMetricUnits(tr("ml/min/kg"));

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -102,6 +102,8 @@ main(int argc, char *argv[])
     QTranslator gcTranslator;
     gcTranslator.load(":translations/gc_" + lang.toString() + ".qm");
     app.installTranslator(&gcTranslator);
+    // Initialize metics once the translator is installed
+    RideMetricFactory::instance().initialize();
 
     QStringList args( app.arguments() );
 


### PR DESCRIPTION
The code setting metric names and units was moved from constructors to
initialize methods, to be called after translator initialization.
English Name is preserved as InternalName for metadata.xlm compatibility
in metric override.
Q_DECLARE_TR_FUNCTIONS(class-name) macro is used to set tr() context
when class-name is not QObject sub-class.
