### PR TITLE
Enable Metadata translation

### DIFF
--- a/src/LTMPlot.cpp
+++ b/src/LTMPlot.cpp
@@ -726,10 +726,13 @@ LTMPlot::setData(LTMSettings *set)
 
     // draw zone labels axisid of -1 means delete whats there
     // cause no watts are being displayed
-    if (settings->shadeZones == true)
-        refreshZoneLabels(axes.value("watts", -1));
-    else
+    if (settings->shadeZones == true) {
+        int axisid = axes.value("watts", -1);
+        if (axisid == -1) axisid = axes.value(tr("watts"), -1); // Try translated version
+        refreshZoneLabels(axisid);
+    } else {
         refreshZoneLabels(-1); // turn em off
+    }
 
     // show legend?
     if (settings->legend == false) this->legend()->clear();

--- a/src/LTMTool.cpp
+++ b/src/LTMTool.cpp
@@ -457,7 +457,7 @@ LTMTool::LTMTool(MainWindow *parent, const QDir &home, bool multi) : QWidget(par
             metametric.smooth = false;
             metametric.trend = false;
             metametric.topN = 5;
-            metametric.uname = metametric.name = field.name;
+            metametric.uname = metametric.name = sp.displayName(field.name);
             metametric.uunits = "";
             metrics.append(metametric);
         }

--- a/src/Pages.cpp
+++ b/src/Pages.cpp
@@ -2019,6 +2019,7 @@ FieldsPage::FieldsPage(QWidget *parent, QList<FieldDefinition>fieldDefinitions) 
 #endif
 
     SpecialFields specials;
+    SpecialTabs specialTabs;
     foreach(FieldDefinition field, fieldDefinitions) {
         QTreeWidgetItem *add;
         QComboBox *comboButton = new QComboBox(this);
@@ -2037,9 +2038,9 @@ FieldsPage::FieldsPage(QWidget *parent, QList<FieldDefinition>fieldDefinitions) 
         add->setFlags(add->flags() | Qt::ItemIsEditable);
 
         // tab name
-        add->setText(0, field.tab);
+        add->setText(0, specialTabs.displayName(field.tab));
         // field name
-        add->setText(1, field.name);
+        add->setText(1, specials.displayName(field.name));
         // values
         add->setText(3, field.values.join(","));
 
@@ -2155,6 +2156,7 @@ void
 FieldsPage::getDefinitions(QList<FieldDefinition> &fieldList)
 {
     SpecialFields sp;
+    SpecialTabs st;
     QStringList checkdups;
 
     // clear current just in case
@@ -2169,8 +2171,8 @@ FieldsPage::getDefinitions(QList<FieldDefinition> &fieldList)
         if (checkdups.contains(item->text(1))) continue;
         else checkdups << item->text(1);
 
-        add.tab = item->text(0);
-        add.name = item->text(1);
+        add.tab = st.internalName(item->text(0));
+        add.name = sp.internalName(item->text(1));
         add.values = item->text(3).split(QRegExp("(, *|,)"), QString::KeepEmptyParts);
         add.diary = ((QCheckBox*)fields->itemWidget(item, 4))->isChecked();
 

--- a/src/RideMetadata.cpp
+++ b/src/RideMetadata.cpp
@@ -228,10 +228,11 @@ RideMetadata::configUpdate()
         if (fieldDefinitions[i].tab == "") continue; // not to be shown!
 
         Form *form;
-        if ((form = tabList.value(fieldDefinitions[i].tab, NULL)) == NULL) {
+        QString tabName = specialTabs.displayName(fieldDefinitions[i].tab);
+        if ((form = tabList.value(tabName, NULL)) == NULL) {
             form = new Form(this);
-            tabs->addTab(form, fieldDefinitions[i].tab);
-            tabList.insert(fieldDefinitions[i].tab, form);
+            tabs->addTab(form, tabName);
+            tabList.insert(tabName, form);
         }
         form->addField(fieldDefinitions[i]);
     }
@@ -406,7 +407,7 @@ FormField::FormField(FieldDefinition field, RideMetadata *meta) : definition(fie
         if (units != "") units = QString(" (%1)").arg(units);
     }
 
-    label = new QLabel(QString("%1%2").arg(field.name).arg(units), this);
+    label = new QLabel(QString("%1%2").arg(meta->sp.displayName(field.name)).arg(units), this);
     //label->setFont(font);
     //label->setFixedHeight(18);
 

--- a/src/RideMetadata.h
+++ b/src/RideMetadata.h
@@ -133,6 +133,7 @@ class RideMetadata : public QWidget
         SpecialFields sp;
 
         MainWindow *main;
+        SpecialTabs specialTabs;
 
     public slots:
         void configUpdate();

--- a/src/SpecialFields.cpp
+++ b/src/SpecialFields.cpp
@@ -23,54 +23,55 @@
 
 SpecialFields::SpecialFields()
 {
-    names_  << "Start Date"    // linked to RideFile::starttime
-            << "Start Time"    // linked to RideFile::starttime
-            << "Identifier"    // linkned to RideFile::id
-            << "Workout Code" // in WKO and possibly others
-            << "Sport"        // in WKO and possible others
-            << "Objective"    // in WKO as "goal" nad possibly others
-            << "Summary"      // embeds the RideSummary widget
-            << "Notes"        // linked to MainWindow::rideNotes
-            << "Keywords"     // extracted from Notes / used for highlighting calendar
-            << "Recording Interval" // linked to RideFile::recIntSecs
-            << "Weight"       // in WKO and possibly others
-            << "Device"       // RideFile::devicetype
-            << "Device Info"  // in WKO and TCX and possibly others
-            << "Dropouts"     // calculated from source data by FixGaps
-            << "Dropout Time" // calculated from source data vy FixGaps
-            << "Spikes"       // calculated from source data by FixSpikes
-            << "Spike Time"   // calculated from source data by FixSpikes
-            << "Torque Adjust" // the last torque adjust applied
-            << "Filename"      // set by the rideFile reader
-            << "Year"          // set by the rideFile reader
-            << "Change History" // set by RideFileCommand
-            << "Calendar Text" // set by openRideFile and rideMetadata
-            << "Data"          // set by openRideFile for areDataPresent
-            ;
+    namesmap.insert("Start Date", tr("Start Date"));                 // linked to RideFile::starttime
+    namesmap.insert("Start Time", tr("Start Time"));                 // linked to RideFile::starttime
+    namesmap.insert("Identifier", tr("Identifier"));                 // linked to RideFile::id
+    namesmap.insert("Workout Code", tr("Workout Code"));             // in WKO and possibly others
+    namesmap.insert("Sport", tr("Sport"));                           // in WKO and possible others
+    namesmap.insert("Objective", tr("Objective"));                   // in WKO as "goal" nad possibly others
+    namesmap.insert("Summary", tr("Summary"));                       // embeds the RideSummary widget
+    namesmap.insert("Notes", tr("Notes"));                           // linked to MainWindow::rideNotes
+    namesmap.insert("Keywords", tr("Keywords"));                     // extracted from Notes / used for highlighting calendar
+    namesmap.insert("Recording Interval", tr("Recording Interval")); // linked to RideFile::recIntSecs
+    namesmap.insert("Weight", tr("Weight"));                         // in WKO and possibly others
+    namesmap.insert("Device", tr("Device"));                         // RideFile::devicetype
+    namesmap.insert("Device Info", tr("Device Info"));               // in WKO and TCX and possibly others
+    namesmap.insert("Dropouts", tr("Dropouts"));                     // calculated from source data by FixGaps
+    namesmap.insert("Dropout Time", tr("Dropout Time"));             // calculated from source data vy FixGaps
+    namesmap.insert("Spikes", tr("Spikes"));                         // calculated from source data by FixSpikes
+    namesmap.insert("Spike Time", tr("Spike Time"));                 // calculated from source data by FixSpikes
+    namesmap.insert("Torque Adjust", tr("Torque Adjust"));           // the last torque adjust applied
+    namesmap.insert("Filename", tr("Filename"));                     // set by the rideFile reader
+    namesmap.insert("Year", tr("Year"));                             // set by the rideFile reader
+    namesmap.insert("Change History", tr("Change History"));         // set by RideFileCommand
+    namesmap.insert("Calendar Text", tr("Calendar Text"));           // set by openRideFile and rideMetadata
+    namesmap.insert("Data", tr("Data"));                             // set by openRideFile for areDataPresent
 
     // now add all the metric fields (for metric overrides)
     const RideMetricFactory &factory = RideMetricFactory::instance();
     for (int i=0; i<factory.metricCount(); i++) {
         const RideMetric *add = factory.rideMetric(factory.metricName(i));
         QTextEdit processHTML(add->name());
-        names_ << processHTML.toPlainText();
-        metricmap.insert(processHTML.toPlainText(), add);
+        QTextEdit processHTMLinternal(add->internalName());
+        // add->internalName() used for compatibility win metadata.xml, could be replaced by factory.metricName(i) or add->symbol()
+        namesmap.insert(processHTMLinternal.toPlainText(), processHTML.toPlainText());
+        metricmap.insert(processHTMLinternal.toPlainText(), add);
     }
 
     model_ = new QStringListModel;
-    model_->setStringList(names_);
+    model_->setStringList(namesmap.keys());
 }
 
 bool
 SpecialFields::isSpecial(QString &name) const
 {
-    return names_.contains(name);
+    return namesmap.contains(name);
 }
 
 bool
 SpecialFields::isUser(QString &name) const
 {
-    return !names_.contains(name);
+    return !namesmap.contains(name);
 }
 
 bool
@@ -103,3 +104,52 @@ SpecialFields::rideMetric(QString&name) const
 {
     return metricmap.value(name, NULL);
 }
+
+QString
+SpecialFields::displayName(QString &name) const
+{
+    // return localized name for display
+    if (namesmap.contains(name)) return namesmap.value(name);
+    else return(name);
+}
+
+QString
+SpecialFields::internalName(QString displayName) const
+{
+    // return internal name for storage
+    QMapIterator<QString, QString> i(namesmap);
+    while (i.hasNext()) {
+        i.next();
+        if (i.value() == displayName) return i.key();
+    }
+    return(displayName);
+}
+
+SpecialTabs::SpecialTabs()
+{
+    namesmap.insert("Workout", tr("Workout"));
+    namesmap.insert("Notes", tr("Notes"));
+    namesmap.insert("Metric", tr("Metric"));
+    namesmap.insert("Metric", tr("Extra"));
+}
+
+QString
+SpecialTabs::displayName(QString &internalName) const
+{
+    // return localized name for display
+    if (namesmap.contains(internalName)) return namesmap.value(internalName);
+    else return(internalName);
+}
+
+QString
+SpecialTabs::internalName(QString displayName) const
+{
+    // return internal name for storage
+    QMapIterator<QString, QString> i(namesmap);
+    while (i.hasNext()) {
+        i.next();
+        if (i.value() == displayName) return i.key();
+    }
+    return(displayName);
+}
+

--- a/src/SpecialFields.h
+++ b/src/SpecialFields.h
@@ -20,12 +20,15 @@
 #define _GC_SpecialFields_h
 #include "GoldenCheetah.h"
 
+#include <QApplication>
 #include <QStringList>
 #include <QStringListModel>
 #include "RideMetric.h"
 
 class SpecialFields
 {
+    Q_DECLARE_TR_FUNCTIONS(SpecialFields)
+
     public:
         SpecialFields();
 
@@ -38,15 +41,29 @@ class SpecialFields
         QString makeTechName(QString &) const;        // return a SQL friendly name
         QString metricSymbol(QString &) const;        // return symbol for user friendly name
         const RideMetric *rideMetric(QString&) const; // retuen metric ptr for user friendly name
+        QString displayName(QString &) const;         // return display (localized) name for name
+        QString internalName(QString) const;          // return internal (english) Name for display
 
         // the config pane uses the model
-        const QStringList &names() const { return names_; }
         QStringListModel *model() { return model_; }
 
     private:
-        QStringList names_;
+        QMap<QString, QString> namesmap; // Map Internal (english) name to external (Localized) name
         QMap<QString, const RideMetric *> metricmap;
         QStringListModel *model_;
+};
+
+class SpecialTabs
+{
+    Q_DECLARE_TR_FUNCTIONS(SpecialTabs)
+
+    public:
+        SpecialTabs();
+        QString displayName(QString &) const;       // return display (localized)
+        QString internalName(QString) const;        // return internal (english)
+
+    private:
+        QMap<QString, QString> namesmap; // Map Internal (english) name to external (Localized) name
 };
 
 #endif

--- a/src/translations/gc_cs.ts
+++ b/src/translations/gc_cs.ts
@@ -254,13 +254,13 @@
 <context>
     <name>AerobicDecoupling</name>
     <message>
-        <location filename="../AerobicDecoupling.cpp" line="50"/>
+        <location filename="../AerobicDecoupling.cpp" line="52"/>
         <source>Aerobic Decoupling</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../AerobicDecoupling.cpp" line="52"/>
-        <location filename="../AerobicDecoupling.cpp" line="53"/>
+        <location filename="../AerobicDecoupling.cpp" line="54"/>
+        <location filename="../AerobicDecoupling.cpp" line="55"/>
         <source>%</source>
         <translation>%</translation>
     </message>
@@ -394,42 +394,42 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="916"/>
+        <location filename="../AllPlot.cpp" line="909"/>
         <source>KPH</source>
         <translation>km/h</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="916"/>
+        <location filename="../AllPlot.cpp" line="909"/>
         <source>MPH</source>
         <translation>mi/h</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="932"/>
+        <location filename="../AllPlot.cpp" line="925"/>
         <source>Nm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="932"/>
+        <location filename="../AllPlot.cpp" line="925"/>
         <source>ftLb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="945"/>
+        <location filename="../AllPlot.cpp" line="938"/>
         <source>Meters</source>
         <translation>Metry</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="945"/>
+        <location filename="../AllPlot.cpp" line="938"/>
         <source>Feet</source>
         <translation>Stopy</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="971"/>
+        <location filename="../AllPlot.cpp" line="981"/>
         <source>Distance </source>
         <translation>Vzdálenost</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="973"/>
+        <location filename="../AllPlot.cpp" line="983"/>
         <source>Time (Hours:Minutes)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -559,13 +559,13 @@
 <context>
     <name>AverageWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="55"/>
+        <location filename="../WattsPerKilogram.cpp" line="58"/>
         <source>Watts Per Kilogram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="57"/>
-        <location filename="../WattsPerKilogram.cpp" line="58"/>
+        <location filename="../WattsPerKilogram.cpp" line="60"/>
+        <location filename="../WattsPerKilogram.cpp" line="61"/>
         <source>wpk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -573,13 +573,13 @@
 <context>
     <name>AvgCadence</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="433"/>
+        <location filename="../BasicRideMetrics.cpp" line="488"/>
         <source>Average Cadence</source>
         <translation>Průměrná kadence</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="434"/>
-        <location filename="../BasicRideMetrics.cpp" line="435"/>
+        <location filename="../BasicRideMetrics.cpp" line="489"/>
+        <location filename="../BasicRideMetrics.cpp" line="490"/>
         <source>rpm</source>
         <translation>ot/m</translation>
     </message>
@@ -587,13 +587,13 @@
 <context>
     <name>AvgHeartRate</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="399"/>
+        <location filename="../BasicRideMetrics.cpp" line="448"/>
         <source>Average Heart Rate</source>
         <translation>Průměrný tep</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="400"/>
-        <location filename="../BasicRideMetrics.cpp" line="401"/>
+        <location filename="../BasicRideMetrics.cpp" line="449"/>
+        <location filename="../BasicRideMetrics.cpp" line="450"/>
         <source>bpm</source>
         <translation>bpm</translation>
     </message>
@@ -601,13 +601,13 @@
 <context>
     <name>AvgPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="331"/>
+        <location filename="../BasicRideMetrics.cpp" line="368"/>
         <source>Average Power</source>
         <translation>Průměrný výkon</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="332"/>
-        <location filename="../BasicRideMetrics.cpp" line="333"/>
+        <location filename="../BasicRideMetrics.cpp" line="369"/>
+        <location filename="../BasicRideMetrics.cpp" line="370"/>
         <source>watts</source>
         <translation>Waty</translation>
     </message>
@@ -615,17 +615,17 @@
 <context>
     <name>AvgSpeed</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="244"/>
+        <location filename="../BasicRideMetrics.cpp" line="271"/>
         <source>Average Speed</source>
         <translation>Průměrná rychlost</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="245"/>
+        <location filename="../BasicRideMetrics.cpp" line="272"/>
         <source>kph</source>
         <translation>km/h</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="246"/>
+        <location filename="../BasicRideMetrics.cpp" line="273"/>
         <source>mph</source>
         <translation>mi/h</translation>
     </message>
@@ -633,17 +633,17 @@
 <context>
     <name>AvgTemp</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="467"/>
+        <location filename="../BasicRideMetrics.cpp" line="528"/>
         <source>Average Temp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="468"/>
+        <location filename="../BasicRideMetrics.cpp" line="529"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="469"/>
+        <location filename="../BasicRideMetrics.cpp" line="530"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
@@ -747,7 +747,7 @@
 <context>
     <name>BikeScore</name>
     <message>
-        <location filename="../BikeScore.cpp" line="181"/>
+        <location filename="../BikeScore.cpp" line="196"/>
         <source>BikeScore&amp;#8482;</source>
         <translation>BikeScore&amp;#8482;</translation>
     </message>
@@ -755,54 +755,54 @@
 <context>
     <name>CPPage</name>
     <message>
-        <location filename="../Pages.cpp" line="2455"/>
+        <location filename="../Pages.cpp" line="2457"/>
         <source>Add CP</source>
         <translation>Přidej CP</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2456"/>
+        <location filename="../Pages.cpp" line="2458"/>
         <source>Delete CP</source>
         <translation>Smaž CP</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2457"/>
+        <location filename="../Pages.cpp" line="2459"/>
         <source>Default</source>
         <translation>Základní</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2460"/>
+        <location filename="../Pages.cpp" line="2462"/>
         <source>Add Zone</source>
         <translation>Přidej zónu</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2461"/>
+        <location filename="../Pages.cpp" line="2463"/>
         <source>Delete Zone</source>
         <translation>Smaž zónu</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2475"/>
-        <location filename="../Pages.cpp" line="2493"/>
+        <location filename="../Pages.cpp" line="2477"/>
+        <location filename="../Pages.cpp" line="2495"/>
         <source>From Date</source>
         <translation>Od </translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2476"/>
-        <location filename="../Pages.cpp" line="2494"/>
+        <location filename="../Pages.cpp" line="2478"/>
+        <location filename="../Pages.cpp" line="2496"/>
         <source>Critical Power</source>
         <translation>Kriticky výkon CP</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2523"/>
+        <location filename="../Pages.cpp" line="2525"/>
         <source>Short</source>
         <translation>Setřiď</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2524"/>
+        <location filename="../Pages.cpp" line="2526"/>
         <source>Long</source>
         <translation>Dlouhý</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2525"/>
+        <location filename="../Pages.cpp" line="2527"/>
         <source>From Watts</source>
         <translation>Od watů</translation>
     </message>
@@ -810,7 +810,7 @@
 <context>
     <name>CPWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="120"/>
+        <location filename="../WattsPerKilogram.cpp" line="128"/>
         <source>60 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -905,7 +905,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ChartSettings.cpp" line="42"/>
+        <location filename="../ChartSettings.cpp" line="41"/>
         <source>Done</source>
         <translation type="unfinished">Hotovo</translation>
     </message>
@@ -1485,7 +1485,7 @@ Prosím o strpení, bude chvíli trvat.
 <context>
     <name>CriticalPower</name>
     <message>
-        <location filename="../PeakPower.cpp" line="63"/>
+        <location filename="../PeakPower.cpp" line="67"/>
         <source>60 min Peak Power</source>
         <translation>60 min špička</translation>
     </message>
@@ -1637,12 +1637,12 @@ Prosím o strpení, bude chvíli trvat.
 <context>
     <name>DBAccess</name>
     <message>
-        <location filename="../DBAccess.cpp" line="112"/>
+        <location filename="../DBAccess.cpp" line="113"/>
         <source>Cannot open database</source>
         <translation>Nemohu otevřít databázi</translation>
     </message>
     <message>
-        <location filename="../DBAccess.cpp" line="113"/>
+        <location filename="../DBAccess.cpp" line="114"/>
         <source>Unable to establish a database connection.
 This feature requires SQLite support. Please read the Qt SQL driver documentation for information how to build it.
 
@@ -1656,13 +1656,13 @@ Zmáčkni tlačítko Zrušit</translation>
 <context>
     <name>DanielsEquivalentPower</name>
     <message>
-        <location filename="../DanielsPoints.cpp" line="110"/>
+        <location filename="../DanielsPoints.cpp" line="116"/>
         <source>Daniels EqP</source>
         <translation>Daniels EqP</translation>
     </message>
     <message>
-        <location filename="../DanielsPoints.cpp" line="111"/>
-        <location filename="../DanielsPoints.cpp" line="112"/>
+        <location filename="../DanielsPoints.cpp" line="117"/>
+        <location filename="../DanielsPoints.cpp" line="118"/>
         <source>watts</source>
         <translation>watty</translation>
     </message>
@@ -1670,7 +1670,7 @@ Zmáčkni tlačítko Zrušit</translation>
 <context>
     <name>DanielsPoints</name>
     <message>
-        <location filename="../DanielsPoints.cpp" line="49"/>
+        <location filename="../DanielsPoints.cpp" line="51"/>
         <source>Daniels Points</source>
         <translation>Daniels Points</translation>
     </message>
@@ -1973,52 +1973,17 @@ then click &quot;Rescan&quot; to check again.</source>
 <context>
     <name>EditMetricDetailDialog</name>
     <message>
-        <location filename="../LTMTool.cpp" line="638"/>
+        <location filename="../LTMTool.cpp" line="701"/>
         <source>Settings</source>
         <translation>Nastavení</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="662"/>
-        <source>Filter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="664"/>
-        <source>No filter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="665"/>
-        <source>Include</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="666"/>
-        <source>Exclude</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="668"/>
-        <source>From</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="673"/>
-        <source>To</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="678"/>
-        <source>Show on plot</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="780"/>
+        <location filename="../LTMTool.cpp" line="814"/>
         <source>&amp;OK</source>
         <translation>&amp; OK</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="781"/>
+        <location filename="../LTMTool.cpp" line="815"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Zrušit</translation>
     </message>
@@ -2062,7 +2027,7 @@ then click &quot;Rescan&quot; to check again.</source>
 <context>
     <name>EfficiencyFactor</name>
     <message>
-        <location filename="../Coggan.cpp" line="198"/>
+        <location filename="../Coggan.cpp" line="217"/>
         <source>Efficiency Factor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2070,17 +2035,17 @@ then click &quot;Rescan&quot; to check again.</source>
 <context>
     <name>ElevationGain</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="170"/>
+        <location filename="../BasicRideMetrics.cpp" line="189"/>
         <source>Elevation Gain</source>
         <translation>Získané převýšení</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="172"/>
+        <location filename="../BasicRideMetrics.cpp" line="191"/>
         <source>meters</source>
         <translation>metry</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="173"/>
+        <location filename="../BasicRideMetrics.cpp" line="192"/>
         <source>feet</source>
         <translation>stopy</translation>
     </message>
@@ -2350,7 +2315,7 @@ NEJASNE</translation>
 <context>
     <name>FormField</name>
     <message>
-        <location filename="../RideMetadata.cpp" line="545"/>
+        <location filename="../RideMetadata.cpp" line="546"/>
         <source>You entered &apos;%1&apos; which is not an expected value.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2448,7 +2413,7 @@ NEJASNE</translation>
 <context>
     <name>Gradient</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="758"/>
+        <location filename="../BasicRideMetrics.cpp" line="851"/>
         <source>Gradient</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2464,7 +2429,7 @@ NEJASNE</translation>
 <context>
     <name>GroupByModel</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="724"/>
+        <location filename="../RideNavigator.cpp" line="726"/>
         <source>Date</source>
         <translation type="unfinished">Datum</translation>
     </message>
@@ -2547,12 +2512,12 @@ NEJASNE</translation>
 <context>
     <name>HomeWindow</name>
     <message>
-        <location filename="../HomeWindow.cpp" line="712"/>
+        <location filename="../HomeWindow.cpp" line="713"/>
         <source>Are you sure you want to remove the chart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../HomeWindow.cpp" line="713"/>
+        <location filename="../HomeWindow.cpp" line="714"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2596,38 +2561,38 @@ NEJASNE</translation>
 <context>
     <name>HrSchemePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2826"/>
+        <location filename="../Pages.cpp" line="2828"/>
         <source>Add</source>
         <translation>Přidej</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2827"/>
+        <location filename="../Pages.cpp" line="2829"/>
         <source>Rename</source>
         <translation>Přejmenuj</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2828"/>
+        <location filename="../Pages.cpp" line="2830"/>
         <source>Delete</source>
         <translation>Smaž</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2837"/>
+        <location filename="../Pages.cpp" line="2839"/>
         <source>Short</source>
         <translation>Třiď</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2838"/>
+        <location filename="../Pages.cpp" line="2840"/>
         <source>Long</source>
         <translation>Délka</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2839"/>
+        <location filename="../Pages.cpp" line="2841"/>
         <source>Percent of LT</source>
         <translatorcomment>いまいち</translatorcomment>
         <translation>Procento z LT</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2840"/>
+        <location filename="../Pages.cpp" line="2842"/>
         <source>Trimp k</source>
         <translatorcomment>でいいのかな？</translatorcomment>
         <translation>Trimp k</translation>
@@ -2636,12 +2601,12 @@ NEJASNE</translation>
 <context>
     <name>HrZonePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2809"/>
+        <location filename="../Pages.cpp" line="2811"/>
         <source>Lactic Threshold History</source>
         <translation>Historie LT</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2810"/>
+        <location filename="../Pages.cpp" line="2812"/>
         <source>Default Zones</source>
         <translation>Základní zóny</translation>
     </message>
@@ -2649,7 +2614,7 @@ NEJASNE</translation>
 <context>
     <name>HrZoneTime1</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="72"/>
+        <location filename="../HrTimeInZone.cpp" line="77"/>
         <source>H1 Time in Zone</source>
         <translation>H1 čas v zóně</translation>
     </message>
@@ -2657,7 +2622,7 @@ NEJASNE</translation>
 <context>
     <name>HrZoneTime2</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="84"/>
+        <location filename="../HrTimeInZone.cpp" line="94"/>
         <source>H2 Time in Zone</source>
         <translation>H2 čas v zóně</translation>
     </message>
@@ -2665,7 +2630,7 @@ NEJASNE</translation>
 <context>
     <name>HrZoneTime3</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="96"/>
+        <location filename="../HrTimeInZone.cpp" line="111"/>
         <source>H3 Time in Zone</source>
         <translation>H3 čas v zóně</translation>
     </message>
@@ -2673,7 +2638,7 @@ NEJASNE</translation>
 <context>
     <name>HrZoneTime4</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="108"/>
+        <location filename="../HrTimeInZone.cpp" line="128"/>
         <source>H4 Time in Zone</source>
         <translation>H4 čas v zóně</translation>
     </message>
@@ -2681,7 +2646,7 @@ NEJASNE</translation>
 <context>
     <name>HrZoneTime5</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="120"/>
+        <location filename="../HrTimeInZone.cpp" line="145"/>
         <source>H5 Time in Zone</source>
         <translation>H5 čas v zóně</translation>
     </message>
@@ -2689,7 +2654,7 @@ NEJASNE</translation>
 <context>
     <name>HrZoneTime6</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="132"/>
+        <location filename="../HrTimeInZone.cpp" line="162"/>
         <source>H6 Time in Zone</source>
         <translation>H6 čas v zóně</translation>
     </message>
@@ -2697,7 +2662,7 @@ NEJASNE</translation>
 <context>
     <name>HrZoneTime7</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="144"/>
+        <location filename="../HrTimeInZone.cpp" line="179"/>
         <source>H7 Time in Zone</source>
         <translation>H7 čas v zóně</translation>
     </message>
@@ -2705,7 +2670,7 @@ NEJASNE</translation>
 <context>
     <name>HrZoneTime8</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="156"/>
+        <location filename="../HrTimeInZone.cpp" line="196"/>
         <source>H8 Time in Zone</source>
         <translation>H8 čas v zóně</translation>
     </message>
@@ -2925,7 +2890,8 @@ NEJASNE
 <context>
     <name>LTMPlot</name>
     <message>
-        <location filename="../LTMPlot.cpp" line="1120"/>
+        <location filename="../LTMPlot.cpp" line="731"/>
+        <location filename="../LTMPlot.cpp" line="1123"/>
         <source>watts</source>
         <translation>waty</translation>
     </message>
@@ -2947,33 +2913,33 @@ NEJASNE
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="253"/>
-        <location filename="../LTMSidebar.cpp" line="289"/>
+        <location filename="../LTMSidebar.cpp" line="257"/>
+        <location filename="../LTMSidebar.cpp" line="293"/>
         <source>Edit details</source>
         <translation type="unfinished">Editovat detaily</translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="254"/>
+        <location filename="../LTMSidebar.cpp" line="258"/>
         <source>Delete range</source>
         <translation type="unfinished">Smazat rozsah</translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="255"/>
+        <location filename="../LTMSidebar.cpp" line="259"/>
         <source>Add Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="290"/>
+        <location filename="../LTMSidebar.cpp" line="294"/>
         <source>Delete event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="300"/>
+        <location filename="../LTMSidebar.cpp" line="304"/>
         <source>Add event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="537"/>
+        <location filename="../LTMSidebar.cpp" line="541"/>
         <source>^(Average|Max) </source>
         <translation type="unfinished"></translation>
     </message>
@@ -2985,7 +2951,7 @@ NEJASNE
         <translation type="obsolete">Časový rozsah</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="69"/>
+        <location filename="../LTMTool.cpp" line="124"/>
         <source>Metric</source>
         <translation>Metrika</translation>
     </message>
@@ -3030,8 +2996,8 @@ NEJASNE
         <translation type="obsolete">Posledních 12 měsíců</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="511"/>
-        <location filename="../LTMTool.cpp" line="519"/>
+        <location filename="../LTMTool.cpp" line="574"/>
+        <location filename="../LTMTool.cpp" line="582"/>
         <source>Unknown Metric</source>
         <translation>Neznámá metrika</translation>
     </message>
@@ -3048,12 +3014,47 @@ NEJASNE
         <translation type="obsolete">Smazat rozsah</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="544"/>
+        <location filename="../LTMTool.cpp" line="59"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="69"/>
+        <source>Chart</source>
+        <translation type="unfinished">Graf</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="101"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="102"/>
+        <source>Manage</source>
+        <translation type="unfinished">Spravovat</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="518"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="519"/>
+        <source>Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="520"/>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="607"/>
         <source>Pick Color</source>
         <translation>Vyber barvu</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="545"/>
+        <location filename="../LTMTool.cpp" line="608"/>
         <source>Settings</source>
         <translation>Nastavení</translation>
     </message>
@@ -3061,19 +3062,16 @@ NEJASNE
 <context>
     <name>LTMWindow</name>
     <message>
-        <location filename="../LTMWindow.cpp" line="135"/>
         <source>Add</source>
-        <translation>Přidat</translation>
+        <translation type="obsolete">Přidat</translation>
     </message>
     <message>
-        <location filename="../LTMWindow.cpp" line="137"/>
         <source>Manage</source>
-        <translation>Spravovat</translation>
+        <translation type="obsolete">Spravovat</translation>
     </message>
     <message>
-        <location filename="../LTMWindow.cpp" line="105"/>
         <source>Chart</source>
-        <translation>Graf</translation>
+        <translation type="obsolete">Graf</translation>
     </message>
     <message>
         <source>Days</source>
@@ -3099,71 +3097,71 @@ NEJASNE
 <context>
     <name>LTPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3001"/>
+        <location filename="../Pages.cpp" line="3003"/>
         <source>Add LT</source>
         <translation>Přidej LT</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3002"/>
+        <location filename="../Pages.cpp" line="3004"/>
         <source>Delete LT</source>
         <translation>Smaž LT</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3003"/>
+        <location filename="../Pages.cpp" line="3005"/>
         <source>Default</source>
         <translation>Výchozí</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3006"/>
+        <location filename="../Pages.cpp" line="3008"/>
         <source>Add Zone</source>
         <translation>Přidej zónu</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3007"/>
+        <location filename="../Pages.cpp" line="3009"/>
         <source>Delete Zone</source>
         <translation>Smaž zónu</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3021"/>
-        <location filename="../Pages.cpp" line="3061"/>
+        <location filename="../Pages.cpp" line="3023"/>
+        <location filename="../Pages.cpp" line="3063"/>
         <source>From Date</source>
         <translation>Od data</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3022"/>
-        <location filename="../Pages.cpp" line="3062"/>
+        <location filename="../Pages.cpp" line="3024"/>
+        <location filename="../Pages.cpp" line="3064"/>
         <source>Lactic Threshold</source>
         <translation>Laktátový práh</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3039"/>
-        <location filename="../Pages.cpp" line="3063"/>
+        <location filename="../Pages.cpp" line="3041"/>
+        <location filename="../Pages.cpp" line="3065"/>
         <source>Rest HR</source>
         <translation>Klidový tep</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3040"/>
-        <location filename="../Pages.cpp" line="3064"/>
+        <location filename="../Pages.cpp" line="3042"/>
+        <location filename="../Pages.cpp" line="3066"/>
         <source>Max HR</source>
         <translation>Maximální tep</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3101"/>
+        <location filename="../Pages.cpp" line="3103"/>
         <source>Short</source>
         <translation>Krátký</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3102"/>
+        <location filename="../Pages.cpp" line="3104"/>
         <source>Long</source>
         <translation>Dlouhý</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3103"/>
+        <location filename="../Pages.cpp" line="3105"/>
         <source>From BPM</source>
         <translation>Od bpm</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3104"/>
+        <location filename="../Pages.cpp" line="3106"/>
         <source>Trimp k</source>
         <translation>Trimp k</translation>
     </message>
@@ -3171,13 +3169,13 @@ NEJASNE
 <context>
     <name>LeftRightBalance</name>
     <message>
-        <location filename="../LeftRightBalance.cpp" line="33"/>
+        <location filename="../LeftRightBalance.cpp" line="36"/>
         <source>Left/Right Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftRightBalance.cpp" line="34"/>
-        <location filename="../LeftRightBalance.cpp" line="35"/>
+        <location filename="../LeftRightBalance.cpp" line="37"/>
+        <location filename="../LeftRightBalance.cpp" line="38"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
@@ -3189,7 +3187,7 @@ NEJASNE
         <translation type="obsolete">Špatný název souboru se záznamem</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2210"/>
+        <location filename="../MainWindow.cpp" line="2216"/>
         <source>Invalid date/time in filename:
 %1
 Skipping file...</source>
@@ -3199,13 +3197,13 @@ Přeskakuji soubor...</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="281"/>
-        <location filename="../MainWindow.cpp" line="2230"/>
+        <location filename="../MainWindow.cpp" line="2236"/>
         <source>Zones File Error</source>
         <translation>Chyba v souboru se zónami</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="284"/>
-        <location filename="../MainWindow.cpp" line="2234"/>
+        <location filename="../MainWindow.cpp" line="2240"/>
         <source>Reading Zones File</source>
         <translation>Načítám soubor se zónami</translation>
     </message>
@@ -3215,7 +3213,7 @@ Přeskakuji soubor...</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="565"/>
-        <location filename="../MainWindow.cpp" line="1209"/>
+        <location filename="../MainWindow.cpp" line="1215"/>
         <source>Intervals</source>
         <translation>Intervaly</translation>
     </message>
@@ -3240,22 +3238,22 @@ Přeskakuji soubor...</translation>
         <translation type="obsolete">&amp;Cyklista</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="743"/>
+        <location filename="../MainWindow.cpp" line="747"/>
         <source>&amp;New...</source>
         <translation>&amp;Nový...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="743"/>
+        <location filename="../MainWindow.cpp" line="747"/>
         <source>Ctrl+N</source>
         <translation>Ctrl+N</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="744"/>
+        <location filename="../MainWindow.cpp" line="748"/>
         <source>&amp;Open...</source>
         <translation>&amp;Otevřít...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="744"/>
+        <location filename="../MainWindow.cpp" line="748"/>
         <source>Ctrl+O</source>
         <translation>Ctrl+O</translation>
     </message>
@@ -3264,7 +3262,7 @@ Přeskakuji soubor...</translation>
         <translation type="obsolete">&amp;Konec</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="746"/>
+        <location filename="../MainWindow.cpp" line="750"/>
         <source>Ctrl+Q</source>
         <translation>Ctrl+Q</translation>
     </message>
@@ -3273,24 +3271,24 @@ Přeskakuji soubor...</translation>
         <translation type="obsolete">&amp;Jízda</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="775"/>
+        <location filename="../MainWindow.cpp" line="779"/>
         <source>Ctrl+S</source>
         <translation>Ctrl+S</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="749"/>
+        <location filename="../MainWindow.cpp" line="753"/>
         <source>&amp;Download from device...</source>
         <translation>&amp;Stáhnout z přístroje...</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="291"/>
-        <location filename="../MainWindow.cpp" line="2241"/>
+        <location filename="../MainWindow.cpp" line="2247"/>
         <source>HR Zones File Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="294"/>
-        <location filename="../MainWindow.cpp" line="2245"/>
+        <location filename="../MainWindow.cpp" line="2251"/>
         <source>Reading HR Zones File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3311,210 +3309,210 @@ Přeskakuji soubor...</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="454"/>
-        <location filename="../MainWindow.cpp" line="845"/>
+        <location filename="../MainWindow.cpp" line="849"/>
         <source>Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="461"/>
-        <location filename="../MainWindow.cpp" line="848"/>
+        <location filename="../MainWindow.cpp" line="852"/>
         <source>Diary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="468"/>
-        <location filename="../MainWindow.cpp" line="844"/>
+        <location filename="../MainWindow.cpp" line="848"/>
         <source>Analysis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="474"/>
-        <location filename="../MainWindow.cpp" line="846"/>
+        <location filename="../MainWindow.cpp" line="850"/>
         <source>Train</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="524"/>
-        <location filename="../MainWindow.cpp" line="1160"/>
+        <location filename="../MainWindow.cpp" line="1166"/>
         <source>All Activities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="742"/>
+        <location filename="../MainWindow.cpp" line="746"/>
         <source>&amp;Athlete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="745"/>
+        <location filename="../MainWindow.cpp" line="749"/>
         <source>&amp;Close Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="745"/>
+        <location filename="../MainWindow.cpp" line="749"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="746"/>
+        <location filename="../MainWindow.cpp" line="750"/>
         <source>&amp;Quit All Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="748"/>
+        <location filename="../MainWindow.cpp" line="752"/>
         <source>A&amp;ctivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="749"/>
+        <location filename="../MainWindow.cpp" line="753"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="751"/>
+        <location filename="../MainWindow.cpp" line="755"/>
         <source>&amp;Manual activity entry...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="753"/>
+        <location filename="../MainWindow.cpp" line="757"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="754"/>
+        <location filename="../MainWindow.cpp" line="758"/>
         <source>&amp;Batch export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="755"/>
+        <location filename="../MainWindow.cpp" line="759"/>
         <source>Export Metrics as CSV...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="758"/>
+        <location filename="../MainWindow.cpp" line="762"/>
         <source>&amp;Upload to TrainingPeaks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="758"/>
+        <location filename="../MainWindow.cpp" line="762"/>
         <source>Ctrl+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="759"/>
+        <location filename="../MainWindow.cpp" line="763"/>
         <source>Down&amp;load from TrainingPeaks...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="759"/>
+        <location filename="../MainWindow.cpp" line="763"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="775"/>
+        <location filename="../MainWindow.cpp" line="779"/>
         <source>&amp;Save activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="776"/>
+        <location filename="../MainWindow.cpp" line="780"/>
         <source>D&amp;elete activity...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="777"/>
+        <location filename="../MainWindow.cpp" line="781"/>
         <source>Split &amp;activity...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="782"/>
+        <location filename="../MainWindow.cpp" line="786"/>
         <source>Critical Power Calculator...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="783"/>
+        <location filename="../MainWindow.cpp" line="787"/>
         <source>Air Density (Rho) Estimator...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="786"/>
+        <location filename="../MainWindow.cpp" line="790"/>
         <source>Get &amp;Withings Data...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="788"/>
+        <location filename="../MainWindow.cpp" line="792"/>
         <source>Get &amp;Zeo Data...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="791"/>
+        <location filename="../MainWindow.cpp" line="795"/>
         <source>Workout Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="792"/>
+        <location filename="../MainWindow.cpp" line="796"/>
         <source>Get Workouts from ErgDB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="796"/>
-        <location filename="../MainWindow.cpp" line="1197"/>
+        <location filename="../MainWindow.cpp" line="800"/>
+        <location filename="../MainWindow.cpp" line="1203"/>
         <source>Upload Activity to Calendar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="797"/>
+        <location filename="../MainWindow.cpp" line="801"/>
         <source>Import Calendar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="798"/>
+        <location filename="../MainWindow.cpp" line="802"/>
         <source>Export Calendar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="799"/>
+        <location filename="../MainWindow.cpp" line="803"/>
         <source>Refresh Calendar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="802"/>
+        <location filename="../MainWindow.cpp" line="806"/>
         <source>Find intervals...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1692"/>
+        <location filename="../MainWindow.cpp" line="1698"/>
         <source>Select Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1692"/>
-        <location filename="../MainWindow.cpp" line="1778"/>
-        <location filename="../MainWindow.cpp" line="1786"/>
+        <location filename="../MainWindow.cpp" line="1698"/>
+        <location filename="../MainWindow.cpp" line="1784"/>
+        <location filename="../MainWindow.cpp" line="1792"/>
         <source>No activity selected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1703"/>
+        <location filename="../MainWindow.cpp" line="1709"/>
         <source>Export Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1716"/>
+        <location filename="../MainWindow.cpp" line="1722"/>
         <source>Export Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1717"/>
+        <location filename="../MainWindow.cpp" line="1723"/>
         <source>Failed to export ride, please check permissions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2188"/>
+        <location filename="../MainWindow.cpp" line="2194"/>
         <source>Range from %1 to %2
 Athlete CP set to %3 watts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2209"/>
+        <location filename="../MainWindow.cpp" line="2215"/>
         <source>Invalid Activity File Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3523,12 +3521,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">&amp;Exportovat to CSV...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="753"/>
+        <location filename="../MainWindow.cpp" line="757"/>
         <source>Ctrl+E</source>
         <translation>Ctrl+E</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="750"/>
+        <location filename="../MainWindow.cpp" line="754"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
@@ -3537,7 +3535,7 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Nalézt &amp;nejlepší intervaly...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="754"/>
+        <location filename="../MainWindow.cpp" line="758"/>
         <source>Ctrl+B</source>
         <translation>Ctrl+B</translation>
     </message>
@@ -3606,12 +3604,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Editor</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="750"/>
+        <location filename="../MainWindow.cpp" line="754"/>
         <source>&amp;Import from file...</source>
         <translation>&amp;Import ze souboru...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="751"/>
+        <location filename="../MainWindow.cpp" line="755"/>
         <source>Ctrl+M</source>
         <translation>Ctrl+M</translation>
     </message>
@@ -3632,12 +3630,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">&amp;Uložit záznam</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="780"/>
+        <location filename="../MainWindow.cpp" line="784"/>
         <source>&amp;Tools</source>
         <translation>&amp;Nástroje</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="781"/>
+        <location filename="../MainWindow.cpp" line="785"/>
         <source>&amp;Options...</source>
         <translation>&amp;Volby...</translation>
     </message>
@@ -3646,89 +3644,89 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Výpočet kritického výkonu</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="825"/>
+        <location filename="../MainWindow.cpp" line="829"/>
         <source>&amp;View</source>
         <translation>&amp;Pohled</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="827"/>
+        <location filename="../MainWindow.cpp" line="831"/>
         <source>Toggle Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="829"/>
+        <location filename="../MainWindow.cpp" line="833"/>
         <source>Show Left Sidebar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="833"/>
+        <location filename="../MainWindow.cpp" line="837"/>
         <source>Show Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="838"/>
+        <location filename="../MainWindow.cpp" line="842"/>
         <source>Tabbed View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="852"/>
+        <location filename="../MainWindow.cpp" line="856"/>
         <source>Reset Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="854"/>
+        <location filename="../MainWindow.cpp" line="858"/>
         <source>&amp;Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="861"/>
+        <location filename="../MainWindow.cpp" line="865"/>
         <source>&amp;Help</source>
         <translation>&amp;Nápověda</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="862"/>
+        <location filename="../MainWindow.cpp" line="866"/>
         <source>&amp;User Guide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="863"/>
+        <location filename="../MainWindow.cpp" line="867"/>
         <source>&amp;Log a bug or feature request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="865"/>
+        <location filename="../MainWindow.cpp" line="869"/>
         <source>&amp;About GoldenCheetah</source>
         <translation>&amp; O aplikaci GoldenCheetah</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1164"/>
+        <location filename="../MainWindow.cpp" line="1170"/>
         <source>Save Changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1167"/>
+        <location filename="../MainWindow.cpp" line="1173"/>
         <source>Revert to Saved version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1170"/>
-        <location filename="../MainWindow.cpp" line="1786"/>
+        <location filename="../MainWindow.cpp" line="1176"/>
+        <location filename="../MainWindow.cpp" line="1792"/>
         <source>Delete Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1179"/>
-        <location filename="../MainWindow.cpp" line="1778"/>
+        <location filename="../MainWindow.cpp" line="1185"/>
+        <location filename="../MainWindow.cpp" line="1784"/>
         <source>Split Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1192"/>
+        <location filename="../MainWindow.cpp" line="1198"/>
         <source>Tweet Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1612"/>
+        <location filename="../MainWindow.cpp" line="1618"/>
         <source>Can&apos;t rename %1 to %2</source>
         <translation>Nelze přejmenovat %1 na %2</translation>
     </message>
@@ -3797,42 +3795,42 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Soubor %1 nelze otevřít pro zápis</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1739"/>
+        <location filename="../MainWindow.cpp" line="1745"/>
         <source>Import from File</source>
         <translation>Import ze soubouru</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1756"/>
+        <location filename="../MainWindow.cpp" line="1762"/>
         <source>No Activity To Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1757"/>
+        <location filename="../MainWindow.cpp" line="1763"/>
         <source>There is no currently selected ride to save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1791"/>
+        <location filename="../MainWindow.cpp" line="1797"/>
         <source>Are you sure you want to delete the activity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1845"/>
+        <location filename="../MainWindow.cpp" line="1851"/>
         <source>Export Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1845"/>
+        <location filename="../MainWindow.cpp" line="1851"/>
         <source>Comma Separated Variables (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1920"/>
+        <location filename="../MainWindow.cpp" line="1926"/>
         <source>Workout Directory Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1977"/>
+        <location filename="../MainWindow.cpp" line="1983"/>
         <source> (%1 watts)</source>
         <translation> (%1 wattů)</translation>
     </message>
@@ -3849,12 +3847,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Smazat záznam</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1173"/>
+        <location filename="../MainWindow.cpp" line="1179"/>
         <source>Find Best Intervals</source>
         <translation>Nalézt nejlepší interval</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1176"/>
+        <location filename="../MainWindow.cpp" line="1182"/>
         <source>Find Power Peaks</source>
         <translation>Nalézt špičku výkonu</translation>
     </message>
@@ -3863,27 +3861,27 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Poslat na Twitter.com</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1214"/>
+        <location filename="../MainWindow.cpp" line="1220"/>
         <source>Rename interval</source>
         <translation>Přejmenovat interval</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1215"/>
+        <location filename="../MainWindow.cpp" line="1221"/>
         <source>Delete interval</source>
         <translation>Smazat interval</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1216"/>
+        <location filename="../MainWindow.cpp" line="1222"/>
         <source>Zoom to interval</source>
         <translation>Zoom intervalu</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1217"/>
+        <location filename="../MainWindow.cpp" line="1223"/>
         <source>Bring to Front</source>
         <translation>Do popředí</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1218"/>
+        <location filename="../MainWindow.cpp" line="1224"/>
         <source>Send to back</source>
         <translation>Do pozadí</translation>
     </message>
@@ -3918,7 +3916,7 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Nemohu zapsat poznámky do %1</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2187"/>
+        <location filename="../MainWindow.cpp" line="2193"/>
         <source>CP saved</source>
         <translation>CP uložen</translation>
     </message>
@@ -3941,7 +3939,7 @@ CP závodníka nastaven na %3 wattů</translation>
         <translation type="obsolete">Opravdu chceš smazat záznam?:</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1793"/>
+        <location filename="../MainWindow.cpp" line="1799"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
@@ -4161,13 +4159,13 @@ CP závodníka nastaven na %3 wattů</translation>
 <context>
     <name>MaxCadence</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="606"/>
+        <location filename="../BasicRideMetrics.cpp" line="683"/>
         <source>Max Cadence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="607"/>
-        <location filename="../BasicRideMetrics.cpp" line="608"/>
+        <location filename="../BasicRideMetrics.cpp" line="684"/>
+        <location filename="../BasicRideMetrics.cpp" line="685"/>
         <source>rpm</source>
         <translation type="unfinished">ot/m</translation>
     </message>
@@ -4175,13 +4173,13 @@ CP závodníka nastaven na %3 wattů</translation>
 <context>
     <name>MaxHr</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="538"/>
+        <location filename="../BasicRideMetrics.cpp" line="607"/>
         <source>Max Heartrate</source>
         <translation>Max tepová frekvence</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="539"/>
-        <location filename="../BasicRideMetrics.cpp" line="540"/>
+        <location filename="../BasicRideMetrics.cpp" line="608"/>
+        <location filename="../BasicRideMetrics.cpp" line="609"/>
         <source>bpm</source>
         <translation>bpm</translation>
     </message>
@@ -4189,13 +4187,13 @@ CP závodníka nastaven na %3 wattů</translation>
 <context>
     <name>MaxPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="509"/>
+        <location filename="../BasicRideMetrics.cpp" line="574"/>
         <source>Max Power</source>
         <translation>Maximální výkon</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="510"/>
-        <location filename="../BasicRideMetrics.cpp" line="511"/>
+        <location filename="../BasicRideMetrics.cpp" line="575"/>
+        <location filename="../BasicRideMetrics.cpp" line="576"/>
         <source>watts</source>
         <translation>watty</translation>
     </message>
@@ -4203,7 +4201,7 @@ CP závodníka nastaven na %3 wattů</translation>
 <context>
     <name>MaxPowerVariance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="848"/>
+        <location filename="../BasicRideMetrics.cpp" line="949"/>
         <source>Max Power Variance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4211,17 +4209,17 @@ CP závodníka nastaven na %3 wattů</translation>
 <context>
     <name>MaxSpeed</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="567"/>
+        <location filename="../BasicRideMetrics.cpp" line="640"/>
         <source>Max Speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="568"/>
+        <location filename="../BasicRideMetrics.cpp" line="641"/>
         <source>kph</source>
         <translation type="unfinished">km/h</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="569"/>
+        <location filename="../BasicRideMetrics.cpp" line="642"/>
         <source>mph</source>
         <translation type="unfinished">mi/h</translation>
     </message>
@@ -4229,17 +4227,17 @@ CP závodníka nastaven na %3 wattů</translation>
 <context>
     <name>MaxTemp</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="643"/>
+        <location filename="../BasicRideMetrics.cpp" line="724"/>
         <source>Max Temp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="644"/>
+        <location filename="../BasicRideMetrics.cpp" line="725"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="645"/>
+        <location filename="../BasicRideMetrics.cpp" line="726"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4247,7 +4245,7 @@ CP závodníka nastaven na %3 wattů</translation>
 <context>
     <name>MeanPowerVariance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="801"/>
+        <location filename="../BasicRideMetrics.cpp" line="898"/>
         <source>Average Power Variance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4255,42 +4253,42 @@ CP závodníka nastaven na %3 wattů</translation>
 <context>
     <name>MeasuresPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3395"/>
+        <location filename="../Pages.cpp" line="3397"/>
         <source>Move up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3396"/>
+        <location filename="../Pages.cpp" line="3398"/>
         <source>Move down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3397"/>
+        <location filename="../Pages.cpp" line="3399"/>
         <source>Insert</source>
         <translation type="unfinished">Vložit</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3398"/>
+        <location filename="../Pages.cpp" line="3400"/>
         <source>Rename</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3399"/>
+        <location filename="../Pages.cpp" line="3401"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3410"/>
+        <location filename="../Pages.cpp" line="3412"/>
         <source>Screen Tab</source>
         <translation type="unfinished">Obrazovka Tab Nerovný</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3411"/>
+        <location filename="../Pages.cpp" line="3413"/>
         <source>Measure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3412"/>
+        <location filename="../Pages.cpp" line="3414"/>
         <source>Type</source>
         <translation type="unfinished">Typ</translation>
     </message>
@@ -4509,17 +4507,17 @@ Elapsed: %1
 <context>
     <name>NavigatorCellDelegate</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="941"/>
+        <location filename="../RideNavigator.cpp" line="944"/>
         <source>Date</source>
         <translation type="unfinished">Datum</translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="944"/>
+        <location filename="../RideNavigator.cpp" line="947"/>
         <source>Time</source>
         <translation type="unfinished">Čas</translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="947"/>
+        <location filename="../RideNavigator.cpp" line="950"/>
         <source>Last updated</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4646,13 +4644,13 @@ Elapsed: %1
 <context>
     <name>NinetyFivePercentHeartRate</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="688"/>
+        <location filename="../BasicRideMetrics.cpp" line="773"/>
         <source>95% Heartrate</source>
         <translation>95% maximálni TF</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="689"/>
-        <location filename="../BasicRideMetrics.cpp" line="690"/>
+        <location filename="../BasicRideMetrics.cpp" line="774"/>
+        <location filename="../BasicRideMetrics.cpp" line="775"/>
         <source>bpm</source>
         <translation>bpm</translation>
     </message>
@@ -4660,13 +4658,13 @@ Elapsed: %1
 <context>
     <name>NonZeroPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="365"/>
+        <location filename="../BasicRideMetrics.cpp" line="408"/>
         <source>Nonzero Average Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="366"/>
-        <location filename="../BasicRideMetrics.cpp" line="367"/>
+        <location filename="../BasicRideMetrics.cpp" line="409"/>
+        <location filename="../BasicRideMetrics.cpp" line="410"/>
         <source>watts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4674,17 +4672,17 @@ Elapsed: %1
 <context>
     <name>Pace</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="288"/>
+        <location filename="../BasicRideMetrics.cpp" line="319"/>
         <source>Pace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="290"/>
+        <location filename="../BasicRideMetrics.cpp" line="321"/>
         <source>min/km</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="291"/>
+        <location filename="../BasicRideMetrics.cpp" line="322"/>
         <source>min/mile</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4876,7 +4874,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakPower10m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="162"/>
+        <location filename="../PeakPower.cpp" line="202"/>
         <source>10 min Peak Power</source>
         <translation>10 min Maximální výkon</translation>
     </message>
@@ -4884,7 +4882,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakPower10s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="96"/>
+        <location filename="../PeakPower.cpp" line="112"/>
         <source>10 sec Peak Power</source>
         <translation>10 sec Maximální výkon</translation>
     </message>
@@ -4892,7 +4890,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakPower15s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="107"/>
+        <location filename="../PeakPower.cpp" line="127"/>
         <source>15 sec Peak Power</source>
         <translation>15 sec Maximální výkon</translation>
     </message>
@@ -4900,7 +4898,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakPower1m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="140"/>
+        <location filename="../PeakPower.cpp" line="172"/>
         <source>1 min Peak Power</source>
         <translation>1 min Maximální výkon</translation>
     </message>
@@ -4908,7 +4906,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakPower1s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="74"/>
+        <location filename="../PeakPower.cpp" line="82"/>
         <source>1 sec Peak Power</source>
         <translation>1 sec Maximální výkon</translation>
     </message>
@@ -4916,7 +4914,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakPower20m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="173"/>
+        <location filename="../PeakPower.cpp" line="217"/>
         <source>20 min Peak Power</source>
         <translation>20 min Maximální výkon</translation>
     </message>
@@ -4924,7 +4922,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakPower20s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="118"/>
+        <location filename="../PeakPower.cpp" line="142"/>
         <source>20 sec Peak Power</source>
         <translation>20 sec Maximální výkon</translation>
     </message>
@@ -4932,7 +4930,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakPower30m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="184"/>
+        <location filename="../PeakPower.cpp" line="232"/>
         <source>30 min Peak Power</source>
         <translation>30 min Maximální výkon</translation>
     </message>
@@ -4940,7 +4938,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakPower30s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="129"/>
+        <location filename="../PeakPower.cpp" line="157"/>
         <source>30 sec Peak Power</source>
         <translation>30 sec Maximální výkon</translation>
     </message>
@@ -4948,7 +4946,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakPower5m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="151"/>
+        <location filename="../PeakPower.cpp" line="187"/>
         <source>5 min Peak Power</source>
         <translation>5 min Maximální výkon</translation>
     </message>
@@ -4956,7 +4954,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakPower5s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="85"/>
+        <location filename="../PeakPower.cpp" line="97"/>
         <source>5 sec Peak Power</source>
         <translation>5 sec Maximální výkon</translation>
     </message>
@@ -4964,13 +4962,13 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakPowerHr10m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="263"/>
+        <location filename="../PeakPower.cpp" line="324"/>
         <source>10 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="264"/>
-        <location filename="../PeakPower.cpp" line="265"/>
+        <location filename="../PeakPower.cpp" line="325"/>
+        <location filename="../PeakPower.cpp" line="326"/>
         <source>bpm</source>
         <translation type="unfinished">bpm</translation>
     </message>
@@ -4978,13 +4976,13 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakPowerHr1m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="235"/>
+        <location filename="../PeakPower.cpp" line="288"/>
         <source>1 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="236"/>
-        <location filename="../PeakPower.cpp" line="237"/>
+        <location filename="../PeakPower.cpp" line="289"/>
+        <location filename="../PeakPower.cpp" line="290"/>
         <source>bpm</source>
         <translation type="unfinished">bpm</translation>
     </message>
@@ -4992,13 +4990,13 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakPowerHr20m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="277"/>
+        <location filename="../PeakPower.cpp" line="342"/>
         <source>20 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="278"/>
-        <location filename="../PeakPower.cpp" line="279"/>
+        <location filename="../PeakPower.cpp" line="343"/>
+        <location filename="../PeakPower.cpp" line="344"/>
         <source>bpm</source>
         <translation type="unfinished">bpm</translation>
     </message>
@@ -5006,13 +5004,13 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakPowerHr30m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="291"/>
+        <location filename="../PeakPower.cpp" line="360"/>
         <source>30 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="292"/>
-        <location filename="../PeakPower.cpp" line="293"/>
+        <location filename="../PeakPower.cpp" line="361"/>
+        <location filename="../PeakPower.cpp" line="362"/>
         <source>bpm</source>
         <translation type="unfinished">bpm</translation>
     </message>
@@ -5020,22 +5018,8 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakPowerHr5m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="249"/>
-        <source>5 min Peak Power HR</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../PeakPower.cpp" line="250"/>
-        <location filename="../PeakPower.cpp" line="251"/>
-        <source>bpm</source>
-        <translation type="unfinished">bpm</translation>
-    </message>
-</context>
-<context>
-    <name>PeakPowerHr60m</name>
-    <message>
         <location filename="../PeakPower.cpp" line="306"/>
-        <source>60 min Peak Power HR</source>
+        <source>5 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5046,10 +5030,24 @@ Chcete pokračovat?</translation>
     </message>
 </context>
 <context>
+    <name>PeakPowerHr60m</name>
+    <message>
+        <location filename="../PeakPower.cpp" line="379"/>
+        <source>60 min Peak Power HR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../PeakPower.cpp" line="380"/>
+        <location filename="../PeakPower.cpp" line="381"/>
+        <source>bpm</source>
+        <translation type="unfinished">bpm</translation>
+    </message>
+</context>
+<context>
     <name>PeakWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="89"/>
-        <location filename="../WattsPerKilogram.cpp" line="90"/>
+        <location filename="../WattsPerKilogram.cpp" line="93"/>
+        <location filename="../WattsPerKilogram.cpp" line="94"/>
         <source>wpk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5057,7 +5055,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakWPK10m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="219"/>
+        <location filename="../WattsPerKilogram.cpp" line="263"/>
         <source>10 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5065,7 +5063,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakWPK10s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="153"/>
+        <location filename="../WattsPerKilogram.cpp" line="173"/>
         <source>10 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5073,7 +5071,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakWPK15s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="164"/>
+        <location filename="../WattsPerKilogram.cpp" line="188"/>
         <source>15 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5081,7 +5079,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakWPK1m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="197"/>
+        <location filename="../WattsPerKilogram.cpp" line="233"/>
         <source>1 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5089,7 +5087,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakWPK1s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="131"/>
+        <location filename="../WattsPerKilogram.cpp" line="143"/>
         <source>1 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5097,7 +5095,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakWPK20m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="230"/>
+        <location filename="../WattsPerKilogram.cpp" line="278"/>
         <source>20 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5105,7 +5103,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakWPK20s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="175"/>
+        <location filename="../WattsPerKilogram.cpp" line="203"/>
         <source>20 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5113,7 +5111,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakWPK30m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="241"/>
+        <location filename="../WattsPerKilogram.cpp" line="293"/>
         <source>30 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5121,7 +5119,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakWPK30s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="186"/>
+        <location filename="../WattsPerKilogram.cpp" line="218"/>
         <source>30 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5129,7 +5127,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakWPK5m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="208"/>
+        <location filename="../WattsPerKilogram.cpp" line="248"/>
         <source>5 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5137,7 +5135,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>PeakWPK5s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="142"/>
+        <location filename="../WattsPerKilogram.cpp" line="158"/>
         <source>5 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5149,22 +5147,22 @@ Chcete pokračovat?</translation>
         <translation type="obsolete">Performance Manager</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="118"/>
+        <location filename="../PerfPlot.cpp" line="147"/>
         <source>Daily</source>
         <translation>Denní</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="138"/>
+        <location filename="../PerfPlot.cpp" line="167"/>
         <source>Short Term Stress</source>
         <translation>Short Term Stress</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="152"/>
+        <location filename="../PerfPlot.cpp" line="181"/>
         <source>Long Term Stress</source>
         <translation>Long Term Stress</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="166"/>
+        <location filename="../PerfPlot.cpp" line="195"/>
         <source>Stress Balance</source>
         <translation>Stres bilance</translation>
     </message>
@@ -5276,85 +5274,91 @@ Chcete pokračovat?</translation>
     <name>PowerHist</name>
     <message>
         <location filename="../PowerHist.cpp" line="77"/>
-        <location filename="../PowerHist.cpp" line="902"/>
+        <location filename="../PowerHist.cpp" line="940"/>
         <source>Time (minutes)</source>
         <translation>Čas (min)</translation>
     </message>
     <message>
         <location filename="../PowerHist.cpp" line="77"/>
-        <location filename="../PowerHist.cpp" line="902"/>
+        <location filename="../PowerHist.cpp" line="940"/>
         <source>Time (percent)</source>
         <translation>Čas (%)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="877"/>
+        <location filename="../PowerHist.cpp" line="910"/>
         <source>Power (watts)</source>
         <translation>Výkon (watty)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="876"/>
+        <location filename="../PowerHist.cpp" line="909"/>
+        <location filename="../PowerHist.cpp" line="914"/>
         <source>Power zone</source>
         <translation>Zóna výkonu</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="882"/>
+        <location filename="../PowerHist.cpp" line="920"/>
         <source>Heartrate (bpm)</source>
         <translation>Tepové frekvence (tepy/m)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="881"/>
+        <location filename="../PowerHist.cpp" line="919"/>
         <source>Heartrate zone</source>
         <translation>Zóna tepové frekvence </translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="886"/>
+        <location filename="../PowerHist.cpp" line="915"/>
+        <source>Power (watts/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../PowerHist.cpp" line="924"/>
         <source>Cadence (rpm)</source>
         <translation>Kadence (ot/m)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>Speed (%1)</source>
         <translation>Rychlost (%1)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>kph</source>
         <translation>km/h</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>mph</source>
         <translation>mi/h</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>Torque (%1)</source>
         <translation>Točivý moment (%1)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>N-m</source>
         <translation>N-m</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>ft-lbf</source>
         <translation>ft-lbf</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="898"/>
+        <location filename="../PowerHist.cpp" line="936"/>
         <source>Unknown data series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="962"/>
-        <location filename="../PowerHist.cpp" line="975"/>
+        <location filename="../PowerHist.cpp" line="1000"/>
+        <location filename="../PowerHist.cpp" line="1013"/>
         <source>minutes</source>
         <translation>minuty</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="962"/>
-        <location filename="../PowerHist.cpp" line="975"/>
+        <location filename="../PowerHist.cpp" line="1000"/>
+        <location filename="../PowerHist.cpp" line="1013"/>
         <source>%</source>
         <translation>%</translation>
     </message>
@@ -5362,27 +5366,27 @@ Chcete pokračovat?</translation>
 <context>
     <name>ProcessorPage</name>
     <message>
-        <location filename="../Pages.cpp" line="2198"/>
+        <location filename="../Pages.cpp" line="2200"/>
         <source>Processor</source>
         <translation>Procesor</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2199"/>
+        <location filename="../Pages.cpp" line="2201"/>
         <source>Apply</source>
         <translation>Provést</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2200"/>
+        <location filename="../Pages.cpp" line="2202"/>
         <source>Settings</source>
         <translation>Nastavení</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2224"/>
+        <location filename="../Pages.cpp" line="2226"/>
         <source>Manual</source>
         <translation>Ruční</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2225"/>
+        <location filename="../Pages.cpp" line="2227"/>
         <source>Auto</source>
         <translation>Auto</translation>
     </message>
@@ -5792,7 +5796,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>RelativeIntensity</name>
     <message>
-        <location filename="../BikeScore.cpp" line="136"/>
+        <location filename="../BikeScore.cpp" line="147"/>
         <source>Relative Intensity</source>
         <translation>Relativní intenzita</translation>
     </message>
@@ -5800,7 +5804,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>ResponseIndex</name>
     <message>
-        <location filename="../BikeScore.cpp" line="218"/>
+        <location filename="../BikeScore.cpp" line="237"/>
         <source>Response Index</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5808,7 +5812,7 @@ Chcete pokračovat?</translation>
 <context>
     <name>RideCount</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="34"/>
+        <location filename="../BasicRideMetrics.cpp" line="37"/>
         <source>Rides</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5816,9 +5820,9 @@ Chcete pokračovat?</translation>
 <context>
     <name>RideDelegate</name>
     <message>
-        <location filename="../RideImportWizard.cpp" line="995"/>
-        <location filename="../RideImportWizard.cpp" line="1032"/>
-        <location filename="../RideImportWizard.cpp" line="1048"/>
+        <location filename="../RideImportWizard.cpp" line="998"/>
+        <location filename="../RideImportWizard.cpp" line="1035"/>
+        <location filename="../RideImportWizard.cpp" line="1051"/>
         <source>dd MMM yyyy</source>
         <translation>dd MMM yyyy</translation>
     </message>
@@ -6379,9 +6383,9 @@ Chcete pokračovat?</translation>
     </message>
     <message>
         <location filename="../RideImportWizard.cpp" line="74"/>
-        <location filename="../RideImportWizard.cpp" line="696"/>
-        <location filename="../RideImportWizard.cpp" line="738"/>
-        <location filename="../RideImportWizard.cpp" line="890"/>
+        <location filename="../RideImportWizard.cpp" line="699"/>
+        <location filename="../RideImportWizard.cpp" line="741"/>
+        <location filename="../RideImportWizard.cpp" line="893"/>
         <source>Abort</source>
         <translation>Přerušit</translation>
     </message>
@@ -6452,12 +6456,12 @@ Chcete pokračovat?</translation>
     </message>
     <message>
         <location filename="../RideImportWizard.cpp" line="268"/>
-        <location filename="../RideImportWizard.cpp" line="454"/>
-        <location filename="../RideImportWizard.cpp" line="506"/>
-        <location filename="../RideImportWizard.cpp" line="717"/>
-        <location filename="../RideImportWizard.cpp" line="756"/>
-        <location filename="../RideImportWizard.cpp" line="895"/>
-        <location filename="../RideImportWizard.cpp" line="918"/>
+        <location filename="../RideImportWizard.cpp" line="457"/>
+        <location filename="../RideImportWizard.cpp" line="509"/>
+        <location filename="../RideImportWizard.cpp" line="720"/>
+        <location filename="../RideImportWizard.cpp" line="759"/>
+        <location filename="../RideImportWizard.cpp" line="898"/>
+        <location filename="../RideImportWizard.cpp" line="921"/>
         <source>Error</source>
         <translation>Chyba</translation>
     </message>
@@ -6467,157 +6471,157 @@ Chcete pokračovat?</translation>
         <translation>Analyzuji...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="378"/>
+        <location filename="../RideImportWizard.cpp" line="381"/>
         <source>Validated</source>
         <translation>Ověřeno</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="380"/>
+        <location filename="../RideImportWizard.cpp" line="383"/>
         <source>Warning - </source>
         <translation>Varování - </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="394"/>
-        <location filename="../RideImportWizard.cpp" line="619"/>
-        <location filename="../RideImportWizard.cpp" line="765"/>
+        <location filename="../RideImportWizard.cpp" line="397"/>
+        <location filename="../RideImportWizard.cpp" line="622"/>
+        <location filename="../RideImportWizard.cpp" line="768"/>
         <source>dd MMM yyyy</source>
         <translation>dd MMM yyyy</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="395"/>
+        <location filename="../RideImportWizard.cpp" line="398"/>
         <source>hh:mm:ss ap</source>
         <translation>hh:mm:ss ap</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="432"/>
+        <location filename="../RideImportWizard.cpp" line="435"/>
         <source>Error - </source>
         <translation>Chyba - </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="380"/>
-        <location filename="../RideImportWizard.cpp" line="432"/>
+        <location filename="../RideImportWizard.cpp" line="383"/>
+        <location filename="../RideImportWizard.cpp" line="435"/>
         <source> </source>
         <translation> .</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="447"/>
+        <location filename="../RideImportWizard.cpp" line="450"/>
         <source>Step 3 of 4: Confirm Date and Time</source>
         <translation>Krok 3. ze 4: Potvrďte Datum a čas</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="464"/>
+        <location filename="../RideImportWizard.cpp" line="467"/>
         <source>Save</source>
         <translation>Uložit</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="573"/>
-        <location filename="../RideImportWizard.cpp" line="623"/>
+        <location filename="../RideImportWizard.cpp" line="576"/>
+        <location filename="../RideImportWizard.cpp" line="626"/>
         <source>hh:mm:ss</source>
         <translation>hh:mm:ss</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="582"/>
+        <location filename="../RideImportWizard.cpp" line="585"/>
         <source>Invalid Selection</source>
         <translation>Špatný výběr</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="582"/>
+        <location filename="../RideImportWizard.cpp" line="585"/>
         <source>More than 24hrs of rides to fit into a day</source>
         <translation>Den má 24h, záznam je však delší než 24 hodin</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="627"/>
-        <location filename="../RideImportWizard.cpp" line="766"/>
+        <location filename="../RideImportWizard.cpp" line="630"/>
+        <location filename="../RideImportWizard.cpp" line="769"/>
         <source>hh:mm:ss a</source>
         <translation>hh:mm:ss a</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="736"/>
+        <location filename="../RideImportWizard.cpp" line="739"/>
         <source>Step 4 of 4: Save to Library</source>
         <translation>Krok 4. z 4: Uložit do adresáře se záznamy</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="758"/>
+        <location filename="../RideImportWizard.cpp" line="761"/>
         <source>Saving...</source>
         <translation>Ukládám záznamy...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="834"/>
+        <location filename="../RideImportWizard.cpp" line="837"/>
         <source>Error - Source is Target</source>
         <translation>Chyba - zdroj je zároveň cílem</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="845"/>
+        <location filename="../RideImportWizard.cpp" line="848"/>
         <source>Overwriting file...</source>
         <translation>Přepsání souboru ...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="847"/>
+        <location filename="../RideImportWizard.cpp" line="850"/>
         <source>/</source>
         <translation>/</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="847"/>
+        <location filename="../RideImportWizard.cpp" line="850"/>
         <source>.tmp</source>
         <translation>.tmp</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="821"/>
-        <location filename="../RideImportWizard.cpp" line="854"/>
+        <location filename="../RideImportWizard.cpp" line="824"/>
+        <location filename="../RideImportWizard.cpp" line="857"/>
         <source>File Overwritten</source>
         <translation>Soubor přepsán</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="857"/>
-        <location filename="../RideImportWizard.cpp" line="859"/>
+        <location filename="../RideImportWizard.cpp" line="860"/>
+        <location filename="../RideImportWizard.cpp" line="862"/>
         <source>Error - overwrite failed</source>
         <translation>Chyba - nepodařilo se soubor přepsat</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="790"/>
-        <location filename="../RideImportWizard.cpp" line="862"/>
+        <location filename="../RideImportWizard.cpp" line="793"/>
+        <location filename="../RideImportWizard.cpp" line="865"/>
         <source>Error - File exists</source>
         <translation>Chyba - soubor již existuje</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="865"/>
+        <location filename="../RideImportWizard.cpp" line="868"/>
         <source>Saving file...</source>
         <translation>Ukládání souboru...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="823"/>
-        <location filename="../RideImportWizard.cpp" line="868"/>
+        <location filename="../RideImportWizard.cpp" line="826"/>
+        <location filename="../RideImportWizard.cpp" line="871"/>
         <source>File Saved</source>
         <translation>Soubor byl uložen</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="877"/>
+        <location filename="../RideImportWizard.cpp" line="880"/>
         <source>Error - copy failed</source>
         <translation>Chyba - kopírování se nezdařilo</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="888"/>
+        <location filename="../RideImportWizard.cpp" line="891"/>
         <source>Step 5 of 5: Calculating Critical Powers</source>
         <translation>Krok 5 z 5: Výpočet kritického výkonu</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="896"/>
+        <location filename="../RideImportWizard.cpp" line="899"/>
         <source>Calculating...</source>
         <translation>Počítám ...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="905"/>
+        <location filename="../RideImportWizard.cpp" line="908"/>
         <source>Completed.</source>
         <translation>Hotovo.</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="923"/>
+        <location filename="../RideImportWizard.cpp" line="926"/>
         <source>Import Complete. %1 of %2 successful.</source>
         <translation>Import dokončen. %1 z %2 úspěšné.</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="704"/>
-        <location filename="../RideImportWizard.cpp" line="928"/>
+        <location filename="../RideImportWizard.cpp" line="707"/>
+        <location filename="../RideImportWizard.cpp" line="931"/>
         <source>Finish</source>
         <translation>Skončit</translation>
     </message>
@@ -6625,22 +6629,22 @@ Chcete pokračovat?</translation>
 <context>
     <name>RideNavigator</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="540"/>
+        <location filename="../RideNavigator.cpp" line="542"/>
         <source>Remove Column</source>
         <translation type="unfinished">Odstranit sloupec</translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="546"/>
+        <location filename="../RideNavigator.cpp" line="548"/>
         <source>Column Chooser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="551"/>
+        <location filename="../RideNavigator.cpp" line="553"/>
         <source>Do Not Show in Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="551"/>
+        <location filename="../RideNavigator.cpp" line="553"/>
         <source>Show In Groups</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7007,32 +7011,32 @@ Chceš to udělat?
 <context>
     <name>SchemePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2295"/>
+        <location filename="../Pages.cpp" line="2297"/>
         <source>Add</source>
         <translation>Přidat</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2296"/>
+        <location filename="../Pages.cpp" line="2298"/>
         <source>Rename</source>
         <translation>Přejmenovat</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2297"/>
+        <location filename="../Pages.cpp" line="2299"/>
         <source>Delete</source>
         <translation>Smazat</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2306"/>
+        <location filename="../Pages.cpp" line="2308"/>
         <source>Short</source>
         <translation>Krátký</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2307"/>
+        <location filename="../Pages.cpp" line="2309"/>
         <source>Long</source>
         <translation>Délka</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2308"/>
+        <location filename="../Pages.cpp" line="2310"/>
         <source>Percent of CP</source>
         <translation>Procento z CP</translation>
     </message>
@@ -7117,42 +7121,42 @@ Chceš to udělat?
 <context>
     <name>SeasonsPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3673"/>
+        <location filename="../Pages.cpp" line="3675"/>
         <source>Move up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3674"/>
+        <location filename="../Pages.cpp" line="3676"/>
         <source>Move down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3675"/>
+        <location filename="../Pages.cpp" line="3677"/>
         <source>Add</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3676"/>
+        <location filename="../Pages.cpp" line="3678"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3685"/>
+        <location filename="../Pages.cpp" line="3687"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3686"/>
+        <location filename="../Pages.cpp" line="3688"/>
         <source>Type</source>
         <translation type="unfinished">Typ</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3687"/>
+        <location filename="../Pages.cpp" line="3689"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3688"/>
+        <location filename="../Pages.cpp" line="3690"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7160,7 +7164,7 @@ Chceš to udělat?
 <context>
     <name>SessionRPE</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="302"/>
+        <location filename="../TRIMPPoints.cpp" line="316"/>
         <source>Session RPE</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7187,6 +7191,147 @@ Chceš to udělat?
     <message>
         <location filename="../SmallPlot.cpp" line="237"/>
         <source>Time (minutes)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SpecialFields</name>
+    <message>
+        <location filename="../SpecialFields.cpp" line="26"/>
+        <source>Start Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="27"/>
+        <source>Start Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="28"/>
+        <source>Identifier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="29"/>
+        <source>Workout Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="30"/>
+        <source>Sport</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="31"/>
+        <source>Objective</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="32"/>
+        <source>Summary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="33"/>
+        <source>Notes</source>
+        <translation type="unfinished">Poznámky</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="34"/>
+        <source>Keywords</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="35"/>
+        <source>Recording Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="36"/>
+        <source>Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="37"/>
+        <source>Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="38"/>
+        <source>Device Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="39"/>
+        <source>Dropouts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="40"/>
+        <source>Dropout Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="41"/>
+        <source>Spikes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="42"/>
+        <source>Spike Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="43"/>
+        <source>Torque Adjust</source>
+        <translation type="unfinished">Nastavení kroutícího momentu</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="44"/>
+        <source>Filename</source>
+        <translation type="unfinished">Název souboru</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="45"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="46"/>
+        <source>Change History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="47"/>
+        <source>Calendar Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="48"/>
+        <source>Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SpecialTabs</name>
+    <message>
+        <location filename="../SpecialFields.cpp" line="130"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="131"/>
+        <source>Notes</source>
+        <translation type="unfinished">Poznámky</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="132"/>
+        <source>Metric</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="133"/>
+        <source>Extra</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -7604,22 +7749,22 @@ Chceš to udělat?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="388"/>
+        <location filename="../StravaDialog.cpp" line="389"/>
         <source>Upload ride... Sending</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="398"/>
+        <location filename="../StravaDialog.cpp" line="399"/>
         <source>Upload finished.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="430"/>
+        <location filename="../StravaDialog.cpp" line="431"/>
         <source>Ride processing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="501"/>
+        <location filename="../StravaDialog.cpp" line="502"/>
         <source>Searching corresponding Ride</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7872,7 +8017,7 @@ Chceš to udělat?
 <context>
     <name>TRIMP100Points</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="114"/>
+        <location filename="../TRIMPPoints.cpp" line="120"/>
         <source>TRIMP(100) Points</source>
         <translation>TRIMP (100) bodů</translation>
     </message>
@@ -7880,7 +8025,7 @@ Chceš to udělat?
 <context>
     <name>TRIMPPoints</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="47"/>
+        <location filename="../TRIMPPoints.cpp" line="49"/>
         <source>TRIMP Points</source>
         <translation>TRIMP body</translation>
     </message>
@@ -7888,7 +8033,7 @@ Chceš to udělat?
 <context>
     <name>TRIMPZonalPoints</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="180"/>
+        <location filename="../TRIMPPoints.cpp" line="190"/>
         <source>TRIMP Zonal Points</source>
         <translation>TRIMP zonální body</translation>
     </message>
@@ -7896,13 +8041,13 @@ Chceš to udělat?
 <context>
     <name>TimeRiding</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="94"/>
+        <location filename="../BasicRideMetrics.cpp" line="105"/>
         <source>Time Riding</source>
         <translation>Čas jízdy</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="95"/>
-        <location filename="../BasicRideMetrics.cpp" line="96"/>
+        <location filename="../BasicRideMetrics.cpp" line="106"/>
+        <location filename="../BasicRideMetrics.cpp" line="107"/>
         <source>seconds</source>
         <translation>sekundy</translation>
     </message>
@@ -7986,17 +8131,17 @@ Chceš to udělat?
 <context>
     <name>TotalDistance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="129"/>
+        <location filename="../BasicRideMetrics.cpp" line="144"/>
         <source>Distance</source>
         <translation>Vzdálenost</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="131"/>
+        <location filename="../BasicRideMetrics.cpp" line="146"/>
         <source>km</source>
         <translation>km</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="132"/>
+        <location filename="../BasicRideMetrics.cpp" line="147"/>
         <source>miles</source>
         <translation>míle</translation>
     </message>
@@ -8004,13 +8149,13 @@ Chceš to udělat?
 <context>
     <name>TotalWork</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="213"/>
+        <location filename="../BasicRideMetrics.cpp" line="236"/>
         <source>Work</source>
         <translation>Práce</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="214"/>
-        <location filename="../BasicRideMetrics.cpp" line="215"/>
+        <location filename="../BasicRideMetrics.cpp" line="237"/>
+        <location filename="../BasicRideMetrics.cpp" line="238"/>
         <source>kJ</source>
         <translation>kJ</translation>
     </message>
@@ -8084,6 +8229,14 @@ Press F3 on Controller when done.</source>
         <location filename="../TrainTool.cpp" line="1279"/>
         <source>Done</source>
         <translation type="unfinished">Hotovo</translation>
+    </message>
+</context>
+<context>
+    <name>TreeMapWindow</name>
+    <message>
+        <location filename="../TreeMapWindow.cpp" line="100"/>
+        <source>Metric</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -8379,7 +8532,7 @@ Tento vygenerovaný PIN vlož do políčka. K dokončení stiskni tlačítko Ulo
 <context>
     <name>VAM</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="722"/>
+        <location filename="../BasicRideMetrics.cpp" line="811"/>
         <source>VAM</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8387,7 +8540,7 @@ Tento vygenerovaný PIN vlož do políčka. K dokončení stiskni tlačítko Ulo
 <context>
     <name>VariabilityIndex</name>
     <message>
-        <location filename="../BikeScore.cpp" line="102"/>
+        <location filename="../BikeScore.cpp" line="109"/>
         <source>Skiba VI</source>
         <translation>Skiba VI</translation>
     </message>
@@ -8419,13 +8572,13 @@ Tento vygenerovaný PIN vlož do políčka. K dokončení stiskni tlačítko Ulo
 <context>
     <name>Vo2max</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="252"/>
+        <location filename="../WattsPerKilogram.cpp" line="308"/>
         <source>Estimated VO2MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="254"/>
-        <location filename="../WattsPerKilogram.cpp" line="255"/>
+        <location filename="../WattsPerKilogram.cpp" line="310"/>
+        <location filename="../WattsPerKilogram.cpp" line="311"/>
         <source>ml/min/kg</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8532,13 +8685,13 @@ Tento vygenerovaný PIN vlož do políčka. K dokončení stiskni tlačítko Ulo
 <context>
     <name>WorkoutTime</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="60"/>
+        <location filename="../BasicRideMetrics.cpp" line="67"/>
         <source>Duration</source>
         <translation>Trvání</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="61"/>
-        <location filename="../BasicRideMetrics.cpp" line="62"/>
+        <location filename="../BasicRideMetrics.cpp" line="68"/>
+        <location filename="../BasicRideMetrics.cpp" line="69"/>
         <source>seconds</source>
         <translation>skundy</translation>
     </message>
@@ -8574,13 +8727,13 @@ Tento vygenerovaný PIN vlož do políčka. K dokončení stiskni tlačítko Ulo
 <context>
     <name>XPower</name>
     <message>
-        <location filename="../BikeScore.cpp" line="45"/>
+        <location filename="../BikeScore.cpp" line="48"/>
         <source>xPower</source>
         <translation>xPower</translation>
     </message>
     <message>
-        <location filename="../BikeScore.cpp" line="47"/>
-        <location filename="../BikeScore.cpp" line="48"/>
+        <location filename="../BikeScore.cpp" line="50"/>
+        <location filename="../BikeScore.cpp" line="51"/>
         <source>watts</source>
         <translation>waty</translation>
     </message>
@@ -8603,12 +8756,12 @@ Tento vygenerovaný PIN vlož do políčka. K dokončení stiskni tlačítko Ulo
 <context>
     <name>ZonePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2278"/>
+        <location filename="../Pages.cpp" line="2280"/>
         <source>Critical Power History</source>
         <translation>Historie kritického výkonu</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2279"/>
+        <location filename="../Pages.cpp" line="2281"/>
         <source>Default Zones</source>
         <translation>Výchozí zóny</translation>
     </message>
@@ -8616,7 +8769,7 @@ Tento vygenerovaný PIN vlož do políčka. K dokončení stiskni tlačítko Ulo
 <context>
     <name>ZoneTime1</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="74"/>
+        <location filename="../TimeInZone.cpp" line="79"/>
         <source>L1 Time in Zone</source>
         <translation>Čas v zóně L1</translation>
     </message>
@@ -8624,7 +8777,7 @@ Tento vygenerovaný PIN vlož do políčka. K dokončení stiskni tlačítko Ulo
 <context>
     <name>ZoneTime10</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="182"/>
+        <location filename="../TimeInZone.cpp" line="232"/>
         <source>L10 Time in Zone</source>
         <translation>Čas v zóně L10</translation>
     </message>
@@ -8632,7 +8785,7 @@ Tento vygenerovaný PIN vlož do políčka. K dokončení stiskni tlačítko Ulo
 <context>
     <name>ZoneTime2</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="86"/>
+        <location filename="../TimeInZone.cpp" line="96"/>
         <source>L2 Time in Zone</source>
         <translation>Čas v zóně L2</translation>
     </message>
@@ -8640,7 +8793,7 @@ Tento vygenerovaný PIN vlož do políčka. K dokončení stiskni tlačítko Ulo
 <context>
     <name>ZoneTime3</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="98"/>
+        <location filename="../TimeInZone.cpp" line="113"/>
         <source>L3 Time in Zone</source>
         <translation>Čas v zóně L3</translation>
     </message>
@@ -8648,7 +8801,7 @@ Tento vygenerovaný PIN vlož do políčka. K dokončení stiskni tlačítko Ulo
 <context>
     <name>ZoneTime4</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="110"/>
+        <location filename="../TimeInZone.cpp" line="130"/>
         <source>L4 Time in Zone</source>
         <translation>Čas v zóně L4</translation>
     </message>
@@ -8656,7 +8809,7 @@ Tento vygenerovaný PIN vlož do políčka. K dokončení stiskni tlačítko Ulo
 <context>
     <name>ZoneTime5</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="122"/>
+        <location filename="../TimeInZone.cpp" line="147"/>
         <source>L5 Time in Zone</source>
         <translation>Čas v zóně L5</translation>
     </message>
@@ -8664,7 +8817,7 @@ Tento vygenerovaný PIN vlož do políčka. K dokončení stiskni tlačítko Ulo
 <context>
     <name>ZoneTime6</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="134"/>
+        <location filename="../TimeInZone.cpp" line="164"/>
         <source>L6 Time in Zone</source>
         <translation>Čas v zóně L6</translation>
     </message>
@@ -8672,7 +8825,7 @@ Tento vygenerovaný PIN vlož do políčka. K dokončení stiskni tlačítko Ulo
 <context>
     <name>ZoneTime7</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="146"/>
+        <location filename="../TimeInZone.cpp" line="181"/>
         <source>L7 Time in Zone</source>
         <translation>Čas v zóně L7</translation>
     </message>
@@ -8680,7 +8833,7 @@ Tento vygenerovaný PIN vlož do políčka. K dokončení stiskni tlačítko Ulo
 <context>
     <name>ZoneTime8</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="158"/>
+        <location filename="../TimeInZone.cpp" line="198"/>
         <source>L8 Time in Zone</source>
         <translation>Čas v zóně L8</translation>
     </message>
@@ -8688,7 +8841,7 @@ Tento vygenerovaný PIN vlož do políčka. K dokončení stiskni tlačítko Ulo
 <context>
     <name>ZoneTime9</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="170"/>
+        <location filename="../TimeInZone.cpp" line="215"/>
         <source>L9 Time in Zone</source>
         <translation>Čas v zóně L9</translation>
     </message>

--- a/src/translations/gc_de.ts
+++ b/src/translations/gc_de.ts
@@ -254,13 +254,13 @@
 <context>
     <name>AerobicDecoupling</name>
     <message>
-        <location filename="../AerobicDecoupling.cpp" line="50"/>
+        <location filename="../AerobicDecoupling.cpp" line="52"/>
         <source>Aerobic Decoupling</source>
         <translation>Aerobes Decoupling</translation>
     </message>
     <message>
-        <location filename="../AerobicDecoupling.cpp" line="52"/>
-        <location filename="../AerobicDecoupling.cpp" line="53"/>
+        <location filename="../AerobicDecoupling.cpp" line="54"/>
+        <location filename="../AerobicDecoupling.cpp" line="55"/>
         <source>%</source>
         <translation>%</translation>
     </message>
@@ -394,42 +394,42 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="916"/>
+        <location filename="../AllPlot.cpp" line="909"/>
         <source>KPH</source>
         <translation>km/h</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="916"/>
+        <location filename="../AllPlot.cpp" line="909"/>
         <source>MPH</source>
         <translation>mi/h</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="932"/>
+        <location filename="../AllPlot.cpp" line="925"/>
         <source>Nm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="932"/>
+        <location filename="../AllPlot.cpp" line="925"/>
         <source>ftLb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="945"/>
+        <location filename="../AllPlot.cpp" line="938"/>
         <source>Meters</source>
         <translation>Meter</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="945"/>
+        <location filename="../AllPlot.cpp" line="938"/>
         <source>Feet</source>
         <translation>Fuß</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="971"/>
+        <location filename="../AllPlot.cpp" line="981"/>
         <source>Distance </source>
         <translation>Distanz</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="973"/>
+        <location filename="../AllPlot.cpp" line="983"/>
         <source>Time (Hours:Minutes)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -559,13 +559,13 @@
 <context>
     <name>AverageWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="55"/>
+        <location filename="../WattsPerKilogram.cpp" line="58"/>
         <source>Watts Per Kilogram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="57"/>
-        <location filename="../WattsPerKilogram.cpp" line="58"/>
+        <location filename="../WattsPerKilogram.cpp" line="60"/>
+        <location filename="../WattsPerKilogram.cpp" line="61"/>
         <source>wpk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -573,13 +573,13 @@
 <context>
     <name>AvgCadence</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="433"/>
+        <location filename="../BasicRideMetrics.cpp" line="488"/>
         <source>Average Cadence</source>
         <translation>Durchschnittliche Trittfrequenz</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="434"/>
-        <location filename="../BasicRideMetrics.cpp" line="435"/>
+        <location filename="../BasicRideMetrics.cpp" line="489"/>
+        <location filename="../BasicRideMetrics.cpp" line="490"/>
         <source>rpm</source>
         <translation>upm</translation>
     </message>
@@ -587,13 +587,13 @@
 <context>
     <name>AvgHeartRate</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="399"/>
+        <location filename="../BasicRideMetrics.cpp" line="448"/>
         <source>Average Heart Rate</source>
         <translation>Durchschnittliche Herzfrequenz</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="400"/>
-        <location filename="../BasicRideMetrics.cpp" line="401"/>
+        <location filename="../BasicRideMetrics.cpp" line="449"/>
+        <location filename="../BasicRideMetrics.cpp" line="450"/>
         <source>bpm</source>
         <translation>spm</translation>
     </message>
@@ -601,13 +601,13 @@
 <context>
     <name>AvgPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="331"/>
+        <location filename="../BasicRideMetrics.cpp" line="368"/>
         <source>Average Power</source>
         <translation>Durchschnittliche Leistung</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="332"/>
-        <location filename="../BasicRideMetrics.cpp" line="333"/>
+        <location filename="../BasicRideMetrics.cpp" line="369"/>
+        <location filename="../BasicRideMetrics.cpp" line="370"/>
         <source>watts</source>
         <translation>Watt</translation>
     </message>
@@ -615,17 +615,17 @@
 <context>
     <name>AvgSpeed</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="244"/>
+        <location filename="../BasicRideMetrics.cpp" line="271"/>
         <source>Average Speed</source>
         <translation>Durchschnittliche Geschwindigkeit</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="245"/>
+        <location filename="../BasicRideMetrics.cpp" line="272"/>
         <source>kph</source>
         <translation>km/h</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="246"/>
+        <location filename="../BasicRideMetrics.cpp" line="273"/>
         <source>mph</source>
         <translation>mi/h</translation>
     </message>
@@ -633,17 +633,17 @@
 <context>
     <name>AvgTemp</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="467"/>
+        <location filename="../BasicRideMetrics.cpp" line="528"/>
         <source>Average Temp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="468"/>
+        <location filename="../BasicRideMetrics.cpp" line="529"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="469"/>
+        <location filename="../BasicRideMetrics.cpp" line="530"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
@@ -747,7 +747,7 @@
 <context>
     <name>BikeScore</name>
     <message>
-        <location filename="../BikeScore.cpp" line="181"/>
+        <location filename="../BikeScore.cpp" line="196"/>
         <source>BikeScore&amp;#8482;</source>
         <translation>BikeScore™</translation>
     </message>
@@ -755,54 +755,54 @@
 <context>
     <name>CPPage</name>
     <message>
-        <location filename="../Pages.cpp" line="2455"/>
+        <location filename="../Pages.cpp" line="2457"/>
         <source>Add CP</source>
         <translation>CP hinzufügen</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2456"/>
+        <location filename="../Pages.cpp" line="2458"/>
         <source>Delete CP</source>
         <translation>CP löschen</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2457"/>
+        <location filename="../Pages.cpp" line="2459"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2460"/>
+        <location filename="../Pages.cpp" line="2462"/>
         <source>Add Zone</source>
         <translation>Zone hinzufügen</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2461"/>
+        <location filename="../Pages.cpp" line="2463"/>
         <source>Delete Zone</source>
         <translation>Zone löschen</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2475"/>
-        <location filename="../Pages.cpp" line="2493"/>
+        <location filename="../Pages.cpp" line="2477"/>
+        <location filename="../Pages.cpp" line="2495"/>
         <source>From Date</source>
         <translation>Vom</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2476"/>
-        <location filename="../Pages.cpp" line="2494"/>
+        <location filename="../Pages.cpp" line="2478"/>
+        <location filename="../Pages.cpp" line="2496"/>
         <source>Critical Power</source>
         <translation>CriticalPower</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2523"/>
+        <location filename="../Pages.cpp" line="2525"/>
         <source>Short</source>
         <translation>kurz</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2524"/>
+        <location filename="../Pages.cpp" line="2526"/>
         <source>Long</source>
         <translation>lang</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2525"/>
+        <location filename="../Pages.cpp" line="2527"/>
         <source>From Watts</source>
         <translation>Von Watt</translation>
     </message>
@@ -810,7 +810,7 @@
 <context>
     <name>CPWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="120"/>
+        <location filename="../WattsPerKilogram.cpp" line="128"/>
         <source>60 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -905,7 +905,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ChartSettings.cpp" line="42"/>
+        <location filename="../ChartSettings.cpp" line="41"/>
         <source>Done</source>
         <translation type="unfinished">Fertig</translation>
     </message>
@@ -1491,7 +1491,7 @@ Dies kann einige Zeit benötigen.
 <context>
     <name>CriticalPower</name>
     <message>
-        <location filename="../PeakPower.cpp" line="63"/>
+        <location filename="../PeakPower.cpp" line="67"/>
         <source>60 min Peak Power</source>
         <translation>60min Leistungamaximum</translation>
     </message>
@@ -1643,12 +1643,12 @@ Dies kann einige Zeit benötigen.
 <context>
     <name>DBAccess</name>
     <message>
-        <location filename="../DBAccess.cpp" line="112"/>
+        <location filename="../DBAccess.cpp" line="113"/>
         <source>Cannot open database</source>
         <translation>Kann Datenbank nicht öffnen</translation>
     </message>
     <message>
-        <location filename="../DBAccess.cpp" line="113"/>
+        <location filename="../DBAccess.cpp" line="114"/>
         <source>Unable to establish a database connection.
 This feature requires SQLite support. Please read the Qt SQL driver documentation for information how to build it.
 
@@ -1662,13 +1662,13 @@ Klicken Sie auf &quot;Abbrechen&quot; um dies Fenster zu schließen.</translatio
 <context>
     <name>DanielsEquivalentPower</name>
     <message>
-        <location filename="../DanielsPoints.cpp" line="110"/>
+        <location filename="../DanielsPoints.cpp" line="116"/>
         <source>Daniels EqP</source>
         <translation>DanielsPoints</translation>
     </message>
     <message>
-        <location filename="../DanielsPoints.cpp" line="111"/>
-        <location filename="../DanielsPoints.cpp" line="112"/>
+        <location filename="../DanielsPoints.cpp" line="117"/>
+        <location filename="../DanielsPoints.cpp" line="118"/>
         <source>watts</source>
         <translation>Watt</translation>
     </message>
@@ -1676,7 +1676,7 @@ Klicken Sie auf &quot;Abbrechen&quot; um dies Fenster zu schließen.</translatio
 <context>
     <name>DanielsPoints</name>
     <message>
-        <location filename="../DanielsPoints.cpp" line="49"/>
+        <location filename="../DanielsPoints.cpp" line="51"/>
         <source>Daniels Points</source>
         <translation>DanielsPoints</translation>
     </message>
@@ -1988,52 +1988,17 @@ Wählen Sie dann &quot;Erneut suchen&quot; um fortzufahren.</translation>
 <context>
     <name>EditMetricDetailDialog</name>
     <message>
-        <location filename="../LTMTool.cpp" line="638"/>
+        <location filename="../LTMTool.cpp" line="701"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="662"/>
-        <source>Filter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="664"/>
-        <source>No filter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="665"/>
-        <source>Include</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="666"/>
-        <source>Exclude</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="668"/>
-        <source>From</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="673"/>
-        <source>To</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="678"/>
-        <source>Show on plot</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="780"/>
+        <location filename="../LTMTool.cpp" line="814"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="781"/>
+        <location filename="../LTMTool.cpp" line="815"/>
         <source>&amp;Cancel</source>
         <translation>Abbre&amp;chen</translation>
     </message>
@@ -2077,7 +2042,7 @@ Wählen Sie dann &quot;Erneut suchen&quot; um fortzufahren.</translation>
 <context>
     <name>EfficiencyFactor</name>
     <message>
-        <location filename="../Coggan.cpp" line="198"/>
+        <location filename="../Coggan.cpp" line="217"/>
         <source>Efficiency Factor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2085,17 +2050,17 @@ Wählen Sie dann &quot;Erneut suchen&quot; um fortzufahren.</translation>
 <context>
     <name>ElevationGain</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="170"/>
+        <location filename="../BasicRideMetrics.cpp" line="189"/>
         <source>Elevation Gain</source>
         <translation>Höhenmeter</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="172"/>
+        <location filename="../BasicRideMetrics.cpp" line="191"/>
         <source>meters</source>
         <translation>Meter</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="173"/>
+        <location filename="../BasicRideMetrics.cpp" line="192"/>
         <source>feet</source>
         <translation>Fuß</translation>
     </message>
@@ -2361,7 +2326,7 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
 <context>
     <name>FormField</name>
     <message>
-        <location filename="../RideMetadata.cpp" line="545"/>
+        <location filename="../RideMetadata.cpp" line="546"/>
         <source>You entered &apos;%1&apos; which is not an expected value.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2459,7 +2424,7 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
 <context>
     <name>Gradient</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="758"/>
+        <location filename="../BasicRideMetrics.cpp" line="851"/>
         <source>Gradient</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2475,7 +2440,7 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
 <context>
     <name>GroupByModel</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="724"/>
+        <location filename="../RideNavigator.cpp" line="726"/>
         <source>Date</source>
         <translation type="unfinished">Datum</translation>
     </message>
@@ -2558,12 +2523,12 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
 <context>
     <name>HomeWindow</name>
     <message>
-        <location filename="../HomeWindow.cpp" line="712"/>
+        <location filename="../HomeWindow.cpp" line="713"/>
         <source>Are you sure you want to remove the chart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../HomeWindow.cpp" line="713"/>
+        <location filename="../HomeWindow.cpp" line="714"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2607,37 +2572,37 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
 <context>
     <name>HrSchemePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2826"/>
+        <location filename="../Pages.cpp" line="2828"/>
         <source>Add</source>
         <translation>Hinzufügen</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2827"/>
+        <location filename="../Pages.cpp" line="2829"/>
         <source>Rename</source>
         <translation>Umbenennen</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2828"/>
+        <location filename="../Pages.cpp" line="2830"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2837"/>
+        <location filename="../Pages.cpp" line="2839"/>
         <source>Short</source>
         <translation>Kurz</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2838"/>
+        <location filename="../Pages.cpp" line="2840"/>
         <source>Long</source>
         <translation>Lang</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2839"/>
+        <location filename="../Pages.cpp" line="2841"/>
         <source>Percent of LT</source>
         <translation>Prozent der LT</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2840"/>
+        <location filename="../Pages.cpp" line="2842"/>
         <source>Trimp k</source>
         <translation>TRIMP k</translation>
     </message>
@@ -2645,12 +2610,12 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
 <context>
     <name>HrZonePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2809"/>
+        <location filename="../Pages.cpp" line="2811"/>
         <source>Lactic Threshold History</source>
         <translation>Laktat-Schwellenwerte der Vergangenheit</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2810"/>
+        <location filename="../Pages.cpp" line="2812"/>
         <source>Default Zones</source>
         <translation>Voreingestellte Zonen</translation>
     </message>
@@ -2658,7 +2623,7 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
 <context>
     <name>HrZoneTime1</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="72"/>
+        <location filename="../HrTimeInZone.cpp" line="77"/>
         <source>H1 Time in Zone</source>
         <translation>H1 Zeit in Zone</translation>
     </message>
@@ -2666,7 +2631,7 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
 <context>
     <name>HrZoneTime2</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="84"/>
+        <location filename="../HrTimeInZone.cpp" line="94"/>
         <source>H2 Time in Zone</source>
         <translation>H2 Zeit in Zone</translation>
     </message>
@@ -2674,7 +2639,7 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
 <context>
     <name>HrZoneTime3</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="96"/>
+        <location filename="../HrTimeInZone.cpp" line="111"/>
         <source>H3 Time in Zone</source>
         <translation>H3 Zeit in Zone</translation>
     </message>
@@ -2682,7 +2647,7 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
 <context>
     <name>HrZoneTime4</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="108"/>
+        <location filename="../HrTimeInZone.cpp" line="128"/>
         <source>H4 Time in Zone</source>
         <translation>H4 Zeit in Zone</translation>
     </message>
@@ -2690,7 +2655,7 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
 <context>
     <name>HrZoneTime5</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="120"/>
+        <location filename="../HrTimeInZone.cpp" line="145"/>
         <source>H5 Time in Zone</source>
         <translation>H5 Zeit in Zone</translation>
     </message>
@@ -2698,7 +2663,7 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
 <context>
     <name>HrZoneTime6</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="132"/>
+        <location filename="../HrTimeInZone.cpp" line="162"/>
         <source>H6 Time in Zone</source>
         <translation>H6 Zeit in Zone</translation>
     </message>
@@ -2706,7 +2671,7 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
 <context>
     <name>HrZoneTime7</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="144"/>
+        <location filename="../HrTimeInZone.cpp" line="179"/>
         <source>H7 Time in Zone</source>
         <translation>H7 Zeit in Zone</translation>
     </message>
@@ -2714,7 +2679,7 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
 <context>
     <name>HrZoneTime8</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="156"/>
+        <location filename="../HrTimeInZone.cpp" line="196"/>
         <source>H8 Time in Zone</source>
         <translation>H8 Zeit in Zone</translation>
     </message>
@@ -2942,7 +2907,8 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
 <context>
     <name>LTMPlot</name>
     <message>
-        <location filename="../LTMPlot.cpp" line="1120"/>
+        <location filename="../LTMPlot.cpp" line="731"/>
+        <location filename="../LTMPlot.cpp" line="1123"/>
         <source>watts</source>
         <translation>Watt</translation>
     </message>
@@ -2964,33 +2930,33 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="253"/>
-        <location filename="../LTMSidebar.cpp" line="289"/>
+        <location filename="../LTMSidebar.cpp" line="257"/>
+        <location filename="../LTMSidebar.cpp" line="293"/>
         <source>Edit details</source>
         <translation type="unfinished">Einzelheiten bearbeiten</translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="254"/>
+        <location filename="../LTMSidebar.cpp" line="258"/>
         <source>Delete range</source>
         <translation type="unfinished">Bereich löschen</translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="255"/>
+        <location filename="../LTMSidebar.cpp" line="259"/>
         <source>Add Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="290"/>
+        <location filename="../LTMSidebar.cpp" line="294"/>
         <source>Delete event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="300"/>
+        <location filename="../LTMSidebar.cpp" line="304"/>
         <source>Add event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="537"/>
+        <location filename="../LTMSidebar.cpp" line="541"/>
         <source>^(Average|Max) </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3002,7 +2968,7 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
         <translation type="obsolete">Datumsbereich</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="69"/>
+        <location filename="../LTMTool.cpp" line="124"/>
         <source>Metric</source>
         <translation>Eigenschaft</translation>
     </message>
@@ -3047,8 +3013,8 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
         <translation type="obsolete">Letzten 12 Monate</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="511"/>
-        <location filename="../LTMTool.cpp" line="519"/>
+        <location filename="../LTMTool.cpp" line="574"/>
+        <location filename="../LTMTool.cpp" line="582"/>
         <source>Unknown Metric</source>
         <translation>Unbekannte Eigenschaft</translation>
     </message>
@@ -3065,12 +3031,47 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
         <translation type="obsolete">Bereich löschen</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="544"/>
+        <location filename="../LTMTool.cpp" line="59"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="69"/>
+        <source>Chart</source>
+        <translation type="unfinished">Graph</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="101"/>
+        <source>Add</source>
+        <translation type="unfinished">Hinzufügen</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="102"/>
+        <source>Manage</source>
+        <translation type="unfinished">Verwalten</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="518"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="519"/>
+        <source>Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="520"/>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="607"/>
         <source>Pick Color</source>
         <translation>Farbe auswählen</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="545"/>
+        <location filename="../LTMTool.cpp" line="608"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
@@ -3078,19 +3079,16 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
 <context>
     <name>LTMWindow</name>
     <message>
-        <location filename="../LTMWindow.cpp" line="135"/>
         <source>Add</source>
-        <translation>Hinzufügen</translation>
+        <translation type="obsolete">Hinzufügen</translation>
     </message>
     <message>
-        <location filename="../LTMWindow.cpp" line="137"/>
         <source>Manage</source>
-        <translation>Verwalten</translation>
+        <translation type="obsolete">Verwalten</translation>
     </message>
     <message>
-        <location filename="../LTMWindow.cpp" line="105"/>
         <source>Chart</source>
-        <translation>Graph</translation>
+        <translation type="obsolete">Graph</translation>
     </message>
     <message>
         <source>Days</source>
@@ -3117,71 +3115,71 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
 <context>
     <name>LTPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3001"/>
+        <location filename="../Pages.cpp" line="3003"/>
         <source>Add LT</source>
         <translation>LT hinzufügen</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3002"/>
+        <location filename="../Pages.cpp" line="3004"/>
         <source>Delete LT</source>
         <translation>LT löschen</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3003"/>
+        <location filename="../Pages.cpp" line="3005"/>
         <source>Default</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3006"/>
+        <location filename="../Pages.cpp" line="3008"/>
         <source>Add Zone</source>
         <translation>Zone hinzufügen</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3007"/>
+        <location filename="../Pages.cpp" line="3009"/>
         <source>Delete Zone</source>
         <translation>Zone enfernen</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3021"/>
-        <location filename="../Pages.cpp" line="3061"/>
+        <location filename="../Pages.cpp" line="3023"/>
+        <location filename="../Pages.cpp" line="3063"/>
         <source>From Date</source>
         <translation>Von</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3022"/>
-        <location filename="../Pages.cpp" line="3062"/>
+        <location filename="../Pages.cpp" line="3024"/>
+        <location filename="../Pages.cpp" line="3064"/>
         <source>Lactic Threshold</source>
         <translation>Laktat Schwellenwert</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3039"/>
-        <location filename="../Pages.cpp" line="3063"/>
+        <location filename="../Pages.cpp" line="3041"/>
+        <location filename="../Pages.cpp" line="3065"/>
         <source>Rest HR</source>
         <translation>Ruheherzfrequenz</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3040"/>
-        <location filename="../Pages.cpp" line="3064"/>
+        <location filename="../Pages.cpp" line="3042"/>
+        <location filename="../Pages.cpp" line="3066"/>
         <source>Max HR</source>
         <translation>Maximale Herzfrequenz</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3101"/>
+        <location filename="../Pages.cpp" line="3103"/>
         <source>Short</source>
         <translation>Kurz</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3102"/>
+        <location filename="../Pages.cpp" line="3104"/>
         <source>Long</source>
         <translation>lang</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3103"/>
+        <location filename="../Pages.cpp" line="3105"/>
         <source>From BPM</source>
         <translation>Von spm</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3104"/>
+        <location filename="../Pages.cpp" line="3106"/>
         <source>Trimp k</source>
         <translation>TRIMP K</translation>
     </message>
@@ -3189,13 +3187,13 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
 <context>
     <name>LeftRightBalance</name>
     <message>
-        <location filename="../LeftRightBalance.cpp" line="33"/>
+        <location filename="../LeftRightBalance.cpp" line="36"/>
         <source>Left/Right Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftRightBalance.cpp" line="34"/>
-        <location filename="../LeftRightBalance.cpp" line="35"/>
+        <location filename="../LeftRightBalance.cpp" line="37"/>
+        <location filename="../LeftRightBalance.cpp" line="38"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
@@ -3207,7 +3205,7 @@ Drehmomentkorrektur - Dies definiert einen Linearfaktor in Nm (oder Pfund pro Qu
         <translation type="obsolete">Ungültiger Fahrername</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2210"/>
+        <location filename="../MainWindow.cpp" line="2216"/>
         <source>Invalid date/time in filename:
 %1
 Skipping file...</source>
@@ -3217,13 +3215,13 @@ Skipping file...</source>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="281"/>
-        <location filename="../MainWindow.cpp" line="2230"/>
+        <location filename="../MainWindow.cpp" line="2236"/>
         <source>Zones File Error</source>
         <translation>Fehler mit der Zonendatei</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="284"/>
-        <location filename="../MainWindow.cpp" line="2234"/>
+        <location filename="../MainWindow.cpp" line="2240"/>
         <source>Reading Zones File</source>
         <translation>Lese Zonendatei</translation>
     </message>
@@ -3233,7 +3231,7 @@ Skipping file...</source>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="565"/>
-        <location filename="../MainWindow.cpp" line="1209"/>
+        <location filename="../MainWindow.cpp" line="1215"/>
         <source>Intervals</source>
         <translation>Intervalle</translation>
     </message>
@@ -3258,22 +3256,22 @@ Skipping file...</source>
         <translation type="obsolete">Fahrer</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="743"/>
+        <location filename="../MainWindow.cpp" line="747"/>
         <source>&amp;New...</source>
         <translation>&amp;Neu...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="743"/>
+        <location filename="../MainWindow.cpp" line="747"/>
         <source>Ctrl+N</source>
         <translation>Ctrl+N</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="744"/>
+        <location filename="../MainWindow.cpp" line="748"/>
         <source>&amp;Open...</source>
         <translation>&amp;Öffnen...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="744"/>
+        <location filename="../MainWindow.cpp" line="748"/>
         <source>Ctrl+O</source>
         <translation>Ctrl+Ö</translation>
     </message>
@@ -3282,7 +3280,7 @@ Skipping file...</source>
         <translation type="obsolete">&amp;Fertig</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="746"/>
+        <location filename="../MainWindow.cpp" line="750"/>
         <source>Ctrl+Q</source>
         <translation>Ctrl+F</translation>
     </message>
@@ -3291,24 +3289,24 @@ Skipping file...</source>
         <translation type="obsolete">T&amp;rainingseinheiten</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="775"/>
+        <location filename="../MainWindow.cpp" line="779"/>
         <source>Ctrl+S</source>
         <translation>Ctrl+R</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="749"/>
+        <location filename="../MainWindow.cpp" line="753"/>
         <source>&amp;Download from device...</source>
         <translation>&amp;Download vom Gerät</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="291"/>
-        <location filename="../MainWindow.cpp" line="2241"/>
+        <location filename="../MainWindow.cpp" line="2247"/>
         <source>HR Zones File Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="294"/>
-        <location filename="../MainWindow.cpp" line="2245"/>
+        <location filename="../MainWindow.cpp" line="2251"/>
         <source>Reading HR Zones File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3329,210 +3327,210 @@ Skipping file...</source>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="454"/>
-        <location filename="../MainWindow.cpp" line="845"/>
+        <location filename="../MainWindow.cpp" line="849"/>
         <source>Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="461"/>
-        <location filename="../MainWindow.cpp" line="848"/>
+        <location filename="../MainWindow.cpp" line="852"/>
         <source>Diary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="468"/>
-        <location filename="../MainWindow.cpp" line="844"/>
+        <location filename="../MainWindow.cpp" line="848"/>
         <source>Analysis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="474"/>
-        <location filename="../MainWindow.cpp" line="846"/>
+        <location filename="../MainWindow.cpp" line="850"/>
         <source>Train</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="524"/>
-        <location filename="../MainWindow.cpp" line="1160"/>
+        <location filename="../MainWindow.cpp" line="1166"/>
         <source>All Activities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="742"/>
+        <location filename="../MainWindow.cpp" line="746"/>
         <source>&amp;Athlete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="745"/>
+        <location filename="../MainWindow.cpp" line="749"/>
         <source>&amp;Close Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="745"/>
+        <location filename="../MainWindow.cpp" line="749"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="746"/>
+        <location filename="../MainWindow.cpp" line="750"/>
         <source>&amp;Quit All Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="748"/>
+        <location filename="../MainWindow.cpp" line="752"/>
         <source>A&amp;ctivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="749"/>
+        <location filename="../MainWindow.cpp" line="753"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="751"/>
+        <location filename="../MainWindow.cpp" line="755"/>
         <source>&amp;Manual activity entry...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="753"/>
+        <location filename="../MainWindow.cpp" line="757"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="754"/>
+        <location filename="../MainWindow.cpp" line="758"/>
         <source>&amp;Batch export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="755"/>
+        <location filename="../MainWindow.cpp" line="759"/>
         <source>Export Metrics as CSV...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="758"/>
+        <location filename="../MainWindow.cpp" line="762"/>
         <source>&amp;Upload to TrainingPeaks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="758"/>
+        <location filename="../MainWindow.cpp" line="762"/>
         <source>Ctrl+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="759"/>
+        <location filename="../MainWindow.cpp" line="763"/>
         <source>Down&amp;load from TrainingPeaks...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="759"/>
+        <location filename="../MainWindow.cpp" line="763"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="775"/>
+        <location filename="../MainWindow.cpp" line="779"/>
         <source>&amp;Save activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="776"/>
+        <location filename="../MainWindow.cpp" line="780"/>
         <source>D&amp;elete activity...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="777"/>
+        <location filename="../MainWindow.cpp" line="781"/>
         <source>Split &amp;activity...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="782"/>
+        <location filename="../MainWindow.cpp" line="786"/>
         <source>Critical Power Calculator...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="783"/>
+        <location filename="../MainWindow.cpp" line="787"/>
         <source>Air Density (Rho) Estimator...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="786"/>
+        <location filename="../MainWindow.cpp" line="790"/>
         <source>Get &amp;Withings Data...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="788"/>
+        <location filename="../MainWindow.cpp" line="792"/>
         <source>Get &amp;Zeo Data...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="791"/>
+        <location filename="../MainWindow.cpp" line="795"/>
         <source>Workout Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="792"/>
+        <location filename="../MainWindow.cpp" line="796"/>
         <source>Get Workouts from ErgDB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="796"/>
-        <location filename="../MainWindow.cpp" line="1197"/>
+        <location filename="../MainWindow.cpp" line="800"/>
+        <location filename="../MainWindow.cpp" line="1203"/>
         <source>Upload Activity to Calendar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="797"/>
+        <location filename="../MainWindow.cpp" line="801"/>
         <source>Import Calendar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="798"/>
+        <location filename="../MainWindow.cpp" line="802"/>
         <source>Export Calendar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="799"/>
+        <location filename="../MainWindow.cpp" line="803"/>
         <source>Refresh Calendar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="802"/>
+        <location filename="../MainWindow.cpp" line="806"/>
         <source>Find intervals...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1692"/>
+        <location filename="../MainWindow.cpp" line="1698"/>
         <source>Select Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1692"/>
-        <location filename="../MainWindow.cpp" line="1778"/>
-        <location filename="../MainWindow.cpp" line="1786"/>
+        <location filename="../MainWindow.cpp" line="1698"/>
+        <location filename="../MainWindow.cpp" line="1784"/>
+        <location filename="../MainWindow.cpp" line="1792"/>
         <source>No activity selected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1703"/>
+        <location filename="../MainWindow.cpp" line="1709"/>
         <source>Export Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1716"/>
+        <location filename="../MainWindow.cpp" line="1722"/>
         <source>Export Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1717"/>
+        <location filename="../MainWindow.cpp" line="1723"/>
         <source>Failed to export ride, please check permissions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2188"/>
+        <location filename="../MainWindow.cpp" line="2194"/>
         <source>Range from %1 to %2
 Athlete CP set to %3 watts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2209"/>
+        <location filename="../MainWindow.cpp" line="2215"/>
         <source>Invalid Activity File Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3541,12 +3539,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">&amp;Export in *.csv Datei...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="753"/>
+        <location filename="../MainWindow.cpp" line="757"/>
         <source>Ctrl+E</source>
         <translation>Ctrl+E</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="750"/>
+        <location filename="../MainWindow.cpp" line="754"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
@@ -3555,7 +3553,7 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Finde &amp;bestes Intervall</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="754"/>
+        <location filename="../MainWindow.cpp" line="758"/>
         <source>Ctrl+B</source>
         <translation>Ctrl+B</translation>
     </message>
@@ -3620,12 +3618,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Editor</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="750"/>
+        <location filename="../MainWindow.cpp" line="754"/>
         <source>&amp;Import from file...</source>
         <translation>Aus Datei &amp;importieren...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="751"/>
+        <location filename="../MainWindow.cpp" line="755"/>
         <source>Ctrl+M</source>
         <translation>Crtl+M</translation>
     </message>
@@ -3646,12 +3644,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Trainingseinheit &amp;speichern...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="780"/>
+        <location filename="../MainWindow.cpp" line="784"/>
         <source>&amp;Tools</source>
         <translation>&amp;Werkzeuge</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="781"/>
+        <location filename="../MainWindow.cpp" line="785"/>
         <source>&amp;Options...</source>
         <translation>&amp;Optionen...</translation>
     </message>
@@ -3660,89 +3658,89 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Critical Power Kalkulator</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="825"/>
+        <location filename="../MainWindow.cpp" line="829"/>
         <source>&amp;View</source>
         <translation>Ansich&amp;t</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="827"/>
+        <location filename="../MainWindow.cpp" line="831"/>
         <source>Toggle Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="829"/>
+        <location filename="../MainWindow.cpp" line="833"/>
         <source>Show Left Sidebar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="833"/>
+        <location filename="../MainWindow.cpp" line="837"/>
         <source>Show Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="838"/>
+        <location filename="../MainWindow.cpp" line="842"/>
         <source>Tabbed View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="852"/>
+        <location filename="../MainWindow.cpp" line="856"/>
         <source>Reset Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="854"/>
+        <location filename="../MainWindow.cpp" line="858"/>
         <source>&amp;Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="861"/>
+        <location filename="../MainWindow.cpp" line="865"/>
         <source>&amp;Help</source>
         <translation>&amp;Hilfe</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="862"/>
+        <location filename="../MainWindow.cpp" line="866"/>
         <source>&amp;User Guide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="863"/>
+        <location filename="../MainWindow.cpp" line="867"/>
         <source>&amp;Log a bug or feature request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="865"/>
+        <location filename="../MainWindow.cpp" line="869"/>
         <source>&amp;About GoldenCheetah</source>
         <translation>Über GoldenCheet&amp;ah</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1164"/>
+        <location filename="../MainWindow.cpp" line="1170"/>
         <source>Save Changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1167"/>
+        <location filename="../MainWindow.cpp" line="1173"/>
         <source>Revert to Saved version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1170"/>
-        <location filename="../MainWindow.cpp" line="1786"/>
+        <location filename="../MainWindow.cpp" line="1176"/>
+        <location filename="../MainWindow.cpp" line="1792"/>
         <source>Delete Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1179"/>
-        <location filename="../MainWindow.cpp" line="1778"/>
+        <location filename="../MainWindow.cpp" line="1185"/>
+        <location filename="../MainWindow.cpp" line="1784"/>
         <source>Split Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1192"/>
+        <location filename="../MainWindow.cpp" line="1198"/>
         <source>Tweet Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1612"/>
+        <location filename="../MainWindow.cpp" line="1618"/>
         <source>Can&apos;t rename %1 to %2</source>
         <translation>Kann nicht %1 in %2 umbenennen!</translation>
     </message>
@@ -3811,42 +3809,42 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Die Datei %1 kann nicht gespweichert werden</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1739"/>
+        <location filename="../MainWindow.cpp" line="1745"/>
         <source>Import from File</source>
         <translation>Aus Datei importieren...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1756"/>
+        <location filename="../MainWindow.cpp" line="1762"/>
         <source>No Activity To Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1757"/>
+        <location filename="../MainWindow.cpp" line="1763"/>
         <source>There is no currently selected ride to save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1791"/>
+        <location filename="../MainWindow.cpp" line="1797"/>
         <source>Are you sure you want to delete the activity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1845"/>
+        <location filename="../MainWindow.cpp" line="1851"/>
         <source>Export Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1845"/>
+        <location filename="../MainWindow.cpp" line="1851"/>
         <source>Comma Separated Variables (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1920"/>
+        <location filename="../MainWindow.cpp" line="1926"/>
         <source>Workout Directory Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1977"/>
+        <location filename="../MainWindow.cpp" line="1983"/>
         <source> (%1 watts)</source>
         <translation>(%1 Watt)</translation>
     </message>
@@ -3863,12 +3861,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Trainingseinheit löschen</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1173"/>
+        <location filename="../MainWindow.cpp" line="1179"/>
         <source>Find Best Intervals</source>
         <translation>Finde bestes Intervall</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1176"/>
+        <location filename="../MainWindow.cpp" line="1182"/>
         <source>Find Power Peaks</source>
         <translation>Finde Leistungsspitzen</translation>
     </message>
@@ -3877,27 +3875,27 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">&quot;Tweete&quot; die Trainingseinheit</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1214"/>
+        <location filename="../MainWindow.cpp" line="1220"/>
         <source>Rename interval</source>
         <translation>Intervall umbenennen</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1215"/>
+        <location filename="../MainWindow.cpp" line="1221"/>
         <source>Delete interval</source>
         <translation>Intervall löschen</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1216"/>
+        <location filename="../MainWindow.cpp" line="1222"/>
         <source>Zoom to interval</source>
         <translation>In das Intervall zoomen</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1217"/>
+        <location filename="../MainWindow.cpp" line="1223"/>
         <source>Bring to Front</source>
         <translation>Nach Vorne bringen</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1218"/>
+        <location filename="../MainWindow.cpp" line="1224"/>
         <source>Send to back</source>
         <translation>In den Hintergrund verschieben</translation>
     </message>
@@ -3936,7 +3934,7 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Kann Bemerkung %1 nicht speichern</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2187"/>
+        <location filename="../MainWindow.cpp" line="2193"/>
         <source>CP saved</source>
         <translation>CP gespeichert</translation>
     </message>
@@ -3959,7 +3957,7 @@ Fahrer CP wurde auf %3 Watt gesetzt.</translation>
         <translation type="obsolete">Sind Sie sicher, dass Sie diese Trainingseinheit löschen möchten?</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1793"/>
+        <location filename="../MainWindow.cpp" line="1799"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
@@ -4184,13 +4182,13 @@ Fahrer CP wurde auf %3 Watt gesetzt.</translation>
 <context>
     <name>MaxCadence</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="606"/>
+        <location filename="../BasicRideMetrics.cpp" line="683"/>
         <source>Max Cadence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="607"/>
-        <location filename="../BasicRideMetrics.cpp" line="608"/>
+        <location filename="../BasicRideMetrics.cpp" line="684"/>
+        <location filename="../BasicRideMetrics.cpp" line="685"/>
         <source>rpm</source>
         <translation type="unfinished">upm</translation>
     </message>
@@ -4198,13 +4196,13 @@ Fahrer CP wurde auf %3 Watt gesetzt.</translation>
 <context>
     <name>MaxHr</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="538"/>
+        <location filename="../BasicRideMetrics.cpp" line="607"/>
         <source>Max Heartrate</source>
         <translation>Maximale Herzfrequenz</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="539"/>
-        <location filename="../BasicRideMetrics.cpp" line="540"/>
+        <location filename="../BasicRideMetrics.cpp" line="608"/>
+        <location filename="../BasicRideMetrics.cpp" line="609"/>
         <source>bpm</source>
         <translation>spm</translation>
     </message>
@@ -4212,13 +4210,13 @@ Fahrer CP wurde auf %3 Watt gesetzt.</translation>
 <context>
     <name>MaxPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="509"/>
+        <location filename="../BasicRideMetrics.cpp" line="574"/>
         <source>Max Power</source>
         <translation>Maximale Leistung</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="510"/>
-        <location filename="../BasicRideMetrics.cpp" line="511"/>
+        <location filename="../BasicRideMetrics.cpp" line="575"/>
+        <location filename="../BasicRideMetrics.cpp" line="576"/>
         <source>watts</source>
         <translation>Watt</translation>
     </message>
@@ -4226,7 +4224,7 @@ Fahrer CP wurde auf %3 Watt gesetzt.</translation>
 <context>
     <name>MaxPowerVariance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="848"/>
+        <location filename="../BasicRideMetrics.cpp" line="949"/>
         <source>Max Power Variance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4234,17 +4232,17 @@ Fahrer CP wurde auf %3 Watt gesetzt.</translation>
 <context>
     <name>MaxSpeed</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="567"/>
+        <location filename="../BasicRideMetrics.cpp" line="640"/>
         <source>Max Speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="568"/>
+        <location filename="../BasicRideMetrics.cpp" line="641"/>
         <source>kph</source>
         <translation type="unfinished">km/h</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="569"/>
+        <location filename="../BasicRideMetrics.cpp" line="642"/>
         <source>mph</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4252,17 +4250,17 @@ Fahrer CP wurde auf %3 Watt gesetzt.</translation>
 <context>
     <name>MaxTemp</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="643"/>
+        <location filename="../BasicRideMetrics.cpp" line="724"/>
         <source>Max Temp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="644"/>
+        <location filename="../BasicRideMetrics.cpp" line="725"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="645"/>
+        <location filename="../BasicRideMetrics.cpp" line="726"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4270,7 +4268,7 @@ Fahrer CP wurde auf %3 Watt gesetzt.</translation>
 <context>
     <name>MeanPowerVariance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="801"/>
+        <location filename="../BasicRideMetrics.cpp" line="898"/>
         <source>Average Power Variance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4278,42 +4276,42 @@ Fahrer CP wurde auf %3 Watt gesetzt.</translation>
 <context>
     <name>MeasuresPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3395"/>
+        <location filename="../Pages.cpp" line="3397"/>
         <source>Move up</source>
         <translation type="unfinished">Nach oben</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3396"/>
+        <location filename="../Pages.cpp" line="3398"/>
         <source>Move down</source>
         <translation type="unfinished">Nach unten</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3397"/>
+        <location filename="../Pages.cpp" line="3399"/>
         <source>Insert</source>
         <translation type="unfinished">Einfügen</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3398"/>
+        <location filename="../Pages.cpp" line="3400"/>
         <source>Rename</source>
         <translation type="unfinished">Umbenennen</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3399"/>
+        <location filename="../Pages.cpp" line="3401"/>
         <source>Delete</source>
         <translation type="unfinished">Löschen</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3410"/>
+        <location filename="../Pages.cpp" line="3412"/>
         <source>Screen Tab</source>
         <translation type="unfinished">Reiter</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3411"/>
+        <location filename="../Pages.cpp" line="3413"/>
         <source>Measure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3412"/>
+        <location filename="../Pages.cpp" line="3414"/>
         <source>Type</source>
         <translation type="unfinished">Typ</translation>
     </message>
@@ -4532,17 +4530,17 @@ Elapsed: %1
 <context>
     <name>NavigatorCellDelegate</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="941"/>
+        <location filename="../RideNavigator.cpp" line="944"/>
         <source>Date</source>
         <translation type="unfinished">Datum</translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="944"/>
+        <location filename="../RideNavigator.cpp" line="947"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="947"/>
+        <location filename="../RideNavigator.cpp" line="950"/>
         <source>Last updated</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4669,13 +4667,13 @@ Elapsed: %1
 <context>
     <name>NinetyFivePercentHeartRate</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="688"/>
+        <location filename="../BasicRideMetrics.cpp" line="773"/>
         <source>95% Heartrate</source>
         <translation>95% der maximalen Herzfrequenz</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="689"/>
-        <location filename="../BasicRideMetrics.cpp" line="690"/>
+        <location filename="../BasicRideMetrics.cpp" line="774"/>
+        <location filename="../BasicRideMetrics.cpp" line="775"/>
         <source>bpm</source>
         <translation>spm</translation>
     </message>
@@ -4683,13 +4681,13 @@ Elapsed: %1
 <context>
     <name>NonZeroPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="365"/>
+        <location filename="../BasicRideMetrics.cpp" line="408"/>
         <source>Nonzero Average Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="366"/>
-        <location filename="../BasicRideMetrics.cpp" line="367"/>
+        <location filename="../BasicRideMetrics.cpp" line="409"/>
+        <location filename="../BasicRideMetrics.cpp" line="410"/>
         <source>watts</source>
         <translation type="unfinished">Watt</translation>
     </message>
@@ -4697,17 +4695,17 @@ Elapsed: %1
 <context>
     <name>Pace</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="288"/>
+        <location filename="../BasicRideMetrics.cpp" line="319"/>
         <source>Pace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="290"/>
+        <location filename="../BasicRideMetrics.cpp" line="321"/>
         <source>min/km</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="291"/>
+        <location filename="../BasicRideMetrics.cpp" line="322"/>
         <source>min/mile</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4899,7 +4897,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakPower10m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="162"/>
+        <location filename="../PeakPower.cpp" line="202"/>
         <source>10 min Peak Power</source>
         <translation>10min Leistungsmaximum</translation>
     </message>
@@ -4907,7 +4905,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakPower10s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="96"/>
+        <location filename="../PeakPower.cpp" line="112"/>
         <source>10 sec Peak Power</source>
         <translation>10sek Leistungsmaximum</translation>
     </message>
@@ -4915,7 +4913,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakPower15s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="107"/>
+        <location filename="../PeakPower.cpp" line="127"/>
         <source>15 sec Peak Power</source>
         <translation>15sek Leistungsmaximum</translation>
     </message>
@@ -4923,7 +4921,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakPower1m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="140"/>
+        <location filename="../PeakPower.cpp" line="172"/>
         <source>1 min Peak Power</source>
         <translation>1min Leistungsmaximum</translation>
     </message>
@@ -4931,7 +4929,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakPower1s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="74"/>
+        <location filename="../PeakPower.cpp" line="82"/>
         <source>1 sec Peak Power</source>
         <translation>1sek Leistungsmaximum</translation>
     </message>
@@ -4939,7 +4937,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakPower20m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="173"/>
+        <location filename="../PeakPower.cpp" line="217"/>
         <source>20 min Peak Power</source>
         <translation>20min Leistungsmaximum</translation>
     </message>
@@ -4947,7 +4945,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakPower20s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="118"/>
+        <location filename="../PeakPower.cpp" line="142"/>
         <source>20 sec Peak Power</source>
         <translation>20sek Leistungsmaximum</translation>
     </message>
@@ -4955,7 +4953,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakPower30m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="184"/>
+        <location filename="../PeakPower.cpp" line="232"/>
         <source>30 min Peak Power</source>
         <translation>30min Leistungsmaximum</translation>
     </message>
@@ -4963,7 +4961,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakPower30s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="129"/>
+        <location filename="../PeakPower.cpp" line="157"/>
         <source>30 sec Peak Power</source>
         <translation>30sek Leistungsmaximum</translation>
     </message>
@@ -4971,7 +4969,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakPower5m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="151"/>
+        <location filename="../PeakPower.cpp" line="187"/>
         <source>5 min Peak Power</source>
         <translation>5min Leistungsmaximum</translation>
     </message>
@@ -4979,7 +4977,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakPower5s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="85"/>
+        <location filename="../PeakPower.cpp" line="97"/>
         <source>5 sec Peak Power</source>
         <translation>5sek Leistungsmaximum</translation>
     </message>
@@ -4987,13 +4985,13 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakPowerHr10m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="263"/>
+        <location filename="../PeakPower.cpp" line="324"/>
         <source>10 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="264"/>
-        <location filename="../PeakPower.cpp" line="265"/>
+        <location filename="../PeakPower.cpp" line="325"/>
+        <location filename="../PeakPower.cpp" line="326"/>
         <source>bpm</source>
         <translation type="unfinished">spm</translation>
     </message>
@@ -5001,13 +4999,13 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakPowerHr1m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="235"/>
+        <location filename="../PeakPower.cpp" line="288"/>
         <source>1 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="236"/>
-        <location filename="../PeakPower.cpp" line="237"/>
+        <location filename="../PeakPower.cpp" line="289"/>
+        <location filename="../PeakPower.cpp" line="290"/>
         <source>bpm</source>
         <translation type="unfinished">spm</translation>
     </message>
@@ -5015,13 +5013,13 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakPowerHr20m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="277"/>
+        <location filename="../PeakPower.cpp" line="342"/>
         <source>20 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="278"/>
-        <location filename="../PeakPower.cpp" line="279"/>
+        <location filename="../PeakPower.cpp" line="343"/>
+        <location filename="../PeakPower.cpp" line="344"/>
         <source>bpm</source>
         <translation type="unfinished">spm</translation>
     </message>
@@ -5029,13 +5027,13 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakPowerHr30m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="291"/>
+        <location filename="../PeakPower.cpp" line="360"/>
         <source>30 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="292"/>
-        <location filename="../PeakPower.cpp" line="293"/>
+        <location filename="../PeakPower.cpp" line="361"/>
+        <location filename="../PeakPower.cpp" line="362"/>
         <source>bpm</source>
         <translation type="unfinished">spm</translation>
     </message>
@@ -5043,22 +5041,8 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakPowerHr5m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="249"/>
-        <source>5 min Peak Power HR</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../PeakPower.cpp" line="250"/>
-        <location filename="../PeakPower.cpp" line="251"/>
-        <source>bpm</source>
-        <translation type="unfinished">spm</translation>
-    </message>
-</context>
-<context>
-    <name>PeakPowerHr60m</name>
-    <message>
         <location filename="../PeakPower.cpp" line="306"/>
-        <source>60 min Peak Power HR</source>
+        <source>5 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5069,10 +5053,24 @@ Möchten Sie fortfahren?</translation>
     </message>
 </context>
 <context>
+    <name>PeakPowerHr60m</name>
+    <message>
+        <location filename="../PeakPower.cpp" line="379"/>
+        <source>60 min Peak Power HR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../PeakPower.cpp" line="380"/>
+        <location filename="../PeakPower.cpp" line="381"/>
+        <source>bpm</source>
+        <translation type="unfinished">spm</translation>
+    </message>
+</context>
+<context>
     <name>PeakWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="89"/>
-        <location filename="../WattsPerKilogram.cpp" line="90"/>
+        <location filename="../WattsPerKilogram.cpp" line="93"/>
+        <location filename="../WattsPerKilogram.cpp" line="94"/>
         <source>wpk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5080,7 +5078,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakWPK10m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="219"/>
+        <location filename="../WattsPerKilogram.cpp" line="263"/>
         <source>10 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5088,7 +5086,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakWPK10s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="153"/>
+        <location filename="../WattsPerKilogram.cpp" line="173"/>
         <source>10 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5096,7 +5094,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakWPK15s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="164"/>
+        <location filename="../WattsPerKilogram.cpp" line="188"/>
         <source>15 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5104,7 +5102,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakWPK1m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="197"/>
+        <location filename="../WattsPerKilogram.cpp" line="233"/>
         <source>1 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5112,7 +5110,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakWPK1s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="131"/>
+        <location filename="../WattsPerKilogram.cpp" line="143"/>
         <source>1 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5120,7 +5118,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakWPK20m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="230"/>
+        <location filename="../WattsPerKilogram.cpp" line="278"/>
         <source>20 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5128,7 +5126,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakWPK20s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="175"/>
+        <location filename="../WattsPerKilogram.cpp" line="203"/>
         <source>20 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5136,7 +5134,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakWPK30m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="241"/>
+        <location filename="../WattsPerKilogram.cpp" line="293"/>
         <source>30 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5144,7 +5142,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakWPK30s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="186"/>
+        <location filename="../WattsPerKilogram.cpp" line="218"/>
         <source>30 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5152,7 +5150,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakWPK5m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="208"/>
+        <location filename="../WattsPerKilogram.cpp" line="248"/>
         <source>5 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5160,7 +5158,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>PeakWPK5s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="142"/>
+        <location filename="../WattsPerKilogram.cpp" line="158"/>
         <source>5 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5172,22 +5170,22 @@ Möchten Sie fortfahren?</translation>
         <translation type="obsolete">PerformanceManager</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="118"/>
+        <location filename="../PerfPlot.cpp" line="147"/>
         <source>Daily</source>
         <translation>Täglich</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="138"/>
+        <location filename="../PerfPlot.cpp" line="167"/>
         <source>Short Term Stress</source>
         <translation>ShortTermStress</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="152"/>
+        <location filename="../PerfPlot.cpp" line="181"/>
         <source>Long Term Stress</source>
         <translation>LongTermStress</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="166"/>
+        <location filename="../PerfPlot.cpp" line="195"/>
         <source>Stress Balance</source>
         <translation>StressBalance</translation>
     </message>
@@ -5299,85 +5297,91 @@ Möchten Sie fortfahren?</translation>
     <name>PowerHist</name>
     <message>
         <location filename="../PowerHist.cpp" line="77"/>
-        <location filename="../PowerHist.cpp" line="902"/>
+        <location filename="../PowerHist.cpp" line="940"/>
         <source>Time (minutes)</source>
         <translation>Zeit (Minuten)</translation>
     </message>
     <message>
         <location filename="../PowerHist.cpp" line="77"/>
-        <location filename="../PowerHist.cpp" line="902"/>
+        <location filename="../PowerHist.cpp" line="940"/>
         <source>Time (percent)</source>
         <translation>Zeit (Prozent)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="877"/>
+        <location filename="../PowerHist.cpp" line="910"/>
         <source>Power (watts)</source>
         <translation>Leistung (Watt)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="876"/>
+        <location filename="../PowerHist.cpp" line="909"/>
+        <location filename="../PowerHist.cpp" line="914"/>
         <source>Power zone</source>
         <translation>Leistungszonen</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="882"/>
+        <location filename="../PowerHist.cpp" line="920"/>
         <source>Heartrate (bpm)</source>
         <translation>Herzfrequenz (spm)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="881"/>
+        <location filename="../PowerHist.cpp" line="919"/>
         <source>Heartrate zone</source>
         <translation>Herzfrequenzzone</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="886"/>
+        <location filename="../PowerHist.cpp" line="915"/>
+        <source>Power (watts/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../PowerHist.cpp" line="924"/>
         <source>Cadence (rpm)</source>
         <translation>Trittfrequenz (upm)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>Speed (%1)</source>
         <translation>Geschwindigkeit (%1)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>kph</source>
         <translation>km/h</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>mph</source>
         <translation>mi/h</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>Torque (%1)</source>
         <translation>Drehmoment (%1)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>N-m</source>
         <translation>Nm</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>ft-lbf</source>
         <translation>ftLbf</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="898"/>
+        <location filename="../PowerHist.cpp" line="936"/>
         <source>Unknown data series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="962"/>
-        <location filename="../PowerHist.cpp" line="975"/>
+        <location filename="../PowerHist.cpp" line="1000"/>
+        <location filename="../PowerHist.cpp" line="1013"/>
         <source>minutes</source>
         <translation>Minuten</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="962"/>
-        <location filename="../PowerHist.cpp" line="975"/>
+        <location filename="../PowerHist.cpp" line="1000"/>
+        <location filename="../PowerHist.cpp" line="1013"/>
         <source>%</source>
         <translation>%</translation>
     </message>
@@ -5385,27 +5389,27 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>ProcessorPage</name>
     <message>
-        <location filename="../Pages.cpp" line="2198"/>
+        <location filename="../Pages.cpp" line="2200"/>
         <source>Processor</source>
         <translation>Prozessor</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2199"/>
+        <location filename="../Pages.cpp" line="2201"/>
         <source>Apply</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2200"/>
+        <location filename="../Pages.cpp" line="2202"/>
         <source>Settings</source>
         <translation>Einstellungen</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2224"/>
+        <location filename="../Pages.cpp" line="2226"/>
         <source>Manual</source>
         <translation>manuell</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2225"/>
+        <location filename="../Pages.cpp" line="2227"/>
         <source>Auto</source>
         <translation>automatisch</translation>
     </message>
@@ -5815,7 +5819,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>RelativeIntensity</name>
     <message>
-        <location filename="../BikeScore.cpp" line="136"/>
+        <location filename="../BikeScore.cpp" line="147"/>
         <source>Relative Intensity</source>
         <translation>Relative Intensität</translation>
     </message>
@@ -5823,7 +5827,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>ResponseIndex</name>
     <message>
-        <location filename="../BikeScore.cpp" line="218"/>
+        <location filename="../BikeScore.cpp" line="237"/>
         <source>Response Index</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5831,7 +5835,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>RideCount</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="34"/>
+        <location filename="../BasicRideMetrics.cpp" line="37"/>
         <source>Rides</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5839,9 +5843,9 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>RideDelegate</name>
     <message>
-        <location filename="../RideImportWizard.cpp" line="995"/>
-        <location filename="../RideImportWizard.cpp" line="1032"/>
-        <location filename="../RideImportWizard.cpp" line="1048"/>
+        <location filename="../RideImportWizard.cpp" line="998"/>
+        <location filename="../RideImportWizard.cpp" line="1035"/>
+        <location filename="../RideImportWizard.cpp" line="1051"/>
         <source>dd MMM yyyy</source>
         <translation>dd MMM yyyy</translation>
     </message>
@@ -6399,9 +6403,9 @@ Möchten Sie fortfahren?</translation>
     </message>
     <message>
         <location filename="../RideImportWizard.cpp" line="74"/>
-        <location filename="../RideImportWizard.cpp" line="696"/>
-        <location filename="../RideImportWizard.cpp" line="738"/>
-        <location filename="../RideImportWizard.cpp" line="890"/>
+        <location filename="../RideImportWizard.cpp" line="699"/>
+        <location filename="../RideImportWizard.cpp" line="741"/>
+        <location filename="../RideImportWizard.cpp" line="893"/>
         <source>Abort</source>
         <translation>Abbre&amp;chen</translation>
     </message>
@@ -6472,12 +6476,12 @@ Möchten Sie fortfahren?</translation>
     </message>
     <message>
         <location filename="../RideImportWizard.cpp" line="268"/>
-        <location filename="../RideImportWizard.cpp" line="454"/>
-        <location filename="../RideImportWizard.cpp" line="506"/>
-        <location filename="../RideImportWizard.cpp" line="717"/>
-        <location filename="../RideImportWizard.cpp" line="756"/>
-        <location filename="../RideImportWizard.cpp" line="895"/>
-        <location filename="../RideImportWizard.cpp" line="918"/>
+        <location filename="../RideImportWizard.cpp" line="457"/>
+        <location filename="../RideImportWizard.cpp" line="509"/>
+        <location filename="../RideImportWizard.cpp" line="720"/>
+        <location filename="../RideImportWizard.cpp" line="759"/>
+        <location filename="../RideImportWizard.cpp" line="898"/>
+        <location filename="../RideImportWizard.cpp" line="921"/>
         <source>Error</source>
         <translation>Fehler</translation>
     </message>
@@ -6487,157 +6491,157 @@ Möchten Sie fortfahren?</translation>
         <translation>Analysiere...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="378"/>
+        <location filename="../RideImportWizard.cpp" line="381"/>
         <source>Validated</source>
         <translation>Erfolgreich geprüft</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="380"/>
+        <location filename="../RideImportWizard.cpp" line="383"/>
         <source>Warning - </source>
         <translation>Warnung - </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="394"/>
-        <location filename="../RideImportWizard.cpp" line="619"/>
-        <location filename="../RideImportWizard.cpp" line="765"/>
+        <location filename="../RideImportWizard.cpp" line="397"/>
+        <location filename="../RideImportWizard.cpp" line="622"/>
+        <location filename="../RideImportWizard.cpp" line="768"/>
         <source>dd MMM yyyy</source>
         <translation>dd MMM yyyy</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="395"/>
+        <location filename="../RideImportWizard.cpp" line="398"/>
         <source>hh:mm:ss ap</source>
         <translation>hh:mm:ss ap</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="432"/>
+        <location filename="../RideImportWizard.cpp" line="435"/>
         <source>Error - </source>
         <translation>Fehler - </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="380"/>
-        <location filename="../RideImportWizard.cpp" line="432"/>
+        <location filename="../RideImportWizard.cpp" line="383"/>
+        <location filename="../RideImportWizard.cpp" line="435"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="447"/>
+        <location filename="../RideImportWizard.cpp" line="450"/>
         <source>Step 3 of 4: Confirm Date and Time</source>
         <translation>Schritt 3 von 5: Überprüfen Sie bitte Datum und Uhrzeit</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="464"/>
+        <location filename="../RideImportWizard.cpp" line="467"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="573"/>
-        <location filename="../RideImportWizard.cpp" line="623"/>
+        <location filename="../RideImportWizard.cpp" line="576"/>
+        <location filename="../RideImportWizard.cpp" line="626"/>
         <source>hh:mm:ss</source>
         <translation>hh:mm:ss</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="582"/>
+        <location filename="../RideImportWizard.cpp" line="585"/>
         <source>Invalid Selection</source>
         <translation>Ungültige Auswahl</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="582"/>
+        <location filename="../RideImportWizard.cpp" line="585"/>
         <source>More than 24hrs of rides to fit into a day</source>
         <translation>Mehr als 24 Trainingsstunden für ausgewählten Tag zugeordnet!</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="627"/>
-        <location filename="../RideImportWizard.cpp" line="766"/>
+        <location filename="../RideImportWizard.cpp" line="630"/>
+        <location filename="../RideImportWizard.cpp" line="769"/>
         <source>hh:mm:ss a</source>
         <translation>hh:mm:ss a</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="736"/>
+        <location filename="../RideImportWizard.cpp" line="739"/>
         <source>Step 4 of 4: Save to Library</source>
         <translation>Schritt 4 von 5: Datei wird in die Datenbank gespeichert</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="758"/>
+        <location filename="../RideImportWizard.cpp" line="761"/>
         <source>Saving...</source>
         <translation>Speichern...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="834"/>
+        <location filename="../RideImportWizard.cpp" line="837"/>
         <source>Error - Source is Target</source>
         <translation>Fehler: Quelle ist mit dem Ziel identisch</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="845"/>
+        <location filename="../RideImportWizard.cpp" line="848"/>
         <source>Overwriting file...</source>
         <translation>Überschreibe Dateien...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="847"/>
+        <location filename="../RideImportWizard.cpp" line="850"/>
         <source>/</source>
         <translation>/</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="847"/>
+        <location filename="../RideImportWizard.cpp" line="850"/>
         <source>.tmp</source>
         <translation>*.tmp</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="821"/>
-        <location filename="../RideImportWizard.cpp" line="854"/>
+        <location filename="../RideImportWizard.cpp" line="824"/>
+        <location filename="../RideImportWizard.cpp" line="857"/>
         <source>File Overwritten</source>
         <translation>Datei überschrieben</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="857"/>
-        <location filename="../RideImportWizard.cpp" line="859"/>
+        <location filename="../RideImportWizard.cpp" line="860"/>
+        <location filename="../RideImportWizard.cpp" line="862"/>
         <source>Error - overwrite failed</source>
         <translation>Fehler: Überschreiben fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="790"/>
-        <location filename="../RideImportWizard.cpp" line="862"/>
+        <location filename="../RideImportWizard.cpp" line="793"/>
+        <location filename="../RideImportWizard.cpp" line="865"/>
         <source>Error - File exists</source>
         <translation>Fehler: Datei ist schon vorhanden</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="865"/>
+        <location filename="../RideImportWizard.cpp" line="868"/>
         <source>Saving file...</source>
         <translation>Speichere Datei...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="823"/>
-        <location filename="../RideImportWizard.cpp" line="868"/>
+        <location filename="../RideImportWizard.cpp" line="826"/>
+        <location filename="../RideImportWizard.cpp" line="871"/>
         <source>File Saved</source>
         <translation>Datei gespeichert</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="877"/>
+        <location filename="../RideImportWizard.cpp" line="880"/>
         <source>Error - copy failed</source>
         <translation>Fehler: Kopieren fehlgeschlagen</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="888"/>
+        <location filename="../RideImportWizard.cpp" line="891"/>
         <source>Step 5 of 5: Calculating Critical Powers</source>
         <translation>Schritt 5 von 5: Berechne CriticalPower</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="896"/>
+        <location filename="../RideImportWizard.cpp" line="899"/>
         <source>Calculating...</source>
         <translation>Berechne...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="905"/>
+        <location filename="../RideImportWizard.cpp" line="908"/>
         <source>Completed.</source>
         <translation>Vollständig.</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="923"/>
+        <location filename="../RideImportWizard.cpp" line="926"/>
         <source>Import Complete. %1 of %2 successful.</source>
         <translation>Import vollständig! %1 von %2 erfolgreich übertragen.</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="704"/>
-        <location filename="../RideImportWizard.cpp" line="928"/>
+        <location filename="../RideImportWizard.cpp" line="707"/>
+        <location filename="../RideImportWizard.cpp" line="931"/>
         <source>Finish</source>
         <translation>Fertig</translation>
     </message>
@@ -6645,22 +6649,22 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>RideNavigator</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="540"/>
+        <location filename="../RideNavigator.cpp" line="542"/>
         <source>Remove Column</source>
         <translation type="unfinished">Spalte löschen</translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="546"/>
+        <location filename="../RideNavigator.cpp" line="548"/>
         <source>Column Chooser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="551"/>
+        <location filename="../RideNavigator.cpp" line="553"/>
         <source>Do Not Show in Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="551"/>
+        <location filename="../RideNavigator.cpp" line="553"/>
         <source>Show In Groups</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7026,32 +7030,32 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>SchemePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2295"/>
+        <location filename="../Pages.cpp" line="2297"/>
         <source>Add</source>
         <translation>Hinzufügen</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2296"/>
+        <location filename="../Pages.cpp" line="2298"/>
         <source>Rename</source>
         <translation>Umbenennen</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2297"/>
+        <location filename="../Pages.cpp" line="2299"/>
         <source>Delete</source>
         <translation>Löschen</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2306"/>
+        <location filename="../Pages.cpp" line="2308"/>
         <source>Short</source>
         <translation>Kurz</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2307"/>
+        <location filename="../Pages.cpp" line="2309"/>
         <source>Long</source>
         <translation>Lang</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2308"/>
+        <location filename="../Pages.cpp" line="2310"/>
         <source>Percent of CP</source>
         <translation>Prozent der CP</translation>
     </message>
@@ -7136,42 +7140,42 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>SeasonsPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3673"/>
+        <location filename="../Pages.cpp" line="3675"/>
         <source>Move up</source>
         <translation type="unfinished">Nach oben</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3674"/>
+        <location filename="../Pages.cpp" line="3676"/>
         <source>Move down</source>
         <translation type="unfinished">Nach unten</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3675"/>
+        <location filename="../Pages.cpp" line="3677"/>
         <source>Add</source>
         <translation type="unfinished">Hinzufügen</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3676"/>
+        <location filename="../Pages.cpp" line="3678"/>
         <source>Delete</source>
         <translation type="unfinished">Löschen</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3685"/>
+        <location filename="../Pages.cpp" line="3687"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3686"/>
+        <location filename="../Pages.cpp" line="3688"/>
         <source>Type</source>
         <translation type="unfinished">Typ</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3687"/>
+        <location filename="../Pages.cpp" line="3689"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3688"/>
+        <location filename="../Pages.cpp" line="3690"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7179,7 +7183,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>SessionRPE</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="302"/>
+        <location filename="../TRIMPPoints.cpp" line="316"/>
         <source>Session RPE</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7206,6 +7210,147 @@ Möchten Sie fortfahren?</translation>
         <location filename="../SmallPlot.cpp" line="237"/>
         <source>Time (minutes)</source>
         <translation type="unfinished">Zeit (Minuten)</translation>
+    </message>
+</context>
+<context>
+    <name>SpecialFields</name>
+    <message>
+        <location filename="../SpecialFields.cpp" line="26"/>
+        <source>Start Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="27"/>
+        <source>Start Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="28"/>
+        <source>Identifier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="29"/>
+        <source>Workout Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="30"/>
+        <source>Sport</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="31"/>
+        <source>Objective</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="32"/>
+        <source>Summary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="33"/>
+        <source>Notes</source>
+        <translation type="unfinished">Bemerkungen</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="34"/>
+        <source>Keywords</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="35"/>
+        <source>Recording Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="36"/>
+        <source>Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="37"/>
+        <source>Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="38"/>
+        <source>Device Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="39"/>
+        <source>Dropouts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="40"/>
+        <source>Dropout Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="41"/>
+        <source>Spikes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="42"/>
+        <source>Spike Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="43"/>
+        <source>Torque Adjust</source>
+        <translation type="unfinished">Drehmomentabgleich</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="44"/>
+        <source>Filename</source>
+        <translation type="unfinished">Dateiname</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="45"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="46"/>
+        <source>Change History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="47"/>
+        <source>Calendar Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="48"/>
+        <source>Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SpecialTabs</name>
+    <message>
+        <location filename="../SpecialFields.cpp" line="130"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="131"/>
+        <source>Notes</source>
+        <translation type="unfinished">Bemerkungen</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="132"/>
+        <source>Metric</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="133"/>
+        <source>Extra</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -7622,22 +7767,22 @@ Möchten Sie fortfahren?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="388"/>
+        <location filename="../StravaDialog.cpp" line="389"/>
         <source>Upload ride... Sending</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="398"/>
+        <location filename="../StravaDialog.cpp" line="399"/>
         <source>Upload finished.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="430"/>
+        <location filename="../StravaDialog.cpp" line="431"/>
         <source>Ride processing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="501"/>
+        <location filename="../StravaDialog.cpp" line="502"/>
         <source>Searching corresponding Ride</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7890,7 +8035,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>TRIMP100Points</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="114"/>
+        <location filename="../TRIMPPoints.cpp" line="120"/>
         <source>TRIMP(100) Points</source>
         <translation>TRIMP(100) Punkte</translation>
     </message>
@@ -7898,7 +8043,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>TRIMPPoints</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="47"/>
+        <location filename="../TRIMPPoints.cpp" line="49"/>
         <source>TRIMP Points</source>
         <translation>TRIMP Punkte</translation>
     </message>
@@ -7906,7 +8051,7 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>TRIMPZonalPoints</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="180"/>
+        <location filename="../TRIMPPoints.cpp" line="190"/>
         <source>TRIMP Zonal Points</source>
         <translation>TRIMP Punkte für Zonen</translation>
     </message>
@@ -7914,13 +8059,13 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>TimeRiding</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="94"/>
+        <location filename="../BasicRideMetrics.cpp" line="105"/>
         <source>Time Riding</source>
         <translation>Fahrzeit</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="95"/>
-        <location filename="../BasicRideMetrics.cpp" line="96"/>
+        <location filename="../BasicRideMetrics.cpp" line="106"/>
+        <location filename="../BasicRideMetrics.cpp" line="107"/>
         <source>seconds</source>
         <translation>Sekunden</translation>
     </message>
@@ -8004,17 +8149,17 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>TotalDistance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="129"/>
+        <location filename="../BasicRideMetrics.cpp" line="144"/>
         <source>Distance</source>
         <translation>Distance</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="131"/>
+        <location filename="../BasicRideMetrics.cpp" line="146"/>
         <source>km</source>
         <translation>km</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="132"/>
+        <location filename="../BasicRideMetrics.cpp" line="147"/>
         <source>miles</source>
         <translation>Meilen</translation>
     </message>
@@ -8022,13 +8167,13 @@ Möchten Sie fortfahren?</translation>
 <context>
     <name>TotalWork</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="213"/>
+        <location filename="../BasicRideMetrics.cpp" line="236"/>
         <source>Work</source>
         <translation>Arbeit</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="214"/>
-        <location filename="../BasicRideMetrics.cpp" line="215"/>
+        <location filename="../BasicRideMetrics.cpp" line="237"/>
+        <location filename="../BasicRideMetrics.cpp" line="238"/>
         <source>kJ</source>
         <translation>kJ</translation>
     </message>
@@ -8102,6 +8247,14 @@ Press F3 on Controller when done.</source>
         <location filename="../TrainTool.cpp" line="1279"/>
         <source>Done</source>
         <translation type="unfinished">Fertig</translation>
+    </message>
+</context>
+<context>
+    <name>TreeMapWindow</name>
+    <message>
+        <location filename="../TreeMapWindow.cpp" line="100"/>
+        <source>Metric</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -8396,7 +8549,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>VAM</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="722"/>
+        <location filename="../BasicRideMetrics.cpp" line="811"/>
         <source>VAM</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8404,7 +8557,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>VariabilityIndex</name>
     <message>
-        <location filename="../BikeScore.cpp" line="102"/>
+        <location filename="../BikeScore.cpp" line="109"/>
         <source>Skiba VI</source>
         <translation>Skiba VI</translation>
     </message>
@@ -8436,13 +8589,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>Vo2max</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="252"/>
+        <location filename="../WattsPerKilogram.cpp" line="308"/>
         <source>Estimated VO2MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="254"/>
-        <location filename="../WattsPerKilogram.cpp" line="255"/>
+        <location filename="../WattsPerKilogram.cpp" line="310"/>
+        <location filename="../WattsPerKilogram.cpp" line="311"/>
         <source>ml/min/kg</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8548,13 +8701,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WorkoutTime</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="60"/>
+        <location filename="../BasicRideMetrics.cpp" line="67"/>
         <source>Duration</source>
         <translation>Dauer</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="61"/>
-        <location filename="../BasicRideMetrics.cpp" line="62"/>
+        <location filename="../BasicRideMetrics.cpp" line="68"/>
+        <location filename="../BasicRideMetrics.cpp" line="69"/>
         <source>seconds</source>
         <translation>Sekunden</translation>
     </message>
@@ -8590,13 +8743,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>XPower</name>
     <message>
-        <location filename="../BikeScore.cpp" line="45"/>
+        <location filename="../BikeScore.cpp" line="48"/>
         <source>xPower</source>
         <translation>xPower</translation>
     </message>
     <message>
-        <location filename="../BikeScore.cpp" line="47"/>
-        <location filename="../BikeScore.cpp" line="48"/>
+        <location filename="../BikeScore.cpp" line="50"/>
+        <location filename="../BikeScore.cpp" line="51"/>
         <source>watts</source>
         <translation>Watt</translation>
     </message>
@@ -8619,12 +8772,12 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZonePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2278"/>
+        <location filename="../Pages.cpp" line="2280"/>
         <source>Critical Power History</source>
         <translation>CriticalPower der Vergangenheit</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2279"/>
+        <location filename="../Pages.cpp" line="2281"/>
         <source>Default Zones</source>
         <translation>Voreingestellte Zonen</translation>
     </message>
@@ -8632,7 +8785,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime1</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="74"/>
+        <location filename="../TimeInZone.cpp" line="79"/>
         <source>L1 Time in Zone</source>
         <translation>L1 Zeit in Zone</translation>
     </message>
@@ -8640,7 +8793,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime10</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="182"/>
+        <location filename="../TimeInZone.cpp" line="232"/>
         <source>L10 Time in Zone</source>
         <translation>L10 Zeit in Zone</translation>
     </message>
@@ -8648,7 +8801,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime2</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="86"/>
+        <location filename="../TimeInZone.cpp" line="96"/>
         <source>L2 Time in Zone</source>
         <translation>L2 Zeit in Zone</translation>
     </message>
@@ -8656,7 +8809,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime3</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="98"/>
+        <location filename="../TimeInZone.cpp" line="113"/>
         <source>L3 Time in Zone</source>
         <translation>L3 Zeit in Zone</translation>
     </message>
@@ -8664,7 +8817,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime4</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="110"/>
+        <location filename="../TimeInZone.cpp" line="130"/>
         <source>L4 Time in Zone</source>
         <translation>L4 Zeit in Zone</translation>
     </message>
@@ -8672,7 +8825,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime5</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="122"/>
+        <location filename="../TimeInZone.cpp" line="147"/>
         <source>L5 Time in Zone</source>
         <translation>L5 Zeit in Zone</translation>
     </message>
@@ -8680,7 +8833,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime6</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="134"/>
+        <location filename="../TimeInZone.cpp" line="164"/>
         <source>L6 Time in Zone</source>
         <translation>L6 Zeit in Zone</translation>
     </message>
@@ -8688,7 +8841,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime7</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="146"/>
+        <location filename="../TimeInZone.cpp" line="181"/>
         <source>L7 Time in Zone</source>
         <translation>L7 Zeit in Zone</translation>
     </message>
@@ -8696,7 +8849,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime8</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="158"/>
+        <location filename="../TimeInZone.cpp" line="198"/>
         <source>L8 Time in Zone</source>
         <translation>L8 Zeit in Zone</translation>
     </message>
@@ -8704,7 +8857,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime9</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="170"/>
+        <location filename="../TimeInZone.cpp" line="215"/>
         <source>L9 Time in Zone</source>
         <translation>L9 Zeit in Zone</translation>
     </message>

--- a/src/translations/gc_es.ts
+++ b/src/translations/gc_es.ts
@@ -254,13 +254,13 @@
 <context>
     <name>AerobicDecoupling</name>
     <message>
-        <location filename="../AerobicDecoupling.cpp" line="50"/>
+        <location filename="../AerobicDecoupling.cpp" line="52"/>
         <source>Aerobic Decoupling</source>
         <translation>Desacopl. Aer?bico</translation>
     </message>
     <message>
-        <location filename="../AerobicDecoupling.cpp" line="52"/>
-        <location filename="../AerobicDecoupling.cpp" line="53"/>
+        <location filename="../AerobicDecoupling.cpp" line="54"/>
+        <location filename="../AerobicDecoupling.cpp" line="55"/>
         <source>%</source>
         <translation>%</translation>
     </message>
@@ -402,7 +402,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="973"/>
+        <location filename="../AllPlot.cpp" line="983"/>
         <source>Time (Hours:Minutes)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -423,37 +423,37 @@
         <translation type="obsolete">km/h</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="916"/>
+        <location filename="../AllPlot.cpp" line="909"/>
         <source>MPH</source>
         <translation>MPH</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="916"/>
+        <location filename="../AllPlot.cpp" line="909"/>
         <source>KPH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="932"/>
+        <location filename="../AllPlot.cpp" line="925"/>
         <source>Nm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="932"/>
+        <location filename="../AllPlot.cpp" line="925"/>
         <source>ftLb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="945"/>
+        <location filename="../AllPlot.cpp" line="938"/>
         <source>Meters</source>
         <translation>Metros</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="945"/>
+        <location filename="../AllPlot.cpp" line="938"/>
         <source>Feet</source>
         <translation>Pies</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="971"/>
+        <location filename="../AllPlot.cpp" line="981"/>
         <source>Distance </source>
         <translation>Distancia </translation>
     </message>
@@ -583,13 +583,13 @@
 <context>
     <name>AverageWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="55"/>
+        <location filename="../WattsPerKilogram.cpp" line="58"/>
         <source>Watts Per Kilogram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="57"/>
-        <location filename="../WattsPerKilogram.cpp" line="58"/>
+        <location filename="../WattsPerKilogram.cpp" line="60"/>
+        <location filename="../WattsPerKilogram.cpp" line="61"/>
         <source>wpk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -597,13 +597,13 @@
 <context>
     <name>AvgCadence</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="433"/>
+        <location filename="../BasicRideMetrics.cpp" line="488"/>
         <source>Average Cadence</source>
         <translation>Cadencia Media</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="434"/>
-        <location filename="../BasicRideMetrics.cpp" line="435"/>
+        <location filename="../BasicRideMetrics.cpp" line="489"/>
+        <location filename="../BasicRideMetrics.cpp" line="490"/>
         <source>rpm</source>
         <translation>rpm</translation>
     </message>
@@ -611,13 +611,13 @@
 <context>
     <name>AvgHeartRate</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="399"/>
+        <location filename="../BasicRideMetrics.cpp" line="448"/>
         <source>Average Heart Rate</source>
         <translation>Frec. Card?aca Media</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="400"/>
-        <location filename="../BasicRideMetrics.cpp" line="401"/>
+        <location filename="../BasicRideMetrics.cpp" line="449"/>
+        <location filename="../BasicRideMetrics.cpp" line="450"/>
         <source>bpm</source>
         <translation>ppm</translation>
     </message>
@@ -625,13 +625,13 @@
 <context>
     <name>AvgPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="331"/>
+        <location filename="../BasicRideMetrics.cpp" line="368"/>
         <source>Average Power</source>
         <translation>Potencia Media</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="332"/>
-        <location filename="../BasicRideMetrics.cpp" line="333"/>
+        <location filename="../BasicRideMetrics.cpp" line="369"/>
+        <location filename="../BasicRideMetrics.cpp" line="370"/>
         <source>watts</source>
         <translation>vatios</translation>
     </message>
@@ -639,12 +639,12 @@
 <context>
     <name>AvgSpeed</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="244"/>
+        <location filename="../BasicRideMetrics.cpp" line="271"/>
         <source>Average Speed</source>
         <translation>Velocidad Media</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="245"/>
+        <location filename="../BasicRideMetrics.cpp" line="272"/>
         <source>kph</source>
         <translation type="unfinished"></translation>
     </message>
@@ -653,7 +653,7 @@
         <translation type="obsolete">km/h</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="246"/>
+        <location filename="../BasicRideMetrics.cpp" line="273"/>
         <source>mph</source>
         <translation>mph</translation>
     </message>
@@ -661,17 +661,17 @@
 <context>
     <name>AvgTemp</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="467"/>
+        <location filename="../BasicRideMetrics.cpp" line="528"/>
         <source>Average Temp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="468"/>
+        <location filename="../BasicRideMetrics.cpp" line="529"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="469"/>
+        <location filename="../BasicRideMetrics.cpp" line="530"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
@@ -775,7 +775,7 @@
 <context>
     <name>BikeScore</name>
     <message>
-        <location filename="../BikeScore.cpp" line="181"/>
+        <location filename="../BikeScore.cpp" line="196"/>
         <source>BikeScore&amp;#8482;</source>
         <translation>BikeScore&amp;#8482;</translation>
     </message>
@@ -783,54 +783,54 @@
 <context>
     <name>CPPage</name>
     <message>
-        <location filename="../Pages.cpp" line="2455"/>
+        <location filename="../Pages.cpp" line="2457"/>
         <source>Add CP</source>
         <translation>Agregar PC</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2456"/>
+        <location filename="../Pages.cpp" line="2458"/>
         <source>Delete CP</source>
         <translation>Borrar PC</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2457"/>
+        <location filename="../Pages.cpp" line="2459"/>
         <source>Default</source>
         <translation>Por defecto</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2460"/>
+        <location filename="../Pages.cpp" line="2462"/>
         <source>Add Zone</source>
         <translation>Agregar Zona</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2461"/>
+        <location filename="../Pages.cpp" line="2463"/>
         <source>Delete Zone</source>
         <translation>Borrar Zona</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2475"/>
-        <location filename="../Pages.cpp" line="2493"/>
+        <location filename="../Pages.cpp" line="2477"/>
+        <location filename="../Pages.cpp" line="2495"/>
         <source>From Date</source>
         <translation>Desde </translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2476"/>
-        <location filename="../Pages.cpp" line="2494"/>
+        <location filename="../Pages.cpp" line="2478"/>
+        <location filename="../Pages.cpp" line="2496"/>
         <source>Critical Power</source>
         <translation>Potencia Cr?tica</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2523"/>
+        <location filename="../Pages.cpp" line="2525"/>
         <source>Short</source>
         <translation>Corto</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2524"/>
+        <location filename="../Pages.cpp" line="2526"/>
         <source>Long</source>
         <translation>Largo</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2525"/>
+        <location filename="../Pages.cpp" line="2527"/>
         <source>From Watts</source>
         <translation>Desde vatios</translation>
     </message>
@@ -838,7 +838,7 @@
 <context>
     <name>CPWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="120"/>
+        <location filename="../WattsPerKilogram.cpp" line="128"/>
         <source>60 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -933,7 +933,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ChartSettings.cpp" line="42"/>
+        <location filename="../ChartSettings.cpp" line="41"/>
         <source>Done</source>
         <translation type="unfinished">Listo</translation>
     </message>
@@ -1525,7 +1525,7 @@ Puede demorar.
 <context>
     <name>CriticalPower</name>
     <message>
-        <location filename="../PeakPower.cpp" line="63"/>
+        <location filename="../PeakPower.cpp" line="67"/>
         <source>60 min Peak Power</source>
         <translation>Potencia M?x. 60 min</translation>
     </message>
@@ -1685,12 +1685,12 @@ Puede demorar.
 <context>
     <name>DBAccess</name>
     <message>
-        <location filename="../DBAccess.cpp" line="112"/>
+        <location filename="../DBAccess.cpp" line="113"/>
         <source>Cannot open database</source>
         <translation>No se puede abrir la base de datos</translation>
     </message>
     <message>
-        <location filename="../DBAccess.cpp" line="113"/>
+        <location filename="../DBAccess.cpp" line="114"/>
         <source>Unable to establish a database connection.
 This feature requires SQLite support. Please read the Qt SQL driver documentation for information how to build it.
 
@@ -1704,13 +1704,13 @@ Cancelar para salir.</translation>
 <context>
     <name>DanielsEquivalentPower</name>
     <message>
-        <location filename="../DanielsPoints.cpp" line="110"/>
+        <location filename="../DanielsPoints.cpp" line="116"/>
         <source>Daniels EqP</source>
         <translation>Potencia Equivalente Daniels</translation>
     </message>
     <message>
-        <location filename="../DanielsPoints.cpp" line="111"/>
-        <location filename="../DanielsPoints.cpp" line="112"/>
+        <location filename="../DanielsPoints.cpp" line="117"/>
+        <location filename="../DanielsPoints.cpp" line="118"/>
         <source>watts</source>
         <translation>vatios</translation>
     </message>
@@ -1718,7 +1718,7 @@ Cancelar para salir.</translation>
 <context>
     <name>DanielsPoints</name>
     <message>
-        <location filename="../DanielsPoints.cpp" line="49"/>
+        <location filename="../DanielsPoints.cpp" line="51"/>
         <source>Daniels Points</source>
         <translation>Puntos Daniels</translation>
     </message>
@@ -2092,7 +2092,7 @@ Puede ser necesario (re)instalar el controlador FTDI o PL2303 antes de descargar
 <context>
     <name>EditMetricDetailDialog</name>
     <message>
-        <location filename="../LTMTool.cpp" line="638"/>
+        <location filename="../LTMTool.cpp" line="701"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
@@ -2181,47 +2181,20 @@ Puede ser necesario (re)instalar el controlador FTDI o PL2303 antes de descargar
         <translation type="obsolete">L?nea de Tendencia</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="662"/>
-        <source>Filter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="664"/>
-        <source>No filter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="665"/>
         <source>Include</source>
-        <translation type="unfinished">Incluir</translation>
+        <translation type="obsolete">Incluir</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="666"/>
         <source>Exclude</source>
-        <translation type="unfinished">Excluir</translation>
+        <translation type="obsolete">Excluir</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="668"/>
-        <source>From</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="673"/>
-        <source>To</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="678"/>
-        <source>Show on plot</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="780"/>
+        <location filename="../LTMTool.cpp" line="814"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="781"/>
+        <location filename="../LTMTool.cpp" line="815"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancelar</translation>
     </message>
@@ -2265,7 +2238,7 @@ Puede ser necesario (re)instalar el controlador FTDI o PL2303 antes de descargar
 <context>
     <name>EfficiencyFactor</name>
     <message>
-        <location filename="../Coggan.cpp" line="198"/>
+        <location filename="../Coggan.cpp" line="217"/>
         <source>Efficiency Factor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2273,17 +2246,17 @@ Puede ser necesario (re)instalar el controlador FTDI o PL2303 antes de descargar
 <context>
     <name>ElevationGain</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="170"/>
+        <location filename="../BasicRideMetrics.cpp" line="189"/>
         <source>Elevation Gain</source>
         <translation>Desnivel Acumulado</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="172"/>
+        <location filename="../BasicRideMetrics.cpp" line="191"/>
         <source>meters</source>
         <translation>metros</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="173"/>
+        <location filename="../BasicRideMetrics.cpp" line="192"/>
         <source>feet</source>
         <translation>pi?s</translation>
     </message>
@@ -2605,7 +2578,7 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
 <context>
     <name>FormField</name>
     <message>
-        <location filename="../RideMetadata.cpp" line="545"/>
+        <location filename="../RideMetadata.cpp" line="546"/>
         <source>You entered &apos;%1&apos; which is not an expected value.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2886,7 +2859,7 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
 <context>
     <name>Gradient</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="758"/>
+        <location filename="../BasicRideMetrics.cpp" line="851"/>
         <source>Gradient</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2902,7 +2875,7 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
 <context>
     <name>GroupByModel</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="724"/>
+        <location filename="../RideNavigator.cpp" line="726"/>
         <source>Date</source>
         <translation type="unfinished">Fecha</translation>
     </message>
@@ -2985,12 +2958,12 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
 <context>
     <name>HomeWindow</name>
     <message>
-        <location filename="../HomeWindow.cpp" line="712"/>
+        <location filename="../HomeWindow.cpp" line="713"/>
         <source>Are you sure you want to remove the chart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../HomeWindow.cpp" line="713"/>
+        <location filename="../HomeWindow.cpp" line="714"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3034,37 +3007,37 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
 <context>
     <name>HrSchemePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2826"/>
+        <location filename="../Pages.cpp" line="2828"/>
         <source>Add</source>
         <translation>Agregar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2827"/>
+        <location filename="../Pages.cpp" line="2829"/>
         <source>Rename</source>
         <translation>Renombrar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2828"/>
+        <location filename="../Pages.cpp" line="2830"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2837"/>
+        <location filename="../Pages.cpp" line="2839"/>
         <source>Short</source>
         <translation>Corto</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2838"/>
+        <location filename="../Pages.cpp" line="2840"/>
         <source>Long</source>
         <translation>Largo</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2839"/>
+        <location filename="../Pages.cpp" line="2841"/>
         <source>Percent of LT</source>
         <translation>Porcentaje del UL</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2840"/>
+        <location filename="../Pages.cpp" line="2842"/>
         <source>Trimp k</source>
         <translation>Trimp k</translation>
     </message>
@@ -3072,12 +3045,12 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
 <context>
     <name>HrZonePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2809"/>
+        <location filename="../Pages.cpp" line="2811"/>
         <source>Lactic Threshold History</source>
         <translation>Hist?rico del Umbral</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2810"/>
+        <location filename="../Pages.cpp" line="2812"/>
         <source>Default Zones</source>
         <translation>Zonas por defecto</translation>
     </message>
@@ -3085,7 +3058,7 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
 <context>
     <name>HrZoneTime1</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="72"/>
+        <location filename="../HrTimeInZone.cpp" line="77"/>
         <source>H1 Time in Zone</source>
         <translation>H1 Tiempo en Zona</translation>
     </message>
@@ -3093,7 +3066,7 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
 <context>
     <name>HrZoneTime2</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="84"/>
+        <location filename="../HrTimeInZone.cpp" line="94"/>
         <source>H2 Time in Zone</source>
         <translation>H2 Tiempo en Zona</translation>
     </message>
@@ -3101,7 +3074,7 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
 <context>
     <name>HrZoneTime3</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="96"/>
+        <location filename="../HrTimeInZone.cpp" line="111"/>
         <source>H3 Time in Zone</source>
         <translation>H3 Tiempo en Zona</translation>
     </message>
@@ -3109,7 +3082,7 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
 <context>
     <name>HrZoneTime4</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="108"/>
+        <location filename="../HrTimeInZone.cpp" line="128"/>
         <source>H4 Time in Zone</source>
         <translation>H4 Tiempo en Zona</translation>
     </message>
@@ -3117,7 +3090,7 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
 <context>
     <name>HrZoneTime5</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="120"/>
+        <location filename="../HrTimeInZone.cpp" line="145"/>
         <source>H5 Time in Zone</source>
         <translation>H5 Tiempo en Zona</translation>
     </message>
@@ -3125,7 +3098,7 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
 <context>
     <name>HrZoneTime6</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="132"/>
+        <location filename="../HrTimeInZone.cpp" line="162"/>
         <source>H6 Time in Zone</source>
         <translation>H6 Tiempo en Zona</translation>
     </message>
@@ -3133,7 +3106,7 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
 <context>
     <name>HrZoneTime7</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="144"/>
+        <location filename="../HrTimeInZone.cpp" line="179"/>
         <source>H7 Time in Zone</source>
         <translation>H7 Tiempo en Zona</translation>
     </message>
@@ -3141,7 +3114,7 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
 <context>
     <name>HrZoneTime8</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="156"/>
+        <location filename="../HrTimeInZone.cpp" line="196"/>
         <source>H8 Time in Zone</source>
         <translation>H8 Tiempo en Zona</translation>
     </message>
@@ -3413,7 +3386,8 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
         <translation type="obsolete">horas</translation>
     </message>
     <message>
-        <location filename="../LTMPlot.cpp" line="1120"/>
+        <location filename="../LTMPlot.cpp" line="731"/>
+        <location filename="../LTMPlot.cpp" line="1123"/>
         <source>watts</source>
         <translation>vatios</translation>
     </message>
@@ -3435,33 +3409,33 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="253"/>
-        <location filename="../LTMSidebar.cpp" line="289"/>
+        <location filename="../LTMSidebar.cpp" line="257"/>
+        <location filename="../LTMSidebar.cpp" line="293"/>
         <source>Edit details</source>
         <translation type="unfinished">Editar detalles</translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="254"/>
+        <location filename="../LTMSidebar.cpp" line="258"/>
         <source>Delete range</source>
         <translation type="unfinished">Eliminar rango</translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="255"/>
+        <location filename="../LTMSidebar.cpp" line="259"/>
         <source>Add Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="290"/>
+        <location filename="../LTMSidebar.cpp" line="294"/>
         <source>Delete event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="300"/>
+        <location filename="../LTMSidebar.cpp" line="304"/>
         <source>Add event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="537"/>
+        <location filename="../LTMSidebar.cpp" line="541"/>
         <source>^(Average|Max) </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3473,7 +3447,7 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
         <translation type="obsolete">Rango de Fechas</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="69"/>
+        <location filename="../LTMTool.cpp" line="124"/>
         <source>Metric</source>
         <translation>M?trica</translation>
     </message>
@@ -3590,8 +3564,8 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
         <translation type="obsolete">?ltimos 12 meses</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="511"/>
-        <location filename="../LTMTool.cpp" line="519"/>
+        <location filename="../LTMTool.cpp" line="574"/>
+        <location filename="../LTMTool.cpp" line="582"/>
         <source>Unknown Metric</source>
         <translation>M?trica desconocida</translation>
     </message>
@@ -3608,12 +3582,47 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
         <translation type="obsolete">Eliminar rango</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="544"/>
+        <location filename="../LTMTool.cpp" line="59"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="69"/>
+        <source>Chart</source>
+        <translation type="unfinished">Gr?fico</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="101"/>
+        <source>Add</source>
+        <translation type="unfinished">Agregar</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="102"/>
+        <source>Manage</source>
+        <translation type="unfinished">Administrar</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="518"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="519"/>
+        <source>Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="520"/>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="607"/>
         <source>Pick Color</source>
         <translation>Seleccionar Color</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="545"/>
+        <location filename="../LTMTool.cpp" line="608"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
@@ -3669,19 +3678,16 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
 <context>
     <name>LTMWindow</name>
     <message>
-        <location filename="../LTMWindow.cpp" line="135"/>
         <source>Add</source>
-        <translation>Agregar</translation>
+        <translation type="obsolete">Agregar</translation>
     </message>
     <message>
-        <location filename="../LTMWindow.cpp" line="137"/>
         <source>Manage</source>
-        <translation>Administrar</translation>
+        <translation type="obsolete">Administrar</translation>
     </message>
     <message>
-        <location filename="../LTMWindow.cpp" line="105"/>
         <source>Chart</source>
-        <translation>Gr?fico</translation>
+        <translation type="obsolete">Gr?fico</translation>
     </message>
     <message>
         <source>Days</source>
@@ -3707,71 +3713,71 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
 <context>
     <name>LTPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3001"/>
+        <location filename="../Pages.cpp" line="3003"/>
         <source>Add LT</source>
         <translation>Agregar UL</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3002"/>
+        <location filename="../Pages.cpp" line="3004"/>
         <source>Delete LT</source>
         <translation>Eliminar UL</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3003"/>
+        <location filename="../Pages.cpp" line="3005"/>
         <source>Default</source>
         <translation>Por defecto</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3006"/>
+        <location filename="../Pages.cpp" line="3008"/>
         <source>Add Zone</source>
         <translation>Agregar Zona</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3007"/>
+        <location filename="../Pages.cpp" line="3009"/>
         <source>Delete Zone</source>
         <translation>Eliminar Zona</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3021"/>
-        <location filename="../Pages.cpp" line="3061"/>
+        <location filename="../Pages.cpp" line="3023"/>
+        <location filename="../Pages.cpp" line="3063"/>
         <source>From Date</source>
         <translation>Desde </translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3022"/>
-        <location filename="../Pages.cpp" line="3062"/>
+        <location filename="../Pages.cpp" line="3024"/>
+        <location filename="../Pages.cpp" line="3064"/>
         <source>Lactic Threshold</source>
         <translation>Umbral de Lactato</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3039"/>
-        <location filename="../Pages.cpp" line="3063"/>
+        <location filename="../Pages.cpp" line="3041"/>
+        <location filename="../Pages.cpp" line="3065"/>
         <source>Rest HR</source>
         <translation>FC Reposo</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3040"/>
-        <location filename="../Pages.cpp" line="3064"/>
+        <location filename="../Pages.cpp" line="3042"/>
+        <location filename="../Pages.cpp" line="3066"/>
         <source>Max HR</source>
         <translation>FC Max</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3101"/>
+        <location filename="../Pages.cpp" line="3103"/>
         <source>Short</source>
         <translation>Abreviatura</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3102"/>
+        <location filename="../Pages.cpp" line="3104"/>
         <source>Long</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3103"/>
+        <location filename="../Pages.cpp" line="3105"/>
         <source>From BPM</source>
         <translation>Desde PPM</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3104"/>
+        <location filename="../Pages.cpp" line="3106"/>
         <source>Trimp k</source>
         <translation></translation>
     </message>
@@ -3779,13 +3785,13 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
 <context>
     <name>LeftRightBalance</name>
     <message>
-        <location filename="../LeftRightBalance.cpp" line="33"/>
+        <location filename="../LeftRightBalance.cpp" line="36"/>
         <source>Left/Right Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftRightBalance.cpp" line="34"/>
-        <location filename="../LeftRightBalance.cpp" line="35"/>
+        <location filename="../LeftRightBalance.cpp" line="37"/>
+        <location filename="../LeftRightBalance.cpp" line="38"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
@@ -3806,7 +3812,7 @@ encendido y muestra &quot;PC-Link&quot;</translation>
         <translation type="obsolete">Nombre de archivo inv?lido</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2210"/>
+        <location filename="../MainWindow.cpp" line="2216"/>
         <source>Invalid date/time in filename:
 %1
 Skipping file...</source>
@@ -3816,13 +3822,13 @@ Saltando archivo...</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="281"/>
-        <location filename="../MainWindow.cpp" line="2230"/>
+        <location filename="../MainWindow.cpp" line="2236"/>
         <source>Zones File Error</source>
         <translation>Error en Archivo de Zonas</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="284"/>
-        <location filename="../MainWindow.cpp" line="2234"/>
+        <location filename="../MainWindow.cpp" line="2240"/>
         <source>Reading Zones File</source>
         <translation>Leyendo Archivo de Zonas</translation>
     </message>
@@ -3832,7 +3838,7 @@ Saltando archivo...</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="565"/>
-        <location filename="../MainWindow.cpp" line="1209"/>
+        <location filename="../MainWindow.cpp" line="1215"/>
         <source>Intervals</source>
         <translation>Intervalos</translation>
     </message>
@@ -3857,22 +3863,22 @@ Saltando archivo...</translation>
         <translation type="obsolete">&amp;Ciclista</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="743"/>
+        <location filename="../MainWindow.cpp" line="747"/>
         <source>&amp;New...</source>
         <translation>&amp;Nuevo...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="743"/>
+        <location filename="../MainWindow.cpp" line="747"/>
         <source>Ctrl+N</source>
         <translation>Ctrl+N</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="744"/>
+        <location filename="../MainWindow.cpp" line="748"/>
         <source>&amp;Open...</source>
         <translation>&amp;Abrir...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="744"/>
+        <location filename="../MainWindow.cpp" line="748"/>
         <source>Ctrl+O</source>
         <translation>Ctrl+O</translation>
     </message>
@@ -3881,7 +3887,7 @@ Saltando archivo...</translation>
         <translation type="obsolete">&amp;Salir</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="746"/>
+        <location filename="../MainWindow.cpp" line="750"/>
         <source>Ctrl+Q</source>
         <translation>Ctrl+Q</translation>
     </message>
@@ -3890,24 +3896,24 @@ Saltando archivo...</translation>
         <translation type="obsolete">&amp;Entrenamiento</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="775"/>
+        <location filename="../MainWindow.cpp" line="779"/>
         <source>Ctrl+S</source>
         <translation>Ctrl+S</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="749"/>
+        <location filename="../MainWindow.cpp" line="753"/>
         <source>&amp;Download from device...</source>
         <translation>&amp;Descargar del dispositivo...</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="291"/>
-        <location filename="../MainWindow.cpp" line="2241"/>
+        <location filename="../MainWindow.cpp" line="2247"/>
         <source>HR Zones File Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="294"/>
-        <location filename="../MainWindow.cpp" line="2245"/>
+        <location filename="../MainWindow.cpp" line="2251"/>
         <source>Reading HR Zones File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3928,210 +3934,210 @@ Saltando archivo...</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="454"/>
-        <location filename="../MainWindow.cpp" line="845"/>
+        <location filename="../MainWindow.cpp" line="849"/>
         <source>Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="461"/>
-        <location filename="../MainWindow.cpp" line="848"/>
+        <location filename="../MainWindow.cpp" line="852"/>
         <source>Diary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="468"/>
-        <location filename="../MainWindow.cpp" line="844"/>
+        <location filename="../MainWindow.cpp" line="848"/>
         <source>Analysis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="474"/>
-        <location filename="../MainWindow.cpp" line="846"/>
+        <location filename="../MainWindow.cpp" line="850"/>
         <source>Train</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="524"/>
-        <location filename="../MainWindow.cpp" line="1160"/>
+        <location filename="../MainWindow.cpp" line="1166"/>
         <source>All Activities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="742"/>
+        <location filename="../MainWindow.cpp" line="746"/>
         <source>&amp;Athlete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="745"/>
+        <location filename="../MainWindow.cpp" line="749"/>
         <source>&amp;Close Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="745"/>
+        <location filename="../MainWindow.cpp" line="749"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="746"/>
+        <location filename="../MainWindow.cpp" line="750"/>
         <source>&amp;Quit All Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="748"/>
+        <location filename="../MainWindow.cpp" line="752"/>
         <source>A&amp;ctivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="749"/>
+        <location filename="../MainWindow.cpp" line="753"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="751"/>
+        <location filename="../MainWindow.cpp" line="755"/>
         <source>&amp;Manual activity entry...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="753"/>
+        <location filename="../MainWindow.cpp" line="757"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="754"/>
+        <location filename="../MainWindow.cpp" line="758"/>
         <source>&amp;Batch export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="755"/>
+        <location filename="../MainWindow.cpp" line="759"/>
         <source>Export Metrics as CSV...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="758"/>
+        <location filename="../MainWindow.cpp" line="762"/>
         <source>&amp;Upload to TrainingPeaks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="758"/>
+        <location filename="../MainWindow.cpp" line="762"/>
         <source>Ctrl+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="759"/>
+        <location filename="../MainWindow.cpp" line="763"/>
         <source>Down&amp;load from TrainingPeaks...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="759"/>
+        <location filename="../MainWindow.cpp" line="763"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="775"/>
+        <location filename="../MainWindow.cpp" line="779"/>
         <source>&amp;Save activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="776"/>
+        <location filename="../MainWindow.cpp" line="780"/>
         <source>D&amp;elete activity...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="777"/>
+        <location filename="../MainWindow.cpp" line="781"/>
         <source>Split &amp;activity...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="782"/>
+        <location filename="../MainWindow.cpp" line="786"/>
         <source>Critical Power Calculator...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="783"/>
+        <location filename="../MainWindow.cpp" line="787"/>
         <source>Air Density (Rho) Estimator...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="786"/>
+        <location filename="../MainWindow.cpp" line="790"/>
         <source>Get &amp;Withings Data...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="788"/>
+        <location filename="../MainWindow.cpp" line="792"/>
         <source>Get &amp;Zeo Data...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="791"/>
+        <location filename="../MainWindow.cpp" line="795"/>
         <source>Workout Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="792"/>
+        <location filename="../MainWindow.cpp" line="796"/>
         <source>Get Workouts from ErgDB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="796"/>
-        <location filename="../MainWindow.cpp" line="1197"/>
+        <location filename="../MainWindow.cpp" line="800"/>
+        <location filename="../MainWindow.cpp" line="1203"/>
         <source>Upload Activity to Calendar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="797"/>
+        <location filename="../MainWindow.cpp" line="801"/>
         <source>Import Calendar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="798"/>
+        <location filename="../MainWindow.cpp" line="802"/>
         <source>Export Calendar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="799"/>
+        <location filename="../MainWindow.cpp" line="803"/>
         <source>Refresh Calendar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="802"/>
+        <location filename="../MainWindow.cpp" line="806"/>
         <source>Find intervals...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1692"/>
+        <location filename="../MainWindow.cpp" line="1698"/>
         <source>Select Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1692"/>
-        <location filename="../MainWindow.cpp" line="1778"/>
-        <location filename="../MainWindow.cpp" line="1786"/>
+        <location filename="../MainWindow.cpp" line="1698"/>
+        <location filename="../MainWindow.cpp" line="1784"/>
+        <location filename="../MainWindow.cpp" line="1792"/>
         <source>No activity selected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1703"/>
+        <location filename="../MainWindow.cpp" line="1709"/>
         <source>Export Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1716"/>
+        <location filename="../MainWindow.cpp" line="1722"/>
         <source>Export Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1717"/>
+        <location filename="../MainWindow.cpp" line="1723"/>
         <source>Failed to export ride, please check permissions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2188"/>
+        <location filename="../MainWindow.cpp" line="2194"/>
         <source>Range from %1 to %2
 Athlete CP set to %3 watts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2209"/>
+        <location filename="../MainWindow.cpp" line="2215"/>
         <source>Invalid Activity File Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4140,12 +4146,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">&amp;Exportar a CSV...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="753"/>
+        <location filename="../MainWindow.cpp" line="757"/>
         <source>Ctrl+E</source>
         <translation>Ctrl+E</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="750"/>
+        <location filename="../MainWindow.cpp" line="754"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
@@ -4154,7 +4160,7 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">&amp;Encontrar los mejores intervalos...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="754"/>
+        <location filename="../MainWindow.cpp" line="758"/>
         <source>Ctrl+B</source>
         <translation>Ctrl+B</translation>
     </message>
@@ -4219,12 +4225,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Editor</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="750"/>
+        <location filename="../MainWindow.cpp" line="754"/>
         <source>&amp;Import from file...</source>
         <translation>&amp;Importar de archivo...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="751"/>
+        <location filename="../MainWindow.cpp" line="755"/>
         <source>Ctrl+M</source>
         <translation>Ctrl+M</translation>
     </message>
@@ -4249,12 +4255,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">&amp;Guardar entrenamiento</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="780"/>
+        <location filename="../MainWindow.cpp" line="784"/>
         <source>&amp;Tools</source>
         <translation>&amp;Herramientas</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="781"/>
+        <location filename="../MainWindow.cpp" line="785"/>
         <source>&amp;Options...</source>
         <translation>&amp;Opciones...</translation>
     </message>
@@ -4267,89 +4273,89 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Estimador de la Densidad del Aire (Rho)</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="825"/>
+        <location filename="../MainWindow.cpp" line="829"/>
         <source>&amp;View</source>
         <translation>&amp;Ver</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="827"/>
+        <location filename="../MainWindow.cpp" line="831"/>
         <source>Toggle Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="829"/>
+        <location filename="../MainWindow.cpp" line="833"/>
         <source>Show Left Sidebar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="833"/>
+        <location filename="../MainWindow.cpp" line="837"/>
         <source>Show Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="838"/>
+        <location filename="../MainWindow.cpp" line="842"/>
         <source>Tabbed View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="852"/>
+        <location filename="../MainWindow.cpp" line="856"/>
         <source>Reset Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="854"/>
+        <location filename="../MainWindow.cpp" line="858"/>
         <source>&amp;Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="861"/>
+        <location filename="../MainWindow.cpp" line="865"/>
         <source>&amp;Help</source>
         <translation>&amp;Ayuda</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="862"/>
+        <location filename="../MainWindow.cpp" line="866"/>
         <source>&amp;User Guide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="863"/>
+        <location filename="../MainWindow.cpp" line="867"/>
         <source>&amp;Log a bug or feature request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="865"/>
+        <location filename="../MainWindow.cpp" line="869"/>
         <source>&amp;About GoldenCheetah</source>
         <translation>&amp;Acerca de GoldenCheetah</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1164"/>
+        <location filename="../MainWindow.cpp" line="1170"/>
         <source>Save Changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1167"/>
+        <location filename="../MainWindow.cpp" line="1173"/>
         <source>Revert to Saved version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1170"/>
-        <location filename="../MainWindow.cpp" line="1786"/>
+        <location filename="../MainWindow.cpp" line="1176"/>
+        <location filename="../MainWindow.cpp" line="1792"/>
         <source>Delete Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1179"/>
-        <location filename="../MainWindow.cpp" line="1778"/>
+        <location filename="../MainWindow.cpp" line="1185"/>
+        <location filename="../MainWindow.cpp" line="1784"/>
         <source>Split Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1192"/>
+        <location filename="../MainWindow.cpp" line="1198"/>
         <source>Tweet Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1612"/>
+        <location filename="../MainWindow.cpp" line="1618"/>
         <source>Can&apos;t rename %1 to %2</source>
         <translation>Imposible renombrar %1 a %2</translation>
     </message>
@@ -4422,42 +4428,42 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">El archivo %1 no se puede abrir para escritura</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1739"/>
+        <location filename="../MainWindow.cpp" line="1745"/>
         <source>Import from File</source>
         <translation>Importar de Archivo</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1756"/>
+        <location filename="../MainWindow.cpp" line="1762"/>
         <source>No Activity To Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1757"/>
+        <location filename="../MainWindow.cpp" line="1763"/>
         <source>There is no currently selected ride to save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1791"/>
+        <location filename="../MainWindow.cpp" line="1797"/>
         <source>Are you sure you want to delete the activity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1845"/>
+        <location filename="../MainWindow.cpp" line="1851"/>
         <source>Export Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1845"/>
+        <location filename="../MainWindow.cpp" line="1851"/>
         <source>Comma Separated Variables (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1920"/>
+        <location filename="../MainWindow.cpp" line="1926"/>
         <source>Workout Directory Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1977"/>
+        <location filename="../MainWindow.cpp" line="1983"/>
         <source> (%1 watts)</source>
         <translation> (%1 vatios)</translation>
     </message>
@@ -4474,12 +4480,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Borrar Entrenamiento</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1173"/>
+        <location filename="../MainWindow.cpp" line="1179"/>
         <source>Find Best Intervals</source>
         <translation>Encontrar Mejores Intervalos</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1176"/>
+        <location filename="../MainWindow.cpp" line="1182"/>
         <source>Find Power Peaks</source>
         <translation>Encontrar M?ximos de Potencia</translation>
     </message>
@@ -4488,27 +4494,27 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Twitear Entrenamiento</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1214"/>
+        <location filename="../MainWindow.cpp" line="1220"/>
         <source>Rename interval</source>
         <translation>Renombrar intervalo</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1215"/>
+        <location filename="../MainWindow.cpp" line="1221"/>
         <source>Delete interval</source>
         <translation>Borrar intervalo</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1216"/>
+        <location filename="../MainWindow.cpp" line="1222"/>
         <source>Zoom to interval</source>
         <translation>Enfocar intervalo</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1217"/>
+        <location filename="../MainWindow.cpp" line="1223"/>
         <source>Bring to Front</source>
         <translation>Traer al Frente</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1218"/>
+        <location filename="../MainWindow.cpp" line="1224"/>
         <source>Send to back</source>
         <translation>Mandar al fondo</translation>
     </message>
@@ -4543,7 +4549,7 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">No se puede grabar el archivo de notas %1</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2187"/>
+        <location filename="../MainWindow.cpp" line="2193"/>
         <source>CP saved</source>
         <translation>PC guardado</translation>
     </message>
@@ -4566,7 +4572,7 @@ PC del ciclista %3 vatios</translation>
         <translation type="obsolete">?Esta seguro de querer borrar el entrenamiento?:</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1793"/>
+        <location filename="../MainWindow.cpp" line="1799"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
@@ -4787,13 +4793,13 @@ PC del ciclista %3 vatios</translation>
 <context>
     <name>MaxCadence</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="606"/>
+        <location filename="../BasicRideMetrics.cpp" line="683"/>
         <source>Max Cadence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="607"/>
-        <location filename="../BasicRideMetrics.cpp" line="608"/>
+        <location filename="../BasicRideMetrics.cpp" line="684"/>
+        <location filename="../BasicRideMetrics.cpp" line="685"/>
         <source>rpm</source>
         <translation type="unfinished">rpm</translation>
     </message>
@@ -4801,13 +4807,13 @@ PC del ciclista %3 vatios</translation>
 <context>
     <name>MaxHr</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="538"/>
+        <location filename="../BasicRideMetrics.cpp" line="607"/>
         <source>Max Heartrate</source>
         <translation>Frec. Card?aca M?x</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="539"/>
-        <location filename="../BasicRideMetrics.cpp" line="540"/>
+        <location filename="../BasicRideMetrics.cpp" line="608"/>
+        <location filename="../BasicRideMetrics.cpp" line="609"/>
         <source>bpm</source>
         <translation>ppm</translation>
     </message>
@@ -4815,13 +4821,13 @@ PC del ciclista %3 vatios</translation>
 <context>
     <name>MaxPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="509"/>
+        <location filename="../BasicRideMetrics.cpp" line="574"/>
         <source>Max Power</source>
         <translation>Potencia M?xima</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="510"/>
-        <location filename="../BasicRideMetrics.cpp" line="511"/>
+        <location filename="../BasicRideMetrics.cpp" line="575"/>
+        <location filename="../BasicRideMetrics.cpp" line="576"/>
         <source>watts</source>
         <translation>vatios</translation>
     </message>
@@ -4829,7 +4835,7 @@ PC del ciclista %3 vatios</translation>
 <context>
     <name>MaxPowerVariance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="848"/>
+        <location filename="../BasicRideMetrics.cpp" line="949"/>
         <source>Max Power Variance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4837,17 +4843,17 @@ PC del ciclista %3 vatios</translation>
 <context>
     <name>MaxSpeed</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="567"/>
+        <location filename="../BasicRideMetrics.cpp" line="640"/>
         <source>Max Speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="568"/>
+        <location filename="../BasicRideMetrics.cpp" line="641"/>
         <source>kph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="569"/>
+        <location filename="../BasicRideMetrics.cpp" line="642"/>
         <source>mph</source>
         <translation type="unfinished">mph</translation>
     </message>
@@ -4855,17 +4861,17 @@ PC del ciclista %3 vatios</translation>
 <context>
     <name>MaxTemp</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="643"/>
+        <location filename="../BasicRideMetrics.cpp" line="724"/>
         <source>Max Temp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="644"/>
+        <location filename="../BasicRideMetrics.cpp" line="725"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="645"/>
+        <location filename="../BasicRideMetrics.cpp" line="726"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4873,7 +4879,7 @@ PC del ciclista %3 vatios</translation>
 <context>
     <name>MeanPowerVariance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="801"/>
+        <location filename="../BasicRideMetrics.cpp" line="898"/>
         <source>Average Power Variance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4881,42 +4887,42 @@ PC del ciclista %3 vatios</translation>
 <context>
     <name>MeasuresPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3395"/>
+        <location filename="../Pages.cpp" line="3397"/>
         <source>Move up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3396"/>
+        <location filename="../Pages.cpp" line="3398"/>
         <source>Move down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3397"/>
+        <location filename="../Pages.cpp" line="3399"/>
         <source>Insert</source>
         <translation type="unfinished">Insertar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3398"/>
+        <location filename="../Pages.cpp" line="3400"/>
         <source>Rename</source>
         <translation type="unfinished">Renombrar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3399"/>
+        <location filename="../Pages.cpp" line="3401"/>
         <source>Delete</source>
         <translation type="unfinished">Eliminar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3410"/>
+        <location filename="../Pages.cpp" line="3412"/>
         <source>Screen Tab</source>
         <translation type="unfinished">Pesta?a</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3411"/>
+        <location filename="../Pages.cpp" line="3413"/>
         <source>Measure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3412"/>
+        <location filename="../Pages.cpp" line="3414"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
@@ -5302,17 +5308,17 @@ Elapsed: %1
 <context>
     <name>NavigatorCellDelegate</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="941"/>
+        <location filename="../RideNavigator.cpp" line="944"/>
         <source>Date</source>
         <translation type="unfinished">Fecha</translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="944"/>
+        <location filename="../RideNavigator.cpp" line="947"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="947"/>
+        <location filename="../RideNavigator.cpp" line="950"/>
         <source>Last updated</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5439,13 +5445,13 @@ Elapsed: %1
 <context>
     <name>NinetyFivePercentHeartRate</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="688"/>
+        <location filename="../BasicRideMetrics.cpp" line="773"/>
         <source>95% Heartrate</source>
         <translation>95% Frec. Card?aca</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="689"/>
-        <location filename="../BasicRideMetrics.cpp" line="690"/>
+        <location filename="../BasicRideMetrics.cpp" line="774"/>
+        <location filename="../BasicRideMetrics.cpp" line="775"/>
         <source>bpm</source>
         <translation>ppm</translation>
     </message>
@@ -5453,13 +5459,13 @@ Elapsed: %1
 <context>
     <name>NonZeroPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="365"/>
+        <location filename="../BasicRideMetrics.cpp" line="408"/>
         <source>Nonzero Average Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="366"/>
-        <location filename="../BasicRideMetrics.cpp" line="367"/>
+        <location filename="../BasicRideMetrics.cpp" line="409"/>
+        <location filename="../BasicRideMetrics.cpp" line="410"/>
         <source>watts</source>
         <translation type="unfinished">vatios</translation>
     </message>
@@ -5467,17 +5473,17 @@ Elapsed: %1
 <context>
     <name>Pace</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="288"/>
+        <location filename="../BasicRideMetrics.cpp" line="319"/>
         <source>Pace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="290"/>
+        <location filename="../BasicRideMetrics.cpp" line="321"/>
         <source>min/km</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="291"/>
+        <location filename="../BasicRideMetrics.cpp" line="322"/>
         <source>min/mile</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5669,7 +5675,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower10m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="162"/>
+        <location filename="../PeakPower.cpp" line="202"/>
         <source>10 min Peak Power</source>
         <translation>Potencia M?x. 10 min</translation>
     </message>
@@ -5681,7 +5687,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower10s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="96"/>
+        <location filename="../PeakPower.cpp" line="112"/>
         <source>10 sec Peak Power</source>
         <translation>Potencia M?x. 10 seg</translation>
     </message>
@@ -5693,7 +5699,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower15s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="107"/>
+        <location filename="../PeakPower.cpp" line="127"/>
         <source>15 sec Peak Power</source>
         <translation>Potencia M?x. 15 seg</translation>
     </message>
@@ -5705,7 +5711,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower1m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="140"/>
+        <location filename="../PeakPower.cpp" line="172"/>
         <source>1 min Peak Power</source>
         <translation>Potencia M?x. 1 min</translation>
     </message>
@@ -5717,7 +5723,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower1s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="74"/>
+        <location filename="../PeakPower.cpp" line="82"/>
         <source>1 sec Peak Power</source>
         <translation>Potencia M?x. 1 seg</translation>
     </message>
@@ -5729,7 +5735,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower20m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="173"/>
+        <location filename="../PeakPower.cpp" line="217"/>
         <source>20 min Peak Power</source>
         <translation>Potencia M?x. 20 min</translation>
     </message>
@@ -5741,7 +5747,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower20s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="118"/>
+        <location filename="../PeakPower.cpp" line="142"/>
         <source>20 sec Peak Power</source>
         <translation>Potencia M?x. 20 seg</translation>
     </message>
@@ -5753,7 +5759,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower30m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="184"/>
+        <location filename="../PeakPower.cpp" line="232"/>
         <source>30 min Peak Power</source>
         <translation>Potencia M?x. 30 min</translation>
     </message>
@@ -5765,7 +5771,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower30s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="129"/>
+        <location filename="../PeakPower.cpp" line="157"/>
         <source>30 sec Peak Power</source>
         <translation>Potencia M?x. 30 seg</translation>
     </message>
@@ -5777,7 +5783,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower5m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="151"/>
+        <location filename="../PeakPower.cpp" line="187"/>
         <source>5 min Peak Power</source>
         <translation>Potencia M?x. 5 min</translation>
     </message>
@@ -5789,7 +5795,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower5s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="85"/>
+        <location filename="../PeakPower.cpp" line="97"/>
         <source>5 sec Peak Power</source>
         <translation>Potencia M?x. 5 seg</translation>
     </message>
@@ -5801,13 +5807,13 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr10m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="263"/>
+        <location filename="../PeakPower.cpp" line="324"/>
         <source>10 min Peak Power HR</source>
         <translation>FC en Potencia M?x.10 min</translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="264"/>
-        <location filename="../PeakPower.cpp" line="265"/>
+        <location filename="../PeakPower.cpp" line="325"/>
+        <location filename="../PeakPower.cpp" line="326"/>
         <source>bpm</source>
         <translation>ppm</translation>
     </message>
@@ -5815,13 +5821,13 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr1m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="235"/>
+        <location filename="../PeakPower.cpp" line="288"/>
         <source>1 min Peak Power HR</source>
         <translation>FC en Potencia M?x. 1 min</translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="236"/>
-        <location filename="../PeakPower.cpp" line="237"/>
+        <location filename="../PeakPower.cpp" line="289"/>
+        <location filename="../PeakPower.cpp" line="290"/>
         <source>bpm</source>
         <translation>ppm</translation>
     </message>
@@ -5829,13 +5835,13 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr20m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="277"/>
+        <location filename="../PeakPower.cpp" line="342"/>
         <source>20 min Peak Power HR</source>
         <translation>FC en Potencia M?x. 20 min</translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="278"/>
-        <location filename="../PeakPower.cpp" line="279"/>
+        <location filename="../PeakPower.cpp" line="343"/>
+        <location filename="../PeakPower.cpp" line="344"/>
         <source>bpm</source>
         <translation>ppm</translation>
     </message>
@@ -5843,13 +5849,13 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr30m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="291"/>
+        <location filename="../PeakPower.cpp" line="360"/>
         <source>30 min Peak Power HR</source>
         <translation>FC en Potencia M?x. 30 min</translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="292"/>
-        <location filename="../PeakPower.cpp" line="293"/>
+        <location filename="../PeakPower.cpp" line="361"/>
+        <location filename="../PeakPower.cpp" line="362"/>
         <source>bpm</source>
         <translation>ppm</translation>
     </message>
@@ -5857,23 +5863,9 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr5m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="249"/>
+        <location filename="../PeakPower.cpp" line="306"/>
         <source>5 min Peak Power HR</source>
         <translation>FC en Potencia M?x. 5 min</translation>
-    </message>
-    <message>
-        <location filename="../PeakPower.cpp" line="250"/>
-        <location filename="../PeakPower.cpp" line="251"/>
-        <source>bpm</source>
-        <translation>ppm</translation>
-    </message>
-</context>
-<context>
-    <name>PeakPowerHr60m</name>
-    <message>
-        <location filename="../PeakPower.cpp" line="306"/>
-        <source>60 min Peak Power HR</source>
-        <translation>FC en Potencia M?x. 60 min</translation>
     </message>
     <message>
         <location filename="../PeakPower.cpp" line="307"/>
@@ -5883,10 +5875,24 @@ Do you want to continue?</source>
     </message>
 </context>
 <context>
+    <name>PeakPowerHr60m</name>
+    <message>
+        <location filename="../PeakPower.cpp" line="379"/>
+        <source>60 min Peak Power HR</source>
+        <translation>FC en Potencia M?x. 60 min</translation>
+    </message>
+    <message>
+        <location filename="../PeakPower.cpp" line="380"/>
+        <location filename="../PeakPower.cpp" line="381"/>
+        <source>bpm</source>
+        <translation>ppm</translation>
+    </message>
+</context>
+<context>
     <name>PeakWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="89"/>
-        <location filename="../WattsPerKilogram.cpp" line="90"/>
+        <location filename="../WattsPerKilogram.cpp" line="93"/>
+        <location filename="../WattsPerKilogram.cpp" line="94"/>
         <source>wpk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5894,7 +5900,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK10m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="219"/>
+        <location filename="../WattsPerKilogram.cpp" line="263"/>
         <source>10 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5902,7 +5908,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK10s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="153"/>
+        <location filename="../WattsPerKilogram.cpp" line="173"/>
         <source>10 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5910,7 +5916,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK15s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="164"/>
+        <location filename="../WattsPerKilogram.cpp" line="188"/>
         <source>15 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5918,7 +5924,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK1m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="197"/>
+        <location filename="../WattsPerKilogram.cpp" line="233"/>
         <source>1 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5926,7 +5932,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK1s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="131"/>
+        <location filename="../WattsPerKilogram.cpp" line="143"/>
         <source>1 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5934,7 +5940,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK20m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="230"/>
+        <location filename="../WattsPerKilogram.cpp" line="278"/>
         <source>20 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5942,7 +5948,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK20s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="175"/>
+        <location filename="../WattsPerKilogram.cpp" line="203"/>
         <source>20 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5950,7 +5956,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK30m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="241"/>
+        <location filename="../WattsPerKilogram.cpp" line="293"/>
         <source>30 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5958,7 +5964,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK30s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="186"/>
+        <location filename="../WattsPerKilogram.cpp" line="218"/>
         <source>30 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5966,7 +5972,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK5m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="208"/>
+        <location filename="../WattsPerKilogram.cpp" line="248"/>
         <source>5 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5974,7 +5980,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK5s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="142"/>
+        <location filename="../WattsPerKilogram.cpp" line="158"/>
         <source>5 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5998,22 +6004,22 @@ Do you want to continue?</source>
         <translation type="obsolete">Estr?s Diario</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="118"/>
+        <location filename="../PerfPlot.cpp" line="147"/>
         <source>Daily</source>
         <translation>Diario</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="138"/>
+        <location filename="../PerfPlot.cpp" line="167"/>
         <source>Short Term Stress</source>
         <translation>Estr?s a Corto Plazo</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="152"/>
+        <location filename="../PerfPlot.cpp" line="181"/>
         <source>Long Term Stress</source>
         <translation>Estr?s a Largo Plazo</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="166"/>
+        <location filename="../PerfPlot.cpp" line="195"/>
         <source>Stress Balance</source>
         <translation>Balance de Estr?s</translation>
     </message>
@@ -6125,43 +6131,49 @@ Do you want to continue?</source>
     <name>PowerHist</name>
     <message>
         <location filename="../PowerHist.cpp" line="77"/>
-        <location filename="../PowerHist.cpp" line="902"/>
+        <location filename="../PowerHist.cpp" line="940"/>
         <source>Time (minutes)</source>
         <translation>Tiempo (minutos)</translation>
     </message>
     <message>
         <location filename="../PowerHist.cpp" line="77"/>
-        <location filename="../PowerHist.cpp" line="902"/>
+        <location filename="../PowerHist.cpp" line="940"/>
         <source>Time (percent)</source>
         <translation>Tiempo (porcentaje)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="877"/>
+        <location filename="../PowerHist.cpp" line="910"/>
         <source>Power (watts)</source>
         <translation>Potencia (vatios)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="876"/>
+        <location filename="../PowerHist.cpp" line="909"/>
+        <location filename="../PowerHist.cpp" line="914"/>
         <source>Power zone</source>
         <translation>Zona de Potencia</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="882"/>
+        <location filename="../PowerHist.cpp" line="920"/>
         <source>Heartrate (bpm)</source>
         <translation>Frec. Card?aca (ppm)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="881"/>
+        <location filename="../PowerHist.cpp" line="919"/>
         <source>Heartrate zone</source>
         <translation>Zona de Frecuencia Card?aca</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="886"/>
+        <location filename="../PowerHist.cpp" line="915"/>
+        <source>Power (watts/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../PowerHist.cpp" line="924"/>
         <source>Cadence (rpm)</source>
         <translation>Cadencia (rpm)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>Speed (%1)</source>
         <translation>Velocidad (%1)</translation>
     </message>
@@ -6170,44 +6182,44 @@ Do you want to continue?</source>
         <translation type="obsolete">km/h</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>mph</source>
         <translation>mph</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>kph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>Torque (%1)</source>
         <translation>Par (%1)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>N-m</source>
         <translation>N-m</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>ft-lbf</source>
         <translation>lib-pie</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="898"/>
+        <location filename="../PowerHist.cpp" line="936"/>
         <source>Unknown data series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="962"/>
-        <location filename="../PowerHist.cpp" line="975"/>
+        <location filename="../PowerHist.cpp" line="1000"/>
+        <location filename="../PowerHist.cpp" line="1013"/>
         <source>minutes</source>
         <translation>minutos</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="962"/>
-        <location filename="../PowerHist.cpp" line="975"/>
+        <location filename="../PowerHist.cpp" line="1000"/>
+        <location filename="../PowerHist.cpp" line="1013"/>
         <source>%</source>
         <translation>%</translation>
     </message>
@@ -6224,27 +6236,27 @@ y que muestra la palabra &quot;Host&quot;</translation>
 <context>
     <name>ProcessorPage</name>
     <message>
-        <location filename="../Pages.cpp" line="2198"/>
+        <location filename="../Pages.cpp" line="2200"/>
         <source>Processor</source>
         <translation>Procesador</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2199"/>
+        <location filename="../Pages.cpp" line="2201"/>
         <source>Apply</source>
         <translation>Aplicar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2200"/>
+        <location filename="../Pages.cpp" line="2202"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2224"/>
+        <location filename="../Pages.cpp" line="2226"/>
         <source>Manual</source>
         <translation>Manual</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2225"/>
+        <location filename="../Pages.cpp" line="2227"/>
         <source>Auto</source>
         <translation>Autom?tico</translation>
     </message>
@@ -6654,7 +6666,7 @@ y que muestra la palabra &quot;Host&quot;</translation>
 <context>
     <name>RelativeIntensity</name>
     <message>
-        <location filename="../BikeScore.cpp" line="136"/>
+        <location filename="../BikeScore.cpp" line="147"/>
         <source>Relative Intensity</source>
         <translation>Intensidad Relativa</translation>
     </message>
@@ -6662,7 +6674,7 @@ y que muestra la palabra &quot;Host&quot;</translation>
 <context>
     <name>ResponseIndex</name>
     <message>
-        <location filename="../BikeScore.cpp" line="218"/>
+        <location filename="../BikeScore.cpp" line="237"/>
         <source>Response Index</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6677,7 +6689,7 @@ y que muestra la palabra &quot;Host&quot;</translation>
 <context>
     <name>RideCount</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="34"/>
+        <location filename="../BasicRideMetrics.cpp" line="37"/>
         <source>Rides</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6685,9 +6697,9 @@ y que muestra la palabra &quot;Host&quot;</translation>
 <context>
     <name>RideDelegate</name>
     <message>
-        <location filename="../RideImportWizard.cpp" line="995"/>
-        <location filename="../RideImportWizard.cpp" line="1032"/>
-        <location filename="../RideImportWizard.cpp" line="1048"/>
+        <location filename="../RideImportWizard.cpp" line="998"/>
+        <location filename="../RideImportWizard.cpp" line="1035"/>
+        <location filename="../RideImportWizard.cpp" line="1051"/>
         <source>dd MMM yyyy</source>
         <translation></translation>
     </message>
@@ -7245,9 +7257,9 @@ y que muestra la palabra &quot;Host&quot;</translation>
     </message>
     <message>
         <location filename="../RideImportWizard.cpp" line="74"/>
-        <location filename="../RideImportWizard.cpp" line="696"/>
-        <location filename="../RideImportWizard.cpp" line="738"/>
-        <location filename="../RideImportWizard.cpp" line="890"/>
+        <location filename="../RideImportWizard.cpp" line="699"/>
+        <location filename="../RideImportWizard.cpp" line="741"/>
+        <location filename="../RideImportWizard.cpp" line="893"/>
         <source>Abort</source>
         <translation>Abortar</translation>
     </message>
@@ -7318,12 +7330,12 @@ y que muestra la palabra &quot;Host&quot;</translation>
     </message>
     <message>
         <location filename="../RideImportWizard.cpp" line="268"/>
-        <location filename="../RideImportWizard.cpp" line="454"/>
-        <location filename="../RideImportWizard.cpp" line="506"/>
-        <location filename="../RideImportWizard.cpp" line="717"/>
-        <location filename="../RideImportWizard.cpp" line="756"/>
-        <location filename="../RideImportWizard.cpp" line="895"/>
-        <location filename="../RideImportWizard.cpp" line="918"/>
+        <location filename="../RideImportWizard.cpp" line="457"/>
+        <location filename="../RideImportWizard.cpp" line="509"/>
+        <location filename="../RideImportWizard.cpp" line="720"/>
+        <location filename="../RideImportWizard.cpp" line="759"/>
+        <location filename="../RideImportWizard.cpp" line="898"/>
+        <location filename="../RideImportWizard.cpp" line="921"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
@@ -7333,157 +7345,157 @@ y que muestra la palabra &quot;Host&quot;</translation>
         <translation>Analizando...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="378"/>
+        <location filename="../RideImportWizard.cpp" line="381"/>
         <source>Validated</source>
         <translation>Validado</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="380"/>
+        <location filename="../RideImportWizard.cpp" line="383"/>
         <source>Warning - </source>
         <translation>Advertencia - </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="394"/>
-        <location filename="../RideImportWizard.cpp" line="619"/>
-        <location filename="../RideImportWizard.cpp" line="765"/>
+        <location filename="../RideImportWizard.cpp" line="397"/>
+        <location filename="../RideImportWizard.cpp" line="622"/>
+        <location filename="../RideImportWizard.cpp" line="768"/>
         <source>dd MMM yyyy</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="395"/>
+        <location filename="../RideImportWizard.cpp" line="398"/>
         <source>hh:mm:ss ap</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="432"/>
+        <location filename="../RideImportWizard.cpp" line="435"/>
         <source>Error - </source>
         <translation>Error - </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="380"/>
-        <location filename="../RideImportWizard.cpp" line="432"/>
+        <location filename="../RideImportWizard.cpp" line="383"/>
+        <location filename="../RideImportWizard.cpp" line="435"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="447"/>
+        <location filename="../RideImportWizard.cpp" line="450"/>
         <source>Step 3 of 4: Confirm Date and Time</source>
         <translation>Paso 3 de 4: Confirmar Fecha y Hora</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="464"/>
+        <location filename="../RideImportWizard.cpp" line="467"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="573"/>
-        <location filename="../RideImportWizard.cpp" line="623"/>
+        <location filename="../RideImportWizard.cpp" line="576"/>
+        <location filename="../RideImportWizard.cpp" line="626"/>
         <source>hh:mm:ss</source>
         <translation>hh:mm:ss</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="582"/>
+        <location filename="../RideImportWizard.cpp" line="585"/>
         <source>Invalid Selection</source>
         <translation>Selecci?n Inv?lida</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="582"/>
+        <location filename="../RideImportWizard.cpp" line="585"/>
         <source>More than 24hrs of rides to fit into a day</source>
         <translation>M?s de 24hs de entrenamiento en un dia</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="627"/>
-        <location filename="../RideImportWizard.cpp" line="766"/>
+        <location filename="../RideImportWizard.cpp" line="630"/>
+        <location filename="../RideImportWizard.cpp" line="769"/>
         <source>hh:mm:ss a</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="736"/>
+        <location filename="../RideImportWizard.cpp" line="739"/>
         <source>Step 4 of 4: Save to Library</source>
         <translation>Paso 4 de 4: Guardar en la Biblioteca</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="758"/>
+        <location filename="../RideImportWizard.cpp" line="761"/>
         <source>Saving...</source>
         <translation>Guardando...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="834"/>
+        <location filename="../RideImportWizard.cpp" line="837"/>
         <source>Error - Source is Target</source>
         <translation>Error - El origen y el destino coinciden</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="845"/>
+        <location filename="../RideImportWizard.cpp" line="848"/>
         <source>Overwriting file...</source>
         <translation>Sobrescribiendo Archivo...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="847"/>
+        <location filename="../RideImportWizard.cpp" line="850"/>
         <source>/</source>
         <translation>/</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="847"/>
+        <location filename="../RideImportWizard.cpp" line="850"/>
         <source>.tmp</source>
         <translation>.tmp</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="821"/>
-        <location filename="../RideImportWizard.cpp" line="854"/>
+        <location filename="../RideImportWizard.cpp" line="824"/>
+        <location filename="../RideImportWizard.cpp" line="857"/>
         <source>File Overwritten</source>
         <translation>Archivo Sobrescrito</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="857"/>
-        <location filename="../RideImportWizard.cpp" line="859"/>
+        <location filename="../RideImportWizard.cpp" line="860"/>
+        <location filename="../RideImportWizard.cpp" line="862"/>
         <source>Error - overwrite failed</source>
         <translation>Error - Fall? la sobrescritura</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="790"/>
-        <location filename="../RideImportWizard.cpp" line="862"/>
+        <location filename="../RideImportWizard.cpp" line="793"/>
+        <location filename="../RideImportWizard.cpp" line="865"/>
         <source>Error - File exists</source>
         <translation>Error - El archivo ya existe</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="865"/>
+        <location filename="../RideImportWizard.cpp" line="868"/>
         <source>Saving file...</source>
         <translation>Guardando archivo...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="823"/>
-        <location filename="../RideImportWizard.cpp" line="868"/>
+        <location filename="../RideImportWizard.cpp" line="826"/>
+        <location filename="../RideImportWizard.cpp" line="871"/>
         <source>File Saved</source>
         <translation>Archivo Guardado</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="877"/>
+        <location filename="../RideImportWizard.cpp" line="880"/>
         <source>Error - copy failed</source>
         <translation>Error - fall? la copia</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="888"/>
+        <location filename="../RideImportWizard.cpp" line="891"/>
         <source>Step 5 of 5: Calculating Critical Powers</source>
         <translation>Paso 5 de 5: Calculando Potencias Cr?ticas</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="896"/>
+        <location filename="../RideImportWizard.cpp" line="899"/>
         <source>Calculating...</source>
         <translation>Calculando...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="905"/>
+        <location filename="../RideImportWizard.cpp" line="908"/>
         <source>Completed.</source>
         <translation>Finalizado.</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="923"/>
+        <location filename="../RideImportWizard.cpp" line="926"/>
         <source>Import Complete. %1 of %2 successful.</source>
         <translation>Importaci?n Finalizada. %1 de %2 con ?xito.</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="704"/>
-        <location filename="../RideImportWizard.cpp" line="928"/>
+        <location filename="../RideImportWizard.cpp" line="707"/>
+        <location filename="../RideImportWizard.cpp" line="931"/>
         <source>Finish</source>
         <translation>Fin</translation>
     </message>
@@ -7491,22 +7503,22 @@ y que muestra la palabra &quot;Host&quot;</translation>
 <context>
     <name>RideNavigator</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="540"/>
+        <location filename="../RideNavigator.cpp" line="542"/>
         <source>Remove Column</source>
         <translation type="unfinished">Eliminar Columna</translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="546"/>
+        <location filename="../RideNavigator.cpp" line="548"/>
         <source>Column Chooser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="551"/>
+        <location filename="../RideNavigator.cpp" line="553"/>
         <source>Do Not Show in Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="551"/>
+        <location filename="../RideNavigator.cpp" line="553"/>
         <source>Show In Groups</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7888,32 +7900,32 @@ formato GoldenCheetah. ?Confirmar?</translation>
 <context>
     <name>SchemePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2295"/>
+        <location filename="../Pages.cpp" line="2297"/>
         <source>Add</source>
         <translation>Agregar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2296"/>
+        <location filename="../Pages.cpp" line="2298"/>
         <source>Rename</source>
         <translation>Renombrar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2297"/>
+        <location filename="../Pages.cpp" line="2299"/>
         <source>Delete</source>
         <translation>Eliminar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2306"/>
+        <location filename="../Pages.cpp" line="2308"/>
         <source>Short</source>
         <translation>Abreviatura</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2307"/>
+        <location filename="../Pages.cpp" line="2309"/>
         <source>Long</source>
         <translation>Nombre</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2308"/>
+        <location filename="../Pages.cpp" line="2310"/>
         <source>Percent of CP</source>
         <translation>Porcentaje de PC</translation>
     </message>
@@ -7998,42 +8010,42 @@ formato GoldenCheetah. ?Confirmar?</translation>
 <context>
     <name>SeasonsPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3673"/>
+        <location filename="../Pages.cpp" line="3675"/>
         <source>Move up</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3674"/>
+        <location filename="../Pages.cpp" line="3676"/>
         <source>Move down</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3675"/>
+        <location filename="../Pages.cpp" line="3677"/>
         <source>Add</source>
         <translation type="unfinished">Agregar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3676"/>
+        <location filename="../Pages.cpp" line="3678"/>
         <source>Delete</source>
         <translation type="unfinished">Eliminar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3685"/>
+        <location filename="../Pages.cpp" line="3687"/>
         <source>Name</source>
         <translation type="unfinished">Nombre</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3686"/>
+        <location filename="../Pages.cpp" line="3688"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3687"/>
+        <location filename="../Pages.cpp" line="3689"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3688"/>
+        <location filename="../Pages.cpp" line="3690"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8041,7 +8053,7 @@ formato GoldenCheetah. ?Confirmar?</translation>
 <context>
     <name>SessionRPE</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="302"/>
+        <location filename="../TRIMPPoints.cpp" line="316"/>
         <source>Session RPE</source>
         <translation type="unfinished">RPE Sesi?n</translation>
     </message>
@@ -8073,91 +8085,142 @@ formato GoldenCheetah. ?Confirmar?</translation>
 <context>
     <name>SpecialFields</name>
     <message>
+        <location filename="../SpecialFields.cpp" line="26"/>
         <source>Start Date</source>
-        <translation type="obsolete">Fecha de Inicio</translation>
+        <translation type="unfinished">Fecha de Inicio</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="27"/>
         <source>Start Time</source>
-        <translation type="obsolete">Hora de Inicio</translation>
+        <translation type="unfinished">Hora de Inicio</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="28"/>
+        <source>Identifier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="29"/>
         <source>Workout Code</source>
-        <translation type="obsolete">C?digo Entrenamiento</translation>
+        <translation type="unfinished">C?digo Entrenamiento</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="30"/>
         <source>Sport</source>
-        <translation type="obsolete">Deporte</translation>
+        <translation type="unfinished">Deporte</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="31"/>
         <source>Objective</source>
-        <translation type="obsolete">Objetivo</translation>
+        <translation type="unfinished">Objetivo</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="32"/>
+        <source>Summary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="33"/>
         <source>Notes</source>
-        <translation type="obsolete">Notas</translation>
+        <translation type="unfinished">Notas</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="34"/>
         <source>Keywords</source>
-        <translation type="obsolete">Palabras Clave</translation>
+        <translation type="unfinished">Palabras Clave</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="35"/>
         <source>Recording Interval</source>
-        <translation type="obsolete">Intervalo de Grabaci?n</translation>
+        <translation type="unfinished">Intervalo de Grabaci?n</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="36"/>
         <source>Weight</source>
-        <translation type="obsolete">Peso</translation>
+        <translation type="unfinished">Peso</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="37"/>
         <source>Device</source>
-        <translation type="obsolete">Dispositivo</translation>
+        <translation type="unfinished">Dispositivo</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="38"/>
         <source>Device Info</source>
-        <translation type="obsolete">Info. Dispositivo</translation>
+        <translation type="unfinished">Info. Dispositivo</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="39"/>
         <source>Dropouts</source>
-        <translation type="obsolete">Vac?os</translation>
+        <translation type="unfinished">Vac?os</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="40"/>
         <source>Dropout Time</source>
-        <translation type="obsolete">Tiempo vac?o</translation>
+        <translation type="unfinished">Tiempo vac?o</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="41"/>
         <source>Spikes</source>
-        <translation type="obsolete">Picos</translation>
+        <translation type="unfinished">Picos</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="42"/>
         <source>Spike Time</source>
-        <translation type="obsolete">Tiempo de Picos</translation>
+        <translation type="unfinished">Tiempo de Picos</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="43"/>
         <source>Torque Adjust</source>
-        <translation type="obsolete">Ajuste de Par</translation>
+        <translation type="unfinished">Ajuste de Par</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="44"/>
         <source>Filename</source>
-        <translation type="obsolete">Nombre de Archivo</translation>
+        <translation type="unfinished">Nombre de Archivo</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="45"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="46"/>
         <source>Change History</source>
-        <translation type="obsolete">Hist?rico de Cambios</translation>
+        <translation type="unfinished">Hist?rico de Cambios</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="47"/>
+        <source>Calendar Text</source>
+        <translation type="unfinished">Texto en Calendario</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="48"/>
+        <source>Data</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SpecialTabs</name>
     <message>
+        <location filename="../SpecialFields.cpp" line="130"/>
         <source>Workout</source>
-        <translation type="obsolete">Entrenamiento</translation>
+        <translation type="unfinished">Entrenamiento</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="131"/>
         <source>Notes</source>
-        <translation type="obsolete">Notas</translation>
+        <translation type="unfinished">Notas</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="132"/>
         <source>Metric</source>
-        <translation type="obsolete">M?tricas</translation>
+        <translation type="unfinished">M?tricas</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="133"/>
+        <source>Extra</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -8574,22 +8637,22 @@ formato GoldenCheetah. ?Confirmar?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="388"/>
+        <location filename="../StravaDialog.cpp" line="389"/>
         <source>Upload ride... Sending</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="398"/>
+        <location filename="../StravaDialog.cpp" line="399"/>
         <source>Upload finished.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="430"/>
+        <location filename="../StravaDialog.cpp" line="431"/>
         <source>Ride processing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="501"/>
+        <location filename="../StravaDialog.cpp" line="502"/>
         <source>Searching corresponding Ride</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8858,7 +8921,7 @@ formato GoldenCheetah. ?Confirmar?</translation>
 <context>
     <name>TRIMP100Points</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="114"/>
+        <location filename="../TRIMPPoints.cpp" line="120"/>
         <source>TRIMP(100) Points</source>
         <translation>Puntos TRIMP (100)</translation>
     </message>
@@ -8866,7 +8929,7 @@ formato GoldenCheetah. ?Confirmar?</translation>
 <context>
     <name>TRIMPPoints</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="47"/>
+        <location filename="../TRIMPPoints.cpp" line="49"/>
         <source>TRIMP Points</source>
         <translation>Puntos TRIMP</translation>
     </message>
@@ -8878,7 +8941,7 @@ formato GoldenCheetah. ?Confirmar?</translation>
 <context>
     <name>TRIMPZonalPoints</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="180"/>
+        <location filename="../TRIMPPoints.cpp" line="190"/>
         <source>TRIMP Zonal Points</source>
         <translation>Puntos TRIMP por Zona</translation>
     </message>
@@ -8886,13 +8949,13 @@ formato GoldenCheetah. ?Confirmar?</translation>
 <context>
     <name>TimeRiding</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="94"/>
+        <location filename="../BasicRideMetrics.cpp" line="105"/>
         <source>Time Riding</source>
         <translation>Tiempo Pedaleando</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="95"/>
-        <location filename="../BasicRideMetrics.cpp" line="96"/>
+        <location filename="../BasicRideMetrics.cpp" line="106"/>
+        <location filename="../BasicRideMetrics.cpp" line="107"/>
         <source>seconds</source>
         <translation>segundos</translation>
     </message>
@@ -9000,17 +9063,17 @@ formato GoldenCheetah. ?Confirmar?</translation>
 <context>
     <name>TotalDistance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="129"/>
+        <location filename="../BasicRideMetrics.cpp" line="144"/>
         <source>Distance</source>
         <translation>Distancia</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="131"/>
+        <location filename="../BasicRideMetrics.cpp" line="146"/>
         <source>km</source>
         <translation>km</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="132"/>
+        <location filename="../BasicRideMetrics.cpp" line="147"/>
         <source>miles</source>
         <translation>millas</translation>
     </message>
@@ -9018,13 +9081,13 @@ formato GoldenCheetah. ?Confirmar?</translation>
 <context>
     <name>TotalWork</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="213"/>
+        <location filename="../BasicRideMetrics.cpp" line="236"/>
         <source>Work</source>
         <translation>Trabajo</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="214"/>
-        <location filename="../BasicRideMetrics.cpp" line="215"/>
+        <location filename="../BasicRideMetrics.cpp" line="237"/>
+        <location filename="../BasicRideMetrics.cpp" line="238"/>
         <source>kJ</source>
         <translation>kJ</translation>
     </message>
@@ -9098,6 +9161,14 @@ Press F3 on Controller when done.</source>
         <location filename="../TrainTool.cpp" line="1279"/>
         <source>Done</source>
         <translation type="unfinished">Listo</translation>
+    </message>
+</context>
+<context>
+    <name>TreeMapWindow</name>
+    <message>
+        <location filename="../TreeMapWindow.cpp" line="100"/>
+        <source>Metric</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -9392,7 +9463,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>VAM</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="722"/>
+        <location filename="../BasicRideMetrics.cpp" line="811"/>
         <source>VAM</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9400,7 +9471,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>VariabilityIndex</name>
     <message>
-        <location filename="../BikeScore.cpp" line="102"/>
+        <location filename="../BikeScore.cpp" line="109"/>
         <source>Skiba VI</source>
         <translation>Skiba: IV</translation>
     </message>
@@ -9432,13 +9503,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>Vo2max</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="252"/>
+        <location filename="../WattsPerKilogram.cpp" line="308"/>
         <source>Estimated VO2MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="254"/>
-        <location filename="../WattsPerKilogram.cpp" line="255"/>
+        <location filename="../WattsPerKilogram.cpp" line="310"/>
+        <location filename="../WattsPerKilogram.cpp" line="311"/>
         <source>ml/min/kg</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9584,13 +9655,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WorkoutTime</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="60"/>
+        <location filename="../BasicRideMetrics.cpp" line="67"/>
         <source>Duration</source>
         <translation>Duraci?n</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="61"/>
-        <location filename="../BasicRideMetrics.cpp" line="62"/>
+        <location filename="../BasicRideMetrics.cpp" line="68"/>
+        <location filename="../BasicRideMetrics.cpp" line="69"/>
         <source>seconds</source>
         <translation>segundos</translation>
     </message>
@@ -9626,13 +9697,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>XPower</name>
     <message>
-        <location filename="../BikeScore.cpp" line="45"/>
+        <location filename="../BikeScore.cpp" line="48"/>
         <source>xPower</source>
         <translation>xPower</translation>
     </message>
     <message>
-        <location filename="../BikeScore.cpp" line="47"/>
-        <location filename="../BikeScore.cpp" line="48"/>
+        <location filename="../BikeScore.cpp" line="50"/>
+        <location filename="../BikeScore.cpp" line="51"/>
         <source>watts</source>
         <translation>vatios</translation>
     </message>
@@ -9655,12 +9726,12 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZonePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2278"/>
+        <location filename="../Pages.cpp" line="2280"/>
         <source>Critical Power History</source>
         <translation>Hist?rico de Potencia Cr?tica</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2279"/>
+        <location filename="../Pages.cpp" line="2281"/>
         <source>Default Zones</source>
         <translation>Zonas por defecto</translation>
     </message>
@@ -9675,7 +9746,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime1</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="74"/>
+        <location filename="../TimeInZone.cpp" line="79"/>
         <source>L1 Time in Zone</source>
         <translation>L1 Tiempo en Zona</translation>
     </message>
@@ -9683,7 +9754,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime10</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="182"/>
+        <location filename="../TimeInZone.cpp" line="232"/>
         <source>L10 Time in Zone</source>
         <translation>L10 Tiempo en Zona</translation>
     </message>
@@ -9691,7 +9762,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime2</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="86"/>
+        <location filename="../TimeInZone.cpp" line="96"/>
         <source>L2 Time in Zone</source>
         <translation>L2 Tiempo en Zona</translation>
     </message>
@@ -9699,7 +9770,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime3</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="98"/>
+        <location filename="../TimeInZone.cpp" line="113"/>
         <source>L3 Time in Zone</source>
         <translation>L3 Tiempo en Zona</translation>
     </message>
@@ -9707,7 +9778,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime4</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="110"/>
+        <location filename="../TimeInZone.cpp" line="130"/>
         <source>L4 Time in Zone</source>
         <translation>L4 Tiempo en Zona</translation>
     </message>
@@ -9715,7 +9786,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime5</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="122"/>
+        <location filename="../TimeInZone.cpp" line="147"/>
         <source>L5 Time in Zone</source>
         <translation>L5 Tiempo en Zona</translation>
     </message>
@@ -9723,7 +9794,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime6</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="134"/>
+        <location filename="../TimeInZone.cpp" line="164"/>
         <source>L6 Time in Zone</source>
         <translation>L6 Tiempo en Zona</translation>
     </message>
@@ -9731,7 +9802,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime7</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="146"/>
+        <location filename="../TimeInZone.cpp" line="181"/>
         <source>L7 Time in Zone</source>
         <translation>L7 Tiempo en Zona</translation>
     </message>
@@ -9739,7 +9810,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime8</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="158"/>
+        <location filename="../TimeInZone.cpp" line="198"/>
         <source>L8 Time in Zone</source>
         <translation>L8 Tiempo en Zona</translation>
     </message>
@@ -9747,7 +9818,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime9</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="170"/>
+        <location filename="../TimeInZone.cpp" line="215"/>
         <source>L9 Time in Zone</source>
         <translation>L9 Tiempo en Zona</translation>
     </message>

--- a/src/translations/gc_fr.ts
+++ b/src/translations/gc_fr.ts
@@ -254,13 +254,13 @@
 <context>
     <name>AerobicDecoupling</name>
     <message>
-        <location filename="../AerobicDecoupling.cpp" line="50"/>
+        <location filename="../AerobicDecoupling.cpp" line="52"/>
         <source>Aerobic Decoupling</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AerobicDecoupling.cpp" line="52"/>
-        <location filename="../AerobicDecoupling.cpp" line="53"/>
+        <location filename="../AerobicDecoupling.cpp" line="54"/>
+        <location filename="../AerobicDecoupling.cpp" line="55"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
@@ -394,42 +394,42 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="916"/>
+        <location filename="../AllPlot.cpp" line="909"/>
         <source>KPH</source>
         <translation>km/h</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="916"/>
+        <location filename="../AllPlot.cpp" line="909"/>
         <source>MPH</source>
         <translation>m/h</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="932"/>
+        <location filename="../AllPlot.cpp" line="925"/>
         <source>Nm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="932"/>
+        <location filename="../AllPlot.cpp" line="925"/>
         <source>ftLb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="945"/>
+        <location filename="../AllPlot.cpp" line="938"/>
         <source>Meters</source>
         <translation>Mètres</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="945"/>
+        <location filename="../AllPlot.cpp" line="938"/>
         <source>Feet</source>
         <translation>Pieds</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="971"/>
+        <location filename="../AllPlot.cpp" line="981"/>
         <source>Distance </source>
         <translation>Distance </translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="973"/>
+        <location filename="../AllPlot.cpp" line="983"/>
         <source>Time (Hours:Minutes)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -559,13 +559,13 @@
 <context>
     <name>AverageWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="55"/>
+        <location filename="../WattsPerKilogram.cpp" line="58"/>
         <source>Watts Per Kilogram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="57"/>
-        <location filename="../WattsPerKilogram.cpp" line="58"/>
+        <location filename="../WattsPerKilogram.cpp" line="60"/>
+        <location filename="../WattsPerKilogram.cpp" line="61"/>
         <source>wpk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -573,13 +573,13 @@
 <context>
     <name>AvgCadence</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="433"/>
+        <location filename="../BasicRideMetrics.cpp" line="488"/>
         <source>Average Cadence</source>
         <translation>Cadence moyenne</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="434"/>
-        <location filename="../BasicRideMetrics.cpp" line="435"/>
+        <location filename="../BasicRideMetrics.cpp" line="489"/>
+        <location filename="../BasicRideMetrics.cpp" line="490"/>
         <source>rpm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -587,13 +587,13 @@
 <context>
     <name>AvgHeartRate</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="399"/>
+        <location filename="../BasicRideMetrics.cpp" line="448"/>
         <source>Average Heart Rate</source>
         <translation>Pulsations moyennes</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="400"/>
-        <location filename="../BasicRideMetrics.cpp" line="401"/>
+        <location filename="../BasicRideMetrics.cpp" line="449"/>
+        <location filename="../BasicRideMetrics.cpp" line="450"/>
         <source>bpm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -601,13 +601,13 @@
 <context>
     <name>AvgPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="331"/>
+        <location filename="../BasicRideMetrics.cpp" line="368"/>
         <source>Average Power</source>
         <translation>Puissance moyenne</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="332"/>
-        <location filename="../BasicRideMetrics.cpp" line="333"/>
+        <location filename="../BasicRideMetrics.cpp" line="369"/>
+        <location filename="../BasicRideMetrics.cpp" line="370"/>
         <source>watts</source>
         <translation type="unfinished">watts</translation>
     </message>
@@ -615,17 +615,17 @@
 <context>
     <name>AvgSpeed</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="244"/>
+        <location filename="../BasicRideMetrics.cpp" line="271"/>
         <source>Average Speed</source>
         <translation>Vitesse Moyenne</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="245"/>
+        <location filename="../BasicRideMetrics.cpp" line="272"/>
         <source>kph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="246"/>
+        <location filename="../BasicRideMetrics.cpp" line="273"/>
         <source>mph</source>
         <translation type="unfinished"></translation>
     </message>
@@ -633,17 +633,17 @@
 <context>
     <name>AvgTemp</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="467"/>
+        <location filename="../BasicRideMetrics.cpp" line="528"/>
         <source>Average Temp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="468"/>
+        <location filename="../BasicRideMetrics.cpp" line="529"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="469"/>
+        <location filename="../BasicRideMetrics.cpp" line="530"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
@@ -747,7 +747,7 @@
 <context>
     <name>BikeScore</name>
     <message>
-        <location filename="../BikeScore.cpp" line="181"/>
+        <location filename="../BikeScore.cpp" line="196"/>
         <source>BikeScore&amp;#8482;</source>
         <translation>BikeScore&amp;#8482;</translation>
     </message>
@@ -755,54 +755,54 @@
 <context>
     <name>CPPage</name>
     <message>
-        <location filename="../Pages.cpp" line="2455"/>
+        <location filename="../Pages.cpp" line="2457"/>
         <source>Add CP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2456"/>
+        <location filename="../Pages.cpp" line="2458"/>
         <source>Delete CP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2457"/>
+        <location filename="../Pages.cpp" line="2459"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2460"/>
+        <location filename="../Pages.cpp" line="2462"/>
         <source>Add Zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2461"/>
+        <location filename="../Pages.cpp" line="2463"/>
         <source>Delete Zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2475"/>
-        <location filename="../Pages.cpp" line="2493"/>
+        <location filename="../Pages.cpp" line="2477"/>
+        <location filename="../Pages.cpp" line="2495"/>
         <source>From Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2476"/>
-        <location filename="../Pages.cpp" line="2494"/>
+        <location filename="../Pages.cpp" line="2478"/>
+        <location filename="../Pages.cpp" line="2496"/>
         <source>Critical Power</source>
         <translation type="unfinished">Puissance critique</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2523"/>
+        <location filename="../Pages.cpp" line="2525"/>
         <source>Short</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2524"/>
+        <location filename="../Pages.cpp" line="2526"/>
         <source>Long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2525"/>
+        <location filename="../Pages.cpp" line="2527"/>
         <source>From Watts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -810,7 +810,7 @@
 <context>
     <name>CPWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="120"/>
+        <location filename="../WattsPerKilogram.cpp" line="128"/>
         <source>60 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -905,7 +905,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ChartSettings.cpp" line="42"/>
+        <location filename="../ChartSettings.cpp" line="41"/>
         <source>Done</source>
         <translation type="unfinished">OK</translation>
     </message>
@@ -1486,7 +1486,7 @@ Ceci peut prendre un certain temps.</translation>
 <context>
     <name>CriticalPower</name>
     <message>
-        <location filename="../PeakPower.cpp" line="63"/>
+        <location filename="../PeakPower.cpp" line="67"/>
         <source>60 min Peak Power</source>
         <translation type="unfinished">Pique de puissance sur 5min {60 ?}</translation>
     </message>
@@ -1653,12 +1653,12 @@ Ceci peut prendre un certain temps.</translation>
 <context>
     <name>DBAccess</name>
     <message>
-        <location filename="../DBAccess.cpp" line="112"/>
+        <location filename="../DBAccess.cpp" line="113"/>
         <source>Cannot open database</source>
         <translation>Impossible d&apos;ouvrir la base de données</translation>
     </message>
     <message>
-        <location filename="../DBAccess.cpp" line="113"/>
+        <location filename="../DBAccess.cpp" line="114"/>
         <source>Unable to establish a database connection.
 This feature requires SQLite support. Please read the Qt SQL driver documentation for information how to build it.
 
@@ -1672,13 +1672,13 @@ Choisir Annuler pour sortir.</translation>
 <context>
     <name>DanielsEquivalentPower</name>
     <message>
-        <location filename="../DanielsPoints.cpp" line="110"/>
+        <location filename="../DanielsPoints.cpp" line="116"/>
         <source>Daniels EqP</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../DanielsPoints.cpp" line="111"/>
-        <location filename="../DanielsPoints.cpp" line="112"/>
+        <location filename="../DanielsPoints.cpp" line="117"/>
+        <location filename="../DanielsPoints.cpp" line="118"/>
         <source>watts</source>
         <translation type="unfinished">watts</translation>
     </message>
@@ -1686,7 +1686,7 @@ Choisir Annuler pour sortir.</translation>
 <context>
     <name>DanielsPoints</name>
     <message>
-        <location filename="../DanielsPoints.cpp" line="49"/>
+        <location filename="../DanielsPoints.cpp" line="51"/>
         <source>Daniels Points</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1992,52 +1992,17 @@ pour vérifier une nouvelle fois.</translation>
 <context>
     <name>EditMetricDetailDialog</name>
     <message>
-        <location filename="../LTMTool.cpp" line="638"/>
+        <location filename="../LTMTool.cpp" line="701"/>
         <source>Settings</source>
         <translation>Préférences</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="662"/>
-        <source>Filter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="664"/>
-        <source>No filter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="665"/>
-        <source>Include</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="666"/>
-        <source>Exclude</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="668"/>
-        <source>From</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="673"/>
-        <source>To</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="678"/>
-        <source>Show on plot</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="780"/>
+        <location filename="../LTMTool.cpp" line="814"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="781"/>
+        <location filename="../LTMTool.cpp" line="815"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Annuler</translation>
     </message>
@@ -2081,7 +2046,7 @@ pour vérifier une nouvelle fois.</translation>
 <context>
     <name>EfficiencyFactor</name>
     <message>
-        <location filename="../Coggan.cpp" line="198"/>
+        <location filename="../Coggan.cpp" line="217"/>
         <source>Efficiency Factor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2089,17 +2054,17 @@ pour vérifier une nouvelle fois.</translation>
 <context>
     <name>ElevationGain</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="170"/>
+        <location filename="../BasicRideMetrics.cpp" line="189"/>
         <source>Elevation Gain</source>
         <translation>Dénivelé</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="172"/>
+        <location filename="../BasicRideMetrics.cpp" line="191"/>
         <source>meters</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="173"/>
+        <location filename="../BasicRideMetrics.cpp" line="192"/>
         <source>feet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2335,7 +2300,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>FormField</name>
     <message>
-        <location filename="../RideMetadata.cpp" line="545"/>
+        <location filename="../RideMetadata.cpp" line="546"/>
         <source>You entered &apos;%1&apos; which is not an expected value.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2433,7 +2398,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>Gradient</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="758"/>
+        <location filename="../BasicRideMetrics.cpp" line="851"/>
         <source>Gradient</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2449,7 +2414,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>GroupByModel</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="724"/>
+        <location filename="../RideNavigator.cpp" line="726"/>
         <source>Date</source>
         <translation type="unfinished">Date</translation>
     </message>
@@ -2528,12 +2493,12 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HomeWindow</name>
     <message>
-        <location filename="../HomeWindow.cpp" line="712"/>
+        <location filename="../HomeWindow.cpp" line="713"/>
         <source>Are you sure you want to remove the chart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../HomeWindow.cpp" line="713"/>
+        <location filename="../HomeWindow.cpp" line="714"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2577,37 +2542,37 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrSchemePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2826"/>
+        <location filename="../Pages.cpp" line="2828"/>
         <source>Add</source>
         <translation type="unfinished">Ajouter</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2827"/>
+        <location filename="../Pages.cpp" line="2829"/>
         <source>Rename</source>
         <translation type="unfinished">Renommer</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2828"/>
+        <location filename="../Pages.cpp" line="2830"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2837"/>
+        <location filename="../Pages.cpp" line="2839"/>
         <source>Short</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2838"/>
+        <location filename="../Pages.cpp" line="2840"/>
         <source>Long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2839"/>
+        <location filename="../Pages.cpp" line="2841"/>
         <source>Percent of LT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2840"/>
+        <location filename="../Pages.cpp" line="2842"/>
         <source>Trimp k</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2615,12 +2580,12 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZonePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2809"/>
+        <location filename="../Pages.cpp" line="2811"/>
         <source>Lactic Threshold History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2810"/>
+        <location filename="../Pages.cpp" line="2812"/>
         <source>Default Zones</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2628,7 +2593,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime1</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="72"/>
+        <location filename="../HrTimeInZone.cpp" line="77"/>
         <source>H1 Time in Zone</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2636,7 +2601,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime2</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="84"/>
+        <location filename="../HrTimeInZone.cpp" line="94"/>
         <source>H2 Time in Zone</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2644,7 +2609,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime3</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="96"/>
+        <location filename="../HrTimeInZone.cpp" line="111"/>
         <source>H3 Time in Zone</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2652,7 +2617,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime4</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="108"/>
+        <location filename="../HrTimeInZone.cpp" line="128"/>
         <source>H4 Time in Zone</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2660,7 +2625,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime5</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="120"/>
+        <location filename="../HrTimeInZone.cpp" line="145"/>
         <source>H5 Time in Zone</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2668,7 +2633,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime6</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="132"/>
+        <location filename="../HrTimeInZone.cpp" line="162"/>
         <source>H6 Time in Zone</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2676,7 +2641,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime7</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="144"/>
+        <location filename="../HrTimeInZone.cpp" line="179"/>
         <source>H7 Time in Zone</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2684,7 +2649,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime8</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="156"/>
+        <location filename="../HrTimeInZone.cpp" line="196"/>
         <source>H8 Time in Zone</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2889,7 +2854,8 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LTMPlot</name>
     <message>
-        <location filename="../LTMPlot.cpp" line="1120"/>
+        <location filename="../LTMPlot.cpp" line="731"/>
+        <location filename="../LTMPlot.cpp" line="1123"/>
         <source>watts</source>
         <translation>watts</translation>
     </message>
@@ -2911,33 +2877,33 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="253"/>
-        <location filename="../LTMSidebar.cpp" line="289"/>
+        <location filename="../LTMSidebar.cpp" line="257"/>
+        <location filename="../LTMSidebar.cpp" line="293"/>
         <source>Edit details</source>
         <translation type="unfinished">Editer les détails</translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="254"/>
+        <location filename="../LTMSidebar.cpp" line="258"/>
         <source>Delete range</source>
         <translation type="unfinished">Effacer la plage</translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="255"/>
+        <location filename="../LTMSidebar.cpp" line="259"/>
         <source>Add Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="290"/>
+        <location filename="../LTMSidebar.cpp" line="294"/>
         <source>Delete event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="300"/>
+        <location filename="../LTMSidebar.cpp" line="304"/>
         <source>Add event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="537"/>
+        <location filename="../LTMSidebar.cpp" line="541"/>
         <source>^(Average|Max) </source>
         <translation type="unfinished"></translation>
     </message>
@@ -2949,7 +2915,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="obsolete">Plage de dates</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="69"/>
+        <location filename="../LTMTool.cpp" line="124"/>
         <source>Metric</source>
         <translation>Métrique</translation>
     </message>
@@ -2994,8 +2960,8 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="obsolete">Dernier 12 mois</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="511"/>
-        <location filename="../LTMTool.cpp" line="519"/>
+        <location filename="../LTMTool.cpp" line="574"/>
+        <location filename="../LTMTool.cpp" line="582"/>
         <source>Unknown Metric</source>
         <translation>Métrique inconnue</translation>
     </message>
@@ -3012,12 +2978,47 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="obsolete">Effacer la plage</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="544"/>
+        <location filename="../LTMTool.cpp" line="59"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="69"/>
+        <source>Chart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="101"/>
+        <source>Add</source>
+        <translation type="unfinished">Ajouter</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="102"/>
+        <source>Manage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="518"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="519"/>
+        <source>Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="520"/>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="607"/>
         <source>Pick Color</source>
         <translation>Choisir une couleur</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="545"/>
+        <location filename="../LTMTool.cpp" line="608"/>
         <source>Settings</source>
         <translation>Préférences</translation>
     </message>
@@ -3025,89 +3026,78 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LTMWindow</name>
     <message>
-        <location filename="../LTMWindow.cpp" line="135"/>
         <source>Add</source>
-        <translation type="unfinished">Ajouter</translation>
-    </message>
-    <message>
-        <location filename="../LTMWindow.cpp" line="137"/>
-        <source>Manage</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMWindow.cpp" line="105"/>
-        <source>Chart</source>
-        <translation type="unfinished"></translation>
+        <translation type="obsolete">Ajouter</translation>
     </message>
 </context>
 <context>
     <name>LTPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3001"/>
+        <location filename="../Pages.cpp" line="3003"/>
         <source>Add LT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3002"/>
+        <location filename="../Pages.cpp" line="3004"/>
         <source>Delete LT</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3003"/>
+        <location filename="../Pages.cpp" line="3005"/>
         <source>Default</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3006"/>
+        <location filename="../Pages.cpp" line="3008"/>
         <source>Add Zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3007"/>
+        <location filename="../Pages.cpp" line="3009"/>
         <source>Delete Zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3021"/>
-        <location filename="../Pages.cpp" line="3061"/>
+        <location filename="../Pages.cpp" line="3023"/>
+        <location filename="../Pages.cpp" line="3063"/>
         <source>From Date</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3022"/>
-        <location filename="../Pages.cpp" line="3062"/>
+        <location filename="../Pages.cpp" line="3024"/>
+        <location filename="../Pages.cpp" line="3064"/>
         <source>Lactic Threshold</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3039"/>
-        <location filename="../Pages.cpp" line="3063"/>
+        <location filename="../Pages.cpp" line="3041"/>
+        <location filename="../Pages.cpp" line="3065"/>
         <source>Rest HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3040"/>
-        <location filename="../Pages.cpp" line="3064"/>
+        <location filename="../Pages.cpp" line="3042"/>
+        <location filename="../Pages.cpp" line="3066"/>
         <source>Max HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3101"/>
+        <location filename="../Pages.cpp" line="3103"/>
         <source>Short</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3102"/>
+        <location filename="../Pages.cpp" line="3104"/>
         <source>Long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3103"/>
+        <location filename="../Pages.cpp" line="3105"/>
         <source>From BPM</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3104"/>
+        <location filename="../Pages.cpp" line="3106"/>
         <source>Trimp k</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3115,13 +3105,13 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LeftRightBalance</name>
     <message>
-        <location filename="../LeftRightBalance.cpp" line="33"/>
+        <location filename="../LeftRightBalance.cpp" line="36"/>
         <source>Left/Right Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftRightBalance.cpp" line="34"/>
-        <location filename="../LeftRightBalance.cpp" line="35"/>
+        <location filename="../LeftRightBalance.cpp" line="37"/>
+        <location filename="../LeftRightBalance.cpp" line="38"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3133,7 +3123,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="obsolete">Nom de fichier invalide</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2210"/>
+        <location filename="../MainWindow.cpp" line="2216"/>
         <source>Invalid date/time in filename:
 %1
 Skipping file...</source>
@@ -3142,13 +3132,13 @@ Fichier ignoré...</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="281"/>
-        <location filename="../MainWindow.cpp" line="2230"/>
+        <location filename="../MainWindow.cpp" line="2236"/>
         <source>Zones File Error</source>
         <translation>Erreur dans le fichier des zones</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="284"/>
-        <location filename="../MainWindow.cpp" line="2234"/>
+        <location filename="../MainWindow.cpp" line="2240"/>
         <source>Reading Zones File</source>
         <translation>Lecture du fichier des zones</translation>
     </message>
@@ -3158,7 +3148,7 @@ Fichier ignoré...</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="565"/>
-        <location filename="../MainWindow.cpp" line="1209"/>
+        <location filename="../MainWindow.cpp" line="1215"/>
         <source>Intervals</source>
         <translation>Intervales</translation>
     </message>
@@ -3179,22 +3169,22 @@ Fichier ignoré...</translation>
         <translation type="obsolete">&amp;Cycliste</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="743"/>
+        <location filename="../MainWindow.cpp" line="747"/>
         <source>&amp;New...</source>
         <translation>&amp;Nouveau</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="743"/>
+        <location filename="../MainWindow.cpp" line="747"/>
         <source>Ctrl+N</source>
         <translation>Ctrl+N</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="744"/>
+        <location filename="../MainWindow.cpp" line="748"/>
         <source>&amp;Open...</source>
         <translation>&amp;Ouvrir</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="744"/>
+        <location filename="../MainWindow.cpp" line="748"/>
         <source>Ctrl+O</source>
         <translation>Ctrl+O</translation>
     </message>
@@ -3203,7 +3193,7 @@ Fichier ignoré...</translation>
         <translation type="obsolete">&amp;Quitter</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="746"/>
+        <location filename="../MainWindow.cpp" line="750"/>
         <source>Ctrl+Q</source>
         <translation>Ctrl+Q</translation>
     </message>
@@ -3212,24 +3202,24 @@ Fichier ignoré...</translation>
         <translation type="obsolete">Sortie</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="775"/>
+        <location filename="../MainWindow.cpp" line="779"/>
         <source>Ctrl+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="749"/>
+        <location filename="../MainWindow.cpp" line="753"/>
         <source>&amp;Download from device...</source>
         <translation>&amp;Télécharder depuis l&apos;appareil...</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="291"/>
-        <location filename="../MainWindow.cpp" line="2241"/>
+        <location filename="../MainWindow.cpp" line="2247"/>
         <source>HR Zones File Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="294"/>
-        <location filename="../MainWindow.cpp" line="2245"/>
+        <location filename="../MainWindow.cpp" line="2251"/>
         <source>Reading HR Zones File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3250,210 +3240,210 @@ Fichier ignoré...</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="454"/>
-        <location filename="../MainWindow.cpp" line="845"/>
+        <location filename="../MainWindow.cpp" line="849"/>
         <source>Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="461"/>
-        <location filename="../MainWindow.cpp" line="848"/>
+        <location filename="../MainWindow.cpp" line="852"/>
         <source>Diary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="468"/>
-        <location filename="../MainWindow.cpp" line="844"/>
+        <location filename="../MainWindow.cpp" line="848"/>
         <source>Analysis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="474"/>
-        <location filename="../MainWindow.cpp" line="846"/>
+        <location filename="../MainWindow.cpp" line="850"/>
         <source>Train</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="524"/>
-        <location filename="../MainWindow.cpp" line="1160"/>
+        <location filename="../MainWindow.cpp" line="1166"/>
         <source>All Activities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="742"/>
+        <location filename="../MainWindow.cpp" line="746"/>
         <source>&amp;Athlete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="745"/>
+        <location filename="../MainWindow.cpp" line="749"/>
         <source>&amp;Close Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="745"/>
+        <location filename="../MainWindow.cpp" line="749"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="746"/>
+        <location filename="../MainWindow.cpp" line="750"/>
         <source>&amp;Quit All Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="748"/>
+        <location filename="../MainWindow.cpp" line="752"/>
         <source>A&amp;ctivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="749"/>
+        <location filename="../MainWindow.cpp" line="753"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+T</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="751"/>
+        <location filename="../MainWindow.cpp" line="755"/>
         <source>&amp;Manual activity entry...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="753"/>
+        <location filename="../MainWindow.cpp" line="757"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="754"/>
+        <location filename="../MainWindow.cpp" line="758"/>
         <source>&amp;Batch export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="755"/>
+        <location filename="../MainWindow.cpp" line="759"/>
         <source>Export Metrics as CSV...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="758"/>
+        <location filename="../MainWindow.cpp" line="762"/>
         <source>&amp;Upload to TrainingPeaks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="758"/>
+        <location filename="../MainWindow.cpp" line="762"/>
         <source>Ctrl+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="759"/>
+        <location filename="../MainWindow.cpp" line="763"/>
         <source>Down&amp;load from TrainingPeaks...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="759"/>
+        <location filename="../MainWindow.cpp" line="763"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="775"/>
+        <location filename="../MainWindow.cpp" line="779"/>
         <source>&amp;Save activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="776"/>
+        <location filename="../MainWindow.cpp" line="780"/>
         <source>D&amp;elete activity...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="777"/>
+        <location filename="../MainWindow.cpp" line="781"/>
         <source>Split &amp;activity...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="782"/>
+        <location filename="../MainWindow.cpp" line="786"/>
         <source>Critical Power Calculator...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="783"/>
+        <location filename="../MainWindow.cpp" line="787"/>
         <source>Air Density (Rho) Estimator...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="786"/>
+        <location filename="../MainWindow.cpp" line="790"/>
         <source>Get &amp;Withings Data...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="788"/>
+        <location filename="../MainWindow.cpp" line="792"/>
         <source>Get &amp;Zeo Data...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="791"/>
+        <location filename="../MainWindow.cpp" line="795"/>
         <source>Workout Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="792"/>
+        <location filename="../MainWindow.cpp" line="796"/>
         <source>Get Workouts from ErgDB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="796"/>
-        <location filename="../MainWindow.cpp" line="1197"/>
+        <location filename="../MainWindow.cpp" line="800"/>
+        <location filename="../MainWindow.cpp" line="1203"/>
         <source>Upload Activity to Calendar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="797"/>
+        <location filename="../MainWindow.cpp" line="801"/>
         <source>Import Calendar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="798"/>
+        <location filename="../MainWindow.cpp" line="802"/>
         <source>Export Calendar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="799"/>
+        <location filename="../MainWindow.cpp" line="803"/>
         <source>Refresh Calendar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="802"/>
+        <location filename="../MainWindow.cpp" line="806"/>
         <source>Find intervals...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1692"/>
+        <location filename="../MainWindow.cpp" line="1698"/>
         <source>Select Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1692"/>
-        <location filename="../MainWindow.cpp" line="1778"/>
-        <location filename="../MainWindow.cpp" line="1786"/>
+        <location filename="../MainWindow.cpp" line="1698"/>
+        <location filename="../MainWindow.cpp" line="1784"/>
+        <location filename="../MainWindow.cpp" line="1792"/>
         <source>No activity selected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1703"/>
+        <location filename="../MainWindow.cpp" line="1709"/>
         <source>Export Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1716"/>
+        <location filename="../MainWindow.cpp" line="1722"/>
         <source>Export Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1717"/>
+        <location filename="../MainWindow.cpp" line="1723"/>
         <source>Failed to export ride, please check permissions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2188"/>
+        <location filename="../MainWindow.cpp" line="2194"/>
         <source>Range from %1 to %2
 Athlete CP set to %3 watts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2209"/>
+        <location filename="../MainWindow.cpp" line="2215"/>
         <source>Invalid Activity File Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3462,7 +3452,7 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">&amp;Exporter en CSV...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="753"/>
+        <location filename="../MainWindow.cpp" line="757"/>
         <source>Ctrl+E</source>
         <translation>Ctrl+E</translation>
     </message>
@@ -3471,7 +3461,7 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">&amp;Exporter en GC...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="750"/>
+        <location filename="../MainWindow.cpp" line="754"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
@@ -3480,7 +3470,7 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">&amp;Rechercher les meilleurs intervalles</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="754"/>
+        <location filename="../MainWindow.cpp" line="758"/>
         <source>Ctrl+B</source>
         <translation>Ctrl+M</translation>
     </message>
@@ -3533,12 +3523,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Carte</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="750"/>
+        <location filename="../MainWindow.cpp" line="754"/>
         <source>&amp;Import from file...</source>
         <translation>&amp;Importer des fichiers</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="751"/>
+        <location filename="../MainWindow.cpp" line="755"/>
         <source>Ctrl+M</source>
         <translation>Ctrl+M</translation>
     </message>
@@ -3547,12 +3537,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">&amp;Sauver une sortie</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="780"/>
+        <location filename="../MainWindow.cpp" line="784"/>
         <source>&amp;Tools</source>
         <translation>Outils</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="781"/>
+        <location filename="../MainWindow.cpp" line="785"/>
         <source>&amp;Options...</source>
         <translation>Options</translation>
     </message>
@@ -3561,89 +3551,89 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Estimateur de puissance critique</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="825"/>
+        <location filename="../MainWindow.cpp" line="829"/>
         <source>&amp;View</source>
         <translation>&amp;Voir</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="827"/>
+        <location filename="../MainWindow.cpp" line="831"/>
         <source>Toggle Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="829"/>
+        <location filename="../MainWindow.cpp" line="833"/>
         <source>Show Left Sidebar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="833"/>
+        <location filename="../MainWindow.cpp" line="837"/>
         <source>Show Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="838"/>
+        <location filename="../MainWindow.cpp" line="842"/>
         <source>Tabbed View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="852"/>
+        <location filename="../MainWindow.cpp" line="856"/>
         <source>Reset Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="854"/>
+        <location filename="../MainWindow.cpp" line="858"/>
         <source>&amp;Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="861"/>
+        <location filename="../MainWindow.cpp" line="865"/>
         <source>&amp;Help</source>
         <translation>&amp;Aide</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="862"/>
+        <location filename="../MainWindow.cpp" line="866"/>
         <source>&amp;User Guide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="863"/>
+        <location filename="../MainWindow.cpp" line="867"/>
         <source>&amp;Log a bug or feature request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="865"/>
+        <location filename="../MainWindow.cpp" line="869"/>
         <source>&amp;About GoldenCheetah</source>
         <translation>A &amp;Propos de GoldenCheetah</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1164"/>
+        <location filename="../MainWindow.cpp" line="1170"/>
         <source>Save Changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1167"/>
+        <location filename="../MainWindow.cpp" line="1173"/>
         <source>Revert to Saved version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1170"/>
-        <location filename="../MainWindow.cpp" line="1786"/>
+        <location filename="../MainWindow.cpp" line="1176"/>
+        <location filename="../MainWindow.cpp" line="1792"/>
         <source>Delete Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1179"/>
-        <location filename="../MainWindow.cpp" line="1778"/>
+        <location filename="../MainWindow.cpp" line="1185"/>
+        <location filename="../MainWindow.cpp" line="1784"/>
         <source>Split Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1192"/>
+        <location filename="../MainWindow.cpp" line="1198"/>
         <source>Tweet Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1612"/>
+        <location filename="../MainWindow.cpp" line="1618"/>
         <source>Can&apos;t rename %1 to %2</source>
         <translation>Impossible de renommer %1 en %2</translation>
     </message>
@@ -3692,42 +3682,42 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Impossible de modifier le fichier %1</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1739"/>
+        <location filename="../MainWindow.cpp" line="1745"/>
         <source>Import from File</source>
         <translation>Importer un fichier</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1756"/>
+        <location filename="../MainWindow.cpp" line="1762"/>
         <source>No Activity To Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1757"/>
+        <location filename="../MainWindow.cpp" line="1763"/>
         <source>There is no currently selected ride to save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1791"/>
+        <location filename="../MainWindow.cpp" line="1797"/>
         <source>Are you sure you want to delete the activity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1845"/>
+        <location filename="../MainWindow.cpp" line="1851"/>
         <source>Export Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1845"/>
+        <location filename="../MainWindow.cpp" line="1851"/>
         <source>Comma Separated Variables (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1920"/>
+        <location filename="../MainWindow.cpp" line="1926"/>
         <source>Workout Directory Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1977"/>
+        <location filename="../MainWindow.cpp" line="1983"/>
         <source> (%1 watts)</source>
         <translation></translation>
     </message>
@@ -3740,37 +3730,37 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Effacer la sortie</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1173"/>
+        <location filename="../MainWindow.cpp" line="1179"/>
         <source>Find Best Intervals</source>
         <translation>Trouver les meilleurs intervales</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1176"/>
+        <location filename="../MainWindow.cpp" line="1182"/>
         <source>Find Power Peaks</source>
         <translation>Trouver les pics de puissance</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1214"/>
+        <location filename="../MainWindow.cpp" line="1220"/>
         <source>Rename interval</source>
         <translation>Renommer l&apos;intervale</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1215"/>
+        <location filename="../MainWindow.cpp" line="1221"/>
         <source>Delete interval</source>
         <translation>Effacer l&apos;intervale</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1216"/>
+        <location filename="../MainWindow.cpp" line="1222"/>
         <source>Zoom to interval</source>
         <translation>Zoomer sur l&apos;intervale</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1217"/>
+        <location filename="../MainWindow.cpp" line="1223"/>
         <source>Bring to Front</source>
         <translation>Mettre au premier plan</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1218"/>
+        <location filename="../MainWindow.cpp" line="1224"/>
         <source>Send to back</source>
         <translation>Mettre ne arrière-plan</translation>
     </message>
@@ -3804,7 +3794,7 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Impossible d&apos;enregistrer le fichier de note %1</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2187"/>
+        <location filename="../MainWindow.cpp" line="2193"/>
         <source>CP saved</source>
         <translation>CP sauvée</translation>
     </message>
@@ -3827,7 +3817,7 @@ CP du cycliste fixée à %3 watts</translation>
         <translation type="obsolete">Etes-vous certain de vouloir supprimer la sortie:</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1793"/>
+        <location filename="../MainWindow.cpp" line="1799"/>
         <source>Delete</source>
         <translation>Supprimer</translation>
     </message>
@@ -4047,13 +4037,13 @@ CP du cycliste fixée à %3 watts</translation>
 <context>
     <name>MaxCadence</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="606"/>
+        <location filename="../BasicRideMetrics.cpp" line="683"/>
         <source>Max Cadence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="607"/>
-        <location filename="../BasicRideMetrics.cpp" line="608"/>
+        <location filename="../BasicRideMetrics.cpp" line="684"/>
+        <location filename="../BasicRideMetrics.cpp" line="685"/>
         <source>rpm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4061,13 +4051,13 @@ CP du cycliste fixée à %3 watts</translation>
 <context>
     <name>MaxHr</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="538"/>
+        <location filename="../BasicRideMetrics.cpp" line="607"/>
         <source>Max Heartrate</source>
         <translation>Fréq cardiaque max</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="539"/>
-        <location filename="../BasicRideMetrics.cpp" line="540"/>
+        <location filename="../BasicRideMetrics.cpp" line="608"/>
+        <location filename="../BasicRideMetrics.cpp" line="609"/>
         <source>bpm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4075,13 +4065,13 @@ CP du cycliste fixée à %3 watts</translation>
 <context>
     <name>MaxPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="509"/>
+        <location filename="../BasicRideMetrics.cpp" line="574"/>
         <source>Max Power</source>
         <translation>Puissance max</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="510"/>
-        <location filename="../BasicRideMetrics.cpp" line="511"/>
+        <location filename="../BasicRideMetrics.cpp" line="575"/>
+        <location filename="../BasicRideMetrics.cpp" line="576"/>
         <source>watts</source>
         <translation type="unfinished">watts</translation>
     </message>
@@ -4089,7 +4079,7 @@ CP du cycliste fixée à %3 watts</translation>
 <context>
     <name>MaxPowerVariance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="848"/>
+        <location filename="../BasicRideMetrics.cpp" line="949"/>
         <source>Max Power Variance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4097,17 +4087,17 @@ CP du cycliste fixée à %3 watts</translation>
 <context>
     <name>MaxSpeed</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="567"/>
+        <location filename="../BasicRideMetrics.cpp" line="640"/>
         <source>Max Speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="568"/>
+        <location filename="../BasicRideMetrics.cpp" line="641"/>
         <source>kph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="569"/>
+        <location filename="../BasicRideMetrics.cpp" line="642"/>
         <source>mph</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4115,17 +4105,17 @@ CP du cycliste fixée à %3 watts</translation>
 <context>
     <name>MaxTemp</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="643"/>
+        <location filename="../BasicRideMetrics.cpp" line="724"/>
         <source>Max Temp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="644"/>
+        <location filename="../BasicRideMetrics.cpp" line="725"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="645"/>
+        <location filename="../BasicRideMetrics.cpp" line="726"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4133,7 +4123,7 @@ CP du cycliste fixée à %3 watts</translation>
 <context>
     <name>MeanPowerVariance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="801"/>
+        <location filename="../BasicRideMetrics.cpp" line="898"/>
         <source>Average Power Variance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4141,42 +4131,42 @@ CP du cycliste fixée à %3 watts</translation>
 <context>
     <name>MeasuresPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3395"/>
+        <location filename="../Pages.cpp" line="3397"/>
         <source>Move up</source>
         <translation type="unfinished">Vers le haut</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3396"/>
+        <location filename="../Pages.cpp" line="3398"/>
         <source>Move down</source>
         <translation type="unfinished">Vers le bas</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3397"/>
+        <location filename="../Pages.cpp" line="3399"/>
         <source>Insert</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3398"/>
+        <location filename="../Pages.cpp" line="3400"/>
         <source>Rename</source>
         <translation type="unfinished">Renommer</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3399"/>
+        <location filename="../Pages.cpp" line="3401"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3410"/>
+        <location filename="../Pages.cpp" line="3412"/>
         <source>Screen Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3411"/>
+        <location filename="../Pages.cpp" line="3413"/>
         <source>Measure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3412"/>
+        <location filename="../Pages.cpp" line="3414"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4391,17 +4381,17 @@ Elapsed: %1
 <context>
     <name>NavigatorCellDelegate</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="941"/>
+        <location filename="../RideNavigator.cpp" line="944"/>
         <source>Date</source>
         <translation type="unfinished">Date</translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="944"/>
+        <location filename="../RideNavigator.cpp" line="947"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="947"/>
+        <location filename="../RideNavigator.cpp" line="950"/>
         <source>Last updated</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4528,13 +4518,13 @@ Elapsed: %1
 <context>
     <name>NinetyFivePercentHeartRate</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="688"/>
+        <location filename="../BasicRideMetrics.cpp" line="773"/>
         <source>95% Heartrate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="689"/>
-        <location filename="../BasicRideMetrics.cpp" line="690"/>
+        <location filename="../BasicRideMetrics.cpp" line="774"/>
+        <location filename="../BasicRideMetrics.cpp" line="775"/>
         <source>bpm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4542,13 +4532,13 @@ Elapsed: %1
 <context>
     <name>NonZeroPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="365"/>
+        <location filename="../BasicRideMetrics.cpp" line="408"/>
         <source>Nonzero Average Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="366"/>
-        <location filename="../BasicRideMetrics.cpp" line="367"/>
+        <location filename="../BasicRideMetrics.cpp" line="409"/>
+        <location filename="../BasicRideMetrics.cpp" line="410"/>
         <source>watts</source>
         <translation type="unfinished">watts</translation>
     </message>
@@ -4556,17 +4546,17 @@ Elapsed: %1
 <context>
     <name>Pace</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="288"/>
+        <location filename="../BasicRideMetrics.cpp" line="319"/>
         <source>Pace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="290"/>
+        <location filename="../BasicRideMetrics.cpp" line="321"/>
         <source>min/km</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="291"/>
+        <location filename="../BasicRideMetrics.cpp" line="322"/>
         <source>min/mile</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4756,7 +4746,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower10m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="162"/>
+        <location filename="../PeakPower.cpp" line="202"/>
         <source>10 min Peak Power</source>
         <translation>Pique de puissance sur 10min</translation>
     </message>
@@ -4764,7 +4754,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower10s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="96"/>
+        <location filename="../PeakPower.cpp" line="112"/>
         <source>10 sec Peak Power</source>
         <translation>Pique de puissance sur 10sec</translation>
     </message>
@@ -4772,7 +4762,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower15s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="107"/>
+        <location filename="../PeakPower.cpp" line="127"/>
         <source>15 sec Peak Power</source>
         <translation>Pique de puissance sur 15sec</translation>
     </message>
@@ -4780,7 +4770,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower1m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="140"/>
+        <location filename="../PeakPower.cpp" line="172"/>
         <source>1 min Peak Power</source>
         <translation>Pique de puissance sur 1min</translation>
     </message>
@@ -4788,7 +4778,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower1s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="74"/>
+        <location filename="../PeakPower.cpp" line="82"/>
         <source>1 sec Peak Power</source>
         <translation>Pique de puissance sur 1sec</translation>
     </message>
@@ -4796,7 +4786,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower20m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="173"/>
+        <location filename="../PeakPower.cpp" line="217"/>
         <source>20 min Peak Power</source>
         <translation>Pique de puissance sur 20min</translation>
     </message>
@@ -4804,7 +4794,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower20s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="118"/>
+        <location filename="../PeakPower.cpp" line="142"/>
         <source>20 sec Peak Power</source>
         <translation>Pique de puissance sur 20sec</translation>
     </message>
@@ -4812,7 +4802,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower30m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="184"/>
+        <location filename="../PeakPower.cpp" line="232"/>
         <source>30 min Peak Power</source>
         <translation>Pique de puissance sur 30min</translation>
     </message>
@@ -4820,7 +4810,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower30s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="129"/>
+        <location filename="../PeakPower.cpp" line="157"/>
         <source>30 sec Peak Power</source>
         <translation>Pique de puissance sur 30sec</translation>
     </message>
@@ -4828,7 +4818,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower5m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="151"/>
+        <location filename="../PeakPower.cpp" line="187"/>
         <source>5 min Peak Power</source>
         <translation>Pique de puissance sur 5min</translation>
     </message>
@@ -4836,7 +4826,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower5s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="85"/>
+        <location filename="../PeakPower.cpp" line="97"/>
         <source>5 sec Peak Power</source>
         <translation>Pique de puissance sur 5sec</translation>
     </message>
@@ -4844,13 +4834,13 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr10m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="263"/>
+        <location filename="../PeakPower.cpp" line="324"/>
         <source>10 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="264"/>
-        <location filename="../PeakPower.cpp" line="265"/>
+        <location filename="../PeakPower.cpp" line="325"/>
+        <location filename="../PeakPower.cpp" line="326"/>
         <source>bpm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4858,13 +4848,13 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr1m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="235"/>
+        <location filename="../PeakPower.cpp" line="288"/>
         <source>1 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="236"/>
-        <location filename="../PeakPower.cpp" line="237"/>
+        <location filename="../PeakPower.cpp" line="289"/>
+        <location filename="../PeakPower.cpp" line="290"/>
         <source>bpm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4872,13 +4862,13 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr20m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="277"/>
+        <location filename="../PeakPower.cpp" line="342"/>
         <source>20 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="278"/>
-        <location filename="../PeakPower.cpp" line="279"/>
+        <location filename="../PeakPower.cpp" line="343"/>
+        <location filename="../PeakPower.cpp" line="344"/>
         <source>bpm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4886,13 +4876,13 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr30m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="291"/>
+        <location filename="../PeakPower.cpp" line="360"/>
         <source>30 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="292"/>
-        <location filename="../PeakPower.cpp" line="293"/>
+        <location filename="../PeakPower.cpp" line="361"/>
+        <location filename="../PeakPower.cpp" line="362"/>
         <source>bpm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4900,22 +4890,8 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr5m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="249"/>
-        <source>5 min Peak Power HR</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../PeakPower.cpp" line="250"/>
-        <location filename="../PeakPower.cpp" line="251"/>
-        <source>bpm</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>PeakPowerHr60m</name>
-    <message>
         <location filename="../PeakPower.cpp" line="306"/>
-        <source>60 min Peak Power HR</source>
+        <source>5 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4926,10 +4902,24 @@ Do you want to continue?</source>
     </message>
 </context>
 <context>
+    <name>PeakPowerHr60m</name>
+    <message>
+        <location filename="../PeakPower.cpp" line="379"/>
+        <source>60 min Peak Power HR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../PeakPower.cpp" line="380"/>
+        <location filename="../PeakPower.cpp" line="381"/>
+        <source>bpm</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeakWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="89"/>
-        <location filename="../WattsPerKilogram.cpp" line="90"/>
+        <location filename="../WattsPerKilogram.cpp" line="93"/>
+        <location filename="../WattsPerKilogram.cpp" line="94"/>
         <source>wpk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4937,7 +4927,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK10m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="219"/>
+        <location filename="../WattsPerKilogram.cpp" line="263"/>
         <source>10 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4945,7 +4935,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK10s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="153"/>
+        <location filename="../WattsPerKilogram.cpp" line="173"/>
         <source>10 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4953,7 +4943,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK15s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="164"/>
+        <location filename="../WattsPerKilogram.cpp" line="188"/>
         <source>15 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4961,7 +4951,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK1m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="197"/>
+        <location filename="../WattsPerKilogram.cpp" line="233"/>
         <source>1 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4969,7 +4959,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK1s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="131"/>
+        <location filename="../WattsPerKilogram.cpp" line="143"/>
         <source>1 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4977,7 +4967,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK20m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="230"/>
+        <location filename="../WattsPerKilogram.cpp" line="278"/>
         <source>20 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4985,7 +4975,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK20s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="175"/>
+        <location filename="../WattsPerKilogram.cpp" line="203"/>
         <source>20 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4993,7 +4983,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK30m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="241"/>
+        <location filename="../WattsPerKilogram.cpp" line="293"/>
         <source>30 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5001,7 +4991,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK30s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="186"/>
+        <location filename="../WattsPerKilogram.cpp" line="218"/>
         <source>30 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5009,7 +4999,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK5m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="208"/>
+        <location filename="../WattsPerKilogram.cpp" line="248"/>
         <source>5 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5017,7 +5007,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK5s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="142"/>
+        <location filename="../WattsPerKilogram.cpp" line="158"/>
         <source>5 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5029,22 +5019,22 @@ Do you want to continue?</source>
         <translation type="obsolete">Gestionnaire de performance</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="118"/>
+        <location filename="../PerfPlot.cpp" line="147"/>
         <source>Daily</source>
         <translation>Journalier</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="138"/>
+        <location filename="../PerfPlot.cpp" line="167"/>
         <source>Short Term Stress</source>
         <translation>Charge à court terme (STS)</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="152"/>
+        <location filename="../PerfPlot.cpp" line="181"/>
         <source>Long Term Stress</source>
         <translation>Charge à long terme (LTS)</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="166"/>
+        <location filename="../PerfPlot.cpp" line="195"/>
         <source>Stress Balance</source>
         <translation>Equilibre de charge (SB)</translation>
     </message>
@@ -5148,85 +5138,91 @@ Do you want to continue?</source>
     <name>PowerHist</name>
     <message>
         <location filename="../PowerHist.cpp" line="77"/>
-        <location filename="../PowerHist.cpp" line="902"/>
+        <location filename="../PowerHist.cpp" line="940"/>
         <source>Time (minutes)</source>
         <translation type="unfinished">Temps (minutes)</translation>
     </message>
     <message>
         <location filename="../PowerHist.cpp" line="77"/>
-        <location filename="../PowerHist.cpp" line="902"/>
+        <location filename="../PowerHist.cpp" line="940"/>
         <source>Time (percent)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="877"/>
+        <location filename="../PowerHist.cpp" line="910"/>
         <source>Power (watts)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="876"/>
+        <location filename="../PowerHist.cpp" line="909"/>
+        <location filename="../PowerHist.cpp" line="914"/>
         <source>Power zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="882"/>
+        <location filename="../PowerHist.cpp" line="920"/>
         <source>Heartrate (bpm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="881"/>
+        <location filename="../PowerHist.cpp" line="919"/>
         <source>Heartrate zone</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="886"/>
+        <location filename="../PowerHist.cpp" line="915"/>
+        <source>Power (watts/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../PowerHist.cpp" line="924"/>
         <source>Cadence (rpm)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>Speed (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>kph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>mph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>Torque (%1)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>N-m</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>ft-lbf</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="898"/>
+        <location filename="../PowerHist.cpp" line="936"/>
         <source>Unknown data series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="962"/>
-        <location filename="../PowerHist.cpp" line="975"/>
+        <location filename="../PowerHist.cpp" line="1000"/>
+        <location filename="../PowerHist.cpp" line="1013"/>
         <source>minutes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="962"/>
-        <location filename="../PowerHist.cpp" line="975"/>
+        <location filename="../PowerHist.cpp" line="1000"/>
+        <location filename="../PowerHist.cpp" line="1013"/>
         <source>%</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5234,27 +5230,27 @@ Do you want to continue?</source>
 <context>
     <name>ProcessorPage</name>
     <message>
-        <location filename="../Pages.cpp" line="2198"/>
+        <location filename="../Pages.cpp" line="2200"/>
         <source>Processor</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2199"/>
+        <location filename="../Pages.cpp" line="2201"/>
         <source>Apply</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2200"/>
+        <location filename="../Pages.cpp" line="2202"/>
         <source>Settings</source>
         <translation type="unfinished">Préférences</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2224"/>
+        <location filename="../Pages.cpp" line="2226"/>
         <source>Manual</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2225"/>
+        <location filename="../Pages.cpp" line="2227"/>
         <source>Auto</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5656,7 +5652,7 @@ Do you want to continue?</source>
 <context>
     <name>RelativeIntensity</name>
     <message>
-        <location filename="../BikeScore.cpp" line="136"/>
+        <location filename="../BikeScore.cpp" line="147"/>
         <source>Relative Intensity</source>
         <translation>Intensité relative</translation>
     </message>
@@ -5664,7 +5660,7 @@ Do you want to continue?</source>
 <context>
     <name>ResponseIndex</name>
     <message>
-        <location filename="../BikeScore.cpp" line="218"/>
+        <location filename="../BikeScore.cpp" line="237"/>
         <source>Response Index</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5672,7 +5668,7 @@ Do you want to continue?</source>
 <context>
     <name>RideCount</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="34"/>
+        <location filename="../BasicRideMetrics.cpp" line="37"/>
         <source>Rides</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5680,9 +5676,9 @@ Do you want to continue?</source>
 <context>
     <name>RideDelegate</name>
     <message>
-        <location filename="../RideImportWizard.cpp" line="995"/>
-        <location filename="../RideImportWizard.cpp" line="1032"/>
-        <location filename="../RideImportWizard.cpp" line="1048"/>
+        <location filename="../RideImportWizard.cpp" line="998"/>
+        <location filename="../RideImportWizard.cpp" line="1035"/>
+        <location filename="../RideImportWizard.cpp" line="1051"/>
         <source>dd MMM yyyy</source>
         <translation>dd MMM yyyy</translation>
     </message>
@@ -6236,9 +6232,9 @@ Do you want to continue?</source>
     </message>
     <message>
         <location filename="../RideImportWizard.cpp" line="74"/>
-        <location filename="../RideImportWizard.cpp" line="696"/>
-        <location filename="../RideImportWizard.cpp" line="738"/>
-        <location filename="../RideImportWizard.cpp" line="890"/>
+        <location filename="../RideImportWizard.cpp" line="699"/>
+        <location filename="../RideImportWizard.cpp" line="741"/>
+        <location filename="../RideImportWizard.cpp" line="893"/>
         <source>Abort</source>
         <translation>Interrompre</translation>
     </message>
@@ -6309,12 +6305,12 @@ Do you want to continue?</source>
     </message>
     <message>
         <location filename="../RideImportWizard.cpp" line="268"/>
-        <location filename="../RideImportWizard.cpp" line="454"/>
-        <location filename="../RideImportWizard.cpp" line="506"/>
-        <location filename="../RideImportWizard.cpp" line="717"/>
-        <location filename="../RideImportWizard.cpp" line="756"/>
-        <location filename="../RideImportWizard.cpp" line="895"/>
-        <location filename="../RideImportWizard.cpp" line="918"/>
+        <location filename="../RideImportWizard.cpp" line="457"/>
+        <location filename="../RideImportWizard.cpp" line="509"/>
+        <location filename="../RideImportWizard.cpp" line="720"/>
+        <location filename="../RideImportWizard.cpp" line="759"/>
+        <location filename="../RideImportWizard.cpp" line="898"/>
+        <location filename="../RideImportWizard.cpp" line="921"/>
         <source>Error</source>
         <translation>Erreur</translation>
     </message>
@@ -6324,157 +6320,157 @@ Do you want to continue?</source>
         <translation>Analyse...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="378"/>
+        <location filename="../RideImportWizard.cpp" line="381"/>
         <source>Validated</source>
         <translation>Validé</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="380"/>
+        <location filename="../RideImportWizard.cpp" line="383"/>
         <source>Warning - </source>
         <translation>Attention - </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="394"/>
-        <location filename="../RideImportWizard.cpp" line="619"/>
-        <location filename="../RideImportWizard.cpp" line="765"/>
+        <location filename="../RideImportWizard.cpp" line="397"/>
+        <location filename="../RideImportWizard.cpp" line="622"/>
+        <location filename="../RideImportWizard.cpp" line="768"/>
         <source>dd MMM yyyy</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="395"/>
+        <location filename="../RideImportWizard.cpp" line="398"/>
         <source>hh:mm:ss ap</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="432"/>
+        <location filename="../RideImportWizard.cpp" line="435"/>
         <source>Error - </source>
         <translation>Erreur - </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="380"/>
-        <location filename="../RideImportWizard.cpp" line="432"/>
+        <location filename="../RideImportWizard.cpp" line="383"/>
+        <location filename="../RideImportWizard.cpp" line="435"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="447"/>
+        <location filename="../RideImportWizard.cpp" line="450"/>
         <source>Step 3 of 4: Confirm Date and Time</source>
         <translation>Etape 3 sur 4 : Confirmation de la date et heure</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="464"/>
+        <location filename="../RideImportWizard.cpp" line="467"/>
         <source>Save</source>
         <translation>Sauver</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="573"/>
-        <location filename="../RideImportWizard.cpp" line="623"/>
+        <location filename="../RideImportWizard.cpp" line="576"/>
+        <location filename="../RideImportWizard.cpp" line="626"/>
         <source>hh:mm:ss</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="582"/>
+        <location filename="../RideImportWizard.cpp" line="585"/>
         <source>Invalid Selection</source>
         <translation>Sélection invalide</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="582"/>
+        <location filename="../RideImportWizard.cpp" line="585"/>
         <source>More than 24hrs of rides to fit into a day</source>
         <translation>Plus de 24h de sortie pour une seule journée</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="627"/>
-        <location filename="../RideImportWizard.cpp" line="766"/>
+        <location filename="../RideImportWizard.cpp" line="630"/>
+        <location filename="../RideImportWizard.cpp" line="769"/>
         <source>hh:mm:ss a</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="736"/>
+        <location filename="../RideImportWizard.cpp" line="739"/>
         <source>Step 4 of 4: Save to Library</source>
         <translation>Etape 4 sur 4 : Sauvegarde des sorties</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="758"/>
+        <location filename="../RideImportWizard.cpp" line="761"/>
         <source>Saving...</source>
         <translation>Sauvegarde...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="834"/>
+        <location filename="../RideImportWizard.cpp" line="837"/>
         <source>Error - Source is Target</source>
         <translation>Erreur - La source est aussi la cible</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="845"/>
+        <location filename="../RideImportWizard.cpp" line="848"/>
         <source>Overwriting file...</source>
         <translation>Remplace le fichier...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="847"/>
+        <location filename="../RideImportWizard.cpp" line="850"/>
         <source>/</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="847"/>
+        <location filename="../RideImportWizard.cpp" line="850"/>
         <source>.tmp</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="821"/>
-        <location filename="../RideImportWizard.cpp" line="854"/>
+        <location filename="../RideImportWizard.cpp" line="824"/>
+        <location filename="../RideImportWizard.cpp" line="857"/>
         <source>File Overwritten</source>
         <translation>Fichier remplacà</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="857"/>
-        <location filename="../RideImportWizard.cpp" line="859"/>
+        <location filename="../RideImportWizard.cpp" line="860"/>
+        <location filename="../RideImportWizard.cpp" line="862"/>
         <source>Error - overwrite failed</source>
         <translation>Erreur - Echec du remplacement</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="790"/>
-        <location filename="../RideImportWizard.cpp" line="862"/>
+        <location filename="../RideImportWizard.cpp" line="793"/>
+        <location filename="../RideImportWizard.cpp" line="865"/>
         <source>Error - File exists</source>
         <translation>Erreur - Le fichier existe</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="865"/>
+        <location filename="../RideImportWizard.cpp" line="868"/>
         <source>Saving file...</source>
         <translation>Sauvegarde du fichier...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="823"/>
-        <location filename="../RideImportWizard.cpp" line="868"/>
+        <location filename="../RideImportWizard.cpp" line="826"/>
+        <location filename="../RideImportWizard.cpp" line="871"/>
         <source>File Saved</source>
         <translation>Fichier sauvé</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="877"/>
+        <location filename="../RideImportWizard.cpp" line="880"/>
         <source>Error - copy failed</source>
         <translation>Erreur - La copie a échouée</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="888"/>
+        <location filename="../RideImportWizard.cpp" line="891"/>
         <source>Step 5 of 5: Calculating Critical Powers</source>
         <translation>Etape 5 sur 5 : Calcul des puissances maximales</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="896"/>
+        <location filename="../RideImportWizard.cpp" line="899"/>
         <source>Calculating...</source>
         <translation>Calcul...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="905"/>
+        <location filename="../RideImportWizard.cpp" line="908"/>
         <source>Completed.</source>
         <translation>Accompli.</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="923"/>
+        <location filename="../RideImportWizard.cpp" line="926"/>
         <source>Import Complete. %1 of %2 successful.</source>
         <translation>Importation terminée. %1 sur %2 avec succès.</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="704"/>
-        <location filename="../RideImportWizard.cpp" line="928"/>
+        <location filename="../RideImportWizard.cpp" line="707"/>
+        <location filename="../RideImportWizard.cpp" line="931"/>
         <source>Finish</source>
         <translation>Terminé.</translation>
     </message>
@@ -6482,22 +6478,22 @@ Do you want to continue?</source>
 <context>
     <name>RideNavigator</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="540"/>
+        <location filename="../RideNavigator.cpp" line="542"/>
         <source>Remove Column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="546"/>
+        <location filename="../RideNavigator.cpp" line="548"/>
         <source>Column Chooser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="551"/>
+        <location filename="../RideNavigator.cpp" line="553"/>
         <source>Do Not Show in Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="551"/>
+        <location filename="../RideNavigator.cpp" line="553"/>
         <source>Show In Groups</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6856,32 +6852,32 @@ Voulez-vous continuer?
 <context>
     <name>SchemePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2295"/>
+        <location filename="../Pages.cpp" line="2297"/>
         <source>Add</source>
         <translation type="unfinished">Ajouter</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2296"/>
+        <location filename="../Pages.cpp" line="2298"/>
         <source>Rename</source>
         <translation type="unfinished">Renommer</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2297"/>
+        <location filename="../Pages.cpp" line="2299"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2306"/>
+        <location filename="../Pages.cpp" line="2308"/>
         <source>Short</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2307"/>
+        <location filename="../Pages.cpp" line="2309"/>
         <source>Long</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2308"/>
+        <location filename="../Pages.cpp" line="2310"/>
         <source>Percent of CP</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6966,42 +6962,42 @@ Voulez-vous continuer?
 <context>
     <name>SeasonsPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3673"/>
+        <location filename="../Pages.cpp" line="3675"/>
         <source>Move up</source>
         <translation type="unfinished">Vers le haut</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3674"/>
+        <location filename="../Pages.cpp" line="3676"/>
         <source>Move down</source>
         <translation type="unfinished">Vers le bas</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3675"/>
+        <location filename="../Pages.cpp" line="3677"/>
         <source>Add</source>
         <translation type="unfinished">Ajouter</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3676"/>
+        <location filename="../Pages.cpp" line="3678"/>
         <source>Delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3685"/>
+        <location filename="../Pages.cpp" line="3687"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3686"/>
+        <location filename="../Pages.cpp" line="3688"/>
         <source>Type</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3687"/>
+        <location filename="../Pages.cpp" line="3689"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3688"/>
+        <location filename="../Pages.cpp" line="3690"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7009,7 +7005,7 @@ Voulez-vous continuer?
 <context>
     <name>SessionRPE</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="302"/>
+        <location filename="../TRIMPPoints.cpp" line="316"/>
         <source>Session RPE</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7036,6 +7032,147 @@ Voulez-vous continuer?
         <location filename="../SmallPlot.cpp" line="237"/>
         <source>Time (minutes)</source>
         <translation type="unfinished">Temps (minutes)</translation>
+    </message>
+</context>
+<context>
+    <name>SpecialFields</name>
+    <message>
+        <location filename="../SpecialFields.cpp" line="26"/>
+        <source>Start Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="27"/>
+        <source>Start Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="28"/>
+        <source>Identifier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="29"/>
+        <source>Workout Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="30"/>
+        <source>Sport</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="31"/>
+        <source>Objective</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="32"/>
+        <source>Summary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="33"/>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="34"/>
+        <source>Keywords</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="35"/>
+        <source>Recording Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="36"/>
+        <source>Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="37"/>
+        <source>Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="38"/>
+        <source>Device Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="39"/>
+        <source>Dropouts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="40"/>
+        <source>Dropout Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="41"/>
+        <source>Spikes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="42"/>
+        <source>Spike Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="43"/>
+        <source>Torque Adjust</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="44"/>
+        <source>Filename</source>
+        <translation type="unfinished">Nom du fichier</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="45"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="46"/>
+        <source>Change History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="47"/>
+        <source>Calendar Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="48"/>
+        <source>Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SpecialTabs</name>
+    <message>
+        <location filename="../SpecialFields.cpp" line="130"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="131"/>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="132"/>
+        <source>Metric</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="133"/>
+        <source>Extra</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -7452,22 +7589,22 @@ Voulez-vous continuer?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="388"/>
+        <location filename="../StravaDialog.cpp" line="389"/>
         <source>Upload ride... Sending</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="398"/>
+        <location filename="../StravaDialog.cpp" line="399"/>
         <source>Upload finished.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="430"/>
+        <location filename="../StravaDialog.cpp" line="431"/>
         <source>Ride processing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="501"/>
+        <location filename="../StravaDialog.cpp" line="502"/>
         <source>Searching corresponding Ride</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7720,7 +7857,7 @@ Voulez-vous continuer?
 <context>
     <name>TRIMP100Points</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="114"/>
+        <location filename="../TRIMPPoints.cpp" line="120"/>
         <source>TRIMP(100) Points</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7728,7 +7865,7 @@ Voulez-vous continuer?
 <context>
     <name>TRIMPPoints</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="47"/>
+        <location filename="../TRIMPPoints.cpp" line="49"/>
         <source>TRIMP Points</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7736,7 +7873,7 @@ Voulez-vous continuer?
 <context>
     <name>TRIMPZonalPoints</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="180"/>
+        <location filename="../TRIMPPoints.cpp" line="190"/>
         <source>TRIMP Zonal Points</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7744,13 +7881,13 @@ Voulez-vous continuer?
 <context>
     <name>TimeRiding</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="94"/>
+        <location filename="../BasicRideMetrics.cpp" line="105"/>
         <source>Time Riding</source>
         <translation>Temps en mouvement</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="95"/>
-        <location filename="../BasicRideMetrics.cpp" line="96"/>
+        <location filename="../BasicRideMetrics.cpp" line="106"/>
+        <location filename="../BasicRideMetrics.cpp" line="107"/>
         <source>seconds</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7834,17 +7971,17 @@ Voulez-vous continuer?
 <context>
     <name>TotalDistance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="129"/>
+        <location filename="../BasicRideMetrics.cpp" line="144"/>
         <source>Distance</source>
         <translation>Distance</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="131"/>
+        <location filename="../BasicRideMetrics.cpp" line="146"/>
         <source>km</source>
         <translation type="unfinished">km</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="132"/>
+        <location filename="../BasicRideMetrics.cpp" line="147"/>
         <source>miles</source>
         <translation type="unfinished">miles</translation>
     </message>
@@ -7852,13 +7989,13 @@ Voulez-vous continuer?
 <context>
     <name>TotalWork</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="213"/>
+        <location filename="../BasicRideMetrics.cpp" line="236"/>
         <source>Work</source>
         <translation>Travail</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="214"/>
-        <location filename="../BasicRideMetrics.cpp" line="215"/>
+        <location filename="../BasicRideMetrics.cpp" line="237"/>
+        <location filename="../BasicRideMetrics.cpp" line="238"/>
         <source>kJ</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7932,6 +8069,14 @@ Press F3 on Controller when done.</source>
         <location filename="../TrainTool.cpp" line="1279"/>
         <source>Done</source>
         <translation type="unfinished">OK</translation>
+    </message>
+</context>
+<context>
+    <name>TreeMapWindow</name>
+    <message>
+        <location filename="../TreeMapWindow.cpp" line="100"/>
+        <source>Metric</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -8175,7 +8320,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>VAM</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="722"/>
+        <location filename="../BasicRideMetrics.cpp" line="811"/>
         <source>VAM</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8183,7 +8328,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>VariabilityIndex</name>
     <message>
-        <location filename="../BikeScore.cpp" line="102"/>
+        <location filename="../BikeScore.cpp" line="109"/>
         <source>Skiba VI</source>
         <translation>Skiba VI</translation>
     </message>
@@ -8215,13 +8360,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>Vo2max</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="252"/>
+        <location filename="../WattsPerKilogram.cpp" line="308"/>
         <source>Estimated VO2MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="254"/>
-        <location filename="../WattsPerKilogram.cpp" line="255"/>
+        <location filename="../WattsPerKilogram.cpp" line="310"/>
+        <location filename="../WattsPerKilogram.cpp" line="311"/>
         <source>ml/min/kg</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8327,13 +8472,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WorkoutTime</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="60"/>
+        <location filename="../BasicRideMetrics.cpp" line="67"/>
         <source>Duration</source>
         <translation>Durée</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="61"/>
-        <location filename="../BasicRideMetrics.cpp" line="62"/>
+        <location filename="../BasicRideMetrics.cpp" line="68"/>
+        <location filename="../BasicRideMetrics.cpp" line="69"/>
         <source>seconds</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8369,13 +8514,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>XPower</name>
     <message>
-        <location filename="../BikeScore.cpp" line="45"/>
+        <location filename="../BikeScore.cpp" line="48"/>
         <source>xPower</source>
         <translation>xPower</translation>
     </message>
     <message>
-        <location filename="../BikeScore.cpp" line="47"/>
-        <location filename="../BikeScore.cpp" line="48"/>
+        <location filename="../BikeScore.cpp" line="50"/>
+        <location filename="../BikeScore.cpp" line="51"/>
         <source>watts</source>
         <translation type="unfinished">watts</translation>
     </message>
@@ -8398,12 +8543,12 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZonePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2278"/>
+        <location filename="../Pages.cpp" line="2280"/>
         <source>Critical Power History</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2279"/>
+        <location filename="../Pages.cpp" line="2281"/>
         <source>Default Zones</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8411,7 +8556,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime1</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="74"/>
+        <location filename="../TimeInZone.cpp" line="79"/>
         <source>L1 Time in Zone</source>
         <translation>Temps dans la zone L1</translation>
     </message>
@@ -8419,7 +8564,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime10</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="182"/>
+        <location filename="../TimeInZone.cpp" line="232"/>
         <source>L10 Time in Zone</source>
         <translation type="unfinished">Temps dans la zone L7 {10 ?}</translation>
     </message>
@@ -8427,7 +8572,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime2</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="86"/>
+        <location filename="../TimeInZone.cpp" line="96"/>
         <source>L2 Time in Zone</source>
         <translation>Temps dans la zone L2</translation>
     </message>
@@ -8435,7 +8580,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime3</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="98"/>
+        <location filename="../TimeInZone.cpp" line="113"/>
         <source>L3 Time in Zone</source>
         <translation>Temps dans la zone L3</translation>
     </message>
@@ -8443,7 +8588,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime4</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="110"/>
+        <location filename="../TimeInZone.cpp" line="130"/>
         <source>L4 Time in Zone</source>
         <translation>Temps dans la zone L4</translation>
     </message>
@@ -8451,7 +8596,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime5</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="122"/>
+        <location filename="../TimeInZone.cpp" line="147"/>
         <source>L5 Time in Zone</source>
         <translation>Temps dans la zone L5</translation>
     </message>
@@ -8459,7 +8604,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime6</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="134"/>
+        <location filename="../TimeInZone.cpp" line="164"/>
         <source>L6 Time in Zone</source>
         <translation>Temps dans la zone L6</translation>
     </message>
@@ -8467,7 +8612,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime7</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="146"/>
+        <location filename="../TimeInZone.cpp" line="181"/>
         <source>L7 Time in Zone</source>
         <translation>Temps dans la zone L7</translation>
     </message>
@@ -8475,7 +8620,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime8</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="158"/>
+        <location filename="../TimeInZone.cpp" line="198"/>
         <source>L8 Time in Zone</source>
         <translation type="unfinished">Temps dans la zone L7 {8 ?}</translation>
     </message>
@@ -8483,7 +8628,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime9</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="170"/>
+        <location filename="../TimeInZone.cpp" line="215"/>
         <source>L9 Time in Zone</source>
         <translation type="unfinished">Temps dans la zone L7 {9 ?}</translation>
     </message>

--- a/src/translations/gc_it.ts
+++ b/src/translations/gc_it.ts
@@ -256,13 +256,13 @@ quindi clicca  &quot;Rescan&quot; per avviare la ricerca.</translation>
 <context>
     <name>AerobicDecoupling</name>
     <message>
-        <location filename="../AerobicDecoupling.cpp" line="50"/>
+        <location filename="../AerobicDecoupling.cpp" line="52"/>
         <source>Aerobic Decoupling</source>
         <translation>Unità</translation>
     </message>
     <message>
-        <location filename="../AerobicDecoupling.cpp" line="52"/>
-        <location filename="../AerobicDecoupling.cpp" line="53"/>
+        <location filename="../AerobicDecoupling.cpp" line="54"/>
+        <location filename="../AerobicDecoupling.cpp" line="55"/>
         <source>%</source>
         <translation>%</translation>
     </message>
@@ -396,42 +396,42 @@ quindi clicca  &quot;Rescan&quot; per avviare la ricerca.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="916"/>
+        <location filename="../AllPlot.cpp" line="909"/>
         <source>KPH</source>
         <translation>Km/h</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="916"/>
+        <location filename="../AllPlot.cpp" line="909"/>
         <source>MPH</source>
         <translation>Miglia/h</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="932"/>
+        <location filename="../AllPlot.cpp" line="925"/>
         <source>Nm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="932"/>
+        <location filename="../AllPlot.cpp" line="925"/>
         <source>ftLb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="945"/>
+        <location filename="../AllPlot.cpp" line="938"/>
         <source>Meters</source>
         <translation>Metri</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="945"/>
+        <location filename="../AllPlot.cpp" line="938"/>
         <source>Feet</source>
         <translation>Piedi</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="971"/>
+        <location filename="../AllPlot.cpp" line="981"/>
         <source>Distance </source>
         <translation>Tipo di </translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="973"/>
+        <location filename="../AllPlot.cpp" line="983"/>
         <source>Time (Hours:Minutes)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -561,13 +561,13 @@ quindi clicca  &quot;Rescan&quot; per avviare la ricerca.</translation>
 <context>
     <name>AverageWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="55"/>
+        <location filename="../WattsPerKilogram.cpp" line="58"/>
         <source>Watts Per Kilogram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="57"/>
-        <location filename="../WattsPerKilogram.cpp" line="58"/>
+        <location filename="../WattsPerKilogram.cpp" line="60"/>
+        <location filename="../WattsPerKilogram.cpp" line="61"/>
         <source>wpk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -575,13 +575,13 @@ quindi clicca  &quot;Rescan&quot; per avviare la ricerca.</translation>
 <context>
     <name>AvgCadence</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="433"/>
+        <location filename="../BasicRideMetrics.cpp" line="488"/>
         <source>Average Cadence</source>
         <translation>Cadenza Media</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="434"/>
-        <location filename="../BasicRideMetrics.cpp" line="435"/>
+        <location filename="../BasicRideMetrics.cpp" line="489"/>
+        <location filename="../BasicRideMetrics.cpp" line="490"/>
         <source>rpm</source>
         <translation>rpm</translation>
     </message>
@@ -589,13 +589,13 @@ quindi clicca  &quot;Rescan&quot; per avviare la ricerca.</translation>
 <context>
     <name>AvgHeartRate</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="399"/>
+        <location filename="../BasicRideMetrics.cpp" line="448"/>
         <source>Average Heart Rate</source>
         <translation>FC media</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="400"/>
-        <location filename="../BasicRideMetrics.cpp" line="401"/>
+        <location filename="../BasicRideMetrics.cpp" line="449"/>
+        <location filename="../BasicRideMetrics.cpp" line="450"/>
         <source>bpm</source>
         <translation>bpm</translation>
     </message>
@@ -603,13 +603,13 @@ quindi clicca  &quot;Rescan&quot; per avviare la ricerca.</translation>
 <context>
     <name>AvgPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="331"/>
+        <location filename="../BasicRideMetrics.cpp" line="368"/>
         <source>Average Power</source>
         <translation>Potenza Media</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="332"/>
-        <location filename="../BasicRideMetrics.cpp" line="333"/>
+        <location filename="../BasicRideMetrics.cpp" line="369"/>
+        <location filename="../BasicRideMetrics.cpp" line="370"/>
         <source>watts</source>
         <translation>watt</translation>
     </message>
@@ -617,17 +617,17 @@ quindi clicca  &quot;Rescan&quot; per avviare la ricerca.</translation>
 <context>
     <name>AvgSpeed</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="244"/>
+        <location filename="../BasicRideMetrics.cpp" line="271"/>
         <source>Average Speed</source>
         <translation>Velocità Media</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="245"/>
+        <location filename="../BasicRideMetrics.cpp" line="272"/>
         <source>kph</source>
         <translation>km/h</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="246"/>
+        <location filename="../BasicRideMetrics.cpp" line="273"/>
         <source>mph</source>
         <translation>Miglia/h</translation>
     </message>
@@ -635,17 +635,17 @@ quindi clicca  &quot;Rescan&quot; per avviare la ricerca.</translation>
 <context>
     <name>AvgTemp</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="467"/>
+        <location filename="../BasicRideMetrics.cpp" line="528"/>
         <source>Average Temp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="468"/>
+        <location filename="../BasicRideMetrics.cpp" line="529"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="469"/>
+        <location filename="../BasicRideMetrics.cpp" line="530"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
@@ -751,7 +751,7 @@ quindi clicca  &quot;Rescan&quot; per avviare la ricerca.</translation>
 <context>
     <name>BikeScore</name>
     <message>
-        <location filename="../BikeScore.cpp" line="181"/>
+        <location filename="../BikeScore.cpp" line="196"/>
         <source>BikeScore&amp;#8482;</source>
         <translation>BikeScore&amp;#8482;</translation>
     </message>
@@ -759,54 +759,54 @@ quindi clicca  &quot;Rescan&quot; per avviare la ricerca.</translation>
 <context>
     <name>CPPage</name>
     <message>
-        <location filename="../Pages.cpp" line="2455"/>
+        <location filename="../Pages.cpp" line="2457"/>
         <source>Add CP</source>
         <translation>Aggiungi CP</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2456"/>
+        <location filename="../Pages.cpp" line="2458"/>
         <source>Delete CP</source>
         <translation>Cancella CP</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2457"/>
+        <location filename="../Pages.cpp" line="2459"/>
         <source>Default</source>
         <translation>Default</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2460"/>
+        <location filename="../Pages.cpp" line="2462"/>
         <source>Add Zone</source>
         <translation>Aggiungi Zona</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2461"/>
+        <location filename="../Pages.cpp" line="2463"/>
         <source>Delete Zone</source>
         <translation>Cancella Zona</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2475"/>
-        <location filename="../Pages.cpp" line="2493"/>
+        <location filename="../Pages.cpp" line="2477"/>
+        <location filename="../Pages.cpp" line="2495"/>
         <source>From Date</source>
         <translation>Da (data)</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2476"/>
-        <location filename="../Pages.cpp" line="2494"/>
+        <location filename="../Pages.cpp" line="2478"/>
+        <location filename="../Pages.cpp" line="2496"/>
         <source>Critical Power</source>
         <translation>Potenza Critica (CP)</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2523"/>
+        <location filename="../Pages.cpp" line="2525"/>
         <source>Short</source>
         <translation>Corto</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2524"/>
+        <location filename="../Pages.cpp" line="2526"/>
         <source>Long</source>
         <translation>Lungo</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2525"/>
+        <location filename="../Pages.cpp" line="2527"/>
         <source>From Watts</source>
         <translation>dal watt</translation>
     </message>
@@ -814,7 +814,7 @@ quindi clicca  &quot;Rescan&quot; per avviare la ricerca.</translation>
 <context>
     <name>CPWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="120"/>
+        <location filename="../WattsPerKilogram.cpp" line="128"/>
         <source>60 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -909,7 +909,7 @@ quindi clicca  &quot;Rescan&quot; per avviare la ricerca.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ChartSettings.cpp" line="42"/>
+        <location filename="../ChartSettings.cpp" line="41"/>
         <source>Done</source>
         <translation type="unfinished">Fatto</translation>
     </message>
@@ -1481,7 +1481,7 @@ quindi clicca  &quot;Rescan&quot; per avviare la ricerca.</translation>
 <context>
     <name>CriticalPower</name>
     <message>
-        <location filename="../PeakPower.cpp" line="63"/>
+        <location filename="../PeakPower.cpp" line="67"/>
         <source>60 min Peak Power</source>
         <translation>60 min Picco di Potenza</translation>
     </message>
@@ -1632,12 +1632,12 @@ quindi clicca  &quot;Rescan&quot; per avviare la ricerca.</translation>
 <context>
     <name>DBAccess</name>
     <message>
-        <location filename="../DBAccess.cpp" line="112"/>
+        <location filename="../DBAccess.cpp" line="113"/>
         <source>Cannot open database</source>
         <translation>Non può aprire il database</translation>
     </message>
     <message>
-        <location filename="../DBAccess.cpp" line="113"/>
+        <location filename="../DBAccess.cpp" line="114"/>
         <source>Unable to establish a database connection.
 This feature requires SQLite support. Please read the Qt SQL driver documentation for information how to build it.
 
@@ -1648,13 +1648,13 @@ Click Cancel to exit.</source>
 <context>
     <name>DanielsEquivalentPower</name>
     <message>
-        <location filename="../DanielsPoints.cpp" line="110"/>
+        <location filename="../DanielsPoints.cpp" line="116"/>
         <source>Daniels EqP</source>
         <translation>Daniels EqP</translation>
     </message>
     <message>
-        <location filename="../DanielsPoints.cpp" line="111"/>
-        <location filename="../DanielsPoints.cpp" line="112"/>
+        <location filename="../DanielsPoints.cpp" line="117"/>
+        <location filename="../DanielsPoints.cpp" line="118"/>
         <source>watts</source>
         <translation>watt</translation>
     </message>
@@ -1662,7 +1662,7 @@ Click Cancel to exit.</source>
 <context>
     <name>DanielsPoints</name>
     <message>
-        <location filename="../DanielsPoints.cpp" line="49"/>
+        <location filename="../DanielsPoints.cpp" line="51"/>
         <source>Daniels Points</source>
         <translation>Daniels Points</translation>
     </message>
@@ -1949,52 +1949,17 @@ then click &quot;Rescan&quot; to check again.</source>
 <context>
     <name>EditMetricDetailDialog</name>
     <message>
-        <location filename="../LTMTool.cpp" line="638"/>
+        <location filename="../LTMTool.cpp" line="701"/>
         <source>Settings</source>
         <translation>Impostazioni</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="662"/>
-        <source>Filter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="664"/>
-        <source>No filter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="665"/>
-        <source>Include</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="666"/>
-        <source>Exclude</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="668"/>
-        <source>From</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="673"/>
-        <source>To</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="678"/>
-        <source>Show on plot</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="780"/>
+        <location filename="../LTMTool.cpp" line="814"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="781"/>
+        <location filename="../LTMTool.cpp" line="815"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancella</translation>
     </message>
@@ -2038,7 +2003,7 @@ then click &quot;Rescan&quot; to check again.</source>
 <context>
     <name>EfficiencyFactor</name>
     <message>
-        <location filename="../Coggan.cpp" line="198"/>
+        <location filename="../Coggan.cpp" line="217"/>
         <source>Efficiency Factor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2046,17 +2011,17 @@ then click &quot;Rescan&quot; to check again.</source>
 <context>
     <name>ElevationGain</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="170"/>
+        <location filename="../BasicRideMetrics.cpp" line="189"/>
         <source>Elevation Gain</source>
         <translation>Ascesa</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="172"/>
+        <location filename="../BasicRideMetrics.cpp" line="191"/>
         <source>meters</source>
         <translation>metri</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="173"/>
+        <location filename="../BasicRideMetrics.cpp" line="192"/>
         <source>feet</source>
         <translation>piedi</translation>
     </message>
@@ -2305,7 +2270,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>FormField</name>
     <message>
-        <location filename="../RideMetadata.cpp" line="545"/>
+        <location filename="../RideMetadata.cpp" line="546"/>
         <source>You entered &apos;%1&apos; which is not an expected value.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2403,7 +2368,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>Gradient</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="758"/>
+        <location filename="../BasicRideMetrics.cpp" line="851"/>
         <source>Gradient</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2419,7 +2384,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>GroupByModel</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="724"/>
+        <location filename="../RideNavigator.cpp" line="726"/>
         <source>Date</source>
         <translation type="unfinished">Data</translation>
     </message>
@@ -2502,12 +2467,12 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HomeWindow</name>
     <message>
-        <location filename="../HomeWindow.cpp" line="712"/>
+        <location filename="../HomeWindow.cpp" line="713"/>
         <source>Are you sure you want to remove the chart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../HomeWindow.cpp" line="713"/>
+        <location filename="../HomeWindow.cpp" line="714"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2551,38 +2516,38 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrSchemePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2826"/>
+        <location filename="../Pages.cpp" line="2828"/>
         <source>Add</source>
         <translation>Aggiungi</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2827"/>
+        <location filename="../Pages.cpp" line="2829"/>
         <source>Rename</source>
         <translation>Rinomina</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2828"/>
+        <location filename="../Pages.cpp" line="2830"/>
         <source>Delete</source>
         <translation>Cancella</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2837"/>
+        <location filename="../Pages.cpp" line="2839"/>
         <source>Short</source>
         <translation>Corto</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2838"/>
+        <location filename="../Pages.cpp" line="2840"/>
         <source>Long</source>
         <translation>Lungo</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2839"/>
+        <location filename="../Pages.cpp" line="2841"/>
         <source>Percent of LT</source>
         <translatorcomment>いまいち</translatorcomment>
         <translation>Percentuale di LT</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2840"/>
+        <location filename="../Pages.cpp" line="2842"/>
         <source>Trimp k</source>
         <translatorcomment>でいいのかな？</translatorcomment>
         <translation>Trimp k</translation>
@@ -2591,12 +2556,12 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZonePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2809"/>
+        <location filename="../Pages.cpp" line="2811"/>
         <source>Lactic Threshold History</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2810"/>
+        <location filename="../Pages.cpp" line="2812"/>
         <source>Default Zones</source>
         <translation>Zone di default</translation>
     </message>
@@ -2604,7 +2569,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime1</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="72"/>
+        <location filename="../HrTimeInZone.cpp" line="77"/>
         <source>H1 Time in Zone</source>
         <translation></translation>
     </message>
@@ -2612,7 +2577,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime2</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="84"/>
+        <location filename="../HrTimeInZone.cpp" line="94"/>
         <source>H2 Time in Zone</source>
         <translation></translation>
     </message>
@@ -2620,7 +2585,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime3</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="96"/>
+        <location filename="../HrTimeInZone.cpp" line="111"/>
         <source>H3 Time in Zone</source>
         <translation></translation>
     </message>
@@ -2628,7 +2593,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime4</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="108"/>
+        <location filename="../HrTimeInZone.cpp" line="128"/>
         <source>H4 Time in Zone</source>
         <translation></translation>
     </message>
@@ -2636,7 +2601,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime5</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="120"/>
+        <location filename="../HrTimeInZone.cpp" line="145"/>
         <source>H5 Time in Zone</source>
         <translation></translation>
     </message>
@@ -2644,7 +2609,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime6</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="132"/>
+        <location filename="../HrTimeInZone.cpp" line="162"/>
         <source>H6 Time in Zone</source>
         <translation></translation>
     </message>
@@ -2652,7 +2617,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime7</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="144"/>
+        <location filename="../HrTimeInZone.cpp" line="179"/>
         <source>H7 Time in Zone</source>
         <translation></translation>
     </message>
@@ -2660,7 +2625,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime8</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="156"/>
+        <location filename="../HrTimeInZone.cpp" line="196"/>
         <source>H8 Time in Zone</source>
         <translation></translation>
     </message>
@@ -2853,7 +2818,8 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LTMPlot</name>
     <message>
-        <location filename="../LTMPlot.cpp" line="1120"/>
+        <location filename="../LTMPlot.cpp" line="731"/>
+        <location filename="../LTMPlot.cpp" line="1123"/>
         <source>watts</source>
         <translation>watt</translation>
     </message>
@@ -2871,33 +2837,33 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="253"/>
-        <location filename="../LTMSidebar.cpp" line="289"/>
+        <location filename="../LTMSidebar.cpp" line="257"/>
+        <location filename="../LTMSidebar.cpp" line="293"/>
         <source>Edit details</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="254"/>
+        <location filename="../LTMSidebar.cpp" line="258"/>
         <source>Delete range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="255"/>
+        <location filename="../LTMSidebar.cpp" line="259"/>
         <source>Add Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="290"/>
+        <location filename="../LTMSidebar.cpp" line="294"/>
         <source>Delete event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="300"/>
+        <location filename="../LTMSidebar.cpp" line="304"/>
         <source>Add event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="537"/>
+        <location filename="../LTMSidebar.cpp" line="541"/>
         <source>^(Average|Max) </source>
         <translation type="unfinished"></translation>
     </message>
@@ -2905,44 +2871,64 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LTMTool</name>
     <message>
+        <location filename="../LTMTool.cpp" line="59"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../LTMTool.cpp" line="69"/>
+        <source>Chart</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="101"/>
+        <source>Add</source>
+        <translation type="unfinished">Aggiungi</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="102"/>
+        <source>Manage</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="124"/>
         <source>Metric</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="511"/>
+        <location filename="../LTMTool.cpp" line="518"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
         <location filename="../LTMTool.cpp" line="519"/>
+        <source>Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="520"/>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="574"/>
+        <location filename="../LTMTool.cpp" line="582"/>
         <source>Unknown Metric</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="544"/>
+        <location filename="../LTMTool.cpp" line="607"/>
         <source>Pick Color</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="545"/>
+        <location filename="../LTMTool.cpp" line="608"/>
         <source>Settings</source>
         <translation></translation>
     </message>
 </context>
 <context>
     <name>LTMWindow</name>
-    <message>
-        <location filename="../LTMWindow.cpp" line="135"/>
-        <source>Add</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../LTMWindow.cpp" line="137"/>
-        <source>Manage</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../LTMWindow.cpp" line="105"/>
-        <source>Chart</source>
-        <translation></translation>
-    </message>
     <message>
         <source>Weeks</source>
         <translation type="obsolete">Settimane</translation>
@@ -2955,71 +2941,71 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LTPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3001"/>
+        <location filename="../Pages.cpp" line="3003"/>
         <source>Add LT</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3002"/>
+        <location filename="../Pages.cpp" line="3004"/>
         <source>Delete LT</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3003"/>
+        <location filename="../Pages.cpp" line="3005"/>
         <source>Default</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3006"/>
+        <location filename="../Pages.cpp" line="3008"/>
         <source>Add Zone</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3007"/>
+        <location filename="../Pages.cpp" line="3009"/>
         <source>Delete Zone</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3021"/>
-        <location filename="../Pages.cpp" line="3061"/>
+        <location filename="../Pages.cpp" line="3023"/>
+        <location filename="../Pages.cpp" line="3063"/>
         <source>From Date</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3022"/>
-        <location filename="../Pages.cpp" line="3062"/>
+        <location filename="../Pages.cpp" line="3024"/>
+        <location filename="../Pages.cpp" line="3064"/>
         <source>Lactic Threshold</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3039"/>
-        <location filename="../Pages.cpp" line="3063"/>
+        <location filename="../Pages.cpp" line="3041"/>
+        <location filename="../Pages.cpp" line="3065"/>
         <source>Rest HR</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3040"/>
-        <location filename="../Pages.cpp" line="3064"/>
+        <location filename="../Pages.cpp" line="3042"/>
+        <location filename="../Pages.cpp" line="3066"/>
         <source>Max HR</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3101"/>
+        <location filename="../Pages.cpp" line="3103"/>
         <source>Short</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3102"/>
+        <location filename="../Pages.cpp" line="3104"/>
         <source>Long</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3103"/>
+        <location filename="../Pages.cpp" line="3105"/>
         <source>From BPM</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3104"/>
+        <location filename="../Pages.cpp" line="3106"/>
         <source>Trimp k</source>
         <translation></translation>
     </message>
@@ -3027,13 +3013,13 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LeftRightBalance</name>
     <message>
-        <location filename="../LeftRightBalance.cpp" line="33"/>
+        <location filename="../LeftRightBalance.cpp" line="36"/>
         <source>Left/Right Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftRightBalance.cpp" line="34"/>
-        <location filename="../LeftRightBalance.cpp" line="35"/>
+        <location filename="../LeftRightBalance.cpp" line="37"/>
+        <location filename="../LeftRightBalance.cpp" line="38"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
@@ -3041,7 +3027,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../MainWindow.cpp" line="2210"/>
+        <location filename="../MainWindow.cpp" line="2216"/>
         <source>Invalid date/time in filename:
 %1
 Skipping file...</source>
@@ -3049,19 +3035,19 @@ Skipping file...</source>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="281"/>
-        <location filename="../MainWindow.cpp" line="2230"/>
+        <location filename="../MainWindow.cpp" line="2236"/>
         <source>Zones File Error</source>
         <translation>Errore nel file delle zone</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="284"/>
-        <location filename="../MainWindow.cpp" line="2234"/>
+        <location filename="../MainWindow.cpp" line="2240"/>
         <source>Reading Zones File</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="565"/>
-        <location filename="../MainWindow.cpp" line="1209"/>
+        <location filename="../MainWindow.cpp" line="1215"/>
         <source>Intervals</source>
         <translation></translation>
     </message>
@@ -3074,49 +3060,49 @@ Skipping file...</source>
         <translation type="obsolete">&amp;Ciclista</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="743"/>
+        <location filename="../MainWindow.cpp" line="747"/>
         <source>&amp;New...</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="743"/>
+        <location filename="../MainWindow.cpp" line="747"/>
         <source>Ctrl+N</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="744"/>
+        <location filename="../MainWindow.cpp" line="748"/>
         <source>&amp;Open...</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="744"/>
+        <location filename="../MainWindow.cpp" line="748"/>
         <source>Ctrl+O</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="746"/>
+        <location filename="../MainWindow.cpp" line="750"/>
         <source>Ctrl+Q</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="775"/>
+        <location filename="../MainWindow.cpp" line="779"/>
         <source>Ctrl+S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="749"/>
+        <location filename="../MainWindow.cpp" line="753"/>
         <source>&amp;Download from device...</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="291"/>
-        <location filename="../MainWindow.cpp" line="2241"/>
+        <location filename="../MainWindow.cpp" line="2247"/>
         <source>HR Zones File Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="294"/>
-        <location filename="../MainWindow.cpp" line="2245"/>
+        <location filename="../MainWindow.cpp" line="2251"/>
         <source>Reading HR Zones File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3137,407 +3123,407 @@ Skipping file...</source>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="454"/>
-        <location filename="../MainWindow.cpp" line="845"/>
+        <location filename="../MainWindow.cpp" line="849"/>
         <source>Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="461"/>
-        <location filename="../MainWindow.cpp" line="848"/>
+        <location filename="../MainWindow.cpp" line="852"/>
         <source>Diary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="468"/>
-        <location filename="../MainWindow.cpp" line="844"/>
+        <location filename="../MainWindow.cpp" line="848"/>
         <source>Analysis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="474"/>
-        <location filename="../MainWindow.cpp" line="846"/>
+        <location filename="../MainWindow.cpp" line="850"/>
         <source>Train</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="524"/>
-        <location filename="../MainWindow.cpp" line="1160"/>
+        <location filename="../MainWindow.cpp" line="1166"/>
         <source>All Activities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="742"/>
+        <location filename="../MainWindow.cpp" line="746"/>
         <source>&amp;Athlete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="745"/>
+        <location filename="../MainWindow.cpp" line="749"/>
         <source>&amp;Close Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="745"/>
+        <location filename="../MainWindow.cpp" line="749"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="746"/>
+        <location filename="../MainWindow.cpp" line="750"/>
         <source>&amp;Quit All Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="748"/>
+        <location filename="../MainWindow.cpp" line="752"/>
         <source>A&amp;ctivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="749"/>
+        <location filename="../MainWindow.cpp" line="753"/>
         <source>Ctrl+D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="751"/>
+        <location filename="../MainWindow.cpp" line="755"/>
         <source>&amp;Manual activity entry...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="753"/>
+        <location filename="../MainWindow.cpp" line="757"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="754"/>
+        <location filename="../MainWindow.cpp" line="758"/>
         <source>&amp;Batch export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="755"/>
+        <location filename="../MainWindow.cpp" line="759"/>
         <source>Export Metrics as CSV...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="758"/>
+        <location filename="../MainWindow.cpp" line="762"/>
         <source>&amp;Upload to TrainingPeaks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="758"/>
+        <location filename="../MainWindow.cpp" line="762"/>
         <source>Ctrl+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="759"/>
+        <location filename="../MainWindow.cpp" line="763"/>
         <source>Down&amp;load from TrainingPeaks...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="759"/>
+        <location filename="../MainWindow.cpp" line="763"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="775"/>
+        <location filename="../MainWindow.cpp" line="779"/>
         <source>&amp;Save activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="776"/>
+        <location filename="../MainWindow.cpp" line="780"/>
         <source>D&amp;elete activity...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="777"/>
+        <location filename="../MainWindow.cpp" line="781"/>
         <source>Split &amp;activity...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="782"/>
+        <location filename="../MainWindow.cpp" line="786"/>
         <source>Critical Power Calculator...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="783"/>
+        <location filename="../MainWindow.cpp" line="787"/>
         <source>Air Density (Rho) Estimator...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="786"/>
+        <location filename="../MainWindow.cpp" line="790"/>
         <source>Get &amp;Withings Data...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="788"/>
+        <location filename="../MainWindow.cpp" line="792"/>
         <source>Get &amp;Zeo Data...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="791"/>
+        <location filename="../MainWindow.cpp" line="795"/>
         <source>Workout Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="792"/>
+        <location filename="../MainWindow.cpp" line="796"/>
         <source>Get Workouts from ErgDB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="796"/>
-        <location filename="../MainWindow.cpp" line="1197"/>
+        <location filename="../MainWindow.cpp" line="800"/>
+        <location filename="../MainWindow.cpp" line="1203"/>
         <source>Upload Activity to Calendar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="797"/>
+        <location filename="../MainWindow.cpp" line="801"/>
         <source>Import Calendar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="798"/>
+        <location filename="../MainWindow.cpp" line="802"/>
         <source>Export Calendar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="799"/>
+        <location filename="../MainWindow.cpp" line="803"/>
         <source>Refresh Calendar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="802"/>
+        <location filename="../MainWindow.cpp" line="806"/>
         <source>Find intervals...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1692"/>
+        <location filename="../MainWindow.cpp" line="1698"/>
         <source>Select Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1692"/>
-        <location filename="../MainWindow.cpp" line="1778"/>
-        <location filename="../MainWindow.cpp" line="1786"/>
+        <location filename="../MainWindow.cpp" line="1698"/>
+        <location filename="../MainWindow.cpp" line="1784"/>
+        <location filename="../MainWindow.cpp" line="1792"/>
         <source>No activity selected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1703"/>
+        <location filename="../MainWindow.cpp" line="1709"/>
         <source>Export Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1716"/>
+        <location filename="../MainWindow.cpp" line="1722"/>
         <source>Export Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1717"/>
+        <location filename="../MainWindow.cpp" line="1723"/>
         <source>Failed to export ride, please check permissions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2188"/>
+        <location filename="../MainWindow.cpp" line="2194"/>
         <source>Range from %1 to %2
 Athlete CP set to %3 watts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2209"/>
+        <location filename="../MainWindow.cpp" line="2215"/>
         <source>Invalid Activity File Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="753"/>
+        <location filename="../MainWindow.cpp" line="757"/>
         <source>Ctrl+E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="750"/>
+        <location filename="../MainWindow.cpp" line="754"/>
         <source>Ctrl+I</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="754"/>
+        <location filename="../MainWindow.cpp" line="758"/>
         <source>Ctrl+B</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="750"/>
+        <location filename="../MainWindow.cpp" line="754"/>
         <source>&amp;Import from file...</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="751"/>
+        <location filename="../MainWindow.cpp" line="755"/>
         <source>Ctrl+M</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="780"/>
+        <location filename="../MainWindow.cpp" line="784"/>
         <source>&amp;Tools</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="781"/>
+        <location filename="../MainWindow.cpp" line="785"/>
         <source>&amp;Options...</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="825"/>
+        <location filename="../MainWindow.cpp" line="829"/>
         <source>&amp;View</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="827"/>
+        <location filename="../MainWindow.cpp" line="831"/>
         <source>Toggle Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="829"/>
+        <location filename="../MainWindow.cpp" line="833"/>
         <source>Show Left Sidebar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="833"/>
+        <location filename="../MainWindow.cpp" line="837"/>
         <source>Show Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="838"/>
+        <location filename="../MainWindow.cpp" line="842"/>
         <source>Tabbed View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="852"/>
+        <location filename="../MainWindow.cpp" line="856"/>
         <source>Reset Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="854"/>
+        <location filename="../MainWindow.cpp" line="858"/>
         <source>&amp;Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="861"/>
+        <location filename="../MainWindow.cpp" line="865"/>
         <source>&amp;Help</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="862"/>
+        <location filename="../MainWindow.cpp" line="866"/>
         <source>&amp;User Guide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="863"/>
+        <location filename="../MainWindow.cpp" line="867"/>
         <source>&amp;Log a bug or feature request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="865"/>
+        <location filename="../MainWindow.cpp" line="869"/>
         <source>&amp;About GoldenCheetah</source>
         <translation>&amp;riguardo GoldenCheetah</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1164"/>
+        <location filename="../MainWindow.cpp" line="1170"/>
         <source>Save Changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1167"/>
+        <location filename="../MainWindow.cpp" line="1173"/>
         <source>Revert to Saved version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1170"/>
-        <location filename="../MainWindow.cpp" line="1786"/>
+        <location filename="../MainWindow.cpp" line="1176"/>
+        <location filename="../MainWindow.cpp" line="1792"/>
         <source>Delete Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1179"/>
-        <location filename="../MainWindow.cpp" line="1778"/>
+        <location filename="../MainWindow.cpp" line="1185"/>
+        <location filename="../MainWindow.cpp" line="1784"/>
         <source>Split Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1192"/>
+        <location filename="../MainWindow.cpp" line="1198"/>
         <source>Tweet Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1612"/>
+        <location filename="../MainWindow.cpp" line="1618"/>
         <source>Can&apos;t rename %1 to %2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1739"/>
+        <location filename="../MainWindow.cpp" line="1745"/>
         <source>Import from File</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1756"/>
+        <location filename="../MainWindow.cpp" line="1762"/>
         <source>No Activity To Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1757"/>
+        <location filename="../MainWindow.cpp" line="1763"/>
         <source>There is no currently selected ride to save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1791"/>
+        <location filename="../MainWindow.cpp" line="1797"/>
         <source>Are you sure you want to delete the activity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1845"/>
+        <location filename="../MainWindow.cpp" line="1851"/>
         <source>Export Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1845"/>
+        <location filename="../MainWindow.cpp" line="1851"/>
         <source>Comma Separated Variables (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1920"/>
+        <location filename="../MainWindow.cpp" line="1926"/>
         <source>Workout Directory Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1977"/>
+        <location filename="../MainWindow.cpp" line="1983"/>
         <source> (%1 watts)</source>
         <translation> (%1 watt)</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1173"/>
+        <location filename="../MainWindow.cpp" line="1179"/>
         <source>Find Best Intervals</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1176"/>
+        <location filename="../MainWindow.cpp" line="1182"/>
         <source>Find Power Peaks</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1214"/>
+        <location filename="../MainWindow.cpp" line="1220"/>
         <source>Rename interval</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1215"/>
+        <location filename="../MainWindow.cpp" line="1221"/>
         <source>Delete interval</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1216"/>
+        <location filename="../MainWindow.cpp" line="1222"/>
         <source>Zoom to interval</source>
         <translation>Zoom dell&apos;intervallo</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1217"/>
+        <location filename="../MainWindow.cpp" line="1223"/>
         <source>Bring to Front</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1218"/>
+        <location filename="../MainWindow.cpp" line="1224"/>
         <source>Send to back</source>
         <translation></translation>
     </message>
@@ -3546,12 +3532,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Scrivi errore</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2187"/>
+        <location filename="../MainWindow.cpp" line="2193"/>
         <source>CP saved</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1793"/>
+        <location filename="../MainWindow.cpp" line="1799"/>
         <source>Delete</source>
         <translation></translation>
     </message>
@@ -3771,13 +3757,13 @@ Athlete CP set to %3 watts</source>
 <context>
     <name>MaxCadence</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="606"/>
+        <location filename="../BasicRideMetrics.cpp" line="683"/>
         <source>Max Cadence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="607"/>
-        <location filename="../BasicRideMetrics.cpp" line="608"/>
+        <location filename="../BasicRideMetrics.cpp" line="684"/>
+        <location filename="../BasicRideMetrics.cpp" line="685"/>
         <source>rpm</source>
         <translation type="unfinished">rpm</translation>
     </message>
@@ -3785,13 +3771,13 @@ Athlete CP set to %3 watts</source>
 <context>
     <name>MaxHr</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="538"/>
+        <location filename="../BasicRideMetrics.cpp" line="607"/>
         <source>Max Heartrate</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="539"/>
-        <location filename="../BasicRideMetrics.cpp" line="540"/>
+        <location filename="../BasicRideMetrics.cpp" line="608"/>
+        <location filename="../BasicRideMetrics.cpp" line="609"/>
         <source>bpm</source>
         <translation>bpm</translation>
     </message>
@@ -3799,13 +3785,13 @@ Athlete CP set to %3 watts</source>
 <context>
     <name>MaxPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="509"/>
+        <location filename="../BasicRideMetrics.cpp" line="574"/>
         <source>Max Power</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="510"/>
-        <location filename="../BasicRideMetrics.cpp" line="511"/>
+        <location filename="../BasicRideMetrics.cpp" line="575"/>
+        <location filename="../BasicRideMetrics.cpp" line="576"/>
         <source>watts</source>
         <translation>watt</translation>
     </message>
@@ -3813,7 +3799,7 @@ Athlete CP set to %3 watts</source>
 <context>
     <name>MaxPowerVariance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="848"/>
+        <location filename="../BasicRideMetrics.cpp" line="949"/>
         <source>Max Power Variance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3821,17 +3807,17 @@ Athlete CP set to %3 watts</source>
 <context>
     <name>MaxSpeed</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="567"/>
+        <location filename="../BasicRideMetrics.cpp" line="640"/>
         <source>Max Speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="568"/>
+        <location filename="../BasicRideMetrics.cpp" line="641"/>
         <source>kph</source>
         <translation type="unfinished">km/h</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="569"/>
+        <location filename="../BasicRideMetrics.cpp" line="642"/>
         <source>mph</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3839,17 +3825,17 @@ Athlete CP set to %3 watts</source>
 <context>
     <name>MaxTemp</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="643"/>
+        <location filename="../BasicRideMetrics.cpp" line="724"/>
         <source>Max Temp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="644"/>
+        <location filename="../BasicRideMetrics.cpp" line="725"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="645"/>
+        <location filename="../BasicRideMetrics.cpp" line="726"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3857,7 +3843,7 @@ Athlete CP set to %3 watts</source>
 <context>
     <name>MeanPowerVariance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="801"/>
+        <location filename="../BasicRideMetrics.cpp" line="898"/>
         <source>Average Power Variance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3865,42 +3851,42 @@ Athlete CP set to %3 watts</source>
 <context>
     <name>MeasuresPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3395"/>
+        <location filename="../Pages.cpp" line="3397"/>
         <source>Move up</source>
         <translation type="unfinished">Muovi sopra</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3396"/>
+        <location filename="../Pages.cpp" line="3398"/>
         <source>Move down</source>
         <translation type="unfinished">Muovi sotto</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3397"/>
+        <location filename="../Pages.cpp" line="3399"/>
         <source>Insert</source>
         <translation type="unfinished">Inserisci</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3398"/>
+        <location filename="../Pages.cpp" line="3400"/>
         <source>Rename</source>
         <translation type="unfinished">Rinomina</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3399"/>
+        <location filename="../Pages.cpp" line="3401"/>
         <source>Delete</source>
         <translation type="unfinished">Cancella</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3410"/>
+        <location filename="../Pages.cpp" line="3412"/>
         <source>Screen Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3411"/>
+        <location filename="../Pages.cpp" line="3413"/>
         <source>Measure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3412"/>
+        <location filename="../Pages.cpp" line="3414"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
@@ -4119,17 +4105,17 @@ Elapsed: %1
 <context>
     <name>NavigatorCellDelegate</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="941"/>
+        <location filename="../RideNavigator.cpp" line="944"/>
         <source>Date</source>
         <translation type="unfinished">Data</translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="944"/>
+        <location filename="../RideNavigator.cpp" line="947"/>
         <source>Time</source>
         <translation type="unfinished">Tempo</translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="947"/>
+        <location filename="../RideNavigator.cpp" line="950"/>
         <source>Last updated</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4256,13 +4242,13 @@ Elapsed: %1
 <context>
     <name>NinetyFivePercentHeartRate</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="688"/>
+        <location filename="../BasicRideMetrics.cpp" line="773"/>
         <source>95% Heartrate</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="689"/>
-        <location filename="../BasicRideMetrics.cpp" line="690"/>
+        <location filename="../BasicRideMetrics.cpp" line="774"/>
+        <location filename="../BasicRideMetrics.cpp" line="775"/>
         <source>bpm</source>
         <translation>bpm</translation>
     </message>
@@ -4270,13 +4256,13 @@ Elapsed: %1
 <context>
     <name>NonZeroPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="365"/>
+        <location filename="../BasicRideMetrics.cpp" line="408"/>
         <source>Nonzero Average Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="366"/>
-        <location filename="../BasicRideMetrics.cpp" line="367"/>
+        <location filename="../BasicRideMetrics.cpp" line="409"/>
+        <location filename="../BasicRideMetrics.cpp" line="410"/>
         <source>watts</source>
         <translation type="unfinished">watt</translation>
     </message>
@@ -4284,17 +4270,17 @@ Elapsed: %1
 <context>
     <name>Pace</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="288"/>
+        <location filename="../BasicRideMetrics.cpp" line="319"/>
         <source>Pace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="290"/>
+        <location filename="../BasicRideMetrics.cpp" line="321"/>
         <source>min/km</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="291"/>
+        <location filename="../BasicRideMetrics.cpp" line="322"/>
         <source>min/mile</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4485,7 +4471,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower10m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="162"/>
+        <location filename="../PeakPower.cpp" line="202"/>
         <source>10 min Peak Power</source>
         <translation></translation>
     </message>
@@ -4493,7 +4479,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower10s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="96"/>
+        <location filename="../PeakPower.cpp" line="112"/>
         <source>10 sec Peak Power</source>
         <translation></translation>
     </message>
@@ -4501,7 +4487,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower15s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="107"/>
+        <location filename="../PeakPower.cpp" line="127"/>
         <source>15 sec Peak Power</source>
         <translation></translation>
     </message>
@@ -4509,7 +4495,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower1m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="140"/>
+        <location filename="../PeakPower.cpp" line="172"/>
         <source>1 min Peak Power</source>
         <translation></translation>
     </message>
@@ -4517,7 +4503,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower1s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="74"/>
+        <location filename="../PeakPower.cpp" line="82"/>
         <source>1 sec Peak Power</source>
         <translation></translation>
     </message>
@@ -4525,7 +4511,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower20m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="173"/>
+        <location filename="../PeakPower.cpp" line="217"/>
         <source>20 min Peak Power</source>
         <translation></translation>
     </message>
@@ -4533,7 +4519,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower20s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="118"/>
+        <location filename="../PeakPower.cpp" line="142"/>
         <source>20 sec Peak Power</source>
         <translation></translation>
     </message>
@@ -4541,7 +4527,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower30m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="184"/>
+        <location filename="../PeakPower.cpp" line="232"/>
         <source>30 min Peak Power</source>
         <translation></translation>
     </message>
@@ -4549,7 +4535,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower30s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="129"/>
+        <location filename="../PeakPower.cpp" line="157"/>
         <source>30 sec Peak Power</source>
         <translation></translation>
     </message>
@@ -4557,7 +4543,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower5m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="151"/>
+        <location filename="../PeakPower.cpp" line="187"/>
         <source>5 min Peak Power</source>
         <translation></translation>
     </message>
@@ -4565,7 +4551,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower5s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="85"/>
+        <location filename="../PeakPower.cpp" line="97"/>
         <source>5 sec Peak Power</source>
         <translation></translation>
     </message>
@@ -4573,13 +4559,13 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr10m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="263"/>
+        <location filename="../PeakPower.cpp" line="324"/>
         <source>10 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="264"/>
-        <location filename="../PeakPower.cpp" line="265"/>
+        <location filename="../PeakPower.cpp" line="325"/>
+        <location filename="../PeakPower.cpp" line="326"/>
         <source>bpm</source>
         <translation type="unfinished">bpm</translation>
     </message>
@@ -4587,13 +4573,13 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr1m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="235"/>
+        <location filename="../PeakPower.cpp" line="288"/>
         <source>1 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="236"/>
-        <location filename="../PeakPower.cpp" line="237"/>
+        <location filename="../PeakPower.cpp" line="289"/>
+        <location filename="../PeakPower.cpp" line="290"/>
         <source>bpm</source>
         <translation type="unfinished">bpm</translation>
     </message>
@@ -4601,13 +4587,13 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr20m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="277"/>
+        <location filename="../PeakPower.cpp" line="342"/>
         <source>20 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="278"/>
-        <location filename="../PeakPower.cpp" line="279"/>
+        <location filename="../PeakPower.cpp" line="343"/>
+        <location filename="../PeakPower.cpp" line="344"/>
         <source>bpm</source>
         <translation type="unfinished">bpm</translation>
     </message>
@@ -4615,13 +4601,13 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr30m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="291"/>
+        <location filename="../PeakPower.cpp" line="360"/>
         <source>30 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="292"/>
-        <location filename="../PeakPower.cpp" line="293"/>
+        <location filename="../PeakPower.cpp" line="361"/>
+        <location filename="../PeakPower.cpp" line="362"/>
         <source>bpm</source>
         <translation type="unfinished">bpm</translation>
     </message>
@@ -4629,22 +4615,8 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr5m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="249"/>
-        <source>5 min Peak Power HR</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../PeakPower.cpp" line="250"/>
-        <location filename="../PeakPower.cpp" line="251"/>
-        <source>bpm</source>
-        <translation type="unfinished">bpm</translation>
-    </message>
-</context>
-<context>
-    <name>PeakPowerHr60m</name>
-    <message>
         <location filename="../PeakPower.cpp" line="306"/>
-        <source>60 min Peak Power HR</source>
+        <source>5 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4655,10 +4627,24 @@ Do you want to continue?</source>
     </message>
 </context>
 <context>
+    <name>PeakPowerHr60m</name>
+    <message>
+        <location filename="../PeakPower.cpp" line="379"/>
+        <source>60 min Peak Power HR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../PeakPower.cpp" line="380"/>
+        <location filename="../PeakPower.cpp" line="381"/>
+        <source>bpm</source>
+        <translation type="unfinished">bpm</translation>
+    </message>
+</context>
+<context>
     <name>PeakWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="89"/>
-        <location filename="../WattsPerKilogram.cpp" line="90"/>
+        <location filename="../WattsPerKilogram.cpp" line="93"/>
+        <location filename="../WattsPerKilogram.cpp" line="94"/>
         <source>wpk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4666,7 +4652,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK10m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="219"/>
+        <location filename="../WattsPerKilogram.cpp" line="263"/>
         <source>10 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4674,7 +4660,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK10s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="153"/>
+        <location filename="../WattsPerKilogram.cpp" line="173"/>
         <source>10 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4682,7 +4668,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK15s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="164"/>
+        <location filename="../WattsPerKilogram.cpp" line="188"/>
         <source>15 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4690,7 +4676,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK1m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="197"/>
+        <location filename="../WattsPerKilogram.cpp" line="233"/>
         <source>1 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4698,7 +4684,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK1s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="131"/>
+        <location filename="../WattsPerKilogram.cpp" line="143"/>
         <source>1 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4706,7 +4692,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK20m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="230"/>
+        <location filename="../WattsPerKilogram.cpp" line="278"/>
         <source>20 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4714,7 +4700,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK20s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="175"/>
+        <location filename="../WattsPerKilogram.cpp" line="203"/>
         <source>20 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4722,7 +4708,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK30m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="241"/>
+        <location filename="../WattsPerKilogram.cpp" line="293"/>
         <source>30 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4730,7 +4716,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK30s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="186"/>
+        <location filename="../WattsPerKilogram.cpp" line="218"/>
         <source>30 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4738,7 +4724,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK5m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="208"/>
+        <location filename="../WattsPerKilogram.cpp" line="248"/>
         <source>5 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4746,7 +4732,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK5s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="142"/>
+        <location filename="../WattsPerKilogram.cpp" line="158"/>
         <source>5 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4754,22 +4740,22 @@ Do you want to continue?</source>
 <context>
     <name>PerfPlot</name>
     <message>
-        <location filename="../PerfPlot.cpp" line="118"/>
+        <location filename="../PerfPlot.cpp" line="147"/>
         <source>Daily</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="138"/>
+        <location filename="../PerfPlot.cpp" line="167"/>
         <source>Short Term Stress</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="152"/>
+        <location filename="../PerfPlot.cpp" line="181"/>
         <source>Long Term Stress</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="166"/>
+        <location filename="../PerfPlot.cpp" line="195"/>
         <source>Stress Balance</source>
         <translation></translation>
     </message>
@@ -4873,85 +4859,91 @@ Do you want to continue?</source>
     <name>PowerHist</name>
     <message>
         <location filename="../PowerHist.cpp" line="77"/>
-        <location filename="../PowerHist.cpp" line="902"/>
+        <location filename="../PowerHist.cpp" line="940"/>
         <source>Time (minutes)</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../PowerHist.cpp" line="77"/>
-        <location filename="../PowerHist.cpp" line="902"/>
+        <location filename="../PowerHist.cpp" line="940"/>
         <source>Time (percent)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="877"/>
+        <location filename="../PowerHist.cpp" line="910"/>
         <source>Power (watts)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="876"/>
+        <location filename="../PowerHist.cpp" line="909"/>
+        <location filename="../PowerHist.cpp" line="914"/>
         <source>Power zone</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="882"/>
+        <location filename="../PowerHist.cpp" line="920"/>
         <source>Heartrate (bpm)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="881"/>
+        <location filename="../PowerHist.cpp" line="919"/>
         <source>Heartrate zone</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="886"/>
+        <location filename="../PowerHist.cpp" line="915"/>
+        <source>Power (watts/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../PowerHist.cpp" line="924"/>
         <source>Cadence (rpm)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>Speed (%1)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>kph</source>
         <translation>km/h</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>mph</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>Torque (%1)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>N-m</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>ft-lbf</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="898"/>
+        <location filename="../PowerHist.cpp" line="936"/>
         <source>Unknown data series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="962"/>
-        <location filename="../PowerHist.cpp" line="975"/>
+        <location filename="../PowerHist.cpp" line="1000"/>
+        <location filename="../PowerHist.cpp" line="1013"/>
         <source>minutes</source>
         <translation>minuti</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="962"/>
-        <location filename="../PowerHist.cpp" line="975"/>
+        <location filename="../PowerHist.cpp" line="1000"/>
+        <location filename="../PowerHist.cpp" line="1013"/>
         <source>%</source>
         <translation>%</translation>
     </message>
@@ -4959,27 +4951,27 @@ Do you want to continue?</source>
 <context>
     <name>ProcessorPage</name>
     <message>
-        <location filename="../Pages.cpp" line="2198"/>
+        <location filename="../Pages.cpp" line="2200"/>
         <source>Processor</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2199"/>
+        <location filename="../Pages.cpp" line="2201"/>
         <source>Apply</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2200"/>
+        <location filename="../Pages.cpp" line="2202"/>
         <source>Settings</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2224"/>
+        <location filename="../Pages.cpp" line="2226"/>
         <source>Manual</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2225"/>
+        <location filename="../Pages.cpp" line="2227"/>
         <source>Auto</source>
         <translation></translation>
     </message>
@@ -5286,7 +5278,7 @@ Do you want to continue?</source>
 <context>
     <name>RelativeIntensity</name>
     <message>
-        <location filename="../BikeScore.cpp" line="136"/>
+        <location filename="../BikeScore.cpp" line="147"/>
         <source>Relative Intensity</source>
         <translation></translation>
     </message>
@@ -5294,7 +5286,7 @@ Do you want to continue?</source>
 <context>
     <name>ResponseIndex</name>
     <message>
-        <location filename="../BikeScore.cpp" line="218"/>
+        <location filename="../BikeScore.cpp" line="237"/>
         <source>Response Index</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5302,7 +5294,7 @@ Do you want to continue?</source>
 <context>
     <name>RideCount</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="34"/>
+        <location filename="../BasicRideMetrics.cpp" line="37"/>
         <source>Rides</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5310,9 +5302,9 @@ Do you want to continue?</source>
 <context>
     <name>RideDelegate</name>
     <message>
-        <location filename="../RideImportWizard.cpp" line="995"/>
-        <location filename="../RideImportWizard.cpp" line="1032"/>
-        <location filename="../RideImportWizard.cpp" line="1048"/>
+        <location filename="../RideImportWizard.cpp" line="998"/>
+        <location filename="../RideImportWizard.cpp" line="1035"/>
+        <location filename="../RideImportWizard.cpp" line="1051"/>
         <source>dd MMM yyyy</source>
         <translation>dd MMM yyyy</translation>
     </message>
@@ -5869,9 +5861,9 @@ Do you want to continue?</source>
     </message>
     <message>
         <location filename="../RideImportWizard.cpp" line="74"/>
-        <location filename="../RideImportWizard.cpp" line="696"/>
-        <location filename="../RideImportWizard.cpp" line="738"/>
-        <location filename="../RideImportWizard.cpp" line="890"/>
+        <location filename="../RideImportWizard.cpp" line="699"/>
+        <location filename="../RideImportWizard.cpp" line="741"/>
+        <location filename="../RideImportWizard.cpp" line="893"/>
         <source>Abort</source>
         <translation>Annulla</translation>
     </message>
@@ -5942,12 +5934,12 @@ Do you want to continue?</source>
     </message>
     <message>
         <location filename="../RideImportWizard.cpp" line="268"/>
-        <location filename="../RideImportWizard.cpp" line="454"/>
-        <location filename="../RideImportWizard.cpp" line="506"/>
-        <location filename="../RideImportWizard.cpp" line="717"/>
-        <location filename="../RideImportWizard.cpp" line="756"/>
-        <location filename="../RideImportWizard.cpp" line="895"/>
-        <location filename="../RideImportWizard.cpp" line="918"/>
+        <location filename="../RideImportWizard.cpp" line="457"/>
+        <location filename="../RideImportWizard.cpp" line="509"/>
+        <location filename="../RideImportWizard.cpp" line="720"/>
+        <location filename="../RideImportWizard.cpp" line="759"/>
+        <location filename="../RideImportWizard.cpp" line="898"/>
+        <location filename="../RideImportWizard.cpp" line="921"/>
         <source>Error</source>
         <translation>Errore</translation>
     </message>
@@ -5957,157 +5949,157 @@ Do you want to continue?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="378"/>
+        <location filename="../RideImportWizard.cpp" line="381"/>
         <source>Validated</source>
         <translation>Convalidato/i</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="380"/>
+        <location filename="../RideImportWizard.cpp" line="383"/>
         <source>Warning - </source>
         <translation>Attenzione - </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="394"/>
-        <location filename="../RideImportWizard.cpp" line="619"/>
-        <location filename="../RideImportWizard.cpp" line="765"/>
+        <location filename="../RideImportWizard.cpp" line="397"/>
+        <location filename="../RideImportWizard.cpp" line="622"/>
+        <location filename="../RideImportWizard.cpp" line="768"/>
         <source>dd MMM yyyy</source>
         <translation>dd MMM yyyy</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="395"/>
+        <location filename="../RideImportWizard.cpp" line="398"/>
         <source>hh:mm:ss ap</source>
         <translation>hh:mm:ss ap</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="432"/>
+        <location filename="../RideImportWizard.cpp" line="435"/>
         <source>Error - </source>
         <translation>Errore - </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="380"/>
-        <location filename="../RideImportWizard.cpp" line="432"/>
+        <location filename="../RideImportWizard.cpp" line="383"/>
+        <location filename="../RideImportWizard.cpp" line="435"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="447"/>
+        <location filename="../RideImportWizard.cpp" line="450"/>
         <source>Step 3 of 4: Confirm Date and Time</source>
         <translation>Step 3 di 4: Conferma Data e Ora</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="464"/>
+        <location filename="../RideImportWizard.cpp" line="467"/>
         <source>Save</source>
         <translation>Salva</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="573"/>
-        <location filename="../RideImportWizard.cpp" line="623"/>
+        <location filename="../RideImportWizard.cpp" line="576"/>
+        <location filename="../RideImportWizard.cpp" line="626"/>
         <source>hh:mm:ss</source>
         <translation>hh:mm:ss</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="582"/>
+        <location filename="../RideImportWizard.cpp" line="585"/>
         <source>Invalid Selection</source>
         <translation>Selezione non valida</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="582"/>
+        <location filename="../RideImportWizard.cpp" line="585"/>
         <source>More than 24hrs of rides to fit into a day</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="627"/>
-        <location filename="../RideImportWizard.cpp" line="766"/>
+        <location filename="../RideImportWizard.cpp" line="630"/>
+        <location filename="../RideImportWizard.cpp" line="769"/>
         <source>hh:mm:ss a</source>
         <translation>hh:mm:ss a</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="736"/>
+        <location filename="../RideImportWizard.cpp" line="739"/>
         <source>Step 4 of 4: Save to Library</source>
         <translation>Step 4 di 4: Salvando nella cartella</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="758"/>
+        <location filename="../RideImportWizard.cpp" line="761"/>
         <source>Saving...</source>
         <translation>Salvando...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="834"/>
+        <location filename="../RideImportWizard.cpp" line="837"/>
         <source>Error - Source is Target</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="845"/>
+        <location filename="../RideImportWizard.cpp" line="848"/>
         <source>Overwriting file...</source>
         <translation>Sovrascrivendo il file---</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="847"/>
+        <location filename="../RideImportWizard.cpp" line="850"/>
         <source>/</source>
         <translation>/</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="847"/>
+        <location filename="../RideImportWizard.cpp" line="850"/>
         <source>.tmp</source>
         <translation>.tmp</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="821"/>
-        <location filename="../RideImportWizard.cpp" line="854"/>
+        <location filename="../RideImportWizard.cpp" line="824"/>
+        <location filename="../RideImportWizard.cpp" line="857"/>
         <source>File Overwritten</source>
         <translation>File sovrascritto</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="857"/>
-        <location filename="../RideImportWizard.cpp" line="859"/>
+        <location filename="../RideImportWizard.cpp" line="860"/>
+        <location filename="../RideImportWizard.cpp" line="862"/>
         <source>Error - overwrite failed</source>
         <translation>Errore - sovrascrittura non riuscita</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="790"/>
-        <location filename="../RideImportWizard.cpp" line="862"/>
+        <location filename="../RideImportWizard.cpp" line="793"/>
+        <location filename="../RideImportWizard.cpp" line="865"/>
         <source>Error - File exists</source>
         <translation>Errore - file già esistente</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="865"/>
+        <location filename="../RideImportWizard.cpp" line="868"/>
         <source>Saving file...</source>
         <translation>Salvando il file...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="823"/>
-        <location filename="../RideImportWizard.cpp" line="868"/>
+        <location filename="../RideImportWizard.cpp" line="826"/>
+        <location filename="../RideImportWizard.cpp" line="871"/>
         <source>File Saved</source>
         <translation>File salvato</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="877"/>
+        <location filename="../RideImportWizard.cpp" line="880"/>
         <source>Error - copy failed</source>
         <translation>Errorre - copia non riuscita</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="888"/>
+        <location filename="../RideImportWizard.cpp" line="891"/>
         <source>Step 5 of 5: Calculating Critical Powers</source>
         <translation>Step 5 di 5: Calcolando i CP</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="896"/>
+        <location filename="../RideImportWizard.cpp" line="899"/>
         <source>Calculating...</source>
         <translation>Calcolando...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="905"/>
+        <location filename="../RideImportWizard.cpp" line="908"/>
         <source>Completed.</source>
         <translation>Completato</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="923"/>
+        <location filename="../RideImportWizard.cpp" line="926"/>
         <source>Import Complete. %1 of %2 successful.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="704"/>
-        <location filename="../RideImportWizard.cpp" line="928"/>
+        <location filename="../RideImportWizard.cpp" line="707"/>
+        <location filename="../RideImportWizard.cpp" line="931"/>
         <source>Finish</source>
         <translation>Finisci</translation>
     </message>
@@ -6115,22 +6107,22 @@ Do you want to continue?</source>
 <context>
     <name>RideNavigator</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="540"/>
+        <location filename="../RideNavigator.cpp" line="542"/>
         <source>Remove Column</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="546"/>
+        <location filename="../RideNavigator.cpp" line="548"/>
         <source>Column Chooser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="551"/>
+        <location filename="../RideNavigator.cpp" line="553"/>
         <source>Do Not Show in Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="551"/>
+        <location filename="../RideNavigator.cpp" line="553"/>
         <source>Show In Groups</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6483,32 +6475,32 @@ native format. Should we do so?
 <context>
     <name>SchemePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2295"/>
+        <location filename="../Pages.cpp" line="2297"/>
         <source>Add</source>
         <translation>Aggiungi</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2296"/>
+        <location filename="../Pages.cpp" line="2298"/>
         <source>Rename</source>
         <translation>Rinomina</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2297"/>
+        <location filename="../Pages.cpp" line="2299"/>
         <source>Delete</source>
         <translation>Cancella</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2306"/>
+        <location filename="../Pages.cpp" line="2308"/>
         <source>Short</source>
         <translation>Corto</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2307"/>
+        <location filename="../Pages.cpp" line="2309"/>
         <source>Long</source>
         <translation>Lungo</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2308"/>
+        <location filename="../Pages.cpp" line="2310"/>
         <source>Percent of CP</source>
         <translation>Percentuale di CP</translation>
     </message>
@@ -6593,42 +6585,42 @@ native format. Should we do so?
 <context>
     <name>SeasonsPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3673"/>
+        <location filename="../Pages.cpp" line="3675"/>
         <source>Move up</source>
         <translation type="unfinished">Muovi sopra</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3674"/>
+        <location filename="../Pages.cpp" line="3676"/>
         <source>Move down</source>
         <translation type="unfinished">Muovi sotto</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3675"/>
+        <location filename="../Pages.cpp" line="3677"/>
         <source>Add</source>
         <translation type="unfinished">Aggiungi</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3676"/>
+        <location filename="../Pages.cpp" line="3678"/>
         <source>Delete</source>
         <translation type="unfinished">Cancella</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3685"/>
+        <location filename="../Pages.cpp" line="3687"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3686"/>
+        <location filename="../Pages.cpp" line="3688"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3687"/>
+        <location filename="../Pages.cpp" line="3689"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3688"/>
+        <location filename="../Pages.cpp" line="3690"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6636,7 +6628,7 @@ native format. Should we do so?
 <context>
     <name>SessionRPE</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="302"/>
+        <location filename="../TRIMPPoints.cpp" line="316"/>
         <source>Session RPE</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6664,6 +6656,147 @@ native format. Should we do so?
         <location filename="../SmallPlot.cpp" line="237"/>
         <source>Time (minutes)</source>
         <translation type="unfinished">Tempo (minuti)</translation>
+    </message>
+</context>
+<context>
+    <name>SpecialFields</name>
+    <message>
+        <location filename="../SpecialFields.cpp" line="26"/>
+        <source>Start Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="27"/>
+        <source>Start Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="28"/>
+        <source>Identifier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="29"/>
+        <source>Workout Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="30"/>
+        <source>Sport</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="31"/>
+        <source>Objective</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="32"/>
+        <source>Summary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="33"/>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="34"/>
+        <source>Keywords</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="35"/>
+        <source>Recording Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="36"/>
+        <source>Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="37"/>
+        <source>Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="38"/>
+        <source>Device Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="39"/>
+        <source>Dropouts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="40"/>
+        <source>Dropout Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="41"/>
+        <source>Spikes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="42"/>
+        <source>Spike Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="43"/>
+        <source>Torque Adjust</source>
+        <translation type="unfinished">Aggiusta coppia torcente</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="44"/>
+        <source>Filename</source>
+        <translation type="unfinished">Nome file</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="45"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="46"/>
+        <source>Change History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="47"/>
+        <source>Calendar Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="48"/>
+        <source>Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SpecialTabs</name>
+    <message>
+        <location filename="../SpecialFields.cpp" line="130"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="131"/>
+        <source>Notes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="132"/>
+        <source>Metric</source>
+        <translation type="unfinished">Metrico</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="133"/>
+        <source>Extra</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -7080,22 +7213,22 @@ native format. Should we do so?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="388"/>
+        <location filename="../StravaDialog.cpp" line="389"/>
         <source>Upload ride... Sending</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="398"/>
+        <location filename="../StravaDialog.cpp" line="399"/>
         <source>Upload finished.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="430"/>
+        <location filename="../StravaDialog.cpp" line="431"/>
         <source>Ride processing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="501"/>
+        <location filename="../StravaDialog.cpp" line="502"/>
         <source>Searching corresponding Ride</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7348,7 +7481,7 @@ native format. Should we do so?
 <context>
     <name>TRIMP100Points</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="114"/>
+        <location filename="../TRIMPPoints.cpp" line="120"/>
         <source>TRIMP(100) Points</source>
         <translation>TRIMP(100) Punti</translation>
     </message>
@@ -7356,7 +7489,7 @@ native format. Should we do so?
 <context>
     <name>TRIMPPoints</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="47"/>
+        <location filename="../TRIMPPoints.cpp" line="49"/>
         <source>TRIMP Points</source>
         <translation>Punti TRIMP</translation>
     </message>
@@ -7364,7 +7497,7 @@ native format. Should we do so?
 <context>
     <name>TRIMPZonalPoints</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="180"/>
+        <location filename="../TRIMPPoints.cpp" line="190"/>
         <source>TRIMP Zonal Points</source>
         <translation>TRIMP Punti</translation>
     </message>
@@ -7372,13 +7505,13 @@ native format. Should we do so?
 <context>
     <name>TimeRiding</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="94"/>
+        <location filename="../BasicRideMetrics.cpp" line="105"/>
         <source>Time Riding</source>
         <translation>Tempo</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="95"/>
-        <location filename="../BasicRideMetrics.cpp" line="96"/>
+        <location filename="../BasicRideMetrics.cpp" line="106"/>
+        <location filename="../BasicRideMetrics.cpp" line="107"/>
         <source>seconds</source>
         <translation>secondi</translation>
     </message>
@@ -7462,17 +7595,17 @@ native format. Should we do so?
 <context>
     <name>TotalDistance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="129"/>
+        <location filename="../BasicRideMetrics.cpp" line="144"/>
         <source>Distance</source>
         <translation>Distanza</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="131"/>
+        <location filename="../BasicRideMetrics.cpp" line="146"/>
         <source>km</source>
         <translation>km</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="132"/>
+        <location filename="../BasicRideMetrics.cpp" line="147"/>
         <source>miles</source>
         <translation>miglia</translation>
     </message>
@@ -7480,13 +7613,13 @@ native format. Should we do so?
 <context>
     <name>TotalWork</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="213"/>
+        <location filename="../BasicRideMetrics.cpp" line="236"/>
         <source>Work</source>
         <translation>Lavoro</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="214"/>
-        <location filename="../BasicRideMetrics.cpp" line="215"/>
+        <location filename="../BasicRideMetrics.cpp" line="237"/>
+        <location filename="../BasicRideMetrics.cpp" line="238"/>
         <source>kJ</source>
         <translation>kJ</translation>
     </message>
@@ -7560,6 +7693,14 @@ Press F3 on Controller when done.</source>
         <location filename="../TrainTool.cpp" line="1279"/>
         <source>Done</source>
         <translation type="unfinished">Fatto</translation>
+    </message>
+</context>
+<context>
+    <name>TreeMapWindow</name>
+    <message>
+        <location filename="../TreeMapWindow.cpp" line="100"/>
+        <source>Metric</source>
+        <translation type="unfinished">Metrico</translation>
     </message>
 </context>
 <context>
@@ -7846,7 +7987,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>VAM</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="722"/>
+        <location filename="../BasicRideMetrics.cpp" line="811"/>
         <source>VAM</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7854,7 +7995,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>VariabilityIndex</name>
     <message>
-        <location filename="../BikeScore.cpp" line="102"/>
+        <location filename="../BikeScore.cpp" line="109"/>
         <source>Skiba VI</source>
         <translation></translation>
     </message>
@@ -7875,13 +8016,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>Vo2max</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="252"/>
+        <location filename="../WattsPerKilogram.cpp" line="308"/>
         <source>Estimated VO2MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="254"/>
-        <location filename="../WattsPerKilogram.cpp" line="255"/>
+        <location filename="../WattsPerKilogram.cpp" line="310"/>
+        <location filename="../WattsPerKilogram.cpp" line="311"/>
         <source>ml/min/kg</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7980,13 +8121,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WorkoutTime</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="60"/>
+        <location filename="../BasicRideMetrics.cpp" line="67"/>
         <source>Duration</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="61"/>
-        <location filename="../BasicRideMetrics.cpp" line="62"/>
+        <location filename="../BasicRideMetrics.cpp" line="68"/>
+        <location filename="../BasicRideMetrics.cpp" line="69"/>
         <source>seconds</source>
         <translation>secondi</translation>
     </message>
@@ -8022,13 +8163,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>XPower</name>
     <message>
-        <location filename="../BikeScore.cpp" line="45"/>
+        <location filename="../BikeScore.cpp" line="48"/>
         <source>xPower</source>
         <translation>xPower</translation>
     </message>
     <message>
-        <location filename="../BikeScore.cpp" line="47"/>
-        <location filename="../BikeScore.cpp" line="48"/>
+        <location filename="../BikeScore.cpp" line="50"/>
+        <location filename="../BikeScore.cpp" line="51"/>
         <source>watts</source>
         <translation>watt</translation>
     </message>
@@ -8051,12 +8192,12 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZonePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2278"/>
+        <location filename="../Pages.cpp" line="2280"/>
         <source>Critical Power History</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2279"/>
+        <location filename="../Pages.cpp" line="2281"/>
         <source>Default Zones</source>
         <translation></translation>
     </message>
@@ -8064,7 +8205,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime1</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="74"/>
+        <location filename="../TimeInZone.cpp" line="79"/>
         <source>L1 Time in Zone</source>
         <translation></translation>
     </message>
@@ -8072,7 +8213,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime10</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="182"/>
+        <location filename="../TimeInZone.cpp" line="232"/>
         <source>L10 Time in Zone</source>
         <translation></translation>
     </message>
@@ -8080,7 +8221,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime2</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="86"/>
+        <location filename="../TimeInZone.cpp" line="96"/>
         <source>L2 Time in Zone</source>
         <translation></translation>
     </message>
@@ -8088,7 +8229,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime3</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="98"/>
+        <location filename="../TimeInZone.cpp" line="113"/>
         <source>L3 Time in Zone</source>
         <translation></translation>
     </message>
@@ -8096,7 +8237,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime4</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="110"/>
+        <location filename="../TimeInZone.cpp" line="130"/>
         <source>L4 Time in Zone</source>
         <translation></translation>
     </message>
@@ -8104,7 +8245,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime5</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="122"/>
+        <location filename="../TimeInZone.cpp" line="147"/>
         <source>L5 Time in Zone</source>
         <translation></translation>
     </message>
@@ -8112,7 +8253,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime6</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="134"/>
+        <location filename="../TimeInZone.cpp" line="164"/>
         <source>L6 Time in Zone</source>
         <translation></translation>
     </message>
@@ -8120,7 +8261,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime7</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="146"/>
+        <location filename="../TimeInZone.cpp" line="181"/>
         <source>L7 Time in Zone</source>
         <translation></translation>
     </message>
@@ -8128,7 +8269,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime8</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="158"/>
+        <location filename="../TimeInZone.cpp" line="198"/>
         <source>L8 Time in Zone</source>
         <translation></translation>
     </message>
@@ -8136,7 +8277,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime9</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="170"/>
+        <location filename="../TimeInZone.cpp" line="215"/>
         <source>L9 Time in Zone</source>
         <translation></translation>
     </message>

--- a/src/translations/gc_ja.ts
+++ b/src/translations/gc_ja.ts
@@ -254,13 +254,13 @@
 <context>
     <name>AerobicDecoupling</name>
     <message>
-        <location filename="../AerobicDecoupling.cpp" line="50"/>
+        <location filename="../AerobicDecoupling.cpp" line="52"/>
         <source>Aerobic Decoupling</source>
         <translation>エアロビック・デカップリング</translation>
     </message>
     <message>
-        <location filename="../AerobicDecoupling.cpp" line="52"/>
-        <location filename="../AerobicDecoupling.cpp" line="53"/>
+        <location filename="../AerobicDecoupling.cpp" line="54"/>
+        <location filename="../AerobicDecoupling.cpp" line="55"/>
         <source>%</source>
         <translation>%</translation>
     </message>
@@ -394,42 +394,42 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="916"/>
+        <location filename="../AllPlot.cpp" line="909"/>
         <source>KPH</source>
         <translation>km/h</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="916"/>
+        <location filename="../AllPlot.cpp" line="909"/>
         <source>MPH</source>
         <translation>m/h</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="932"/>
+        <location filename="../AllPlot.cpp" line="925"/>
         <source>Nm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="932"/>
+        <location filename="../AllPlot.cpp" line="925"/>
         <source>ftLb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="945"/>
+        <location filename="../AllPlot.cpp" line="938"/>
         <source>Meters</source>
         <translation>メートル</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="945"/>
+        <location filename="../AllPlot.cpp" line="938"/>
         <source>Feet</source>
         <translation>フィート</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="971"/>
+        <location filename="../AllPlot.cpp" line="981"/>
         <source>Distance </source>
         <translation>距離 </translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="973"/>
+        <location filename="../AllPlot.cpp" line="983"/>
         <source>Time (Hours:Minutes)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -559,13 +559,13 @@
 <context>
     <name>AverageWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="55"/>
+        <location filename="../WattsPerKilogram.cpp" line="58"/>
         <source>Watts Per Kilogram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="57"/>
-        <location filename="../WattsPerKilogram.cpp" line="58"/>
+        <location filename="../WattsPerKilogram.cpp" line="60"/>
+        <location filename="../WattsPerKilogram.cpp" line="61"/>
         <source>wpk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -573,13 +573,13 @@
 <context>
     <name>AvgCadence</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="433"/>
+        <location filename="../BasicRideMetrics.cpp" line="488"/>
         <source>Average Cadence</source>
         <translation>平均ケイデンス</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="434"/>
-        <location filename="../BasicRideMetrics.cpp" line="435"/>
+        <location filename="../BasicRideMetrics.cpp" line="489"/>
+        <location filename="../BasicRideMetrics.cpp" line="490"/>
         <source>rpm</source>
         <translation>rpm</translation>
     </message>
@@ -587,13 +587,13 @@
 <context>
     <name>AvgHeartRate</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="399"/>
+        <location filename="../BasicRideMetrics.cpp" line="448"/>
         <source>Average Heart Rate</source>
         <translation>平均心拍数</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="400"/>
-        <location filename="../BasicRideMetrics.cpp" line="401"/>
+        <location filename="../BasicRideMetrics.cpp" line="449"/>
+        <location filename="../BasicRideMetrics.cpp" line="450"/>
         <source>bpm</source>
         <translation>拍/分</translation>
     </message>
@@ -601,13 +601,13 @@
 <context>
     <name>AvgPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="331"/>
+        <location filename="../BasicRideMetrics.cpp" line="368"/>
         <source>Average Power</source>
         <translation>平均出力</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="332"/>
-        <location filename="../BasicRideMetrics.cpp" line="333"/>
+        <location filename="../BasicRideMetrics.cpp" line="369"/>
+        <location filename="../BasicRideMetrics.cpp" line="370"/>
         <source>watts</source>
         <translation>ワット</translation>
     </message>
@@ -615,17 +615,17 @@
 <context>
     <name>AvgSpeed</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="244"/>
+        <location filename="../BasicRideMetrics.cpp" line="271"/>
         <source>Average Speed</source>
         <translation>平均速度</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="245"/>
+        <location filename="../BasicRideMetrics.cpp" line="272"/>
         <source>kph</source>
         <translation>km/h</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="246"/>
+        <location filename="../BasicRideMetrics.cpp" line="273"/>
         <source>mph</source>
         <translation>m/h</translation>
     </message>
@@ -633,17 +633,17 @@
 <context>
     <name>AvgTemp</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="467"/>
+        <location filename="../BasicRideMetrics.cpp" line="528"/>
         <source>Average Temp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="468"/>
+        <location filename="../BasicRideMetrics.cpp" line="529"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="469"/>
+        <location filename="../BasicRideMetrics.cpp" line="530"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
@@ -747,7 +747,7 @@
 <context>
     <name>BikeScore</name>
     <message>
-        <location filename="../BikeScore.cpp" line="181"/>
+        <location filename="../BikeScore.cpp" line="196"/>
         <source>BikeScore&amp;#8482;</source>
         <translation>BikeScore&amp;#8482;</translation>
     </message>
@@ -755,54 +755,54 @@
 <context>
     <name>CPPage</name>
     <message>
-        <location filename="../Pages.cpp" line="2455"/>
+        <location filename="../Pages.cpp" line="2457"/>
         <source>Add CP</source>
         <translation>CPを追加</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2456"/>
+        <location filename="../Pages.cpp" line="2458"/>
         <source>Delete CP</source>
         <translation>CPを削除</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2457"/>
+        <location filename="../Pages.cpp" line="2459"/>
         <source>Default</source>
         <translation>デフォルト</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2460"/>
+        <location filename="../Pages.cpp" line="2462"/>
         <source>Add Zone</source>
         <translation>ゾーンを追加</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2461"/>
+        <location filename="../Pages.cpp" line="2463"/>
         <source>Delete Zone</source>
         <translation>ゾーンを削除</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2475"/>
-        <location filename="../Pages.cpp" line="2493"/>
+        <location filename="../Pages.cpp" line="2477"/>
+        <location filename="../Pages.cpp" line="2495"/>
         <source>From Date</source>
         <translation>開始日</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2476"/>
-        <location filename="../Pages.cpp" line="2494"/>
+        <location filename="../Pages.cpp" line="2478"/>
+        <location filename="../Pages.cpp" line="2496"/>
         <source>Critical Power</source>
         <translation>クリティカルパワー</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2523"/>
+        <location filename="../Pages.cpp" line="2525"/>
         <source>Short</source>
         <translation>略称</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2524"/>
+        <location filename="../Pages.cpp" line="2526"/>
         <source>Long</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2525"/>
+        <location filename="../Pages.cpp" line="2527"/>
         <source>From Watts</source>
         <translation>最低ワット</translation>
     </message>
@@ -810,7 +810,7 @@
 <context>
     <name>CPWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="120"/>
+        <location filename="../WattsPerKilogram.cpp" line="128"/>
         <source>60 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -905,7 +905,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ChartSettings.cpp" line="42"/>
+        <location filename="../ChartSettings.cpp" line="41"/>
         <source>Done</source>
         <translation type="unfinished">終了</translation>
     </message>
@@ -1486,7 +1486,7 @@ This may take a while.
 <context>
     <name>CriticalPower</name>
     <message>
-        <location filename="../PeakPower.cpp" line="63"/>
+        <location filename="../PeakPower.cpp" line="67"/>
         <source>60 min Peak Power</source>
         <translation>60分間の最大出力</translation>
     </message>
@@ -1638,12 +1638,12 @@ This may take a while.
 <context>
     <name>DBAccess</name>
     <message>
-        <location filename="../DBAccess.cpp" line="112"/>
+        <location filename="../DBAccess.cpp" line="113"/>
         <source>Cannot open database</source>
         <translation>データベースを開けませんでした</translation>
     </message>
     <message>
-        <location filename="../DBAccess.cpp" line="113"/>
+        <location filename="../DBAccess.cpp" line="114"/>
         <source>Unable to establish a database connection.
 This feature requires SQLite support. Please read the Qt SQL driver documentation for information how to build it.
 
@@ -1656,13 +1656,13 @@ Click Cancel to exit.</source>
 <context>
     <name>DanielsEquivalentPower</name>
     <message>
-        <location filename="../DanielsPoints.cpp" line="110"/>
+        <location filename="../DanielsPoints.cpp" line="116"/>
         <source>Daniels EqP</source>
         <translation>Daniels EqP</translation>
     </message>
     <message>
-        <location filename="../DanielsPoints.cpp" line="111"/>
-        <location filename="../DanielsPoints.cpp" line="112"/>
+        <location filename="../DanielsPoints.cpp" line="117"/>
+        <location filename="../DanielsPoints.cpp" line="118"/>
         <source>watts</source>
         <translation>ワット</translation>
     </message>
@@ -1670,7 +1670,7 @@ Click Cancel to exit.</source>
 <context>
     <name>DanielsPoints</name>
     <message>
-        <location filename="../DanielsPoints.cpp" line="49"/>
+        <location filename="../DanielsPoints.cpp" line="51"/>
         <source>Daniels Points</source>
         <translation>Daniels Points</translation>
     </message>
@@ -1975,52 +1975,17 @@ then click &quot;Rescan&quot; to check again.</source>
 <context>
     <name>EditMetricDetailDialog</name>
     <message>
-        <location filename="../LTMTool.cpp" line="638"/>
+        <location filename="../LTMTool.cpp" line="701"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="662"/>
-        <source>Filter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="664"/>
-        <source>No filter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="665"/>
-        <source>Include</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="666"/>
-        <source>Exclude</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="668"/>
-        <source>From</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="673"/>
-        <source>To</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="678"/>
-        <source>Show on plot</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="780"/>
+        <location filename="../LTMTool.cpp" line="814"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="781"/>
+        <location filename="../LTMTool.cpp" line="815"/>
         <source>&amp;Cancel</source>
         <translation>&amp;キャンセル</translation>
     </message>
@@ -2064,7 +2029,7 @@ then click &quot;Rescan&quot; to check again.</source>
 <context>
     <name>EfficiencyFactor</name>
     <message>
-        <location filename="../Coggan.cpp" line="198"/>
+        <location filename="../Coggan.cpp" line="217"/>
         <source>Efficiency Factor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2072,17 +2037,17 @@ then click &quot;Rescan&quot; to check again.</source>
 <context>
     <name>ElevationGain</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="170"/>
+        <location filename="../BasicRideMetrics.cpp" line="189"/>
         <source>Elevation Gain</source>
         <translation>獲得標高</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="172"/>
+        <location filename="../BasicRideMetrics.cpp" line="191"/>
         <source>meters</source>
         <translation>メートル</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="173"/>
+        <location filename="../BasicRideMetrics.cpp" line="192"/>
         <source>feet</source>
         <translation>フィート</translation>
     </message>
@@ -2349,7 +2314,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>FormField</name>
     <message>
-        <location filename="../RideMetadata.cpp" line="545"/>
+        <location filename="../RideMetadata.cpp" line="546"/>
         <source>You entered &apos;%1&apos; which is not an expected value.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2447,7 +2412,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>Gradient</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="758"/>
+        <location filename="../BasicRideMetrics.cpp" line="851"/>
         <source>Gradient</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2463,7 +2428,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>GroupByModel</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="724"/>
+        <location filename="../RideNavigator.cpp" line="726"/>
         <source>Date</source>
         <translation type="unfinished">日付</translation>
     </message>
@@ -2546,12 +2511,12 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HomeWindow</name>
     <message>
-        <location filename="../HomeWindow.cpp" line="712"/>
+        <location filename="../HomeWindow.cpp" line="713"/>
         <source>Are you sure you want to remove the chart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../HomeWindow.cpp" line="713"/>
+        <location filename="../HomeWindow.cpp" line="714"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2595,38 +2560,38 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrSchemePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2826"/>
+        <location filename="../Pages.cpp" line="2828"/>
         <source>Add</source>
         <translation>追加</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2827"/>
+        <location filename="../Pages.cpp" line="2829"/>
         <source>Rename</source>
         <translation>リネーム</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2828"/>
+        <location filename="../Pages.cpp" line="2830"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2837"/>
+        <location filename="../Pages.cpp" line="2839"/>
         <source>Short</source>
         <translation>略称</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2838"/>
+        <location filename="../Pages.cpp" line="2840"/>
         <source>Long</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2839"/>
+        <location filename="../Pages.cpp" line="2841"/>
         <source>Percent of LT</source>
         <translatorcomment>いまいち</translatorcomment>
         <translation>対LTの割合</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2840"/>
+        <location filename="../Pages.cpp" line="2842"/>
         <source>Trimp k</source>
         <translatorcomment>でいいのかな？</translatorcomment>
         <translation>Trimp係数</translation>
@@ -2635,12 +2600,12 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZonePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2809"/>
+        <location filename="../Pages.cpp" line="2811"/>
         <source>Lactic Threshold History</source>
         <translation>LT値履歴</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2810"/>
+        <location filename="../Pages.cpp" line="2812"/>
         <source>Default Zones</source>
         <translation>デフォルトゾーン</translation>
     </message>
@@ -2648,7 +2613,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime1</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="72"/>
+        <location filename="../HrTimeInZone.cpp" line="77"/>
         <source>H1 Time in Zone</source>
         <translation>H1 滞在時間</translation>
     </message>
@@ -2656,7 +2621,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime2</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="84"/>
+        <location filename="../HrTimeInZone.cpp" line="94"/>
         <source>H2 Time in Zone</source>
         <translation>H2 滞在時間</translation>
     </message>
@@ -2664,7 +2629,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime3</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="96"/>
+        <location filename="../HrTimeInZone.cpp" line="111"/>
         <source>H3 Time in Zone</source>
         <translation>H3 滞在時間</translation>
     </message>
@@ -2672,7 +2637,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime4</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="108"/>
+        <location filename="../HrTimeInZone.cpp" line="128"/>
         <source>H4 Time in Zone</source>
         <translation>H4 滞在時間</translation>
     </message>
@@ -2680,7 +2645,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime5</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="120"/>
+        <location filename="../HrTimeInZone.cpp" line="145"/>
         <source>H5 Time in Zone</source>
         <translation>H5 滞在時間</translation>
     </message>
@@ -2688,7 +2653,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime6</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="132"/>
+        <location filename="../HrTimeInZone.cpp" line="162"/>
         <source>H6 Time in Zone</source>
         <translation>H6 滞在時間</translation>
     </message>
@@ -2696,7 +2661,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime7</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="144"/>
+        <location filename="../HrTimeInZone.cpp" line="179"/>
         <source>H7 Time in Zone</source>
         <translation>H7 滞在時間</translation>
     </message>
@@ -2704,7 +2669,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime8</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="156"/>
+        <location filename="../HrTimeInZone.cpp" line="196"/>
         <source>H8 Time in Zone</source>
         <translation>H8 滞在時間</translation>
     </message>
@@ -2910,7 +2875,8 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LTMPlot</name>
     <message>
-        <location filename="../LTMPlot.cpp" line="1120"/>
+        <location filename="../LTMPlot.cpp" line="731"/>
+        <location filename="../LTMPlot.cpp" line="1123"/>
         <source>watts</source>
         <translation>ワット</translation>
     </message>
@@ -2932,33 +2898,33 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="253"/>
-        <location filename="../LTMSidebar.cpp" line="289"/>
+        <location filename="../LTMSidebar.cpp" line="257"/>
+        <location filename="../LTMSidebar.cpp" line="293"/>
         <source>Edit details</source>
         <translation type="unfinished">詳細の編集</translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="254"/>
+        <location filename="../LTMSidebar.cpp" line="258"/>
         <source>Delete range</source>
         <translation type="unfinished">レンジを削除</translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="255"/>
+        <location filename="../LTMSidebar.cpp" line="259"/>
         <source>Add Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="290"/>
+        <location filename="../LTMSidebar.cpp" line="294"/>
         <source>Delete event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="300"/>
+        <location filename="../LTMSidebar.cpp" line="304"/>
         <source>Add event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="537"/>
+        <location filename="../LTMSidebar.cpp" line="541"/>
         <source>^(Average|Max) </source>
         <translation type="unfinished"></translation>
     </message>
@@ -2970,7 +2936,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="obsolete">日付範囲</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="69"/>
+        <location filename="../LTMTool.cpp" line="124"/>
         <source>Metric</source>
         <translation>統計</translation>
     </message>
@@ -3015,8 +2981,8 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="obsolete">直近の12ヶ月</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="511"/>
-        <location filename="../LTMTool.cpp" line="519"/>
+        <location filename="../LTMTool.cpp" line="574"/>
+        <location filename="../LTMTool.cpp" line="582"/>
         <source>Unknown Metric</source>
         <translation>不明な統計</translation>
     </message>
@@ -3033,12 +2999,47 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="obsolete">レンジを削除</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="544"/>
+        <location filename="../LTMTool.cpp" line="59"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="69"/>
+        <source>Chart</source>
+        <translation type="unfinished">チャート</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="101"/>
+        <source>Add</source>
+        <translation type="unfinished">追加</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="102"/>
+        <source>Manage</source>
+        <translation type="unfinished">管理</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="518"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="519"/>
+        <source>Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="520"/>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="607"/>
         <source>Pick Color</source>
         <translation>カラーピッカー</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="545"/>
+        <location filename="../LTMTool.cpp" line="608"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
@@ -3046,19 +3047,16 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LTMWindow</name>
     <message>
-        <location filename="../LTMWindow.cpp" line="135"/>
         <source>Add</source>
-        <translation>追加</translation>
+        <translation type="obsolete">追加</translation>
     </message>
     <message>
-        <location filename="../LTMWindow.cpp" line="137"/>
         <source>Manage</source>
-        <translation>管理</translation>
+        <translation type="obsolete">管理</translation>
     </message>
     <message>
-        <location filename="../LTMWindow.cpp" line="105"/>
         <source>Chart</source>
-        <translation>チャート</translation>
+        <translation type="obsolete">チャート</translation>
     </message>
     <message>
         <source>Days</source>
@@ -3084,71 +3082,71 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LTPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3001"/>
+        <location filename="../Pages.cpp" line="3003"/>
         <source>Add LT</source>
         <translation>LT値を追加</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3002"/>
+        <location filename="../Pages.cpp" line="3004"/>
         <source>Delete LT</source>
         <translation>LT値を削除</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3003"/>
+        <location filename="../Pages.cpp" line="3005"/>
         <source>Default</source>
         <translation>デフォルト</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3006"/>
+        <location filename="../Pages.cpp" line="3008"/>
         <source>Add Zone</source>
         <translation>ゾーンを追加</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3007"/>
+        <location filename="../Pages.cpp" line="3009"/>
         <source>Delete Zone</source>
         <translation>ゾーンを削除</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3021"/>
-        <location filename="../Pages.cpp" line="3061"/>
+        <location filename="../Pages.cpp" line="3023"/>
+        <location filename="../Pages.cpp" line="3063"/>
         <source>From Date</source>
         <translation>開始日</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3022"/>
-        <location filename="../Pages.cpp" line="3062"/>
+        <location filename="../Pages.cpp" line="3024"/>
+        <location filename="../Pages.cpp" line="3064"/>
         <source>Lactic Threshold</source>
         <translation>LT値</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3039"/>
-        <location filename="../Pages.cpp" line="3063"/>
+        <location filename="../Pages.cpp" line="3041"/>
+        <location filename="../Pages.cpp" line="3065"/>
         <source>Rest HR</source>
         <translation>安静時心拍数</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3040"/>
-        <location filename="../Pages.cpp" line="3064"/>
+        <location filename="../Pages.cpp" line="3042"/>
+        <location filename="../Pages.cpp" line="3066"/>
         <source>Max HR</source>
         <translation>最大心拍数</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3101"/>
+        <location filename="../Pages.cpp" line="3103"/>
         <source>Short</source>
         <translation>略称</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3102"/>
+        <location filename="../Pages.cpp" line="3104"/>
         <source>Long</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3103"/>
+        <location filename="../Pages.cpp" line="3105"/>
         <source>From BPM</source>
         <translation>最低心拍数</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3104"/>
+        <location filename="../Pages.cpp" line="3106"/>
         <source>Trimp k</source>
         <translation>Trimp係数</translation>
     </message>
@@ -3156,13 +3154,13 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LeftRightBalance</name>
     <message>
-        <location filename="../LeftRightBalance.cpp" line="33"/>
+        <location filename="../LeftRightBalance.cpp" line="36"/>
         <source>Left/Right Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftRightBalance.cpp" line="34"/>
-        <location filename="../LeftRightBalance.cpp" line="35"/>
+        <location filename="../LeftRightBalance.cpp" line="37"/>
+        <location filename="../LeftRightBalance.cpp" line="38"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
@@ -3174,7 +3172,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="obsolete">無効なライドファイル名</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2210"/>
+        <location filename="../MainWindow.cpp" line="2216"/>
         <source>Invalid date/time in filename:
 %1
 Skipping file...</source>
@@ -3184,13 +3182,13 @@ Skipping file...</source>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="281"/>
-        <location filename="../MainWindow.cpp" line="2230"/>
+        <location filename="../MainWindow.cpp" line="2236"/>
         <source>Zones File Error</source>
         <translation>ゾーン設定ファイルエラー</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="284"/>
-        <location filename="../MainWindow.cpp" line="2234"/>
+        <location filename="../MainWindow.cpp" line="2240"/>
         <source>Reading Zones File</source>
         <translation>ゾーン設定ファイルの読み込み中</translation>
     </message>
@@ -3200,7 +3198,7 @@ Skipping file...</source>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="565"/>
-        <location filename="../MainWindow.cpp" line="1209"/>
+        <location filename="../MainWindow.cpp" line="1215"/>
         <source>Intervals</source>
         <translation>インターバル</translation>
     </message>
@@ -3225,22 +3223,22 @@ Skipping file...</source>
         <translation type="obsolete">&amp;サイクリスト</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="743"/>
+        <location filename="../MainWindow.cpp" line="747"/>
         <source>&amp;New...</source>
         <translation>&amp;新規...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="743"/>
+        <location filename="../MainWindow.cpp" line="747"/>
         <source>Ctrl+N</source>
         <translation>Ctrl+N</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="744"/>
+        <location filename="../MainWindow.cpp" line="748"/>
         <source>&amp;Open...</source>
         <translation>&amp;開く...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="744"/>
+        <location filename="../MainWindow.cpp" line="748"/>
         <source>Ctrl+O</source>
         <translation>Ctrl+O</translation>
     </message>
@@ -3249,7 +3247,7 @@ Skipping file...</source>
         <translation type="obsolete">&amp;終了</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="746"/>
+        <location filename="../MainWindow.cpp" line="750"/>
         <source>Ctrl+Q</source>
         <translation>Ctrl+Q</translation>
     </message>
@@ -3258,24 +3256,24 @@ Skipping file...</source>
         <translation type="obsolete">&amp;ライド</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="775"/>
+        <location filename="../MainWindow.cpp" line="779"/>
         <source>Ctrl+S</source>
         <translation>Ctrl+S</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="749"/>
+        <location filename="../MainWindow.cpp" line="753"/>
         <source>&amp;Download from device...</source>
         <translation>&amp;デバイスからダウンロード...</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="291"/>
-        <location filename="../MainWindow.cpp" line="2241"/>
+        <location filename="../MainWindow.cpp" line="2247"/>
         <source>HR Zones File Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="294"/>
-        <location filename="../MainWindow.cpp" line="2245"/>
+        <location filename="../MainWindow.cpp" line="2251"/>
         <source>Reading HR Zones File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3296,210 +3294,210 @@ Skipping file...</source>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="454"/>
-        <location filename="../MainWindow.cpp" line="845"/>
+        <location filename="../MainWindow.cpp" line="849"/>
         <source>Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="461"/>
-        <location filename="../MainWindow.cpp" line="848"/>
+        <location filename="../MainWindow.cpp" line="852"/>
         <source>Diary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="468"/>
-        <location filename="../MainWindow.cpp" line="844"/>
+        <location filename="../MainWindow.cpp" line="848"/>
         <source>Analysis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="474"/>
-        <location filename="../MainWindow.cpp" line="846"/>
+        <location filename="../MainWindow.cpp" line="850"/>
         <source>Train</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="524"/>
-        <location filename="../MainWindow.cpp" line="1160"/>
+        <location filename="../MainWindow.cpp" line="1166"/>
         <source>All Activities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="742"/>
+        <location filename="../MainWindow.cpp" line="746"/>
         <source>&amp;Athlete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="745"/>
+        <location filename="../MainWindow.cpp" line="749"/>
         <source>&amp;Close Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="745"/>
+        <location filename="../MainWindow.cpp" line="749"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="746"/>
+        <location filename="../MainWindow.cpp" line="750"/>
         <source>&amp;Quit All Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="748"/>
+        <location filename="../MainWindow.cpp" line="752"/>
         <source>A&amp;ctivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="749"/>
+        <location filename="../MainWindow.cpp" line="753"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="751"/>
+        <location filename="../MainWindow.cpp" line="755"/>
         <source>&amp;Manual activity entry...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="753"/>
+        <location filename="../MainWindow.cpp" line="757"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="754"/>
+        <location filename="../MainWindow.cpp" line="758"/>
         <source>&amp;Batch export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="755"/>
+        <location filename="../MainWindow.cpp" line="759"/>
         <source>Export Metrics as CSV...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="758"/>
+        <location filename="../MainWindow.cpp" line="762"/>
         <source>&amp;Upload to TrainingPeaks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="758"/>
+        <location filename="../MainWindow.cpp" line="762"/>
         <source>Ctrl+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="759"/>
+        <location filename="../MainWindow.cpp" line="763"/>
         <source>Down&amp;load from TrainingPeaks...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="759"/>
+        <location filename="../MainWindow.cpp" line="763"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="775"/>
+        <location filename="../MainWindow.cpp" line="779"/>
         <source>&amp;Save activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="776"/>
+        <location filename="../MainWindow.cpp" line="780"/>
         <source>D&amp;elete activity...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="777"/>
+        <location filename="../MainWindow.cpp" line="781"/>
         <source>Split &amp;activity...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="782"/>
+        <location filename="../MainWindow.cpp" line="786"/>
         <source>Critical Power Calculator...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="783"/>
+        <location filename="../MainWindow.cpp" line="787"/>
         <source>Air Density (Rho) Estimator...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="786"/>
+        <location filename="../MainWindow.cpp" line="790"/>
         <source>Get &amp;Withings Data...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="788"/>
+        <location filename="../MainWindow.cpp" line="792"/>
         <source>Get &amp;Zeo Data...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="791"/>
+        <location filename="../MainWindow.cpp" line="795"/>
         <source>Workout Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="792"/>
+        <location filename="../MainWindow.cpp" line="796"/>
         <source>Get Workouts from ErgDB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="796"/>
-        <location filename="../MainWindow.cpp" line="1197"/>
+        <location filename="../MainWindow.cpp" line="800"/>
+        <location filename="../MainWindow.cpp" line="1203"/>
         <source>Upload Activity to Calendar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="797"/>
+        <location filename="../MainWindow.cpp" line="801"/>
         <source>Import Calendar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="798"/>
+        <location filename="../MainWindow.cpp" line="802"/>
         <source>Export Calendar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="799"/>
+        <location filename="../MainWindow.cpp" line="803"/>
         <source>Refresh Calendar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="802"/>
+        <location filename="../MainWindow.cpp" line="806"/>
         <source>Find intervals...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1692"/>
+        <location filename="../MainWindow.cpp" line="1698"/>
         <source>Select Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1692"/>
-        <location filename="../MainWindow.cpp" line="1778"/>
-        <location filename="../MainWindow.cpp" line="1786"/>
+        <location filename="../MainWindow.cpp" line="1698"/>
+        <location filename="../MainWindow.cpp" line="1784"/>
+        <location filename="../MainWindow.cpp" line="1792"/>
         <source>No activity selected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1703"/>
+        <location filename="../MainWindow.cpp" line="1709"/>
         <source>Export Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1716"/>
+        <location filename="../MainWindow.cpp" line="1722"/>
         <source>Export Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1717"/>
+        <location filename="../MainWindow.cpp" line="1723"/>
         <source>Failed to export ride, please check permissions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2188"/>
+        <location filename="../MainWindow.cpp" line="2194"/>
         <source>Range from %1 to %2
 Athlete CP set to %3 watts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2209"/>
+        <location filename="../MainWindow.cpp" line="2215"/>
         <source>Invalid Activity File Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3508,12 +3506,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">&amp;CSVファイルにエクスポート...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="753"/>
+        <location filename="../MainWindow.cpp" line="757"/>
         <source>Ctrl+E</source>
         <translation>Ctrl+E</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="750"/>
+        <location filename="../MainWindow.cpp" line="754"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
@@ -3522,7 +3520,7 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">&amp;ベストインターバルを検索...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="754"/>
+        <location filename="../MainWindow.cpp" line="758"/>
         <source>Ctrl+B</source>
         <translation>Ctrl+B</translation>
     </message>
@@ -3591,12 +3589,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">エディタ</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="750"/>
+        <location filename="../MainWindow.cpp" line="754"/>
         <source>&amp;Import from file...</source>
         <translation>&amp;ファイルの取り込み...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="751"/>
+        <location filename="../MainWindow.cpp" line="755"/>
         <source>Ctrl+M</source>
         <translation>Ctrl+M</translation>
     </message>
@@ -3617,12 +3615,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">&amp;ライドを保存</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="780"/>
+        <location filename="../MainWindow.cpp" line="784"/>
         <source>&amp;Tools</source>
         <translation>&amp;ツール</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="781"/>
+        <location filename="../MainWindow.cpp" line="785"/>
         <source>&amp;Options...</source>
         <translation>&amp;オプション...</translation>
     </message>
@@ -3631,89 +3629,89 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">CP計算機</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="825"/>
+        <location filename="../MainWindow.cpp" line="829"/>
         <source>&amp;View</source>
         <translation>&amp;参照</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="827"/>
+        <location filename="../MainWindow.cpp" line="831"/>
         <source>Toggle Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="829"/>
+        <location filename="../MainWindow.cpp" line="833"/>
         <source>Show Left Sidebar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="833"/>
+        <location filename="../MainWindow.cpp" line="837"/>
         <source>Show Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="838"/>
+        <location filename="../MainWindow.cpp" line="842"/>
         <source>Tabbed View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="852"/>
+        <location filename="../MainWindow.cpp" line="856"/>
         <source>Reset Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="854"/>
+        <location filename="../MainWindow.cpp" line="858"/>
         <source>&amp;Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="861"/>
+        <location filename="../MainWindow.cpp" line="865"/>
         <source>&amp;Help</source>
         <translation>&amp;ヘルプ</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="862"/>
+        <location filename="../MainWindow.cpp" line="866"/>
         <source>&amp;User Guide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="863"/>
+        <location filename="../MainWindow.cpp" line="867"/>
         <source>&amp;Log a bug or feature request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="865"/>
+        <location filename="../MainWindow.cpp" line="869"/>
         <source>&amp;About GoldenCheetah</source>
         <translation>Golden Cheetah について</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1164"/>
+        <location filename="../MainWindow.cpp" line="1170"/>
         <source>Save Changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1167"/>
+        <location filename="../MainWindow.cpp" line="1173"/>
         <source>Revert to Saved version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1170"/>
-        <location filename="../MainWindow.cpp" line="1786"/>
+        <location filename="../MainWindow.cpp" line="1176"/>
+        <location filename="../MainWindow.cpp" line="1792"/>
         <source>Delete Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1179"/>
-        <location filename="../MainWindow.cpp" line="1778"/>
+        <location filename="../MainWindow.cpp" line="1185"/>
+        <location filename="../MainWindow.cpp" line="1784"/>
         <source>Split Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1192"/>
+        <location filename="../MainWindow.cpp" line="1198"/>
         <source>Tweet Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1612"/>
+        <location filename="../MainWindow.cpp" line="1618"/>
         <source>Can&apos;t rename %1 to %2</source>
         <translation>%1 から %2 にリネームできません</translation>
     </message>
@@ -3782,42 +3780,42 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">%1 への書き込みに失敗しました</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1739"/>
+        <location filename="../MainWindow.cpp" line="1745"/>
         <source>Import from File</source>
         <translation>ファイルを取り込み</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1756"/>
+        <location filename="../MainWindow.cpp" line="1762"/>
         <source>No Activity To Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1757"/>
+        <location filename="../MainWindow.cpp" line="1763"/>
         <source>There is no currently selected ride to save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1791"/>
+        <location filename="../MainWindow.cpp" line="1797"/>
         <source>Are you sure you want to delete the activity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1845"/>
+        <location filename="../MainWindow.cpp" line="1851"/>
         <source>Export Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1845"/>
+        <location filename="../MainWindow.cpp" line="1851"/>
         <source>Comma Separated Variables (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1920"/>
+        <location filename="../MainWindow.cpp" line="1926"/>
         <source>Workout Directory Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1977"/>
+        <location filename="../MainWindow.cpp" line="1983"/>
         <source> (%1 watts)</source>
         <translation> (%1 ワット)</translation>
     </message>
@@ -3834,12 +3832,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">ライドを削除</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1173"/>
+        <location filename="../MainWindow.cpp" line="1179"/>
         <source>Find Best Intervals</source>
         <translation>ベストインターバルを検索</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1176"/>
+        <location filename="../MainWindow.cpp" line="1182"/>
         <source>Find Power Peaks</source>
         <translation>ピーク出力を検索</translation>
     </message>
@@ -3848,27 +3846,27 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Twitterに送信</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1214"/>
+        <location filename="../MainWindow.cpp" line="1220"/>
         <source>Rename interval</source>
         <translation>インターバルをリネーム</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1215"/>
+        <location filename="../MainWindow.cpp" line="1221"/>
         <source>Delete interval</source>
         <translation>インターバルを削除</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1216"/>
+        <location filename="../MainWindow.cpp" line="1222"/>
         <source>Zoom to interval</source>
         <translation>インターバルを拡大</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1217"/>
+        <location filename="../MainWindow.cpp" line="1223"/>
         <source>Bring to Front</source>
         <translation>手前へ</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1218"/>
+        <location filename="../MainWindow.cpp" line="1224"/>
         <source>Send to back</source>
         <translation>背面へ</translation>
     </message>
@@ -3903,7 +3901,7 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">ノートファイル %1 の書き込みに失敗</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2187"/>
+        <location filename="../MainWindow.cpp" line="2193"/>
         <source>CP saved</source>
         <translation>CPが保存されました</translation>
     </message>
@@ -3926,7 +3924,7 @@ CP値%3ワットに設定されました</translation>
         <translation type="obsolete">本当にこのライドを削除しますか:</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1793"/>
+        <location filename="../MainWindow.cpp" line="1799"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
@@ -4147,13 +4145,13 @@ CP値%3ワットに設定されました</translation>
 <context>
     <name>MaxCadence</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="606"/>
+        <location filename="../BasicRideMetrics.cpp" line="683"/>
         <source>Max Cadence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="607"/>
-        <location filename="../BasicRideMetrics.cpp" line="608"/>
+        <location filename="../BasicRideMetrics.cpp" line="684"/>
+        <location filename="../BasicRideMetrics.cpp" line="685"/>
         <source>rpm</source>
         <translation type="unfinished">rpm</translation>
     </message>
@@ -4161,13 +4159,13 @@ CP値%3ワットに設定されました</translation>
 <context>
     <name>MaxHr</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="538"/>
+        <location filename="../BasicRideMetrics.cpp" line="607"/>
         <source>Max Heartrate</source>
         <translation>最大心拍数</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="539"/>
-        <location filename="../BasicRideMetrics.cpp" line="540"/>
+        <location filename="../BasicRideMetrics.cpp" line="608"/>
+        <location filename="../BasicRideMetrics.cpp" line="609"/>
         <source>bpm</source>
         <translation>bpm</translation>
     </message>
@@ -4175,13 +4173,13 @@ CP値%3ワットに設定されました</translation>
 <context>
     <name>MaxPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="509"/>
+        <location filename="../BasicRideMetrics.cpp" line="574"/>
         <source>Max Power</source>
         <translation>最大出力</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="510"/>
-        <location filename="../BasicRideMetrics.cpp" line="511"/>
+        <location filename="../BasicRideMetrics.cpp" line="575"/>
+        <location filename="../BasicRideMetrics.cpp" line="576"/>
         <source>watts</source>
         <translation>ワット</translation>
     </message>
@@ -4189,7 +4187,7 @@ CP値%3ワットに設定されました</translation>
 <context>
     <name>MaxPowerVariance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="848"/>
+        <location filename="../BasicRideMetrics.cpp" line="949"/>
         <source>Max Power Variance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4197,17 +4195,17 @@ CP値%3ワットに設定されました</translation>
 <context>
     <name>MaxSpeed</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="567"/>
+        <location filename="../BasicRideMetrics.cpp" line="640"/>
         <source>Max Speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="568"/>
+        <location filename="../BasicRideMetrics.cpp" line="641"/>
         <source>kph</source>
         <translation type="unfinished">km/h</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="569"/>
+        <location filename="../BasicRideMetrics.cpp" line="642"/>
         <source>mph</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4215,17 +4213,17 @@ CP値%3ワットに設定されました</translation>
 <context>
     <name>MaxTemp</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="643"/>
+        <location filename="../BasicRideMetrics.cpp" line="724"/>
         <source>Max Temp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="644"/>
+        <location filename="../BasicRideMetrics.cpp" line="725"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="645"/>
+        <location filename="../BasicRideMetrics.cpp" line="726"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4233,7 +4231,7 @@ CP値%3ワットに設定されました</translation>
 <context>
     <name>MeanPowerVariance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="801"/>
+        <location filename="../BasicRideMetrics.cpp" line="898"/>
         <source>Average Power Variance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4241,42 +4239,42 @@ CP値%3ワットに設定されました</translation>
 <context>
     <name>MeasuresPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3395"/>
+        <location filename="../Pages.cpp" line="3397"/>
         <source>Move up</source>
         <translation type="unfinished">上へ</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3396"/>
+        <location filename="../Pages.cpp" line="3398"/>
         <source>Move down</source>
         <translation type="unfinished">下へ</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3397"/>
+        <location filename="../Pages.cpp" line="3399"/>
         <source>Insert</source>
         <translation type="unfinished">挿入</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3398"/>
+        <location filename="../Pages.cpp" line="3400"/>
         <source>Rename</source>
         <translation type="unfinished">リネーム</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3399"/>
+        <location filename="../Pages.cpp" line="3401"/>
         <source>Delete</source>
         <translation type="unfinished">削除</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3410"/>
+        <location filename="../Pages.cpp" line="3412"/>
         <source>Screen Tab</source>
         <translation type="unfinished">スクリーンタブ</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3411"/>
+        <location filename="../Pages.cpp" line="3413"/>
         <source>Measure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3412"/>
+        <location filename="../Pages.cpp" line="3414"/>
         <source>Type</source>
         <translation type="unfinished">種別</translation>
     </message>
@@ -4495,17 +4493,17 @@ Elapsed: %1
 <context>
     <name>NavigatorCellDelegate</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="941"/>
+        <location filename="../RideNavigator.cpp" line="944"/>
         <source>Date</source>
         <translation type="unfinished">日付</translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="944"/>
+        <location filename="../RideNavigator.cpp" line="947"/>
         <source>Time</source>
         <translation type="unfinished">時間</translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="947"/>
+        <location filename="../RideNavigator.cpp" line="950"/>
         <source>Last updated</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4632,13 +4630,13 @@ Elapsed: %1
 <context>
     <name>NinetyFivePercentHeartRate</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="688"/>
+        <location filename="../BasicRideMetrics.cpp" line="773"/>
         <source>95% Heartrate</source>
         <translation>95% Heartrate</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="689"/>
-        <location filename="../BasicRideMetrics.cpp" line="690"/>
+        <location filename="../BasicRideMetrics.cpp" line="774"/>
+        <location filename="../BasicRideMetrics.cpp" line="775"/>
         <source>bpm</source>
         <translation>bpm</translation>
     </message>
@@ -4646,13 +4644,13 @@ Elapsed: %1
 <context>
     <name>NonZeroPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="365"/>
+        <location filename="../BasicRideMetrics.cpp" line="408"/>
         <source>Nonzero Average Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="366"/>
-        <location filename="../BasicRideMetrics.cpp" line="367"/>
+        <location filename="../BasicRideMetrics.cpp" line="409"/>
+        <location filename="../BasicRideMetrics.cpp" line="410"/>
         <source>watts</source>
         <translation type="unfinished">ワット</translation>
     </message>
@@ -4660,17 +4658,17 @@ Elapsed: %1
 <context>
     <name>Pace</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="288"/>
+        <location filename="../BasicRideMetrics.cpp" line="319"/>
         <source>Pace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="290"/>
+        <location filename="../BasicRideMetrics.cpp" line="321"/>
         <source>min/km</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="291"/>
+        <location filename="../BasicRideMetrics.cpp" line="322"/>
         <source>min/mile</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4863,7 +4861,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower10m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="162"/>
+        <location filename="../PeakPower.cpp" line="202"/>
         <source>10 min Peak Power</source>
         <translation>10分間の最大出力</translation>
     </message>
@@ -4871,7 +4869,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower10s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="96"/>
+        <location filename="../PeakPower.cpp" line="112"/>
         <source>10 sec Peak Power</source>
         <translation>10秒間の最大出力</translation>
     </message>
@@ -4879,7 +4877,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower15s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="107"/>
+        <location filename="../PeakPower.cpp" line="127"/>
         <source>15 sec Peak Power</source>
         <translation>15秒間の最大出力</translation>
     </message>
@@ -4887,7 +4885,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower1m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="140"/>
+        <location filename="../PeakPower.cpp" line="172"/>
         <source>1 min Peak Power</source>
         <translation>1分間の最大出力</translation>
     </message>
@@ -4895,7 +4893,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower1s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="74"/>
+        <location filename="../PeakPower.cpp" line="82"/>
         <source>1 sec Peak Power</source>
         <translation>1秒間の最大出力</translation>
     </message>
@@ -4903,7 +4901,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower20m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="173"/>
+        <location filename="../PeakPower.cpp" line="217"/>
         <source>20 min Peak Power</source>
         <translation>20分間の最大出力</translation>
     </message>
@@ -4911,7 +4909,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower20s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="118"/>
+        <location filename="../PeakPower.cpp" line="142"/>
         <source>20 sec Peak Power</source>
         <translation>20秒間の最大出力</translation>
     </message>
@@ -4919,7 +4917,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower30m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="184"/>
+        <location filename="../PeakPower.cpp" line="232"/>
         <source>30 min Peak Power</source>
         <translation>30分間の最大出力</translation>
     </message>
@@ -4927,7 +4925,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower30s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="129"/>
+        <location filename="../PeakPower.cpp" line="157"/>
         <source>30 sec Peak Power</source>
         <translation>30 sec Peak Power</translation>
     </message>
@@ -4935,7 +4933,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower5m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="151"/>
+        <location filename="../PeakPower.cpp" line="187"/>
         <source>5 min Peak Power</source>
         <translation>5分間の最大出力</translation>
     </message>
@@ -4943,7 +4941,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower5s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="85"/>
+        <location filename="../PeakPower.cpp" line="97"/>
         <source>5 sec Peak Power</source>
         <translation>5秒間の最大出力</translation>
     </message>
@@ -4951,13 +4949,13 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr10m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="263"/>
+        <location filename="../PeakPower.cpp" line="324"/>
         <source>10 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="264"/>
-        <location filename="../PeakPower.cpp" line="265"/>
+        <location filename="../PeakPower.cpp" line="325"/>
+        <location filename="../PeakPower.cpp" line="326"/>
         <source>bpm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4965,13 +4963,13 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr1m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="235"/>
+        <location filename="../PeakPower.cpp" line="288"/>
         <source>1 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="236"/>
-        <location filename="../PeakPower.cpp" line="237"/>
+        <location filename="../PeakPower.cpp" line="289"/>
+        <location filename="../PeakPower.cpp" line="290"/>
         <source>bpm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4979,13 +4977,13 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr20m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="277"/>
+        <location filename="../PeakPower.cpp" line="342"/>
         <source>20 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="278"/>
-        <location filename="../PeakPower.cpp" line="279"/>
+        <location filename="../PeakPower.cpp" line="343"/>
+        <location filename="../PeakPower.cpp" line="344"/>
         <source>bpm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4993,13 +4991,13 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr30m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="291"/>
+        <location filename="../PeakPower.cpp" line="360"/>
         <source>30 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="292"/>
-        <location filename="../PeakPower.cpp" line="293"/>
+        <location filename="../PeakPower.cpp" line="361"/>
+        <location filename="../PeakPower.cpp" line="362"/>
         <source>bpm</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5007,22 +5005,8 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr5m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="249"/>
-        <source>5 min Peak Power HR</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../PeakPower.cpp" line="250"/>
-        <location filename="../PeakPower.cpp" line="251"/>
-        <source>bpm</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
-    <name>PeakPowerHr60m</name>
-    <message>
         <location filename="../PeakPower.cpp" line="306"/>
-        <source>60 min Peak Power HR</source>
+        <source>5 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5033,10 +5017,24 @@ Do you want to continue?</source>
     </message>
 </context>
 <context>
+    <name>PeakPowerHr60m</name>
+    <message>
+        <location filename="../PeakPower.cpp" line="379"/>
+        <source>60 min Peak Power HR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../PeakPower.cpp" line="380"/>
+        <location filename="../PeakPower.cpp" line="381"/>
+        <source>bpm</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>PeakWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="89"/>
-        <location filename="../WattsPerKilogram.cpp" line="90"/>
+        <location filename="../WattsPerKilogram.cpp" line="93"/>
+        <location filename="../WattsPerKilogram.cpp" line="94"/>
         <source>wpk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5044,7 +5042,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK10m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="219"/>
+        <location filename="../WattsPerKilogram.cpp" line="263"/>
         <source>10 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5052,7 +5050,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK10s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="153"/>
+        <location filename="../WattsPerKilogram.cpp" line="173"/>
         <source>10 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5060,7 +5058,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK15s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="164"/>
+        <location filename="../WattsPerKilogram.cpp" line="188"/>
         <source>15 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5068,7 +5066,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK1m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="197"/>
+        <location filename="../WattsPerKilogram.cpp" line="233"/>
         <source>1 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5076,7 +5074,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK1s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="131"/>
+        <location filename="../WattsPerKilogram.cpp" line="143"/>
         <source>1 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5084,7 +5082,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK20m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="230"/>
+        <location filename="../WattsPerKilogram.cpp" line="278"/>
         <source>20 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5092,7 +5090,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK20s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="175"/>
+        <location filename="../WattsPerKilogram.cpp" line="203"/>
         <source>20 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5100,7 +5098,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK30m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="241"/>
+        <location filename="../WattsPerKilogram.cpp" line="293"/>
         <source>30 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5108,7 +5106,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK30s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="186"/>
+        <location filename="../WattsPerKilogram.cpp" line="218"/>
         <source>30 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5116,7 +5114,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK5m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="208"/>
+        <location filename="../WattsPerKilogram.cpp" line="248"/>
         <source>5 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5124,7 +5122,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK5s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="142"/>
+        <location filename="../WattsPerKilogram.cpp" line="158"/>
         <source>5 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5136,22 +5134,22 @@ Do you want to continue?</source>
         <translation type="obsolete">パフォーマンスマネージャ</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="118"/>
+        <location filename="../PerfPlot.cpp" line="147"/>
         <source>Daily</source>
         <translation>デイリー</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="138"/>
+        <location filename="../PerfPlot.cpp" line="167"/>
         <source>Short Term Stress</source>
         <translation>短期ストレス (STS)</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="152"/>
+        <location filename="../PerfPlot.cpp" line="181"/>
         <source>Long Term Stress</source>
         <translation>長期ストレス (LTS)</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="166"/>
+        <location filename="../PerfPlot.cpp" line="195"/>
         <source>Stress Balance</source>
         <translation>ストレスバランス</translation>
     </message>
@@ -5263,85 +5261,91 @@ Do you want to continue?</source>
     <name>PowerHist</name>
     <message>
         <location filename="../PowerHist.cpp" line="77"/>
-        <location filename="../PowerHist.cpp" line="902"/>
+        <location filename="../PowerHist.cpp" line="940"/>
         <source>Time (minutes)</source>
         <translation>時間 (分)</translation>
     </message>
     <message>
         <location filename="../PowerHist.cpp" line="77"/>
-        <location filename="../PowerHist.cpp" line="902"/>
+        <location filename="../PowerHist.cpp" line="940"/>
         <source>Time (percent)</source>
         <translation>時間（%%）</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="877"/>
+        <location filename="../PowerHist.cpp" line="910"/>
         <source>Power (watts)</source>
         <translation>出力（ワット）</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="876"/>
+        <location filename="../PowerHist.cpp" line="909"/>
+        <location filename="../PowerHist.cpp" line="914"/>
         <source>Power zone</source>
         <translation>パワーゾーン</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="882"/>
+        <location filename="../PowerHist.cpp" line="920"/>
         <source>Heartrate (bpm)</source>
         <translation>心拍数 (bpm)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="881"/>
+        <location filename="../PowerHist.cpp" line="919"/>
         <source>Heartrate zone</source>
         <translation>心拍ゾーン</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="886"/>
+        <location filename="../PowerHist.cpp" line="915"/>
+        <source>Power (watts/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../PowerHist.cpp" line="924"/>
         <source>Cadence (rpm)</source>
         <translation>ケイデンス (rpm)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>Speed (%1)</source>
         <translation>速度 (%1)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>kph</source>
         <translation>km/h</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>mph</source>
         <translation>m/h</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>Torque (%1)</source>
         <translation>トルク (%1)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>N-m</source>
         <translation>N-m</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>ft-lbf</source>
         <translation>ft-lbf</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="898"/>
+        <location filename="../PowerHist.cpp" line="936"/>
         <source>Unknown data series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="962"/>
-        <location filename="../PowerHist.cpp" line="975"/>
+        <location filename="../PowerHist.cpp" line="1000"/>
+        <location filename="../PowerHist.cpp" line="1013"/>
         <source>minutes</source>
         <translation>分</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="962"/>
-        <location filename="../PowerHist.cpp" line="975"/>
+        <location filename="../PowerHist.cpp" line="1000"/>
+        <location filename="../PowerHist.cpp" line="1013"/>
         <source>%</source>
         <translation>%</translation>
     </message>
@@ -5349,27 +5353,27 @@ Do you want to continue?</source>
 <context>
     <name>ProcessorPage</name>
     <message>
-        <location filename="../Pages.cpp" line="2198"/>
+        <location filename="../Pages.cpp" line="2200"/>
         <source>Processor</source>
         <translation>処理</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2199"/>
+        <location filename="../Pages.cpp" line="2201"/>
         <source>Apply</source>
         <translation>適用</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2200"/>
+        <location filename="../Pages.cpp" line="2202"/>
         <source>Settings</source>
         <translation>設定</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2224"/>
+        <location filename="../Pages.cpp" line="2226"/>
         <source>Manual</source>
         <translation>手動</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2225"/>
+        <location filename="../Pages.cpp" line="2227"/>
         <source>Auto</source>
         <translation>自動</translation>
     </message>
@@ -5779,7 +5783,7 @@ Do you want to continue?</source>
 <context>
     <name>RelativeIntensity</name>
     <message>
-        <location filename="../BikeScore.cpp" line="136"/>
+        <location filename="../BikeScore.cpp" line="147"/>
         <source>Relative Intensity</source>
         <translation>Relative Intensity</translation>
     </message>
@@ -5787,7 +5791,7 @@ Do you want to continue?</source>
 <context>
     <name>ResponseIndex</name>
     <message>
-        <location filename="../BikeScore.cpp" line="218"/>
+        <location filename="../BikeScore.cpp" line="237"/>
         <source>Response Index</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5795,7 +5799,7 @@ Do you want to continue?</source>
 <context>
     <name>RideCount</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="34"/>
+        <location filename="../BasicRideMetrics.cpp" line="37"/>
         <source>Rides</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5803,9 +5807,9 @@ Do you want to continue?</source>
 <context>
     <name>RideDelegate</name>
     <message>
-        <location filename="../RideImportWizard.cpp" line="995"/>
-        <location filename="../RideImportWizard.cpp" line="1032"/>
-        <location filename="../RideImportWizard.cpp" line="1048"/>
+        <location filename="../RideImportWizard.cpp" line="998"/>
+        <location filename="../RideImportWizard.cpp" line="1035"/>
+        <location filename="../RideImportWizard.cpp" line="1051"/>
         <source>dd MMM yyyy</source>
         <translation>yyyy年MMMMd日</translation>
     </message>
@@ -6366,9 +6370,9 @@ Do you want to continue?</source>
     </message>
     <message>
         <location filename="../RideImportWizard.cpp" line="74"/>
-        <location filename="../RideImportWizard.cpp" line="696"/>
-        <location filename="../RideImportWizard.cpp" line="738"/>
-        <location filename="../RideImportWizard.cpp" line="890"/>
+        <location filename="../RideImportWizard.cpp" line="699"/>
+        <location filename="../RideImportWizard.cpp" line="741"/>
+        <location filename="../RideImportWizard.cpp" line="893"/>
         <source>Abort</source>
         <translation>中止</translation>
     </message>
@@ -6439,12 +6443,12 @@ Do you want to continue?</source>
     </message>
     <message>
         <location filename="../RideImportWizard.cpp" line="268"/>
-        <location filename="../RideImportWizard.cpp" line="454"/>
-        <location filename="../RideImportWizard.cpp" line="506"/>
-        <location filename="../RideImportWizard.cpp" line="717"/>
-        <location filename="../RideImportWizard.cpp" line="756"/>
-        <location filename="../RideImportWizard.cpp" line="895"/>
-        <location filename="../RideImportWizard.cpp" line="918"/>
+        <location filename="../RideImportWizard.cpp" line="457"/>
+        <location filename="../RideImportWizard.cpp" line="509"/>
+        <location filename="../RideImportWizard.cpp" line="720"/>
+        <location filename="../RideImportWizard.cpp" line="759"/>
+        <location filename="../RideImportWizard.cpp" line="898"/>
+        <location filename="../RideImportWizard.cpp" line="921"/>
         <source>Error</source>
         <translation>エラー</translation>
     </message>
@@ -6454,157 +6458,157 @@ Do you want to continue?</source>
         <translation>解析中...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="378"/>
+        <location filename="../RideImportWizard.cpp" line="381"/>
         <source>Validated</source>
         <translation>検証完了</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="380"/>
+        <location filename="../RideImportWizard.cpp" line="383"/>
         <source>Warning - </source>
         <translation>警告 - </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="394"/>
-        <location filename="../RideImportWizard.cpp" line="619"/>
-        <location filename="../RideImportWizard.cpp" line="765"/>
+        <location filename="../RideImportWizard.cpp" line="397"/>
+        <location filename="../RideImportWizard.cpp" line="622"/>
+        <location filename="../RideImportWizard.cpp" line="768"/>
         <source>dd MMM yyyy</source>
         <translation>yyyy年MMMMd日</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="395"/>
+        <location filename="../RideImportWizard.cpp" line="398"/>
         <source>hh:mm:ss ap</source>
         <translation>hh:mm:ss ap</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="432"/>
+        <location filename="../RideImportWizard.cpp" line="435"/>
         <source>Error - </source>
         <translation>エラー - </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="380"/>
-        <location filename="../RideImportWizard.cpp" line="432"/>
+        <location filename="../RideImportWizard.cpp" line="383"/>
+        <location filename="../RideImportWizard.cpp" line="435"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="447"/>
+        <location filename="../RideImportWizard.cpp" line="450"/>
         <source>Step 3 of 4: Confirm Date and Time</source>
         <translation>手順3/4 日付と時間を確認</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="464"/>
+        <location filename="../RideImportWizard.cpp" line="467"/>
         <source>Save</source>
         <translation>保存</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="573"/>
-        <location filename="../RideImportWizard.cpp" line="623"/>
+        <location filename="../RideImportWizard.cpp" line="576"/>
+        <location filename="../RideImportWizard.cpp" line="626"/>
         <source>hh:mm:ss</source>
         <translation>hh:mm:ss</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="582"/>
+        <location filename="../RideImportWizard.cpp" line="585"/>
         <source>Invalid Selection</source>
         <translation>無効な選択</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="582"/>
+        <location filename="../RideImportWizard.cpp" line="585"/>
         <source>More than 24hrs of rides to fit into a day</source>
         <translation>1日に24時間以上のライドが指定されています</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="627"/>
-        <location filename="../RideImportWizard.cpp" line="766"/>
+        <location filename="../RideImportWizard.cpp" line="630"/>
+        <location filename="../RideImportWizard.cpp" line="769"/>
         <source>hh:mm:ss a</source>
         <translation>hh:mm:ss a</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="736"/>
+        <location filename="../RideImportWizard.cpp" line="739"/>
         <source>Step 4 of 4: Save to Library</source>
         <translation>手順4/4 ライブラリに保存</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="758"/>
+        <location filename="../RideImportWizard.cpp" line="761"/>
         <source>Saving...</source>
         <translation>保存中...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="834"/>
+        <location filename="../RideImportWizard.cpp" line="837"/>
         <source>Error - Source is Target</source>
         <translation>エラー - 保存元と保存先が同一です</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="845"/>
+        <location filename="../RideImportWizard.cpp" line="848"/>
         <source>Overwriting file...</source>
         <translation>ファイルを上書き中...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="847"/>
+        <location filename="../RideImportWizard.cpp" line="850"/>
         <source>/</source>
         <translation>/</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="847"/>
+        <location filename="../RideImportWizard.cpp" line="850"/>
         <source>.tmp</source>
         <translation>.tmp</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="821"/>
-        <location filename="../RideImportWizard.cpp" line="854"/>
+        <location filename="../RideImportWizard.cpp" line="824"/>
+        <location filename="../RideImportWizard.cpp" line="857"/>
         <source>File Overwritten</source>
         <translation>ファイルは上書きされました</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="857"/>
-        <location filename="../RideImportWizard.cpp" line="859"/>
+        <location filename="../RideImportWizard.cpp" line="860"/>
+        <location filename="../RideImportWizard.cpp" line="862"/>
         <source>Error - overwrite failed</source>
         <translation>エラー - 上書き失敗</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="790"/>
-        <location filename="../RideImportWizard.cpp" line="862"/>
+        <location filename="../RideImportWizard.cpp" line="793"/>
+        <location filename="../RideImportWizard.cpp" line="865"/>
         <source>Error - File exists</source>
         <translation>エラー - ファイルが存在します</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="865"/>
+        <location filename="../RideImportWizard.cpp" line="868"/>
         <source>Saving file...</source>
         <translation>ファイルを保存中...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="823"/>
-        <location filename="../RideImportWizard.cpp" line="868"/>
+        <location filename="../RideImportWizard.cpp" line="826"/>
+        <location filename="../RideImportWizard.cpp" line="871"/>
         <source>File Saved</source>
         <translation>保存されました</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="877"/>
+        <location filename="../RideImportWizard.cpp" line="880"/>
         <source>Error - copy failed</source>
         <translation>エラー - コピー失敗</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="888"/>
+        <location filename="../RideImportWizard.cpp" line="891"/>
         <source>Step 5 of 5: Calculating Critical Powers</source>
         <translation>手順5/5 クリティカルパワーを計算中</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="896"/>
+        <location filename="../RideImportWizard.cpp" line="899"/>
         <source>Calculating...</source>
         <translation>計算中...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="905"/>
+        <location filename="../RideImportWizard.cpp" line="908"/>
         <source>Completed.</source>
         <translation>完了。</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="923"/>
+        <location filename="../RideImportWizard.cpp" line="926"/>
         <source>Import Complete. %1 of %2 successful.</source>
         <translation>取り込みが完了しました。%1/%2成功。</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="704"/>
-        <location filename="../RideImportWizard.cpp" line="928"/>
+        <location filename="../RideImportWizard.cpp" line="707"/>
+        <location filename="../RideImportWizard.cpp" line="931"/>
         <source>Finish</source>
         <translation>終了</translation>
     </message>
@@ -6612,22 +6616,22 @@ Do you want to continue?</source>
 <context>
     <name>RideNavigator</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="540"/>
+        <location filename="../RideNavigator.cpp" line="542"/>
         <source>Remove Column</source>
         <translation type="unfinished">カラムの削除</translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="546"/>
+        <location filename="../RideNavigator.cpp" line="548"/>
         <source>Column Chooser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="551"/>
+        <location filename="../RideNavigator.cpp" line="553"/>
         <source>Do Not Show in Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="551"/>
+        <location filename="../RideNavigator.cpp" line="553"/>
         <source>Show In Groups</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6992,32 +6996,32 @@ native format. Should we do so?
 <context>
     <name>SchemePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2295"/>
+        <location filename="../Pages.cpp" line="2297"/>
         <source>Add</source>
         <translation>追加</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2296"/>
+        <location filename="../Pages.cpp" line="2298"/>
         <source>Rename</source>
         <translation>リネーム</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2297"/>
+        <location filename="../Pages.cpp" line="2299"/>
         <source>Delete</source>
         <translation>削除</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2306"/>
+        <location filename="../Pages.cpp" line="2308"/>
         <source>Short</source>
         <translation>略称</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2307"/>
+        <location filename="../Pages.cpp" line="2309"/>
         <source>Long</source>
         <translation>名称</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2308"/>
+        <location filename="../Pages.cpp" line="2310"/>
         <source>Percent of CP</source>
         <translation>対CPの割合</translation>
     </message>
@@ -7102,42 +7106,42 @@ native format. Should we do so?
 <context>
     <name>SeasonsPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3673"/>
+        <location filename="../Pages.cpp" line="3675"/>
         <source>Move up</source>
         <translation type="unfinished">上へ</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3674"/>
+        <location filename="../Pages.cpp" line="3676"/>
         <source>Move down</source>
         <translation type="unfinished">下へ</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3675"/>
+        <location filename="../Pages.cpp" line="3677"/>
         <source>Add</source>
         <translation type="unfinished">追加</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3676"/>
+        <location filename="../Pages.cpp" line="3678"/>
         <source>Delete</source>
         <translation type="unfinished">削除</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3685"/>
+        <location filename="../Pages.cpp" line="3687"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3686"/>
+        <location filename="../Pages.cpp" line="3688"/>
         <source>Type</source>
         <translation type="unfinished">種別</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3687"/>
+        <location filename="../Pages.cpp" line="3689"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3688"/>
+        <location filename="../Pages.cpp" line="3690"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7145,7 +7149,7 @@ native format. Should we do so?
 <context>
     <name>SessionRPE</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="302"/>
+        <location filename="../TRIMPPoints.cpp" line="316"/>
         <source>Session RPE</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7173,6 +7177,147 @@ native format. Should we do so?
         <location filename="../SmallPlot.cpp" line="237"/>
         <source>Time (minutes)</source>
         <translation type="unfinished">時間 (分)</translation>
+    </message>
+</context>
+<context>
+    <name>SpecialFields</name>
+    <message>
+        <location filename="../SpecialFields.cpp" line="26"/>
+        <source>Start Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="27"/>
+        <source>Start Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="28"/>
+        <source>Identifier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="29"/>
+        <source>Workout Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="30"/>
+        <source>Sport</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="31"/>
+        <source>Objective</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="32"/>
+        <source>Summary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="33"/>
+        <source>Notes</source>
+        <translation type="unfinished">ノート</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="34"/>
+        <source>Keywords</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="35"/>
+        <source>Recording Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="36"/>
+        <source>Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="37"/>
+        <source>Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="38"/>
+        <source>Device Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="39"/>
+        <source>Dropouts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="40"/>
+        <source>Dropout Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="41"/>
+        <source>Spikes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="42"/>
+        <source>Spike Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="43"/>
+        <source>Torque Adjust</source>
+        <translation type="unfinished">トルク調整</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="44"/>
+        <source>Filename</source>
+        <translation type="unfinished">ファイル名</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="45"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="46"/>
+        <source>Change History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="47"/>
+        <source>Calendar Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="48"/>
+        <source>Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SpecialTabs</name>
+    <message>
+        <location filename="../SpecialFields.cpp" line="130"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="131"/>
+        <source>Notes</source>
+        <translation type="unfinished">ノート</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="132"/>
+        <source>Metric</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="133"/>
+        <source>Extra</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -7589,22 +7734,22 @@ native format. Should we do so?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="388"/>
+        <location filename="../StravaDialog.cpp" line="389"/>
         <source>Upload ride... Sending</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="398"/>
+        <location filename="../StravaDialog.cpp" line="399"/>
         <source>Upload finished.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="430"/>
+        <location filename="../StravaDialog.cpp" line="431"/>
         <source>Ride processing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="501"/>
+        <location filename="../StravaDialog.cpp" line="502"/>
         <source>Searching corresponding Ride</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7857,7 +8002,7 @@ native format. Should we do so?
 <context>
     <name>TRIMP100Points</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="114"/>
+        <location filename="../TRIMPPoints.cpp" line="120"/>
         <source>TRIMP(100) Points</source>
         <translation>TRIMP(100)ポイント</translation>
     </message>
@@ -7865,7 +8010,7 @@ native format. Should we do so?
 <context>
     <name>TRIMPPoints</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="47"/>
+        <location filename="../TRIMPPoints.cpp" line="49"/>
         <source>TRIMP Points</source>
         <translation>TRIMPポイント</translation>
     </message>
@@ -7873,7 +8018,7 @@ native format. Should we do so?
 <context>
     <name>TRIMPZonalPoints</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="180"/>
+        <location filename="../TRIMPPoints.cpp" line="190"/>
         <source>TRIMP Zonal Points</source>
         <translation>ゾーン式TRIMPポイント</translation>
     </message>
@@ -7881,13 +8026,13 @@ native format. Should we do so?
 <context>
     <name>TimeRiding</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="94"/>
+        <location filename="../BasicRideMetrics.cpp" line="105"/>
         <source>Time Riding</source>
         <translation>走行時間</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="95"/>
-        <location filename="../BasicRideMetrics.cpp" line="96"/>
+        <location filename="../BasicRideMetrics.cpp" line="106"/>
+        <location filename="../BasicRideMetrics.cpp" line="107"/>
         <source>seconds</source>
         <translation>秒</translation>
     </message>
@@ -7971,17 +8116,17 @@ native format. Should we do so?
 <context>
     <name>TotalDistance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="129"/>
+        <location filename="../BasicRideMetrics.cpp" line="144"/>
         <source>Distance</source>
         <translation>距離</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="131"/>
+        <location filename="../BasicRideMetrics.cpp" line="146"/>
         <source>km</source>
         <translation>キロメートル</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="132"/>
+        <location filename="../BasicRideMetrics.cpp" line="147"/>
         <source>miles</source>
         <translation>マイル</translation>
     </message>
@@ -7989,13 +8134,13 @@ native format. Should we do so?
 <context>
     <name>TotalWork</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="213"/>
+        <location filename="../BasicRideMetrics.cpp" line="236"/>
         <source>Work</source>
         <translation>エネルギー</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="214"/>
-        <location filename="../BasicRideMetrics.cpp" line="215"/>
+        <location filename="../BasicRideMetrics.cpp" line="237"/>
+        <location filename="../BasicRideMetrics.cpp" line="238"/>
         <source>kJ</source>
         <translation>kJ</translation>
     </message>
@@ -8069,6 +8214,14 @@ Press F3 on Controller when done.</source>
         <location filename="../TrainTool.cpp" line="1279"/>
         <source>Done</source>
         <translation type="unfinished">終了</translation>
+    </message>
+</context>
+<context>
+    <name>TreeMapWindow</name>
+    <message>
+        <location filename="../TreeMapWindow.cpp" line="100"/>
+        <source>Metric</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -8363,7 +8516,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>VAM</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="722"/>
+        <location filename="../BasicRideMetrics.cpp" line="811"/>
         <source>VAM</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8371,7 +8524,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>VariabilityIndex</name>
     <message>
-        <location filename="../BikeScore.cpp" line="102"/>
+        <location filename="../BikeScore.cpp" line="109"/>
         <source>Skiba VI</source>
         <translation>Skiba VI</translation>
     </message>
@@ -8403,13 +8556,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>Vo2max</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="252"/>
+        <location filename="../WattsPerKilogram.cpp" line="308"/>
         <source>Estimated VO2MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="254"/>
-        <location filename="../WattsPerKilogram.cpp" line="255"/>
+        <location filename="../WattsPerKilogram.cpp" line="310"/>
+        <location filename="../WattsPerKilogram.cpp" line="311"/>
         <source>ml/min/kg</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8516,13 +8669,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WorkoutTime</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="60"/>
+        <location filename="../BasicRideMetrics.cpp" line="67"/>
         <source>Duration</source>
         <translation>時間</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="61"/>
-        <location filename="../BasicRideMetrics.cpp" line="62"/>
+        <location filename="../BasicRideMetrics.cpp" line="68"/>
+        <location filename="../BasicRideMetrics.cpp" line="69"/>
         <source>seconds</source>
         <translation>秒</translation>
     </message>
@@ -8558,13 +8711,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>XPower</name>
     <message>
-        <location filename="../BikeScore.cpp" line="45"/>
+        <location filename="../BikeScore.cpp" line="48"/>
         <source>xPower</source>
         <translation>xPower</translation>
     </message>
     <message>
-        <location filename="../BikeScore.cpp" line="47"/>
-        <location filename="../BikeScore.cpp" line="48"/>
+        <location filename="../BikeScore.cpp" line="50"/>
+        <location filename="../BikeScore.cpp" line="51"/>
         <source>watts</source>
         <translation>ワット</translation>
     </message>
@@ -8587,12 +8740,12 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZonePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2278"/>
+        <location filename="../Pages.cpp" line="2280"/>
         <source>Critical Power History</source>
         <translation>CP履歴</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2279"/>
+        <location filename="../Pages.cpp" line="2281"/>
         <source>Default Zones</source>
         <translation>デフォルトゾーン</translation>
     </message>
@@ -8600,7 +8753,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime1</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="74"/>
+        <location filename="../TimeInZone.cpp" line="79"/>
         <source>L1 Time in Zone</source>
         <translation>L1 滞留時間</translation>
     </message>
@@ -8608,7 +8761,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime10</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="182"/>
+        <location filename="../TimeInZone.cpp" line="232"/>
         <source>L10 Time in Zone</source>
         <translation>L10 滞留時間</translation>
     </message>
@@ -8616,7 +8769,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime2</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="86"/>
+        <location filename="../TimeInZone.cpp" line="96"/>
         <source>L2 Time in Zone</source>
         <translation>L2 滞留時間</translation>
     </message>
@@ -8624,7 +8777,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime3</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="98"/>
+        <location filename="../TimeInZone.cpp" line="113"/>
         <source>L3 Time in Zone</source>
         <translation>L3 滞留時間</translation>
     </message>
@@ -8632,7 +8785,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime4</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="110"/>
+        <location filename="../TimeInZone.cpp" line="130"/>
         <source>L4 Time in Zone</source>
         <translation>L4 滞留時間</translation>
     </message>
@@ -8640,7 +8793,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime5</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="122"/>
+        <location filename="../TimeInZone.cpp" line="147"/>
         <source>L5 Time in Zone</source>
         <translation>L5 滞留時間</translation>
     </message>
@@ -8648,7 +8801,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime6</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="134"/>
+        <location filename="../TimeInZone.cpp" line="164"/>
         <source>L6 Time in Zone</source>
         <translation>L6 滞留時間</translation>
     </message>
@@ -8656,7 +8809,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime7</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="146"/>
+        <location filename="../TimeInZone.cpp" line="181"/>
         <source>L7 Time in Zone</source>
         <translation>L7 滞留時間</translation>
     </message>
@@ -8664,7 +8817,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime8</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="158"/>
+        <location filename="../TimeInZone.cpp" line="198"/>
         <source>L8 Time in Zone</source>
         <translation>L8 滞留時間</translation>
     </message>
@@ -8672,7 +8825,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime9</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="170"/>
+        <location filename="../TimeInZone.cpp" line="215"/>
         <source>L9 Time in Zone</source>
         <translation>L9 滞留時間</translation>
     </message>

--- a/src/translations/gc_pt-br.ts
+++ b/src/translations/gc_pt-br.ts
@@ -254,13 +254,13 @@
 <context>
     <name>AerobicDecoupling</name>
     <message>
-        <location filename="../AerobicDecoupling.cpp" line="50"/>
+        <location filename="../AerobicDecoupling.cpp" line="52"/>
         <source>Aerobic Decoupling</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../AerobicDecoupling.cpp" line="52"/>
-        <location filename="../AerobicDecoupling.cpp" line="53"/>
+        <location filename="../AerobicDecoupling.cpp" line="54"/>
+        <location filename="../AerobicDecoupling.cpp" line="55"/>
         <source>%</source>
         <translation>%</translation>
     </message>
@@ -394,42 +394,42 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="916"/>
+        <location filename="../AllPlot.cpp" line="909"/>
         <source>KPH</source>
         <translation>Km/h</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="916"/>
+        <location filename="../AllPlot.cpp" line="909"/>
         <source>MPH</source>
         <translation>MPH</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="932"/>
+        <location filename="../AllPlot.cpp" line="925"/>
         <source>Nm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="932"/>
+        <location filename="../AllPlot.cpp" line="925"/>
         <source>ftLb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="945"/>
+        <location filename="../AllPlot.cpp" line="938"/>
         <source>Meters</source>
         <translation>Metros</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="945"/>
+        <location filename="../AllPlot.cpp" line="938"/>
         <source>Feet</source>
         <translation>Pés</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="971"/>
+        <location filename="../AllPlot.cpp" line="981"/>
         <source>Distance </source>
         <translation>Distância</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="973"/>
+        <location filename="../AllPlot.cpp" line="983"/>
         <source>Time (Hours:Minutes)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -559,13 +559,13 @@
 <context>
     <name>AverageWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="55"/>
+        <location filename="../WattsPerKilogram.cpp" line="58"/>
         <source>Watts Per Kilogram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="57"/>
-        <location filename="../WattsPerKilogram.cpp" line="58"/>
+        <location filename="../WattsPerKilogram.cpp" line="60"/>
+        <location filename="../WattsPerKilogram.cpp" line="61"/>
         <source>wpk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -573,13 +573,13 @@
 <context>
     <name>AvgCadence</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="433"/>
+        <location filename="../BasicRideMetrics.cpp" line="488"/>
         <source>Average Cadence</source>
         <translation>Cadência Média</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="434"/>
-        <location filename="../BasicRideMetrics.cpp" line="435"/>
+        <location filename="../BasicRideMetrics.cpp" line="489"/>
+        <location filename="../BasicRideMetrics.cpp" line="490"/>
         <source>rpm</source>
         <translation>rpm</translation>
     </message>
@@ -587,13 +587,13 @@
 <context>
     <name>AvgHeartRate</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="399"/>
+        <location filename="../BasicRideMetrics.cpp" line="448"/>
         <source>Average Heart Rate</source>
         <translation>Frequência Cardíaca Média</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="400"/>
-        <location filename="../BasicRideMetrics.cpp" line="401"/>
+        <location filename="../BasicRideMetrics.cpp" line="449"/>
+        <location filename="../BasicRideMetrics.cpp" line="450"/>
         <source>bpm</source>
         <translation>bpm</translation>
     </message>
@@ -601,13 +601,13 @@
 <context>
     <name>AvgPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="331"/>
+        <location filename="../BasicRideMetrics.cpp" line="368"/>
         <source>Average Power</source>
         <translation>Potência Média</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="332"/>
-        <location filename="../BasicRideMetrics.cpp" line="333"/>
+        <location filename="../BasicRideMetrics.cpp" line="369"/>
+        <location filename="../BasicRideMetrics.cpp" line="370"/>
         <source>watts</source>
         <translation>watts</translation>
     </message>
@@ -615,17 +615,17 @@
 <context>
     <name>AvgSpeed</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="244"/>
+        <location filename="../BasicRideMetrics.cpp" line="271"/>
         <source>Average Speed</source>
         <translation>Velocidade Média</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="245"/>
+        <location filename="../BasicRideMetrics.cpp" line="272"/>
         <source>kph</source>
         <translation>Km/h</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="246"/>
+        <location filename="../BasicRideMetrics.cpp" line="273"/>
         <source>mph</source>
         <translation>mph</translation>
     </message>
@@ -633,17 +633,17 @@
 <context>
     <name>AvgTemp</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="467"/>
+        <location filename="../BasicRideMetrics.cpp" line="528"/>
         <source>Average Temp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="468"/>
+        <location filename="../BasicRideMetrics.cpp" line="529"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="469"/>
+        <location filename="../BasicRideMetrics.cpp" line="530"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
@@ -747,7 +747,7 @@
 <context>
     <name>BikeScore</name>
     <message>
-        <location filename="../BikeScore.cpp" line="181"/>
+        <location filename="../BikeScore.cpp" line="196"/>
         <source>BikeScore&amp;#8482;</source>
         <translation></translation>
     </message>
@@ -755,54 +755,54 @@
 <context>
     <name>CPPage</name>
     <message>
-        <location filename="../Pages.cpp" line="2455"/>
+        <location filename="../Pages.cpp" line="2457"/>
         <source>Add CP</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2456"/>
+        <location filename="../Pages.cpp" line="2458"/>
         <source>Delete CP</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2457"/>
+        <location filename="../Pages.cpp" line="2459"/>
         <source>Default</source>
         <translation>Padrão</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2460"/>
+        <location filename="../Pages.cpp" line="2462"/>
         <source>Add Zone</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2461"/>
+        <location filename="../Pages.cpp" line="2463"/>
         <source>Delete Zone</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2475"/>
-        <location filename="../Pages.cpp" line="2493"/>
+        <location filename="../Pages.cpp" line="2477"/>
+        <location filename="../Pages.cpp" line="2495"/>
         <source>From Date</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2476"/>
-        <location filename="../Pages.cpp" line="2494"/>
+        <location filename="../Pages.cpp" line="2478"/>
+        <location filename="../Pages.cpp" line="2496"/>
         <source>Critical Power</source>
         <translation>Potência Crítica</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2523"/>
+        <location filename="../Pages.cpp" line="2525"/>
         <source>Short</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2524"/>
+        <location filename="../Pages.cpp" line="2526"/>
         <source>Long</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2525"/>
+        <location filename="../Pages.cpp" line="2527"/>
         <source>From Watts</source>
         <translation></translation>
     </message>
@@ -810,7 +810,7 @@
 <context>
     <name>CPWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="120"/>
+        <location filename="../WattsPerKilogram.cpp" line="128"/>
         <source>60 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -905,7 +905,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ChartSettings.cpp" line="42"/>
+        <location filename="../ChartSettings.cpp" line="41"/>
         <source>Done</source>
         <translation type="unfinished">Feito</translation>
     </message>
@@ -1473,7 +1473,7 @@
 <context>
     <name>CriticalPower</name>
     <message>
-        <location filename="../PeakPower.cpp" line="63"/>
+        <location filename="../PeakPower.cpp" line="67"/>
         <source>60 min Peak Power</source>
         <translation></translation>
     </message>
@@ -1612,12 +1612,12 @@
 <context>
     <name>DBAccess</name>
     <message>
-        <location filename="../DBAccess.cpp" line="112"/>
+        <location filename="../DBAccess.cpp" line="113"/>
         <source>Cannot open database</source>
         <translation>Impossível abrir o banco de dados</translation>
     </message>
     <message>
-        <location filename="../DBAccess.cpp" line="113"/>
+        <location filename="../DBAccess.cpp" line="114"/>
         <source>Unable to establish a database connection.
 This feature requires SQLite support. Please read the Qt SQL driver documentation for information how to build it.
 
@@ -1631,13 +1631,13 @@ Clique em Cancelar para sair.</translation>
 <context>
     <name>DanielsEquivalentPower</name>
     <message>
-        <location filename="../DanielsPoints.cpp" line="110"/>
+        <location filename="../DanielsPoints.cpp" line="116"/>
         <source>Daniels EqP</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../DanielsPoints.cpp" line="111"/>
-        <location filename="../DanielsPoints.cpp" line="112"/>
+        <location filename="../DanielsPoints.cpp" line="117"/>
+        <location filename="../DanielsPoints.cpp" line="118"/>
         <source>watts</source>
         <translation>watts</translation>
     </message>
@@ -1645,7 +1645,7 @@ Clique em Cancelar para sair.</translation>
 <context>
     <name>DanielsPoints</name>
     <message>
-        <location filename="../DanielsPoints.cpp" line="49"/>
+        <location filename="../DanielsPoints.cpp" line="51"/>
         <source>Daniels Points</source>
         <translation></translation>
     </message>
@@ -1916,52 +1916,17 @@ then click &quot;Rescan&quot; to check again.</source>
 <context>
     <name>EditMetricDetailDialog</name>
     <message>
-        <location filename="../LTMTool.cpp" line="638"/>
+        <location filename="../LTMTool.cpp" line="701"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="662"/>
-        <source>Filter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="664"/>
-        <source>No filter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="665"/>
-        <source>Include</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="666"/>
-        <source>Exclude</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="668"/>
-        <source>From</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="673"/>
-        <source>To</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="678"/>
-        <source>Show on plot</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="780"/>
+        <location filename="../LTMTool.cpp" line="814"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="781"/>
+        <location filename="../LTMTool.cpp" line="815"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancelar</translation>
     </message>
@@ -2005,7 +1970,7 @@ then click &quot;Rescan&quot; to check again.</source>
 <context>
     <name>EfficiencyFactor</name>
     <message>
-        <location filename="../Coggan.cpp" line="198"/>
+        <location filename="../Coggan.cpp" line="217"/>
         <source>Efficiency Factor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2013,17 +1978,17 @@ then click &quot;Rescan&quot; to check again.</source>
 <context>
     <name>ElevationGain</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="170"/>
+        <location filename="../BasicRideMetrics.cpp" line="189"/>
         <source>Elevation Gain</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="172"/>
+        <location filename="../BasicRideMetrics.cpp" line="191"/>
         <source>meters</source>
         <translation>metros</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="173"/>
+        <location filename="../BasicRideMetrics.cpp" line="192"/>
         <source>feet</source>
         <translation>pés</translation>
     </message>
@@ -2282,7 +2247,7 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>FormField</name>
     <message>
-        <location filename="../RideMetadata.cpp" line="545"/>
+        <location filename="../RideMetadata.cpp" line="546"/>
         <source>You entered &apos;%1&apos; which is not an expected value.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2376,7 +2341,7 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>Gradient</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="758"/>
+        <location filename="../BasicRideMetrics.cpp" line="851"/>
         <source>Gradient</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2392,7 +2357,7 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>GroupByModel</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="724"/>
+        <location filename="../RideNavigator.cpp" line="726"/>
         <source>Date</source>
         <translation type="unfinished">Data</translation>
     </message>
@@ -2467,12 +2432,12 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>HomeWindow</name>
     <message>
-        <location filename="../HomeWindow.cpp" line="712"/>
+        <location filename="../HomeWindow.cpp" line="713"/>
         <source>Are you sure you want to remove the chart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../HomeWindow.cpp" line="713"/>
+        <location filename="../HomeWindow.cpp" line="714"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2516,38 +2481,38 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>HrSchemePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2826"/>
+        <location filename="../Pages.cpp" line="2828"/>
         <source>Add</source>
         <translation>Adicionar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2827"/>
+        <location filename="../Pages.cpp" line="2829"/>
         <source>Rename</source>
         <translation>Renomear</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2828"/>
+        <location filename="../Pages.cpp" line="2830"/>
         <source>Delete</source>
         <translation>Excluir</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2837"/>
+        <location filename="../Pages.cpp" line="2839"/>
         <source>Short</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2838"/>
+        <location filename="../Pages.cpp" line="2840"/>
         <source>Long</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2839"/>
+        <location filename="../Pages.cpp" line="2841"/>
         <source>Percent of LT</source>
         <translatorcomment>いまいち</translatorcomment>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2840"/>
+        <location filename="../Pages.cpp" line="2842"/>
         <source>Trimp k</source>
         <translatorcomment>でいいのかな？</translatorcomment>
         <translation></translation>
@@ -2556,12 +2521,12 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>HrZonePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2809"/>
+        <location filename="../Pages.cpp" line="2811"/>
         <source>Lactic Threshold History</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2810"/>
+        <location filename="../Pages.cpp" line="2812"/>
         <source>Default Zones</source>
         <translation></translation>
     </message>
@@ -2569,7 +2534,7 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>HrZoneTime1</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="72"/>
+        <location filename="../HrTimeInZone.cpp" line="77"/>
         <source>H1 Time in Zone</source>
         <translation></translation>
     </message>
@@ -2577,7 +2542,7 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>HrZoneTime2</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="84"/>
+        <location filename="../HrTimeInZone.cpp" line="94"/>
         <source>H2 Time in Zone</source>
         <translation></translation>
     </message>
@@ -2585,7 +2550,7 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>HrZoneTime3</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="96"/>
+        <location filename="../HrTimeInZone.cpp" line="111"/>
         <source>H3 Time in Zone</source>
         <translation></translation>
     </message>
@@ -2593,7 +2558,7 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>HrZoneTime4</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="108"/>
+        <location filename="../HrTimeInZone.cpp" line="128"/>
         <source>H4 Time in Zone</source>
         <translation></translation>
     </message>
@@ -2601,7 +2566,7 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>HrZoneTime5</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="120"/>
+        <location filename="../HrTimeInZone.cpp" line="145"/>
         <source>H5 Time in Zone</source>
         <translation></translation>
     </message>
@@ -2609,7 +2574,7 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>HrZoneTime6</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="132"/>
+        <location filename="../HrTimeInZone.cpp" line="162"/>
         <source>H6 Time in Zone</source>
         <translation></translation>
     </message>
@@ -2617,7 +2582,7 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>HrZoneTime7</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="144"/>
+        <location filename="../HrTimeInZone.cpp" line="179"/>
         <source>H7 Time in Zone</source>
         <translation></translation>
     </message>
@@ -2625,7 +2590,7 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>HrZoneTime8</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="156"/>
+        <location filename="../HrTimeInZone.cpp" line="196"/>
         <source>H8 Time in Zone</source>
         <translation></translation>
     </message>
@@ -2818,7 +2783,8 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>LTMPlot</name>
     <message>
-        <location filename="../LTMPlot.cpp" line="1120"/>
+        <location filename="../LTMPlot.cpp" line="731"/>
+        <location filename="../LTMPlot.cpp" line="1123"/>
         <source>watts</source>
         <translation>watts</translation>
     </message>
@@ -2836,33 +2802,33 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="253"/>
-        <location filename="../LTMSidebar.cpp" line="289"/>
+        <location filename="../LTMSidebar.cpp" line="257"/>
+        <location filename="../LTMSidebar.cpp" line="293"/>
         <source>Edit details</source>
         <translation type="unfinished">Editar detalhes</translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="254"/>
+        <location filename="../LTMSidebar.cpp" line="258"/>
         <source>Delete range</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="255"/>
+        <location filename="../LTMSidebar.cpp" line="259"/>
         <source>Add Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="290"/>
+        <location filename="../LTMSidebar.cpp" line="294"/>
         <source>Delete event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="300"/>
+        <location filename="../LTMSidebar.cpp" line="304"/>
         <source>Add event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="537"/>
+        <location filename="../LTMSidebar.cpp" line="541"/>
         <source>^(Average|Max) </source>
         <translation type="unfinished"></translation>
     </message>
@@ -2870,7 +2836,7 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>LTMTool</name>
     <message>
-        <location filename="../LTMTool.cpp" line="69"/>
+        <location filename="../LTMTool.cpp" line="124"/>
         <source>Metric</source>
         <translation></translation>
     </message>
@@ -2911,8 +2877,8 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
         <translation type="obsolete">Últimos 12 meses</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="511"/>
-        <location filename="../LTMTool.cpp" line="519"/>
+        <location filename="../LTMTool.cpp" line="574"/>
+        <location filename="../LTMTool.cpp" line="582"/>
         <source>Unknown Metric</source>
         <translation></translation>
     </message>
@@ -2921,12 +2887,47 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
         <translation type="obsolete">Editar detalhes</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="544"/>
+        <location filename="../LTMTool.cpp" line="59"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="69"/>
+        <source>Chart</source>
+        <translation type="unfinished">Gráfico</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="101"/>
+        <source>Add</source>
+        <translation type="unfinished">Adicionar</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="102"/>
+        <source>Manage</source>
+        <translation type="unfinished">Gerenciar</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="518"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="519"/>
+        <source>Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="520"/>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="607"/>
         <source>Pick Color</source>
         <translation>Selecionar Cor</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="545"/>
+        <location filename="../LTMTool.cpp" line="608"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
@@ -2934,19 +2935,16 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>LTMWindow</name>
     <message>
-        <location filename="../LTMWindow.cpp" line="135"/>
         <source>Add</source>
-        <translation>Adicionar</translation>
+        <translation type="obsolete">Adicionar</translation>
     </message>
     <message>
-        <location filename="../LTMWindow.cpp" line="137"/>
         <source>Manage</source>
-        <translation>Gerenciar</translation>
+        <translation type="obsolete">Gerenciar</translation>
     </message>
     <message>
-        <location filename="../LTMWindow.cpp" line="105"/>
         <source>Chart</source>
-        <translation>Gráfico</translation>
+        <translation type="obsolete">Gráfico</translation>
     </message>
     <message>
         <source>Days</source>
@@ -2968,71 +2966,71 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>LTPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3001"/>
+        <location filename="../Pages.cpp" line="3003"/>
         <source>Add LT</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3002"/>
+        <location filename="../Pages.cpp" line="3004"/>
         <source>Delete LT</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3003"/>
+        <location filename="../Pages.cpp" line="3005"/>
         <source>Default</source>
         <translation>Padrão</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3006"/>
+        <location filename="../Pages.cpp" line="3008"/>
         <source>Add Zone</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3007"/>
+        <location filename="../Pages.cpp" line="3009"/>
         <source>Delete Zone</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3021"/>
-        <location filename="../Pages.cpp" line="3061"/>
+        <location filename="../Pages.cpp" line="3023"/>
+        <location filename="../Pages.cpp" line="3063"/>
         <source>From Date</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3022"/>
-        <location filename="../Pages.cpp" line="3062"/>
+        <location filename="../Pages.cpp" line="3024"/>
+        <location filename="../Pages.cpp" line="3064"/>
         <source>Lactic Threshold</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3039"/>
-        <location filename="../Pages.cpp" line="3063"/>
+        <location filename="../Pages.cpp" line="3041"/>
+        <location filename="../Pages.cpp" line="3065"/>
         <source>Rest HR</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3040"/>
-        <location filename="../Pages.cpp" line="3064"/>
+        <location filename="../Pages.cpp" line="3042"/>
+        <location filename="../Pages.cpp" line="3066"/>
         <source>Max HR</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3101"/>
+        <location filename="../Pages.cpp" line="3103"/>
         <source>Short</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3102"/>
+        <location filename="../Pages.cpp" line="3104"/>
         <source>Long</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3103"/>
+        <location filename="../Pages.cpp" line="3105"/>
         <source>From BPM</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3104"/>
+        <location filename="../Pages.cpp" line="3106"/>
         <source>Trimp k</source>
         <translation></translation>
     </message>
@@ -3040,13 +3038,13 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>LeftRightBalance</name>
     <message>
-        <location filename="../LeftRightBalance.cpp" line="33"/>
+        <location filename="../LeftRightBalance.cpp" line="36"/>
         <source>Left/Right Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftRightBalance.cpp" line="34"/>
-        <location filename="../LeftRightBalance.cpp" line="35"/>
+        <location filename="../LeftRightBalance.cpp" line="37"/>
+        <location filename="../LeftRightBalance.cpp" line="38"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
@@ -3054,7 +3052,7 @@ Ajuste de Torque - define um valor absoluto em libra força por polegada quadrad
 <context>
     <name>MainWindow</name>
     <message>
-        <location filename="../MainWindow.cpp" line="2210"/>
+        <location filename="../MainWindow.cpp" line="2216"/>
         <source>Invalid date/time in filename:
 %1
 Skipping file...</source>
@@ -3064,19 +3062,19 @@ Pulando arquivo...</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="281"/>
-        <location filename="../MainWindow.cpp" line="2230"/>
+        <location filename="../MainWindow.cpp" line="2236"/>
         <source>Zones File Error</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="284"/>
-        <location filename="../MainWindow.cpp" line="2234"/>
+        <location filename="../MainWindow.cpp" line="2240"/>
         <source>Reading Zones File</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="565"/>
-        <location filename="../MainWindow.cpp" line="1209"/>
+        <location filename="../MainWindow.cpp" line="1215"/>
         <source>Intervals</source>
         <translation></translation>
     </message>
@@ -3093,22 +3091,22 @@ Pulando arquivo...</translation>
         <translation type="obsolete">&amp;Ciclista</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="743"/>
+        <location filename="../MainWindow.cpp" line="747"/>
         <source>&amp;New...</source>
         <translation>&amp;Novo...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="743"/>
+        <location filename="../MainWindow.cpp" line="747"/>
         <source>Ctrl+N</source>
         <translation>Ctrl+N</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="744"/>
+        <location filename="../MainWindow.cpp" line="748"/>
         <source>&amp;Open...</source>
         <translation>Abrir... (&amp;O)</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="744"/>
+        <location filename="../MainWindow.cpp" line="748"/>
         <source>Ctrl+O</source>
         <translation>Ctrl+O</translation>
     </message>
@@ -3117,29 +3115,29 @@ Pulando arquivo...</translation>
         <translation type="obsolete">Sair (&amp;Q)</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="746"/>
+        <location filename="../MainWindow.cpp" line="750"/>
         <source>Ctrl+Q</source>
         <translation>Ctrl+Q</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="775"/>
+        <location filename="../MainWindow.cpp" line="779"/>
         <source>Ctrl+S</source>
         <translation>Ctrl+S</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="749"/>
+        <location filename="../MainWindow.cpp" line="753"/>
         <source>&amp;Download from device...</source>
         <translation>&amp;Download do dispositivo...</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="291"/>
-        <location filename="../MainWindow.cpp" line="2241"/>
+        <location filename="../MainWindow.cpp" line="2247"/>
         <source>HR Zones File Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="294"/>
-        <location filename="../MainWindow.cpp" line="2245"/>
+        <location filename="../MainWindow.cpp" line="2251"/>
         <source>Reading HR Zones File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3160,210 +3158,210 @@ Pulando arquivo...</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="454"/>
-        <location filename="../MainWindow.cpp" line="845"/>
+        <location filename="../MainWindow.cpp" line="849"/>
         <source>Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="461"/>
-        <location filename="../MainWindow.cpp" line="848"/>
+        <location filename="../MainWindow.cpp" line="852"/>
         <source>Diary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="468"/>
-        <location filename="../MainWindow.cpp" line="844"/>
+        <location filename="../MainWindow.cpp" line="848"/>
         <source>Analysis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="474"/>
-        <location filename="../MainWindow.cpp" line="846"/>
+        <location filename="../MainWindow.cpp" line="850"/>
         <source>Train</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="524"/>
-        <location filename="../MainWindow.cpp" line="1160"/>
+        <location filename="../MainWindow.cpp" line="1166"/>
         <source>All Activities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="742"/>
+        <location filename="../MainWindow.cpp" line="746"/>
         <source>&amp;Athlete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="745"/>
+        <location filename="../MainWindow.cpp" line="749"/>
         <source>&amp;Close Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="745"/>
+        <location filename="../MainWindow.cpp" line="749"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="746"/>
+        <location filename="../MainWindow.cpp" line="750"/>
         <source>&amp;Quit All Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="748"/>
+        <location filename="../MainWindow.cpp" line="752"/>
         <source>A&amp;ctivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="749"/>
+        <location filename="../MainWindow.cpp" line="753"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="751"/>
+        <location filename="../MainWindow.cpp" line="755"/>
         <source>&amp;Manual activity entry...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="753"/>
+        <location filename="../MainWindow.cpp" line="757"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="754"/>
+        <location filename="../MainWindow.cpp" line="758"/>
         <source>&amp;Batch export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="755"/>
+        <location filename="../MainWindow.cpp" line="759"/>
         <source>Export Metrics as CSV...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="758"/>
+        <location filename="../MainWindow.cpp" line="762"/>
         <source>&amp;Upload to TrainingPeaks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="758"/>
+        <location filename="../MainWindow.cpp" line="762"/>
         <source>Ctrl+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="759"/>
+        <location filename="../MainWindow.cpp" line="763"/>
         <source>Down&amp;load from TrainingPeaks...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="759"/>
+        <location filename="../MainWindow.cpp" line="763"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="775"/>
+        <location filename="../MainWindow.cpp" line="779"/>
         <source>&amp;Save activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="776"/>
+        <location filename="../MainWindow.cpp" line="780"/>
         <source>D&amp;elete activity...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="777"/>
+        <location filename="../MainWindow.cpp" line="781"/>
         <source>Split &amp;activity...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="782"/>
+        <location filename="../MainWindow.cpp" line="786"/>
         <source>Critical Power Calculator...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="783"/>
+        <location filename="../MainWindow.cpp" line="787"/>
         <source>Air Density (Rho) Estimator...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="786"/>
+        <location filename="../MainWindow.cpp" line="790"/>
         <source>Get &amp;Withings Data...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="788"/>
+        <location filename="../MainWindow.cpp" line="792"/>
         <source>Get &amp;Zeo Data...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="791"/>
+        <location filename="../MainWindow.cpp" line="795"/>
         <source>Workout Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="792"/>
+        <location filename="../MainWindow.cpp" line="796"/>
         <source>Get Workouts from ErgDB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="796"/>
-        <location filename="../MainWindow.cpp" line="1197"/>
+        <location filename="../MainWindow.cpp" line="800"/>
+        <location filename="../MainWindow.cpp" line="1203"/>
         <source>Upload Activity to Calendar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="797"/>
+        <location filename="../MainWindow.cpp" line="801"/>
         <source>Import Calendar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="798"/>
+        <location filename="../MainWindow.cpp" line="802"/>
         <source>Export Calendar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="799"/>
+        <location filename="../MainWindow.cpp" line="803"/>
         <source>Refresh Calendar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="802"/>
+        <location filename="../MainWindow.cpp" line="806"/>
         <source>Find intervals...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1692"/>
+        <location filename="../MainWindow.cpp" line="1698"/>
         <source>Select Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1692"/>
-        <location filename="../MainWindow.cpp" line="1778"/>
-        <location filename="../MainWindow.cpp" line="1786"/>
+        <location filename="../MainWindow.cpp" line="1698"/>
+        <location filename="../MainWindow.cpp" line="1784"/>
+        <location filename="../MainWindow.cpp" line="1792"/>
         <source>No activity selected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1703"/>
+        <location filename="../MainWindow.cpp" line="1709"/>
         <source>Export Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1716"/>
+        <location filename="../MainWindow.cpp" line="1722"/>
         <source>Export Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1717"/>
+        <location filename="../MainWindow.cpp" line="1723"/>
         <source>Failed to export ride, please check permissions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2188"/>
+        <location filename="../MainWindow.cpp" line="2194"/>
         <source>Range from %1 to %2
 Athlete CP set to %3 watts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2209"/>
+        <location filename="../MainWindow.cpp" line="2215"/>
         <source>Invalid Activity File Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3372,12 +3370,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">&amp;Exportar para CSV...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="753"/>
+        <location filename="../MainWindow.cpp" line="757"/>
         <source>Ctrl+E</source>
         <translation>Ctrl+E</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="750"/>
+        <location filename="../MainWindow.cpp" line="754"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
@@ -3386,7 +3384,7 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Encontrar melhores intervalos... (&amp;B)</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="754"/>
+        <location filename="../MainWindow.cpp" line="758"/>
         <source>Ctrl+B</source>
         <translation>Ctrl+B</translation>
     </message>
@@ -3419,12 +3417,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Editor</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="750"/>
+        <location filename="../MainWindow.cpp" line="754"/>
         <source>&amp;Import from file...</source>
         <translation>&amp;Importar do arquivo...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="751"/>
+        <location filename="../MainWindow.cpp" line="755"/>
         <source>Ctrl+M</source>
         <translation>Ctrl+M</translation>
     </message>
@@ -3441,99 +3439,99 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Exportar para PWX...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="780"/>
+        <location filename="../MainWindow.cpp" line="784"/>
         <source>&amp;Tools</source>
         <translation>Ferramen&amp;tas</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="781"/>
+        <location filename="../MainWindow.cpp" line="785"/>
         <source>&amp;Options...</source>
         <translation>&amp;Opções...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="825"/>
+        <location filename="../MainWindow.cpp" line="829"/>
         <source>&amp;View</source>
         <translation>&amp;Visualizar</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="827"/>
+        <location filename="../MainWindow.cpp" line="831"/>
         <source>Toggle Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="829"/>
+        <location filename="../MainWindow.cpp" line="833"/>
         <source>Show Left Sidebar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="833"/>
+        <location filename="../MainWindow.cpp" line="837"/>
         <source>Show Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="838"/>
+        <location filename="../MainWindow.cpp" line="842"/>
         <source>Tabbed View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="852"/>
+        <location filename="../MainWindow.cpp" line="856"/>
         <source>Reset Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="854"/>
+        <location filename="../MainWindow.cpp" line="858"/>
         <source>&amp;Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="861"/>
+        <location filename="../MainWindow.cpp" line="865"/>
         <source>&amp;Help</source>
         <translation>Ajuda (&amp;H)</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="862"/>
+        <location filename="../MainWindow.cpp" line="866"/>
         <source>&amp;User Guide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="863"/>
+        <location filename="../MainWindow.cpp" line="867"/>
         <source>&amp;Log a bug or feature request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="865"/>
+        <location filename="../MainWindow.cpp" line="869"/>
         <source>&amp;About GoldenCheetah</source>
         <translation>Sobre o GoldenCheet&amp;ah</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1164"/>
+        <location filename="../MainWindow.cpp" line="1170"/>
         <source>Save Changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1167"/>
+        <location filename="../MainWindow.cpp" line="1173"/>
         <source>Revert to Saved version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1170"/>
-        <location filename="../MainWindow.cpp" line="1786"/>
+        <location filename="../MainWindow.cpp" line="1176"/>
+        <location filename="../MainWindow.cpp" line="1792"/>
         <source>Delete Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1179"/>
-        <location filename="../MainWindow.cpp" line="1778"/>
+        <location filename="../MainWindow.cpp" line="1185"/>
+        <location filename="../MainWindow.cpp" line="1784"/>
         <source>Split Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1192"/>
+        <location filename="../MainWindow.cpp" line="1198"/>
         <source>Tweet Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1612"/>
+        <location filename="../MainWindow.cpp" line="1618"/>
         <source>Can&apos;t rename %1 to %2</source>
         <translation>Impossível renomear %1 para %2</translation>
     </message>
@@ -3590,77 +3588,77 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">O arquivo %1 não pôde ser aberto para escrita</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1739"/>
+        <location filename="../MainWindow.cpp" line="1745"/>
         <source>Import from File</source>
         <translation>Importar de Arquivo</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1756"/>
+        <location filename="../MainWindow.cpp" line="1762"/>
         <source>No Activity To Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1757"/>
+        <location filename="../MainWindow.cpp" line="1763"/>
         <source>There is no currently selected ride to save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1791"/>
+        <location filename="../MainWindow.cpp" line="1797"/>
         <source>Are you sure you want to delete the activity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1845"/>
+        <location filename="../MainWindow.cpp" line="1851"/>
         <source>Export Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1845"/>
+        <location filename="../MainWindow.cpp" line="1851"/>
         <source>Comma Separated Variables (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1920"/>
+        <location filename="../MainWindow.cpp" line="1926"/>
         <source>Workout Directory Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1977"/>
+        <location filename="../MainWindow.cpp" line="1983"/>
         <source> (%1 watts)</source>
         <translation> (%1 watts)</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1173"/>
+        <location filename="../MainWindow.cpp" line="1179"/>
         <source>Find Best Intervals</source>
         <translation>Encontrar Melhores Intervalos</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1176"/>
+        <location filename="../MainWindow.cpp" line="1182"/>
         <source>Find Power Peaks</source>
         <translation>Encontrar Picos de Potência</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1214"/>
+        <location filename="../MainWindow.cpp" line="1220"/>
         <source>Rename interval</source>
         <translation>Renomear intervalo</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1215"/>
+        <location filename="../MainWindow.cpp" line="1221"/>
         <source>Delete interval</source>
         <translation>Excluir intervalo</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1216"/>
+        <location filename="../MainWindow.cpp" line="1222"/>
         <source>Zoom to interval</source>
         <translation>Zoom no intervalo</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1217"/>
+        <location filename="../MainWindow.cpp" line="1223"/>
         <source>Bring to Front</source>
         <translation>Trazer para Frente</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1218"/>
+        <location filename="../MainWindow.cpp" line="1224"/>
         <source>Send to back</source>
         <translation>Enviar para trás</translation>
     </message>
@@ -3681,7 +3679,7 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Erro de Escrita</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2187"/>
+        <location filename="../MainWindow.cpp" line="2193"/>
         <source>CP saved</source>
         <translation></translation>
     </message>
@@ -3694,7 +3692,7 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">&lt;center&gt;&lt;h2&gt;GoldenCheetah&lt;/h2&gt;Software de Análise de Potência para Ciclismo&lt;br&gt;para Linux, Mac, e Windows&lt;p&gt;Data do Build: %1 %2&lt;p&gt;Versão: %3&lt;p&gt;O GoldenCheetah é licenciado sob a &lt;br&gt;&lt;a href=&quot;http://www.gnu.org/copyleft/gpl.html&quot;&gt;GNU General Public License&lt;/a&gt;.&lt;p&gt;O código-fonte pode ser obtido de&lt;br&gt;&lt;a href=&quot;http://goldencheetah.org/&quot;&gt;http://goldencheetah.org/&lt;/a&gt;.&lt;p&gt;Arquivos de Percurso e outros dados são armazenados em&lt;br&gt;&lt;a href=&quot;%4&quot;&gt;%5&lt;/a&gt;&lt;/center&gt;</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1793"/>
+        <location filename="../MainWindow.cpp" line="1799"/>
         <source>Delete</source>
         <translation>Excluir</translation>
     </message>
@@ -3915,13 +3913,13 @@ Athlete CP set to %3 watts</source>
 <context>
     <name>MaxCadence</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="606"/>
+        <location filename="../BasicRideMetrics.cpp" line="683"/>
         <source>Max Cadence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="607"/>
-        <location filename="../BasicRideMetrics.cpp" line="608"/>
+        <location filename="../BasicRideMetrics.cpp" line="684"/>
+        <location filename="../BasicRideMetrics.cpp" line="685"/>
         <source>rpm</source>
         <translation type="unfinished">rpm</translation>
     </message>
@@ -3929,13 +3927,13 @@ Athlete CP set to %3 watts</source>
 <context>
     <name>MaxHr</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="538"/>
+        <location filename="../BasicRideMetrics.cpp" line="607"/>
         <source>Max Heartrate</source>
         <translation>Frequência Cardíaca Máxima</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="539"/>
-        <location filename="../BasicRideMetrics.cpp" line="540"/>
+        <location filename="../BasicRideMetrics.cpp" line="608"/>
+        <location filename="../BasicRideMetrics.cpp" line="609"/>
         <source>bpm</source>
         <translation>bpm</translation>
     </message>
@@ -3943,13 +3941,13 @@ Athlete CP set to %3 watts</source>
 <context>
     <name>MaxPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="509"/>
+        <location filename="../BasicRideMetrics.cpp" line="574"/>
         <source>Max Power</source>
         <translation>Potência Máxima</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="510"/>
-        <location filename="../BasicRideMetrics.cpp" line="511"/>
+        <location filename="../BasicRideMetrics.cpp" line="575"/>
+        <location filename="../BasicRideMetrics.cpp" line="576"/>
         <source>watts</source>
         <translation>watts</translation>
     </message>
@@ -3957,7 +3955,7 @@ Athlete CP set to %3 watts</source>
 <context>
     <name>MaxPowerVariance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="848"/>
+        <location filename="../BasicRideMetrics.cpp" line="949"/>
         <source>Max Power Variance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3965,17 +3963,17 @@ Athlete CP set to %3 watts</source>
 <context>
     <name>MaxSpeed</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="567"/>
+        <location filename="../BasicRideMetrics.cpp" line="640"/>
         <source>Max Speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="568"/>
+        <location filename="../BasicRideMetrics.cpp" line="641"/>
         <source>kph</source>
         <translation type="unfinished">Km/h</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="569"/>
+        <location filename="../BasicRideMetrics.cpp" line="642"/>
         <source>mph</source>
         <translation type="unfinished">mph</translation>
     </message>
@@ -3983,17 +3981,17 @@ Athlete CP set to %3 watts</source>
 <context>
     <name>MaxTemp</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="643"/>
+        <location filename="../BasicRideMetrics.cpp" line="724"/>
         <source>Max Temp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="644"/>
+        <location filename="../BasicRideMetrics.cpp" line="725"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="645"/>
+        <location filename="../BasicRideMetrics.cpp" line="726"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4001,7 +3999,7 @@ Athlete CP set to %3 watts</source>
 <context>
     <name>MeanPowerVariance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="801"/>
+        <location filename="../BasicRideMetrics.cpp" line="898"/>
         <source>Average Power Variance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4009,42 +4007,42 @@ Athlete CP set to %3 watts</source>
 <context>
     <name>MeasuresPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3395"/>
+        <location filename="../Pages.cpp" line="3397"/>
         <source>Move up</source>
         <translation type="unfinished">Mover acima</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3396"/>
+        <location filename="../Pages.cpp" line="3398"/>
         <source>Move down</source>
         <translation type="unfinished">Mover abaixo</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3397"/>
+        <location filename="../Pages.cpp" line="3399"/>
         <source>Insert</source>
         <translation type="unfinished">Inserir</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3398"/>
+        <location filename="../Pages.cpp" line="3400"/>
         <source>Rename</source>
         <translation type="unfinished">Renomear</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3399"/>
+        <location filename="../Pages.cpp" line="3401"/>
         <source>Delete</source>
         <translation type="unfinished">Excluir</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3410"/>
+        <location filename="../Pages.cpp" line="3412"/>
         <source>Screen Tab</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3411"/>
+        <location filename="../Pages.cpp" line="3413"/>
         <source>Measure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3412"/>
+        <location filename="../Pages.cpp" line="3414"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
@@ -4263,17 +4261,17 @@ Elapsed: %1
 <context>
     <name>NavigatorCellDelegate</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="941"/>
+        <location filename="../RideNavigator.cpp" line="944"/>
         <source>Date</source>
         <translation type="unfinished">Data</translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="944"/>
+        <location filename="../RideNavigator.cpp" line="947"/>
         <source>Time</source>
         <translation type="unfinished">Tempo</translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="947"/>
+        <location filename="../RideNavigator.cpp" line="950"/>
         <source>Last updated</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4400,13 +4398,13 @@ Elapsed: %1
 <context>
     <name>NinetyFivePercentHeartRate</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="688"/>
+        <location filename="../BasicRideMetrics.cpp" line="773"/>
         <source>95% Heartrate</source>
         <translation>95% Frequência Cardíaca</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="689"/>
-        <location filename="../BasicRideMetrics.cpp" line="690"/>
+        <location filename="../BasicRideMetrics.cpp" line="774"/>
+        <location filename="../BasicRideMetrics.cpp" line="775"/>
         <source>bpm</source>
         <translation>bpm</translation>
     </message>
@@ -4414,13 +4412,13 @@ Elapsed: %1
 <context>
     <name>NonZeroPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="365"/>
+        <location filename="../BasicRideMetrics.cpp" line="408"/>
         <source>Nonzero Average Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="366"/>
-        <location filename="../BasicRideMetrics.cpp" line="367"/>
+        <location filename="../BasicRideMetrics.cpp" line="409"/>
+        <location filename="../BasicRideMetrics.cpp" line="410"/>
         <source>watts</source>
         <translation type="unfinished">watts</translation>
     </message>
@@ -4428,17 +4426,17 @@ Elapsed: %1
 <context>
     <name>Pace</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="288"/>
+        <location filename="../BasicRideMetrics.cpp" line="319"/>
         <source>Pace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="290"/>
+        <location filename="../BasicRideMetrics.cpp" line="321"/>
         <source>min/km</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="291"/>
+        <location filename="../BasicRideMetrics.cpp" line="322"/>
         <source>min/mile</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4631,7 +4629,7 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakPower10m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="162"/>
+        <location filename="../PeakPower.cpp" line="202"/>
         <source>10 min Peak Power</source>
         <translation>Pico de Potência em 10 min</translation>
     </message>
@@ -4639,7 +4637,7 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakPower10s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="96"/>
+        <location filename="../PeakPower.cpp" line="112"/>
         <source>10 sec Peak Power</source>
         <translation>Pico de Potência em 10 seg</translation>
     </message>
@@ -4647,7 +4645,7 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakPower15s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="107"/>
+        <location filename="../PeakPower.cpp" line="127"/>
         <source>15 sec Peak Power</source>
         <translation>Pico de Potência em 15 seg</translation>
     </message>
@@ -4655,7 +4653,7 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakPower1m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="140"/>
+        <location filename="../PeakPower.cpp" line="172"/>
         <source>1 min Peak Power</source>
         <translation>Pico de Potência em 1 min</translation>
     </message>
@@ -4663,7 +4661,7 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakPower1s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="74"/>
+        <location filename="../PeakPower.cpp" line="82"/>
         <source>1 sec Peak Power</source>
         <translation>Pico de Potência em 1 seg</translation>
     </message>
@@ -4671,7 +4669,7 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakPower20m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="173"/>
+        <location filename="../PeakPower.cpp" line="217"/>
         <source>20 min Peak Power</source>
         <translation>Pico de Potência em 20 min</translation>
     </message>
@@ -4679,7 +4677,7 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakPower20s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="118"/>
+        <location filename="../PeakPower.cpp" line="142"/>
         <source>20 sec Peak Power</source>
         <translation>Pico de Potência em 20 seg</translation>
     </message>
@@ -4687,7 +4685,7 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakPower30m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="184"/>
+        <location filename="../PeakPower.cpp" line="232"/>
         <source>30 min Peak Power</source>
         <translation>Pico de Potência em 30 min</translation>
     </message>
@@ -4695,7 +4693,7 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakPower30s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="129"/>
+        <location filename="../PeakPower.cpp" line="157"/>
         <source>30 sec Peak Power</source>
         <translation>Pico de Potência em 30 seg</translation>
     </message>
@@ -4703,7 +4701,7 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakPower5m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="151"/>
+        <location filename="../PeakPower.cpp" line="187"/>
         <source>5 min Peak Power</source>
         <translation>Pico de Potência em 5 min</translation>
     </message>
@@ -4711,7 +4709,7 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakPower5s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="85"/>
+        <location filename="../PeakPower.cpp" line="97"/>
         <source>5 sec Peak Power</source>
         <translation>Pico de Potência em 5 seg</translation>
     </message>
@@ -4719,13 +4717,13 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakPowerHr10m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="263"/>
+        <location filename="../PeakPower.cpp" line="324"/>
         <source>10 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="264"/>
-        <location filename="../PeakPower.cpp" line="265"/>
+        <location filename="../PeakPower.cpp" line="325"/>
+        <location filename="../PeakPower.cpp" line="326"/>
         <source>bpm</source>
         <translation type="unfinished">bpm</translation>
     </message>
@@ -4733,13 +4731,13 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakPowerHr1m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="235"/>
+        <location filename="../PeakPower.cpp" line="288"/>
         <source>1 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="236"/>
-        <location filename="../PeakPower.cpp" line="237"/>
+        <location filename="../PeakPower.cpp" line="289"/>
+        <location filename="../PeakPower.cpp" line="290"/>
         <source>bpm</source>
         <translation type="unfinished">bpm</translation>
     </message>
@@ -4747,13 +4745,13 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakPowerHr20m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="277"/>
+        <location filename="../PeakPower.cpp" line="342"/>
         <source>20 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="278"/>
-        <location filename="../PeakPower.cpp" line="279"/>
+        <location filename="../PeakPower.cpp" line="343"/>
+        <location filename="../PeakPower.cpp" line="344"/>
         <source>bpm</source>
         <translation type="unfinished">bpm</translation>
     </message>
@@ -4761,13 +4759,13 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakPowerHr30m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="291"/>
+        <location filename="../PeakPower.cpp" line="360"/>
         <source>30 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="292"/>
-        <location filename="../PeakPower.cpp" line="293"/>
+        <location filename="../PeakPower.cpp" line="361"/>
+        <location filename="../PeakPower.cpp" line="362"/>
         <source>bpm</source>
         <translation type="unfinished">bpm</translation>
     </message>
@@ -4775,22 +4773,8 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakPowerHr5m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="249"/>
-        <source>5 min Peak Power HR</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../PeakPower.cpp" line="250"/>
-        <location filename="../PeakPower.cpp" line="251"/>
-        <source>bpm</source>
-        <translation type="unfinished">bpm</translation>
-    </message>
-</context>
-<context>
-    <name>PeakPowerHr60m</name>
-    <message>
         <location filename="../PeakPower.cpp" line="306"/>
-        <source>60 min Peak Power HR</source>
+        <source>5 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -4801,10 +4785,24 @@ Você deseja continuar?</translation>
     </message>
 </context>
 <context>
+    <name>PeakPowerHr60m</name>
+    <message>
+        <location filename="../PeakPower.cpp" line="379"/>
+        <source>60 min Peak Power HR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../PeakPower.cpp" line="380"/>
+        <location filename="../PeakPower.cpp" line="381"/>
+        <source>bpm</source>
+        <translation type="unfinished">bpm</translation>
+    </message>
+</context>
+<context>
     <name>PeakWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="89"/>
-        <location filename="../WattsPerKilogram.cpp" line="90"/>
+        <location filename="../WattsPerKilogram.cpp" line="93"/>
+        <location filename="../WattsPerKilogram.cpp" line="94"/>
         <source>wpk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4812,7 +4810,7 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakWPK10m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="219"/>
+        <location filename="../WattsPerKilogram.cpp" line="263"/>
         <source>10 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4820,7 +4818,7 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakWPK10s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="153"/>
+        <location filename="../WattsPerKilogram.cpp" line="173"/>
         <source>10 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4828,7 +4826,7 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakWPK15s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="164"/>
+        <location filename="../WattsPerKilogram.cpp" line="188"/>
         <source>15 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4836,7 +4834,7 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakWPK1m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="197"/>
+        <location filename="../WattsPerKilogram.cpp" line="233"/>
         <source>1 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4844,7 +4842,7 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakWPK1s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="131"/>
+        <location filename="../WattsPerKilogram.cpp" line="143"/>
         <source>1 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4852,7 +4850,7 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakWPK20m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="230"/>
+        <location filename="../WattsPerKilogram.cpp" line="278"/>
         <source>20 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4860,7 +4858,7 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakWPK20s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="175"/>
+        <location filename="../WattsPerKilogram.cpp" line="203"/>
         <source>20 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4868,7 +4866,7 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakWPK30m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="241"/>
+        <location filename="../WattsPerKilogram.cpp" line="293"/>
         <source>30 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4876,7 +4874,7 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakWPK30s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="186"/>
+        <location filename="../WattsPerKilogram.cpp" line="218"/>
         <source>30 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4884,7 +4882,7 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakWPK5m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="208"/>
+        <location filename="../WattsPerKilogram.cpp" line="248"/>
         <source>5 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4892,7 +4890,7 @@ Você deseja continuar?</translation>
 <context>
     <name>PeakWPK5s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="142"/>
+        <location filename="../WattsPerKilogram.cpp" line="158"/>
         <source>5 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4904,22 +4902,22 @@ Você deseja continuar?</translation>
         <translation type="obsolete">Gerenciador de Performance</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="118"/>
+        <location filename="../PerfPlot.cpp" line="147"/>
         <source>Daily</source>
         <translation>Diário</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="138"/>
+        <location filename="../PerfPlot.cpp" line="167"/>
         <source>Short Term Stress</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="152"/>
+        <location filename="../PerfPlot.cpp" line="181"/>
         <source>Long Term Stress</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="166"/>
+        <location filename="../PerfPlot.cpp" line="195"/>
         <source>Stress Balance</source>
         <translation></translation>
     </message>
@@ -5023,85 +5021,91 @@ Você deseja continuar?</translation>
     <name>PowerHist</name>
     <message>
         <location filename="../PowerHist.cpp" line="77"/>
-        <location filename="../PowerHist.cpp" line="902"/>
+        <location filename="../PowerHist.cpp" line="940"/>
         <source>Time (minutes)</source>
         <translation>Tempo (minutos)</translation>
     </message>
     <message>
         <location filename="../PowerHist.cpp" line="77"/>
-        <location filename="../PowerHist.cpp" line="902"/>
+        <location filename="../PowerHist.cpp" line="940"/>
         <source>Time (percent)</source>
         <translation>Tempo (percentual)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="877"/>
+        <location filename="../PowerHist.cpp" line="910"/>
         <source>Power (watts)</source>
         <translation>Potência (watts)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="876"/>
+        <location filename="../PowerHist.cpp" line="909"/>
+        <location filename="../PowerHist.cpp" line="914"/>
         <source>Power zone</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="882"/>
+        <location filename="../PowerHist.cpp" line="920"/>
         <source>Heartrate (bpm)</source>
         <translation>Frequência Cardíaca (bpm)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="881"/>
+        <location filename="../PowerHist.cpp" line="919"/>
         <source>Heartrate zone</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="886"/>
+        <location filename="../PowerHist.cpp" line="915"/>
+        <source>Power (watts/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../PowerHist.cpp" line="924"/>
         <source>Cadence (rpm)</source>
         <translation>Cadência (rpm)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>Speed (%1)</source>
         <translation>Velocidade (%1)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>kph</source>
         <translation>Km/h</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>mph</source>
         <translation>mph</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>Torque (%1)</source>
         <translation>Torque (%1)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>N-m</source>
         <translation>N-m</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>ft-lbf</source>
         <translation>ft-lbf</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="898"/>
+        <location filename="../PowerHist.cpp" line="936"/>
         <source>Unknown data series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="962"/>
-        <location filename="../PowerHist.cpp" line="975"/>
+        <location filename="../PowerHist.cpp" line="1000"/>
+        <location filename="../PowerHist.cpp" line="1013"/>
         <source>minutes</source>
         <translation>minutos</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="962"/>
-        <location filename="../PowerHist.cpp" line="975"/>
+        <location filename="../PowerHist.cpp" line="1000"/>
+        <location filename="../PowerHist.cpp" line="1013"/>
         <source>%</source>
         <translation>%</translation>
     </message>
@@ -5109,27 +5113,27 @@ Você deseja continuar?</translation>
 <context>
     <name>ProcessorPage</name>
     <message>
-        <location filename="../Pages.cpp" line="2198"/>
+        <location filename="../Pages.cpp" line="2200"/>
         <source>Processor</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2199"/>
+        <location filename="../Pages.cpp" line="2201"/>
         <source>Apply</source>
         <translation>Aplicar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2200"/>
+        <location filename="../Pages.cpp" line="2202"/>
         <source>Settings</source>
         <translation>Ajustes</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2224"/>
+        <location filename="../Pages.cpp" line="2226"/>
         <source>Manual</source>
         <translation>Manual</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2225"/>
+        <location filename="../Pages.cpp" line="2227"/>
         <source>Auto</source>
         <translation>Automático</translation>
     </message>
@@ -5515,7 +5519,7 @@ Você deseja continuar?</translation>
 <context>
     <name>RelativeIntensity</name>
     <message>
-        <location filename="../BikeScore.cpp" line="136"/>
+        <location filename="../BikeScore.cpp" line="147"/>
         <source>Relative Intensity</source>
         <translation></translation>
     </message>
@@ -5523,7 +5527,7 @@ Você deseja continuar?</translation>
 <context>
     <name>ResponseIndex</name>
     <message>
-        <location filename="../BikeScore.cpp" line="218"/>
+        <location filename="../BikeScore.cpp" line="237"/>
         <source>Response Index</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5531,7 +5535,7 @@ Você deseja continuar?</translation>
 <context>
     <name>RideCount</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="34"/>
+        <location filename="../BasicRideMetrics.cpp" line="37"/>
         <source>Rides</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5539,9 +5543,9 @@ Você deseja continuar?</translation>
 <context>
     <name>RideDelegate</name>
     <message>
-        <location filename="../RideImportWizard.cpp" line="995"/>
-        <location filename="../RideImportWizard.cpp" line="1032"/>
-        <location filename="../RideImportWizard.cpp" line="1048"/>
+        <location filename="../RideImportWizard.cpp" line="998"/>
+        <location filename="../RideImportWizard.cpp" line="1035"/>
+        <location filename="../RideImportWizard.cpp" line="1051"/>
         <source>dd MMM yyyy</source>
         <translation></translation>
     </message>
@@ -6102,9 +6106,9 @@ Você deseja continuar?</translation>
     </message>
     <message>
         <location filename="../RideImportWizard.cpp" line="74"/>
-        <location filename="../RideImportWizard.cpp" line="696"/>
-        <location filename="../RideImportWizard.cpp" line="738"/>
-        <location filename="../RideImportWizard.cpp" line="890"/>
+        <location filename="../RideImportWizard.cpp" line="699"/>
+        <location filename="../RideImportWizard.cpp" line="741"/>
+        <location filename="../RideImportWizard.cpp" line="893"/>
         <source>Abort</source>
         <translation>Abortar</translation>
     </message>
@@ -6175,12 +6179,12 @@ Você deseja continuar?</translation>
     </message>
     <message>
         <location filename="../RideImportWizard.cpp" line="268"/>
-        <location filename="../RideImportWizard.cpp" line="454"/>
-        <location filename="../RideImportWizard.cpp" line="506"/>
-        <location filename="../RideImportWizard.cpp" line="717"/>
-        <location filename="../RideImportWizard.cpp" line="756"/>
-        <location filename="../RideImportWizard.cpp" line="895"/>
-        <location filename="../RideImportWizard.cpp" line="918"/>
+        <location filename="../RideImportWizard.cpp" line="457"/>
+        <location filename="../RideImportWizard.cpp" line="509"/>
+        <location filename="../RideImportWizard.cpp" line="720"/>
+        <location filename="../RideImportWizard.cpp" line="759"/>
+        <location filename="../RideImportWizard.cpp" line="898"/>
+        <location filename="../RideImportWizard.cpp" line="921"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
@@ -6190,157 +6194,157 @@ Você deseja continuar?</translation>
         <translation>Analisando...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="378"/>
+        <location filename="../RideImportWizard.cpp" line="381"/>
         <source>Validated</source>
         <translation>Validado</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="380"/>
+        <location filename="../RideImportWizard.cpp" line="383"/>
         <source>Warning - </source>
         <translation>Aviso - </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="394"/>
-        <location filename="../RideImportWizard.cpp" line="619"/>
-        <location filename="../RideImportWizard.cpp" line="765"/>
+        <location filename="../RideImportWizard.cpp" line="397"/>
+        <location filename="../RideImportWizard.cpp" line="622"/>
+        <location filename="../RideImportWizard.cpp" line="768"/>
         <source>dd MMM yyyy</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="395"/>
+        <location filename="../RideImportWizard.cpp" line="398"/>
         <source>hh:mm:ss ap</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="432"/>
+        <location filename="../RideImportWizard.cpp" line="435"/>
         <source>Error - </source>
         <translation>Erro - </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="380"/>
-        <location filename="../RideImportWizard.cpp" line="432"/>
+        <location filename="../RideImportWizard.cpp" line="383"/>
+        <location filename="../RideImportWizard.cpp" line="435"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="447"/>
+        <location filename="../RideImportWizard.cpp" line="450"/>
         <source>Step 3 of 4: Confirm Date and Time</source>
         <translation>Passo 3 de 4: Confirmar Data e Hora</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="464"/>
+        <location filename="../RideImportWizard.cpp" line="467"/>
         <source>Save</source>
         <translation>Salvar</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="573"/>
-        <location filename="../RideImportWizard.cpp" line="623"/>
+        <location filename="../RideImportWizard.cpp" line="576"/>
+        <location filename="../RideImportWizard.cpp" line="626"/>
         <source>hh:mm:ss</source>
         <translation>hh:mm:ss</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="582"/>
+        <location filename="../RideImportWizard.cpp" line="585"/>
         <source>Invalid Selection</source>
         <translation>Seleção Inválida</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="582"/>
+        <location filename="../RideImportWizard.cpp" line="585"/>
         <source>More than 24hrs of rides to fit into a day</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="627"/>
-        <location filename="../RideImportWizard.cpp" line="766"/>
+        <location filename="../RideImportWizard.cpp" line="630"/>
+        <location filename="../RideImportWizard.cpp" line="769"/>
         <source>hh:mm:ss a</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="736"/>
+        <location filename="../RideImportWizard.cpp" line="739"/>
         <source>Step 4 of 4: Save to Library</source>
         <translation>Passo 4 de 4: Salvar na Biblioteca</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="758"/>
+        <location filename="../RideImportWizard.cpp" line="761"/>
         <source>Saving...</source>
         <translation>Salvando...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="834"/>
+        <location filename="../RideImportWizard.cpp" line="837"/>
         <source>Error - Source is Target</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="845"/>
+        <location filename="../RideImportWizard.cpp" line="848"/>
         <source>Overwriting file...</source>
         <translation>Sobrescrevendo arquivo...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="847"/>
+        <location filename="../RideImportWizard.cpp" line="850"/>
         <source>/</source>
         <translation>/</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="847"/>
+        <location filename="../RideImportWizard.cpp" line="850"/>
         <source>.tmp</source>
         <translation>.tmp</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="821"/>
-        <location filename="../RideImportWizard.cpp" line="854"/>
+        <location filename="../RideImportWizard.cpp" line="824"/>
+        <location filename="../RideImportWizard.cpp" line="857"/>
         <source>File Overwritten</source>
         <translation>Arquivo Sobrescrito</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="857"/>
-        <location filename="../RideImportWizard.cpp" line="859"/>
+        <location filename="../RideImportWizard.cpp" line="860"/>
+        <location filename="../RideImportWizard.cpp" line="862"/>
         <source>Error - overwrite failed</source>
         <translation>Erro - a sobrescrita falhou</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="790"/>
-        <location filename="../RideImportWizard.cpp" line="862"/>
+        <location filename="../RideImportWizard.cpp" line="793"/>
+        <location filename="../RideImportWizard.cpp" line="865"/>
         <source>Error - File exists</source>
         <translation>Erro - Arquivo já existe</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="865"/>
+        <location filename="../RideImportWizard.cpp" line="868"/>
         <source>Saving file...</source>
         <translation>Salvando arquivo...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="823"/>
-        <location filename="../RideImportWizard.cpp" line="868"/>
+        <location filename="../RideImportWizard.cpp" line="826"/>
+        <location filename="../RideImportWizard.cpp" line="871"/>
         <source>File Saved</source>
         <translation>Arquivo Salvo</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="877"/>
+        <location filename="../RideImportWizard.cpp" line="880"/>
         <source>Error - copy failed</source>
         <translation>Erro - a cópia falhou</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="888"/>
+        <location filename="../RideImportWizard.cpp" line="891"/>
         <source>Step 5 of 5: Calculating Critical Powers</source>
         <translation>Passo 5 de 5: Calculando Potências Críticas</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="896"/>
+        <location filename="../RideImportWizard.cpp" line="899"/>
         <source>Calculating...</source>
         <translation>Calculando...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="905"/>
+        <location filename="../RideImportWizard.cpp" line="908"/>
         <source>Completed.</source>
         <translation>Concluído.</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="923"/>
+        <location filename="../RideImportWizard.cpp" line="926"/>
         <source>Import Complete. %1 of %2 successful.</source>
         <translation>Importação Concluída. %1 de %2 com sucesso.</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="704"/>
-        <location filename="../RideImportWizard.cpp" line="928"/>
+        <location filename="../RideImportWizard.cpp" line="707"/>
+        <location filename="../RideImportWizard.cpp" line="931"/>
         <source>Finish</source>
         <translation>Fim</translation>
     </message>
@@ -6348,22 +6352,22 @@ Você deseja continuar?</translation>
 <context>
     <name>RideNavigator</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="540"/>
+        <location filename="../RideNavigator.cpp" line="542"/>
         <source>Remove Column</source>
         <translation type="unfinished">Remover Coluna</translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="546"/>
+        <location filename="../RideNavigator.cpp" line="548"/>
         <source>Column Chooser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="551"/>
+        <location filename="../RideNavigator.cpp" line="553"/>
         <source>Do Not Show in Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="551"/>
+        <location filename="../RideNavigator.cpp" line="553"/>
         <source>Show In Groups</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6712,32 +6716,32 @@ native format. Should we do so?
 <context>
     <name>SchemePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2295"/>
+        <location filename="../Pages.cpp" line="2297"/>
         <source>Add</source>
         <translation>Adicionar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2296"/>
+        <location filename="../Pages.cpp" line="2298"/>
         <source>Rename</source>
         <translation>Renomear</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2297"/>
+        <location filename="../Pages.cpp" line="2299"/>
         <source>Delete</source>
         <translation>Excluir</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2306"/>
+        <location filename="../Pages.cpp" line="2308"/>
         <source>Short</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2307"/>
+        <location filename="../Pages.cpp" line="2309"/>
         <source>Long</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2308"/>
+        <location filename="../Pages.cpp" line="2310"/>
         <source>Percent of CP</source>
         <translation></translation>
     </message>
@@ -6822,42 +6826,42 @@ native format. Should we do so?
 <context>
     <name>SeasonsPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3673"/>
+        <location filename="../Pages.cpp" line="3675"/>
         <source>Move up</source>
         <translation type="unfinished">Mover acima</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3674"/>
+        <location filename="../Pages.cpp" line="3676"/>
         <source>Move down</source>
         <translation type="unfinished">Mover abaixo</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3675"/>
+        <location filename="../Pages.cpp" line="3677"/>
         <source>Add</source>
         <translation type="unfinished">Adicionar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3676"/>
+        <location filename="../Pages.cpp" line="3678"/>
         <source>Delete</source>
         <translation type="unfinished">Excluir</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3685"/>
+        <location filename="../Pages.cpp" line="3687"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3686"/>
+        <location filename="../Pages.cpp" line="3688"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3687"/>
+        <location filename="../Pages.cpp" line="3689"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3688"/>
+        <location filename="../Pages.cpp" line="3690"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6865,7 +6869,7 @@ native format. Should we do so?
 <context>
     <name>SessionRPE</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="302"/>
+        <location filename="../TRIMPPoints.cpp" line="316"/>
         <source>Session RPE</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6893,6 +6897,147 @@ native format. Should we do so?
         <location filename="../SmallPlot.cpp" line="237"/>
         <source>Time (minutes)</source>
         <translation type="unfinished">Tempo (minutos)</translation>
+    </message>
+</context>
+<context>
+    <name>SpecialFields</name>
+    <message>
+        <location filename="../SpecialFields.cpp" line="26"/>
+        <source>Start Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="27"/>
+        <source>Start Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="28"/>
+        <source>Identifier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="29"/>
+        <source>Workout Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="30"/>
+        <source>Sport</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="31"/>
+        <source>Objective</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="32"/>
+        <source>Summary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="33"/>
+        <source>Notes</source>
+        <translation type="unfinished">Notas</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="34"/>
+        <source>Keywords</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="35"/>
+        <source>Recording Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="36"/>
+        <source>Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="37"/>
+        <source>Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="38"/>
+        <source>Device Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="39"/>
+        <source>Dropouts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="40"/>
+        <source>Dropout Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="41"/>
+        <source>Spikes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="42"/>
+        <source>Spike Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="43"/>
+        <source>Torque Adjust</source>
+        <translation type="unfinished">Ajuste de Torque</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="44"/>
+        <source>Filename</source>
+        <translation type="unfinished">Nome do Arquivo</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="45"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="46"/>
+        <source>Change History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="47"/>
+        <source>Calendar Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="48"/>
+        <source>Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SpecialTabs</name>
+    <message>
+        <location filename="../SpecialFields.cpp" line="130"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="131"/>
+        <source>Notes</source>
+        <translation type="unfinished">Notas</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="132"/>
+        <source>Metric</source>
+        <translation type="unfinished">Métrico</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="133"/>
+        <source>Extra</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -7309,22 +7454,22 @@ native format. Should we do so?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="388"/>
+        <location filename="../StravaDialog.cpp" line="389"/>
         <source>Upload ride... Sending</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="398"/>
+        <location filename="../StravaDialog.cpp" line="399"/>
         <source>Upload finished.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="430"/>
+        <location filename="../StravaDialog.cpp" line="431"/>
         <source>Ride processing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="501"/>
+        <location filename="../StravaDialog.cpp" line="502"/>
         <source>Searching corresponding Ride</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7577,7 +7722,7 @@ native format. Should we do so?
 <context>
     <name>TRIMP100Points</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="114"/>
+        <location filename="../TRIMPPoints.cpp" line="120"/>
         <source>TRIMP(100) Points</source>
         <translation></translation>
     </message>
@@ -7585,7 +7730,7 @@ native format. Should we do so?
 <context>
     <name>TRIMPPoints</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="47"/>
+        <location filename="../TRIMPPoints.cpp" line="49"/>
         <source>TRIMP Points</source>
         <translation></translation>
     </message>
@@ -7593,7 +7738,7 @@ native format. Should we do so?
 <context>
     <name>TRIMPZonalPoints</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="180"/>
+        <location filename="../TRIMPPoints.cpp" line="190"/>
         <source>TRIMP Zonal Points</source>
         <translation></translation>
     </message>
@@ -7601,13 +7746,13 @@ native format. Should we do so?
 <context>
     <name>TimeRiding</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="94"/>
+        <location filename="../BasicRideMetrics.cpp" line="105"/>
         <source>Time Riding</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="95"/>
-        <location filename="../BasicRideMetrics.cpp" line="96"/>
+        <location filename="../BasicRideMetrics.cpp" line="106"/>
+        <location filename="../BasicRideMetrics.cpp" line="107"/>
         <source>seconds</source>
         <translation>segundos</translation>
     </message>
@@ -7691,17 +7836,17 @@ native format. Should we do so?
 <context>
     <name>TotalDistance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="129"/>
+        <location filename="../BasicRideMetrics.cpp" line="144"/>
         <source>Distance</source>
         <translation>Distância</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="131"/>
+        <location filename="../BasicRideMetrics.cpp" line="146"/>
         <source>km</source>
         <translation>km</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="132"/>
+        <location filename="../BasicRideMetrics.cpp" line="147"/>
         <source>miles</source>
         <translation>milhas</translation>
     </message>
@@ -7709,13 +7854,13 @@ native format. Should we do so?
 <context>
     <name>TotalWork</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="213"/>
+        <location filename="../BasicRideMetrics.cpp" line="236"/>
         <source>Work</source>
         <translation>Trabalho</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="214"/>
-        <location filename="../BasicRideMetrics.cpp" line="215"/>
+        <location filename="../BasicRideMetrics.cpp" line="237"/>
+        <location filename="../BasicRideMetrics.cpp" line="238"/>
         <source>kJ</source>
         <translation>kJ</translation>
     </message>
@@ -7782,6 +7927,14 @@ Press F3 on Controller when done.</source>
         <location filename="../TrainTool.cpp" line="1279"/>
         <source>Done</source>
         <translation type="unfinished">Feito</translation>
+    </message>
+</context>
+<context>
+    <name>TreeMapWindow</name>
+    <message>
+        <location filename="../TreeMapWindow.cpp" line="100"/>
+        <source>Metric</source>
+        <translation type="unfinished">Métrico</translation>
     </message>
 </context>
 <context>
@@ -8076,7 +8229,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>VAM</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="722"/>
+        <location filename="../BasicRideMetrics.cpp" line="811"/>
         <source>VAM</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8084,7 +8237,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>VariabilityIndex</name>
     <message>
-        <location filename="../BikeScore.cpp" line="102"/>
+        <location filename="../BikeScore.cpp" line="109"/>
         <source>Skiba VI</source>
         <translation></translation>
     </message>
@@ -8105,13 +8258,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>Vo2max</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="252"/>
+        <location filename="../WattsPerKilogram.cpp" line="308"/>
         <source>Estimated VO2MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="254"/>
-        <location filename="../WattsPerKilogram.cpp" line="255"/>
+        <location filename="../WattsPerKilogram.cpp" line="310"/>
+        <location filename="../WattsPerKilogram.cpp" line="311"/>
         <source>ml/min/kg</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8210,13 +8363,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WorkoutTime</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="60"/>
+        <location filename="../BasicRideMetrics.cpp" line="67"/>
         <source>Duration</source>
         <translation>Duração</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="61"/>
-        <location filename="../BasicRideMetrics.cpp" line="62"/>
+        <location filename="../BasicRideMetrics.cpp" line="68"/>
+        <location filename="../BasicRideMetrics.cpp" line="69"/>
         <source>seconds</source>
         <translation>segundos</translation>
     </message>
@@ -8252,13 +8405,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>XPower</name>
     <message>
-        <location filename="../BikeScore.cpp" line="45"/>
+        <location filename="../BikeScore.cpp" line="48"/>
         <source>xPower</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../BikeScore.cpp" line="47"/>
-        <location filename="../BikeScore.cpp" line="48"/>
+        <location filename="../BikeScore.cpp" line="50"/>
+        <location filename="../BikeScore.cpp" line="51"/>
         <source>watts</source>
         <translation>watts</translation>
     </message>
@@ -8281,12 +8434,12 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZonePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2278"/>
+        <location filename="../Pages.cpp" line="2280"/>
         <source>Critical Power History</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2279"/>
+        <location filename="../Pages.cpp" line="2281"/>
         <source>Default Zones</source>
         <translation></translation>
     </message>
@@ -8294,7 +8447,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime1</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="74"/>
+        <location filename="../TimeInZone.cpp" line="79"/>
         <source>L1 Time in Zone</source>
         <translation></translation>
     </message>
@@ -8302,7 +8455,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime10</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="182"/>
+        <location filename="../TimeInZone.cpp" line="232"/>
         <source>L10 Time in Zone</source>
         <translation></translation>
     </message>
@@ -8310,7 +8463,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime2</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="86"/>
+        <location filename="../TimeInZone.cpp" line="96"/>
         <source>L2 Time in Zone</source>
         <translation></translation>
     </message>
@@ -8318,7 +8471,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime3</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="98"/>
+        <location filename="../TimeInZone.cpp" line="113"/>
         <source>L3 Time in Zone</source>
         <translation></translation>
     </message>
@@ -8326,7 +8479,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime4</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="110"/>
+        <location filename="../TimeInZone.cpp" line="130"/>
         <source>L4 Time in Zone</source>
         <translation></translation>
     </message>
@@ -8334,7 +8487,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime5</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="122"/>
+        <location filename="../TimeInZone.cpp" line="147"/>
         <source>L5 Time in Zone</source>
         <translation></translation>
     </message>
@@ -8342,7 +8495,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime6</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="134"/>
+        <location filename="../TimeInZone.cpp" line="164"/>
         <source>L6 Time in Zone</source>
         <translation></translation>
     </message>
@@ -8350,7 +8503,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime7</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="146"/>
+        <location filename="../TimeInZone.cpp" line="181"/>
         <source>L7 Time in Zone</source>
         <translation></translation>
     </message>
@@ -8358,7 +8511,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime8</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="158"/>
+        <location filename="../TimeInZone.cpp" line="198"/>
         <source>L8 Time in Zone</source>
         <translation></translation>
     </message>
@@ -8366,7 +8519,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime9</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="170"/>
+        <location filename="../TimeInZone.cpp" line="215"/>
         <source>L9 Time in Zone</source>
         <translation></translation>
     </message>

--- a/src/translations/gc_pt.ts
+++ b/src/translations/gc_pt.ts
@@ -254,13 +254,13 @@
 <context>
     <name>AerobicDecoupling</name>
     <message>
-        <location filename="../AerobicDecoupling.cpp" line="50"/>
+        <location filename="../AerobicDecoupling.cpp" line="52"/>
         <source>Aerobic Decoupling</source>
         <translation>Desacopl. Aer?bica</translation>
     </message>
     <message>
-        <location filename="../AerobicDecoupling.cpp" line="52"/>
-        <location filename="../AerobicDecoupling.cpp" line="53"/>
+        <location filename="../AerobicDecoupling.cpp" line="54"/>
+        <location filename="../AerobicDecoupling.cpp" line="55"/>
         <source>%</source>
         <translation>%</translation>
     </message>
@@ -402,7 +402,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="973"/>
+        <location filename="../AllPlot.cpp" line="983"/>
         <source>Time (Hours:Minutes)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -423,37 +423,37 @@
         <translation type="obsolete">km/h</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="916"/>
+        <location filename="../AllPlot.cpp" line="909"/>
         <source>MPH</source>
         <translation>MPH</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="916"/>
+        <location filename="../AllPlot.cpp" line="909"/>
         <source>KPH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="932"/>
+        <location filename="../AllPlot.cpp" line="925"/>
         <source>Nm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="932"/>
+        <location filename="../AllPlot.cpp" line="925"/>
         <source>ftLb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="945"/>
+        <location filename="../AllPlot.cpp" line="938"/>
         <source>Meters</source>
         <translation>Metros</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="945"/>
+        <location filename="../AllPlot.cpp" line="938"/>
         <source>Feet</source>
         <translation>P?s</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="971"/>
+        <location filename="../AllPlot.cpp" line="981"/>
         <source>Distance </source>
         <translation>Dist?ncia</translation>
     </message>
@@ -583,13 +583,13 @@
 <context>
     <name>AverageWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="55"/>
+        <location filename="../WattsPerKilogram.cpp" line="58"/>
         <source>Watts Per Kilogram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="57"/>
-        <location filename="../WattsPerKilogram.cpp" line="58"/>
+        <location filename="../WattsPerKilogram.cpp" line="60"/>
+        <location filename="../WattsPerKilogram.cpp" line="61"/>
         <source>wpk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -597,13 +597,13 @@
 <context>
     <name>AvgCadence</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="433"/>
+        <location filename="../BasicRideMetrics.cpp" line="488"/>
         <source>Average Cadence</source>
         <translation>Cad?ncia M?dia</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="434"/>
-        <location filename="../BasicRideMetrics.cpp" line="435"/>
+        <location filename="../BasicRideMetrics.cpp" line="489"/>
+        <location filename="../BasicRideMetrics.cpp" line="490"/>
         <source>rpm</source>
         <translation>rpm</translation>
     </message>
@@ -611,13 +611,13 @@
 <context>
     <name>AvgHeartRate</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="399"/>
+        <location filename="../BasicRideMetrics.cpp" line="448"/>
         <source>Average Heart Rate</source>
         <translation>Frequ?ncia Card?aca M?dia</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="400"/>
-        <location filename="../BasicRideMetrics.cpp" line="401"/>
+        <location filename="../BasicRideMetrics.cpp" line="449"/>
+        <location filename="../BasicRideMetrics.cpp" line="450"/>
         <source>bpm</source>
         <translation>BPM</translation>
     </message>
@@ -625,13 +625,13 @@
 <context>
     <name>AvgPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="331"/>
+        <location filename="../BasicRideMetrics.cpp" line="368"/>
         <source>Average Power</source>
         <translation>Pot?ncia m?dia</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="332"/>
-        <location filename="../BasicRideMetrics.cpp" line="333"/>
+        <location filename="../BasicRideMetrics.cpp" line="369"/>
+        <location filename="../BasicRideMetrics.cpp" line="370"/>
         <source>watts</source>
         <translation>Watts</translation>
     </message>
@@ -639,12 +639,12 @@
 <context>
     <name>AvgSpeed</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="244"/>
+        <location filename="../BasicRideMetrics.cpp" line="271"/>
         <source>Average Speed</source>
         <translation>Velocidade m?dia</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="245"/>
+        <location filename="../BasicRideMetrics.cpp" line="272"/>
         <source>kph</source>
         <translation type="unfinished"></translation>
     </message>
@@ -653,7 +653,7 @@
         <translation type="obsolete">km/h</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="246"/>
+        <location filename="../BasicRideMetrics.cpp" line="273"/>
         <source>mph</source>
         <translation></translation>
     </message>
@@ -661,17 +661,17 @@
 <context>
     <name>AvgTemp</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="467"/>
+        <location filename="../BasicRideMetrics.cpp" line="528"/>
         <source>Average Temp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="468"/>
+        <location filename="../BasicRideMetrics.cpp" line="529"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="469"/>
+        <location filename="../BasicRideMetrics.cpp" line="530"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
@@ -775,7 +775,7 @@
 <context>
     <name>BikeScore</name>
     <message>
-        <location filename="../BikeScore.cpp" line="181"/>
+        <location filename="../BikeScore.cpp" line="196"/>
         <source>BikeScore&amp;#8482;</source>
         <translatorcomment>As BikeScore is a trademark name it is used as reference rather then translation.</translatorcomment>
         <translation>BikeScore&amp;#8482</translation>
@@ -784,54 +784,54 @@
 <context>
     <name>CPPage</name>
     <message>
-        <location filename="../Pages.cpp" line="2455"/>
+        <location filename="../Pages.cpp" line="2457"/>
         <source>Add CP</source>
         <translation>Addicionar CP</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2456"/>
+        <location filename="../Pages.cpp" line="2458"/>
         <source>Delete CP</source>
         <translation>Apagar CP</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2457"/>
+        <location filename="../Pages.cpp" line="2459"/>
         <source>Default</source>
         <translation>Padr?o</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2460"/>
+        <location filename="../Pages.cpp" line="2462"/>
         <source>Add Zone</source>
         <translation>Addicionar Zona</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2461"/>
+        <location filename="../Pages.cpp" line="2463"/>
         <source>Delete Zone</source>
         <translation>Apagar Zona</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2475"/>
-        <location filename="../Pages.cpp" line="2493"/>
+        <location filename="../Pages.cpp" line="2477"/>
+        <location filename="../Pages.cpp" line="2495"/>
         <source>From Date</source>
         <translation>Desde do data</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2476"/>
-        <location filename="../Pages.cpp" line="2494"/>
+        <location filename="../Pages.cpp" line="2478"/>
+        <location filename="../Pages.cpp" line="2496"/>
         <source>Critical Power</source>
         <translation>Pot?ncia Cr?tica</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2523"/>
+        <location filename="../Pages.cpp" line="2525"/>
         <source>Short</source>
         <translation>Curto</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2524"/>
+        <location filename="../Pages.cpp" line="2526"/>
         <source>Long</source>
         <translation>Comprido</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2525"/>
+        <location filename="../Pages.cpp" line="2527"/>
         <source>From Watts</source>
         <translation>De watts</translation>
     </message>
@@ -839,7 +839,7 @@
 <context>
     <name>CPWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="120"/>
+        <location filename="../WattsPerKilogram.cpp" line="128"/>
         <source>60 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -934,7 +934,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ChartSettings.cpp" line="42"/>
+        <location filename="../ChartSettings.cpp" line="41"/>
         <source>Done</source>
         <translation type="unfinished">Conclu?do</translation>
     </message>
@@ -1526,7 +1526,7 @@ Pode demorar um pouco.
 <context>
     <name>CriticalPower</name>
     <message>
-        <location filename="../PeakPower.cpp" line="63"/>
+        <location filename="../PeakPower.cpp" line="67"/>
         <source>60 min Peak Power</source>
         <translation>60 min Ponto M?ximo de Pot?ncia</translation>
     </message>
@@ -1685,12 +1685,12 @@ Pode demorar um pouco.
 <context>
     <name>DBAccess</name>
     <message>
-        <location filename="../DBAccess.cpp" line="112"/>
+        <location filename="../DBAccess.cpp" line="113"/>
         <source>Cannot open database</source>
         <translation>N?o foi poss?vel abrir a base de dados</translation>
     </message>
     <message>
-        <location filename="../DBAccess.cpp" line="113"/>
+        <location filename="../DBAccess.cpp" line="114"/>
         <source>Unable to establish a database connection.
 This feature requires SQLite support. Please read the Qt SQL driver documentation for information how to build it.
 
@@ -1703,13 +1703,13 @@ Carrega em Cancelar para sair.</translation>
 <context>
     <name>DanielsEquivalentPower</name>
     <message>
-        <location filename="../DanielsPoints.cpp" line="110"/>
+        <location filename="../DanielsPoints.cpp" line="116"/>
         <source>Daniels EqP</source>
         <translation>Daniels EqP</translation>
     </message>
     <message>
-        <location filename="../DanielsPoints.cpp" line="111"/>
-        <location filename="../DanielsPoints.cpp" line="112"/>
+        <location filename="../DanielsPoints.cpp" line="117"/>
+        <location filename="../DanielsPoints.cpp" line="118"/>
         <source>watts</source>
         <translation>Watts</translation>
     </message>
@@ -1717,7 +1717,7 @@ Carrega em Cancelar para sair.</translation>
 <context>
     <name>DanielsPoints</name>
     <message>
-        <location filename="../DanielsPoints.cpp" line="49"/>
+        <location filename="../DanielsPoints.cpp" line="51"/>
         <source>Daniels Points</source>
         <translation>Daniels Points</translation>
     </message>
@@ -2089,7 +2089,7 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>EditMetricDetailDialog</name>
     <message>
-        <location filename="../LTMTool.cpp" line="638"/>
+        <location filename="../LTMTool.cpp" line="701"/>
         <source>Settings</source>
         <translation>Configura??es</translation>
     </message>
@@ -2174,47 +2174,20 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
         <translation type="obsolete">Linha de tend?ncia</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="662"/>
-        <source>Filter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="664"/>
-        <source>No filter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="665"/>
         <source>Include</source>
-        <translation type="unfinished">Incluir</translation>
+        <translation type="obsolete">Incluir</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="666"/>
         <source>Exclude</source>
-        <translation type="unfinished">Excluir</translation>
+        <translation type="obsolete">Excluir</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="668"/>
-        <source>From</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="673"/>
-        <source>To</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="678"/>
-        <source>Show on plot</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="780"/>
+        <location filename="../LTMTool.cpp" line="814"/>
         <source>&amp;OK</source>
         <translation>&amp;OK</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="781"/>
+        <location filename="../LTMTool.cpp" line="815"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Cancelar</translation>
     </message>
@@ -2258,7 +2231,7 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>EfficiencyFactor</name>
     <message>
-        <location filename="../Coggan.cpp" line="198"/>
+        <location filename="../Coggan.cpp" line="217"/>
         <source>Efficiency Factor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2266,17 +2239,17 @@ You may need to (re)install the FTDI or PL2303 drivers before downloading.</sour
 <context>
     <name>ElevationGain</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="170"/>
+        <location filename="../BasicRideMetrics.cpp" line="189"/>
         <source>Elevation Gain</source>
         <translation>Aumento de eleva??o</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="172"/>
+        <location filename="../BasicRideMetrics.cpp" line="191"/>
         <source>meters</source>
         <translation>metros</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="173"/>
+        <location filename="../BasicRideMetrics.cpp" line="192"/>
         <source>feet</source>
         <translation>P?s</translation>
     </message>
@@ -2586,7 +2559,7 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>FormField</name>
     <message>
-        <location filename="../RideMetadata.cpp" line="545"/>
+        <location filename="../RideMetadata.cpp" line="546"/>
         <source>You entered &apos;%1&apos; which is not an expected value.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2851,7 +2824,7 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>Gradient</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="758"/>
+        <location filename="../BasicRideMetrics.cpp" line="851"/>
         <source>Gradient</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2867,7 +2840,7 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>GroupByModel</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="724"/>
+        <location filename="../RideNavigator.cpp" line="726"/>
         <source>Date</source>
         <translation type="unfinished">Data</translation>
     </message>
@@ -2950,12 +2923,12 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>HomeWindow</name>
     <message>
-        <location filename="../HomeWindow.cpp" line="712"/>
+        <location filename="../HomeWindow.cpp" line="713"/>
         <source>Are you sure you want to remove the chart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../HomeWindow.cpp" line="713"/>
+        <location filename="../HomeWindow.cpp" line="714"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2999,37 +2972,37 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>HrSchemePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2826"/>
+        <location filename="../Pages.cpp" line="2828"/>
         <source>Add</source>
         <translation>Adicionar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2827"/>
+        <location filename="../Pages.cpp" line="2829"/>
         <source>Rename</source>
         <translation>Renomear</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2828"/>
+        <location filename="../Pages.cpp" line="2830"/>
         <source>Delete</source>
         <translation>Apagar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2837"/>
+        <location filename="../Pages.cpp" line="2839"/>
         <source>Short</source>
         <translation>Curto</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2838"/>
+        <location filename="../Pages.cpp" line="2840"/>
         <source>Long</source>
         <translation>Comprido</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2839"/>
+        <location filename="../Pages.cpp" line="2841"/>
         <source>Percent of LT</source>
         <translation>Percentagem de LT</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2840"/>
+        <location filename="../Pages.cpp" line="2842"/>
         <source>Trimp k</source>
         <translation>Trimp k</translation>
     </message>
@@ -3037,12 +3010,12 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>HrZonePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2809"/>
+        <location filename="../Pages.cpp" line="2811"/>
         <source>Lactic Threshold History</source>
         <translation>Hist?ria do limiar l?tico</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2810"/>
+        <location filename="../Pages.cpp" line="2812"/>
         <source>Default Zones</source>
         <translation>Zonas padr?o</translation>
     </message>
@@ -3050,7 +3023,7 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>HrZoneTime1</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="72"/>
+        <location filename="../HrTimeInZone.cpp" line="77"/>
         <source>H1 Time in Zone</source>
         <translation>H1 Tempo na zona</translation>
     </message>
@@ -3058,7 +3031,7 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>HrZoneTime2</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="84"/>
+        <location filename="../HrTimeInZone.cpp" line="94"/>
         <source>H2 Time in Zone</source>
         <translation>H2 Tempo na zona</translation>
     </message>
@@ -3066,7 +3039,7 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>HrZoneTime3</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="96"/>
+        <location filename="../HrTimeInZone.cpp" line="111"/>
         <source>H3 Time in Zone</source>
         <translation>H3 Tempo na zona</translation>
     </message>
@@ -3074,7 +3047,7 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>HrZoneTime4</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="108"/>
+        <location filename="../HrTimeInZone.cpp" line="128"/>
         <source>H4 Time in Zone</source>
         <translation>H4 Tempo na zona</translation>
     </message>
@@ -3082,7 +3055,7 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>HrZoneTime5</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="120"/>
+        <location filename="../HrTimeInZone.cpp" line="145"/>
         <source>H5 Time in Zone</source>
         <translation>H5 Tempo na zona</translation>
     </message>
@@ -3090,7 +3063,7 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>HrZoneTime6</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="132"/>
+        <location filename="../HrTimeInZone.cpp" line="162"/>
         <source>H6 Time in Zone</source>
         <translation>H6 Tempo na zona</translation>
     </message>
@@ -3098,7 +3071,7 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>HrZoneTime7</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="144"/>
+        <location filename="../HrTimeInZone.cpp" line="179"/>
         <source>H7 Time in Zone</source>
         <translation>H7 Tempo na zona</translation>
     </message>
@@ -3106,7 +3079,7 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>HrZoneTime8</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="156"/>
+        <location filename="../HrTimeInZone.cpp" line="196"/>
         <source>H8 Time in Zone</source>
         <translation>H8 Tempo na zona</translation>
     </message>
@@ -3366,7 +3339,8 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
         <translation type="obsolete">Melhor %1</translation>
     </message>
     <message>
-        <location filename="../LTMPlot.cpp" line="1120"/>
+        <location filename="../LTMPlot.cpp" line="731"/>
+        <location filename="../LTMPlot.cpp" line="1123"/>
         <source>watts</source>
         <translation>Watts</translation>
     </message>
@@ -3400,33 +3374,33 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="253"/>
-        <location filename="../LTMSidebar.cpp" line="289"/>
+        <location filename="../LTMSidebar.cpp" line="257"/>
+        <location filename="../LTMSidebar.cpp" line="293"/>
         <source>Edit details</source>
         <translation type="unfinished">Editar dados</translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="254"/>
+        <location filename="../LTMSidebar.cpp" line="258"/>
         <source>Delete range</source>
         <translation type="unfinished">Apagar s?rie</translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="255"/>
+        <location filename="../LTMSidebar.cpp" line="259"/>
         <source>Add Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="290"/>
+        <location filename="../LTMSidebar.cpp" line="294"/>
         <source>Delete event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="300"/>
+        <location filename="../LTMSidebar.cpp" line="304"/>
         <source>Add event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="537"/>
+        <location filename="../LTMSidebar.cpp" line="541"/>
         <source>^(Average|Max) </source>
         <translation type="unfinished"></translation>
     </message>
@@ -3438,7 +3412,7 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
         <translation type="obsolete">S?rie de dados</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="69"/>
+        <location filename="../LTMTool.cpp" line="124"/>
         <source>Metric</source>
         <translation>M?trico</translation>
     </message>
@@ -3555,8 +3529,8 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
         <translation type="obsolete">?ltimos 12 meses</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="511"/>
-        <location filename="../LTMTool.cpp" line="519"/>
+        <location filename="../LTMTool.cpp" line="574"/>
+        <location filename="../LTMTool.cpp" line="582"/>
         <source>Unknown Metric</source>
         <translation>M?trica desconhecida</translation>
     </message>
@@ -3573,12 +3547,47 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
         <translation type="obsolete">Apagar s?rie</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="544"/>
+        <location filename="../LTMTool.cpp" line="59"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="69"/>
+        <source>Chart</source>
+        <translation type="unfinished">Gr?fico</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="101"/>
+        <source>Add</source>
+        <translation type="unfinished">Adicionar</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="102"/>
+        <source>Manage</source>
+        <translation type="unfinished">Gerir</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="518"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="519"/>
+        <source>Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="520"/>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="607"/>
         <source>Pick Color</source>
         <translation>Escolhe cor</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="545"/>
+        <location filename="../LTMTool.cpp" line="608"/>
         <source>Settings</source>
         <translation>Configura??es</translation>
     </message>
@@ -3634,19 +3643,16 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>LTMWindow</name>
     <message>
-        <location filename="../LTMWindow.cpp" line="135"/>
         <source>Add</source>
-        <translation>Adicionar</translation>
+        <translation type="obsolete">Adicionar</translation>
     </message>
     <message>
-        <location filename="../LTMWindow.cpp" line="137"/>
         <source>Manage</source>
-        <translation>Gerir</translation>
+        <translation type="obsolete">Gerir</translation>
     </message>
     <message>
-        <location filename="../LTMWindow.cpp" line="105"/>
         <source>Chart</source>
-        <translation>Gr?fico</translation>
+        <translation type="obsolete">Gr?fico</translation>
     </message>
     <message>
         <source>Days</source>
@@ -3672,71 +3678,71 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>LTPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3001"/>
+        <location filename="../Pages.cpp" line="3003"/>
         <source>Add LT</source>
         <translation>Addicionar LT</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3002"/>
+        <location filename="../Pages.cpp" line="3004"/>
         <source>Delete LT</source>
         <translation>Apagar LT</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3003"/>
+        <location filename="../Pages.cpp" line="3005"/>
         <source>Default</source>
         <translation>Padr?o</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3006"/>
+        <location filename="../Pages.cpp" line="3008"/>
         <source>Add Zone</source>
         <translation>Addicionar Zona</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3007"/>
+        <location filename="../Pages.cpp" line="3009"/>
         <source>Delete Zone</source>
         <translation>Apagar Zona</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3021"/>
-        <location filename="../Pages.cpp" line="3061"/>
+        <location filename="../Pages.cpp" line="3023"/>
+        <location filename="../Pages.cpp" line="3063"/>
         <source>From Date</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3022"/>
-        <location filename="../Pages.cpp" line="3062"/>
+        <location filename="../Pages.cpp" line="3024"/>
+        <location filename="../Pages.cpp" line="3064"/>
         <source>Lactic Threshold</source>
         <translation>Limiar l?tico</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3039"/>
-        <location filename="../Pages.cpp" line="3063"/>
+        <location filename="../Pages.cpp" line="3041"/>
+        <location filename="../Pages.cpp" line="3065"/>
         <source>Rest HR</source>
         <translation>HR do repouso</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3040"/>
-        <location filename="../Pages.cpp" line="3064"/>
+        <location filename="../Pages.cpp" line="3042"/>
+        <location filename="../Pages.cpp" line="3066"/>
         <source>Max HR</source>
         <translation>HR Max</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3101"/>
+        <location filename="../Pages.cpp" line="3103"/>
         <source>Short</source>
         <translation>Curto</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3102"/>
+        <location filename="../Pages.cpp" line="3104"/>
         <source>Long</source>
         <translation>Comprido</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3103"/>
+        <location filename="../Pages.cpp" line="3105"/>
         <source>From BPM</source>
         <translation>De BPM</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3104"/>
+        <location filename="../Pages.cpp" line="3106"/>
         <source>Trimp k</source>
         <translation>Trimp k</translation>
     </message>
@@ -3744,13 +3750,13 @@ Torque Adjust - isto define um valor absoluto em pontos por polegada quadrada ou
 <context>
     <name>LeftRightBalance</name>
     <message>
-        <location filename="../LeftRightBalance.cpp" line="33"/>
+        <location filename="../LeftRightBalance.cpp" line="36"/>
         <source>Left/Right Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftRightBalance.cpp" line="34"/>
-        <location filename="../LeftRightBalance.cpp" line="35"/>
+        <location filename="../LeftRightBalance.cpp" line="37"/>
+        <location filename="../LeftRightBalance.cpp" line="38"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
@@ -3771,7 +3777,7 @@ e que o ecr? mostra &quot;PC Link&quot;</translation>
         <translation type="obsolete">Nome do ficheiro do percurso inv?lido</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2210"/>
+        <location filename="../MainWindow.cpp" line="2216"/>
         <source>Invalid date/time in filename:
 %1
 Skipping file...</source>
@@ -3781,13 +3787,13 @@ A ignorar ficheiro...</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="281"/>
-        <location filename="../MainWindow.cpp" line="2230"/>
+        <location filename="../MainWindow.cpp" line="2236"/>
         <source>Zones File Error</source>
         <translation>Erro nas zonas do ficheiro</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="284"/>
-        <location filename="../MainWindow.cpp" line="2234"/>
+        <location filename="../MainWindow.cpp" line="2240"/>
         <source>Reading Zones File</source>
         <translation>A ler zonas do ficheiro</translation>
     </message>
@@ -3805,7 +3811,7 @@ A ignorar ficheiro...</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="565"/>
-        <location filename="../MainWindow.cpp" line="1209"/>
+        <location filename="../MainWindow.cpp" line="1215"/>
         <source>Intervals</source>
         <translation>Intervalos</translation>
     </message>
@@ -3858,22 +3864,22 @@ A ignorar ficheiro...</translation>
         <translation type="obsolete">&amp;Ciclista</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="743"/>
+        <location filename="../MainWindow.cpp" line="747"/>
         <source>&amp;New...</source>
         <translation>&amp;Novo...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="743"/>
+        <location filename="../MainWindow.cpp" line="747"/>
         <source>Ctrl+N</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="744"/>
+        <location filename="../MainWindow.cpp" line="748"/>
         <source>&amp;Open...</source>
         <translation>&amp;Abrir...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="744"/>
+        <location filename="../MainWindow.cpp" line="748"/>
         <source>Ctrl+O</source>
         <translation></translation>
     </message>
@@ -3882,7 +3888,7 @@ A ignorar ficheiro...</translation>
         <translation type="obsolete">&amp;Desistir</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="746"/>
+        <location filename="../MainWindow.cpp" line="750"/>
         <source>Ctrl+Q</source>
         <translation></translation>
     </message>
@@ -3891,22 +3897,22 @@ A ignorar ficheiro...</translation>
         <translation type="obsolete">&amp;Percurso</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="749"/>
+        <location filename="../MainWindow.cpp" line="753"/>
         <source>&amp;Download from device...</source>
         <translation>&amp;Download do dispositivo...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="749"/>
+        <location filename="../MainWindow.cpp" line="753"/>
         <source>Ctrl+D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="750"/>
+        <location filename="../MainWindow.cpp" line="754"/>
         <source>&amp;Import from file...</source>
         <translation>&amp;Importar do ficheiro...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="750"/>
+        <location filename="../MainWindow.cpp" line="754"/>
         <source>Ctrl+I</source>
         <translation></translation>
     </message>
@@ -3915,7 +3921,7 @@ A ignorar ficheiro...</translation>
         <translation type="obsolete">&amp;Introduzir percurso manualmente...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="751"/>
+        <location filename="../MainWindow.cpp" line="755"/>
         <source>Ctrl+M</source>
         <translation></translation>
     </message>
@@ -3924,7 +3930,7 @@ A ignorar ficheiro...</translation>
         <translation type="obsolete">&amp;Exportar a CSV...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="753"/>
+        <location filename="../MainWindow.cpp" line="757"/>
         <source>Ctrl+E</source>
         <translation></translation>
     </message>
@@ -3945,7 +3951,7 @@ A ignorar ficheiro...</translation>
         <translation type="obsolete">&amp;Guardar percurso</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="775"/>
+        <location filename="../MainWindow.cpp" line="779"/>
         <source>Ctrl+S</source>
         <translation></translation>
     </message>
@@ -3962,7 +3968,7 @@ A ignorar ficheiro...</translation>
         <translation type="obsolete">Encontrar os &amp;melhores intervalos...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="754"/>
+        <location filename="../MainWindow.cpp" line="758"/>
         <source>Ctrl+B</source>
         <translation></translation>
     </message>
@@ -3971,12 +3977,12 @@ A ignorar ficheiro...</translation>
         <translation type="obsolete">Encontrar &amp;picos de pot?ncia...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="780"/>
+        <location filename="../MainWindow.cpp" line="784"/>
         <source>&amp;Tools</source>
         <translation>&amp;Ferramentas</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="781"/>
+        <location filename="../MainWindow.cpp" line="785"/>
         <source>&amp;Options...</source>
         <translation>&amp;Op??es...</translation>
     </message>
@@ -3985,22 +3991,22 @@ A ignorar ficheiro...</translation>
         <translation type="obsolete">Calcular pot?ncia cr?tica</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="825"/>
+        <location filename="../MainWindow.cpp" line="829"/>
         <source>&amp;View</source>
         <translation>&amp;Vista</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="861"/>
+        <location filename="../MainWindow.cpp" line="865"/>
         <source>&amp;Help</source>
         <translation>&amp;Ajuda</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="865"/>
+        <location filename="../MainWindow.cpp" line="869"/>
         <source>&amp;About GoldenCheetah</source>
         <translation>&amp;Sobre GoldenCHeetah</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1612"/>
+        <location filename="../MainWindow.cpp" line="1618"/>
         <source>Can&apos;t rename %1 to %2</source>
         <translation>Nao foi poss?vel renomear %1 a %2</translation>
     </message>
@@ -4057,42 +4063,42 @@ A ignorar ficheiro...</translation>
         <translation type="obsolete">O ficheiro %1 n?o pode ser aberto para grava??o</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1739"/>
+        <location filename="../MainWindow.cpp" line="1745"/>
         <source>Import from File</source>
         <translation>Importar do ficheiro</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1756"/>
+        <location filename="../MainWindow.cpp" line="1762"/>
         <source>No Activity To Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1757"/>
+        <location filename="../MainWindow.cpp" line="1763"/>
         <source>There is no currently selected ride to save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1791"/>
+        <location filename="../MainWindow.cpp" line="1797"/>
         <source>Are you sure you want to delete the activity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1845"/>
+        <location filename="../MainWindow.cpp" line="1851"/>
         <source>Export Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1845"/>
+        <location filename="../MainWindow.cpp" line="1851"/>
         <source>Comma Separated Variables (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1920"/>
+        <location filename="../MainWindow.cpp" line="1926"/>
         <source>Workout Directory Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1977"/>
+        <location filename="../MainWindow.cpp" line="1983"/>
         <source> (%1 watts)</source>
         <translation> (%1 watts)</translation>
     </message>
@@ -4109,12 +4115,12 @@ A ignorar ficheiro...</translation>
         <translation type="obsolete">Apagar percurso</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1173"/>
+        <location filename="../MainWindow.cpp" line="1179"/>
         <source>Find Best Intervals</source>
         <translation>Encontrar os melhores intervalos</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1176"/>
+        <location filename="../MainWindow.cpp" line="1182"/>
         <source>Find Power Peaks</source>
         <translation>Encontrar picos de pot?ncia</translation>
     </message>
@@ -4124,13 +4130,13 @@ A ignorar ficheiro...</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="291"/>
-        <location filename="../MainWindow.cpp" line="2241"/>
+        <location filename="../MainWindow.cpp" line="2247"/>
         <source>HR Zones File Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="294"/>
-        <location filename="../MainWindow.cpp" line="2245"/>
+        <location filename="../MainWindow.cpp" line="2251"/>
         <source>Reading HR Zones File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4151,297 +4157,297 @@ A ignorar ficheiro...</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="454"/>
-        <location filename="../MainWindow.cpp" line="845"/>
+        <location filename="../MainWindow.cpp" line="849"/>
         <source>Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="461"/>
-        <location filename="../MainWindow.cpp" line="848"/>
+        <location filename="../MainWindow.cpp" line="852"/>
         <source>Diary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="468"/>
-        <location filename="../MainWindow.cpp" line="844"/>
+        <location filename="../MainWindow.cpp" line="848"/>
         <source>Analysis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="474"/>
-        <location filename="../MainWindow.cpp" line="846"/>
+        <location filename="../MainWindow.cpp" line="850"/>
         <source>Train</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="524"/>
-        <location filename="../MainWindow.cpp" line="1160"/>
+        <location filename="../MainWindow.cpp" line="1166"/>
         <source>All Activities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="742"/>
+        <location filename="../MainWindow.cpp" line="746"/>
         <source>&amp;Athlete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="745"/>
+        <location filename="../MainWindow.cpp" line="749"/>
         <source>&amp;Close Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="745"/>
+        <location filename="../MainWindow.cpp" line="749"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="746"/>
+        <location filename="../MainWindow.cpp" line="750"/>
         <source>&amp;Quit All Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="748"/>
+        <location filename="../MainWindow.cpp" line="752"/>
         <source>A&amp;ctivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="751"/>
+        <location filename="../MainWindow.cpp" line="755"/>
         <source>&amp;Manual activity entry...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="753"/>
+        <location filename="../MainWindow.cpp" line="757"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="754"/>
+        <location filename="../MainWindow.cpp" line="758"/>
         <source>&amp;Batch export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="755"/>
+        <location filename="../MainWindow.cpp" line="759"/>
         <source>Export Metrics as CSV...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="758"/>
+        <location filename="../MainWindow.cpp" line="762"/>
         <source>&amp;Upload to TrainingPeaks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="758"/>
+        <location filename="../MainWindow.cpp" line="762"/>
         <source>Ctrl+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="759"/>
+        <location filename="../MainWindow.cpp" line="763"/>
         <source>Down&amp;load from TrainingPeaks...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="759"/>
+        <location filename="../MainWindow.cpp" line="763"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="775"/>
+        <location filename="../MainWindow.cpp" line="779"/>
         <source>&amp;Save activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="776"/>
+        <location filename="../MainWindow.cpp" line="780"/>
         <source>D&amp;elete activity...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="777"/>
+        <location filename="../MainWindow.cpp" line="781"/>
         <source>Split &amp;activity...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="782"/>
+        <location filename="../MainWindow.cpp" line="786"/>
         <source>Critical Power Calculator...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="783"/>
+        <location filename="../MainWindow.cpp" line="787"/>
         <source>Air Density (Rho) Estimator...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="786"/>
+        <location filename="../MainWindow.cpp" line="790"/>
         <source>Get &amp;Withings Data...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="788"/>
+        <location filename="../MainWindow.cpp" line="792"/>
         <source>Get &amp;Zeo Data...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="791"/>
+        <location filename="../MainWindow.cpp" line="795"/>
         <source>Workout Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="792"/>
+        <location filename="../MainWindow.cpp" line="796"/>
         <source>Get Workouts from ErgDB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="796"/>
-        <location filename="../MainWindow.cpp" line="1197"/>
+        <location filename="../MainWindow.cpp" line="800"/>
+        <location filename="../MainWindow.cpp" line="1203"/>
         <source>Upload Activity to Calendar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="797"/>
+        <location filename="../MainWindow.cpp" line="801"/>
         <source>Import Calendar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="798"/>
+        <location filename="../MainWindow.cpp" line="802"/>
         <source>Export Calendar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="799"/>
+        <location filename="../MainWindow.cpp" line="803"/>
         <source>Refresh Calendar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="802"/>
+        <location filename="../MainWindow.cpp" line="806"/>
         <source>Find intervals...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="827"/>
+        <location filename="../MainWindow.cpp" line="831"/>
         <source>Toggle Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="829"/>
+        <location filename="../MainWindow.cpp" line="833"/>
         <source>Show Left Sidebar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="833"/>
+        <location filename="../MainWindow.cpp" line="837"/>
         <source>Show Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="838"/>
+        <location filename="../MainWindow.cpp" line="842"/>
         <source>Tabbed View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="852"/>
+        <location filename="../MainWindow.cpp" line="856"/>
         <source>Reset Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="854"/>
+        <location filename="../MainWindow.cpp" line="858"/>
         <source>&amp;Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="862"/>
+        <location filename="../MainWindow.cpp" line="866"/>
         <source>&amp;User Guide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="863"/>
+        <location filename="../MainWindow.cpp" line="867"/>
         <source>&amp;Log a bug or feature request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1164"/>
+        <location filename="../MainWindow.cpp" line="1170"/>
         <source>Save Changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1167"/>
+        <location filename="../MainWindow.cpp" line="1173"/>
         <source>Revert to Saved version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1170"/>
-        <location filename="../MainWindow.cpp" line="1786"/>
+        <location filename="../MainWindow.cpp" line="1176"/>
+        <location filename="../MainWindow.cpp" line="1792"/>
         <source>Delete Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1179"/>
-        <location filename="../MainWindow.cpp" line="1778"/>
+        <location filename="../MainWindow.cpp" line="1185"/>
+        <location filename="../MainWindow.cpp" line="1784"/>
         <source>Split Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1192"/>
+        <location filename="../MainWindow.cpp" line="1198"/>
         <source>Tweet Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1214"/>
+        <location filename="../MainWindow.cpp" line="1220"/>
         <source>Rename interval</source>
         <translation>Renomear intervalo</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1215"/>
+        <location filename="../MainWindow.cpp" line="1221"/>
         <source>Delete interval</source>
         <translation>Apagar intervalo</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1216"/>
+        <location filename="../MainWindow.cpp" line="1222"/>
         <source>Zoom to interval</source>
         <translation>zoom para o intervalo</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1217"/>
+        <location filename="../MainWindow.cpp" line="1223"/>
         <source>Bring to Front</source>
         <translation>Trazer para frente</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1218"/>
+        <location filename="../MainWindow.cpp" line="1224"/>
         <source>Send to back</source>
         <translation>Enviar para tr?s</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1692"/>
+        <location filename="../MainWindow.cpp" line="1698"/>
         <source>Select Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1692"/>
-        <location filename="../MainWindow.cpp" line="1778"/>
-        <location filename="../MainWindow.cpp" line="1786"/>
+        <location filename="../MainWindow.cpp" line="1698"/>
+        <location filename="../MainWindow.cpp" line="1784"/>
+        <location filename="../MainWindow.cpp" line="1792"/>
         <source>No activity selected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1703"/>
+        <location filename="../MainWindow.cpp" line="1709"/>
         <source>Export Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1716"/>
+        <location filename="../MainWindow.cpp" line="1722"/>
         <source>Export Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1717"/>
+        <location filename="../MainWindow.cpp" line="1723"/>
         <source>Failed to export ride, please check permissions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2188"/>
+        <location filename="../MainWindow.cpp" line="2194"/>
         <source>Range from %1 to %2
 Athlete CP set to %3 watts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2209"/>
+        <location filename="../MainWindow.cpp" line="2215"/>
         <source>Invalid Activity File Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4475,7 +4481,7 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Nao foi poss?vel escrever ao ficheiro das notas %1</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2187"/>
+        <location filename="../MainWindow.cpp" line="2193"/>
         <source>CP saved</source>
         <translation>CP guardado</translation>
     </message>
@@ -4499,7 +4505,7 @@ Atleta CP definido a %3 watts
         <translation type="obsolete">Tem a certeza de que deseja apagar o percurso:</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1793"/>
+        <location filename="../MainWindow.cpp" line="1799"/>
         <source>Delete</source>
         <translation>Apagar</translation>
     </message>
@@ -4720,13 +4726,13 @@ Atleta CP definido a %3 watts
 <context>
     <name>MaxCadence</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="606"/>
+        <location filename="../BasicRideMetrics.cpp" line="683"/>
         <source>Max Cadence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="607"/>
-        <location filename="../BasicRideMetrics.cpp" line="608"/>
+        <location filename="../BasicRideMetrics.cpp" line="684"/>
+        <location filename="../BasicRideMetrics.cpp" line="685"/>
         <source>rpm</source>
         <translation type="unfinished">rpm</translation>
     </message>
@@ -4734,13 +4740,13 @@ Atleta CP definido a %3 watts
 <context>
     <name>MaxHr</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="538"/>
+        <location filename="../BasicRideMetrics.cpp" line="607"/>
         <source>Max Heartrate</source>
         <translation>Frequ?ncia Card?aca M?xima</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="539"/>
-        <location filename="../BasicRideMetrics.cpp" line="540"/>
+        <location filename="../BasicRideMetrics.cpp" line="608"/>
+        <location filename="../BasicRideMetrics.cpp" line="609"/>
         <source>bpm</source>
         <translation>BPM</translation>
     </message>
@@ -4748,13 +4754,13 @@ Atleta CP definido a %3 watts
 <context>
     <name>MaxPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="509"/>
+        <location filename="../BasicRideMetrics.cpp" line="574"/>
         <source>Max Power</source>
         <translation>Pot?ncia M?xima</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="510"/>
-        <location filename="../BasicRideMetrics.cpp" line="511"/>
+        <location filename="../BasicRideMetrics.cpp" line="575"/>
+        <location filename="../BasicRideMetrics.cpp" line="576"/>
         <source>watts</source>
         <translation>Watts</translation>
     </message>
@@ -4762,7 +4768,7 @@ Atleta CP definido a %3 watts
 <context>
     <name>MaxPowerVariance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="848"/>
+        <location filename="../BasicRideMetrics.cpp" line="949"/>
         <source>Max Power Variance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4770,17 +4776,17 @@ Atleta CP definido a %3 watts
 <context>
     <name>MaxSpeed</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="567"/>
+        <location filename="../BasicRideMetrics.cpp" line="640"/>
         <source>Max Speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="568"/>
+        <location filename="../BasicRideMetrics.cpp" line="641"/>
         <source>kph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="569"/>
+        <location filename="../BasicRideMetrics.cpp" line="642"/>
         <source>mph</source>
         <translation type="unfinished">mph</translation>
     </message>
@@ -4788,17 +4794,17 @@ Atleta CP definido a %3 watts
 <context>
     <name>MaxTemp</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="643"/>
+        <location filename="../BasicRideMetrics.cpp" line="724"/>
         <source>Max Temp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="644"/>
+        <location filename="../BasicRideMetrics.cpp" line="725"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="645"/>
+        <location filename="../BasicRideMetrics.cpp" line="726"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4806,7 +4812,7 @@ Atleta CP definido a %3 watts
 <context>
     <name>MeanPowerVariance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="801"/>
+        <location filename="../BasicRideMetrics.cpp" line="898"/>
         <source>Average Power Variance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4814,42 +4820,42 @@ Atleta CP definido a %3 watts
 <context>
     <name>MeasuresPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3395"/>
+        <location filename="../Pages.cpp" line="3397"/>
         <source>Move up</source>
         <translation type="unfinished">Mover para cima</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3396"/>
+        <location filename="../Pages.cpp" line="3398"/>
         <source>Move down</source>
         <translation type="unfinished">Mover para baixo</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3397"/>
+        <location filename="../Pages.cpp" line="3399"/>
         <source>Insert</source>
         <translation type="unfinished">Inserir</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3398"/>
+        <location filename="../Pages.cpp" line="3400"/>
         <source>Rename</source>
         <translation type="unfinished">Renomear</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3399"/>
+        <location filename="../Pages.cpp" line="3401"/>
         <source>Delete</source>
         <translation type="unfinished">Apagar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3410"/>
+        <location filename="../Pages.cpp" line="3412"/>
         <source>Screen Tab</source>
         <translation type="unfinished">Separador</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3411"/>
+        <location filename="../Pages.cpp" line="3413"/>
         <source>Measure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3412"/>
+        <location filename="../Pages.cpp" line="3414"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
@@ -5235,17 +5241,17 @@ Elapsed: %1
 <context>
     <name>NavigatorCellDelegate</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="941"/>
+        <location filename="../RideNavigator.cpp" line="944"/>
         <source>Date</source>
         <translation type="unfinished">Data</translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="944"/>
+        <location filename="../RideNavigator.cpp" line="947"/>
         <source>Time</source>
         <translation type="unfinished">Tempo</translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="947"/>
+        <location filename="../RideNavigator.cpp" line="950"/>
         <source>Last updated</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5372,13 +5378,13 @@ Elapsed: %1
 <context>
     <name>NinetyFivePercentHeartRate</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="688"/>
+        <location filename="../BasicRideMetrics.cpp" line="773"/>
         <source>95% Heartrate</source>
         <translation>95% Frequ?ncia Card?aca</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="689"/>
-        <location filename="../BasicRideMetrics.cpp" line="690"/>
+        <location filename="../BasicRideMetrics.cpp" line="774"/>
+        <location filename="../BasicRideMetrics.cpp" line="775"/>
         <source>bpm</source>
         <translation>bpm</translation>
     </message>
@@ -5386,13 +5392,13 @@ Elapsed: %1
 <context>
     <name>NonZeroPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="365"/>
+        <location filename="../BasicRideMetrics.cpp" line="408"/>
         <source>Nonzero Average Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="366"/>
-        <location filename="../BasicRideMetrics.cpp" line="367"/>
+        <location filename="../BasicRideMetrics.cpp" line="409"/>
+        <location filename="../BasicRideMetrics.cpp" line="410"/>
         <source>watts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5400,17 +5406,17 @@ Elapsed: %1
 <context>
     <name>Pace</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="288"/>
+        <location filename="../BasicRideMetrics.cpp" line="319"/>
         <source>Pace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="290"/>
+        <location filename="../BasicRideMetrics.cpp" line="321"/>
         <source>min/km</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="291"/>
+        <location filename="../BasicRideMetrics.cpp" line="322"/>
         <source>min/mile</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5602,7 +5608,7 @@ Quer continuar?</translation>
 <context>
     <name>PeakPower10m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="162"/>
+        <location filename="../PeakPower.cpp" line="202"/>
         <source>10 min Peak Power</source>
         <translation>10 min de pot?ncia pico m?xima</translation>
     </message>
@@ -5614,7 +5620,7 @@ Quer continuar?</translation>
 <context>
     <name>PeakPower10s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="96"/>
+        <location filename="../PeakPower.cpp" line="112"/>
         <source>10 sec Peak Power</source>
         <translation>10 seg de pot?ncia pico m?xima</translation>
     </message>
@@ -5626,7 +5632,7 @@ Quer continuar?</translation>
 <context>
     <name>PeakPower15s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="107"/>
+        <location filename="../PeakPower.cpp" line="127"/>
         <source>15 sec Peak Power</source>
         <translation>15 seg de pot?ncia pico m?xima</translation>
     </message>
@@ -5638,7 +5644,7 @@ Quer continuar?</translation>
 <context>
     <name>PeakPower1m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="140"/>
+        <location filename="../PeakPower.cpp" line="172"/>
         <source>1 min Peak Power</source>
         <translation>1 min de pot?ncia pico m?xima</translation>
     </message>
@@ -5650,7 +5656,7 @@ Quer continuar?</translation>
 <context>
     <name>PeakPower1s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="74"/>
+        <location filename="../PeakPower.cpp" line="82"/>
         <source>1 sec Peak Power</source>
         <translation>1 seg de pot?ncia pico m?xima</translation>
     </message>
@@ -5662,7 +5668,7 @@ Quer continuar?</translation>
 <context>
     <name>PeakPower20m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="173"/>
+        <location filename="../PeakPower.cpp" line="217"/>
         <source>20 min Peak Power</source>
         <translation>20 min Ponto M?ximo de Pot?ncia</translation>
     </message>
@@ -5674,7 +5680,7 @@ Quer continuar?</translation>
 <context>
     <name>PeakPower20s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="118"/>
+        <location filename="../PeakPower.cpp" line="142"/>
         <source>20 sec Peak Power</source>
         <translation>20 seg de pot?ncia pico m?xima</translation>
     </message>
@@ -5682,7 +5688,7 @@ Quer continuar?</translation>
 <context>
     <name>PeakPower30m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="184"/>
+        <location filename="../PeakPower.cpp" line="232"/>
         <source>30 min Peak Power</source>
         <translation>30 min Ponto M?ximo de Pot?ncia</translation>
     </message>
@@ -5694,7 +5700,7 @@ Quer continuar?</translation>
 <context>
     <name>PeakPower30s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="129"/>
+        <location filename="../PeakPower.cpp" line="157"/>
         <source>30 sec Peak Power</source>
         <translation>30 seg de pot?ncia pico m?xima</translation>
     </message>
@@ -5706,7 +5712,7 @@ Quer continuar?</translation>
 <context>
     <name>PeakPower5m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="151"/>
+        <location filename="../PeakPower.cpp" line="187"/>
         <source>5 min Peak Power</source>
         <translation>5 min de pot?ncia pico m?xima</translation>
     </message>
@@ -5718,7 +5724,7 @@ Quer continuar?</translation>
 <context>
     <name>PeakPower5s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="85"/>
+        <location filename="../PeakPower.cpp" line="97"/>
         <source>5 sec Peak Power</source>
         <translation>5 seg de pot?ncia pico m?xima</translation>
     </message>
@@ -5730,13 +5736,13 @@ Quer continuar?</translation>
 <context>
     <name>PeakPowerHr10m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="263"/>
+        <location filename="../PeakPower.cpp" line="324"/>
         <source>10 min Peak Power HR</source>
         <translation>10 min de pot?ncia pico m?xima HR</translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="264"/>
-        <location filename="../PeakPower.cpp" line="265"/>
+        <location filename="../PeakPower.cpp" line="325"/>
+        <location filename="../PeakPower.cpp" line="326"/>
         <source>bpm</source>
         <translation>BPM</translation>
     </message>
@@ -5744,13 +5750,13 @@ Quer continuar?</translation>
 <context>
     <name>PeakPowerHr1m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="235"/>
+        <location filename="../PeakPower.cpp" line="288"/>
         <source>1 min Peak Power HR</source>
         <translation>1 min de pot?ncia pico m?xima HR</translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="236"/>
-        <location filename="../PeakPower.cpp" line="237"/>
+        <location filename="../PeakPower.cpp" line="289"/>
+        <location filename="../PeakPower.cpp" line="290"/>
         <source>bpm</source>
         <translation>BPM</translation>
     </message>
@@ -5758,13 +5764,13 @@ Quer continuar?</translation>
 <context>
     <name>PeakPowerHr20m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="277"/>
+        <location filename="../PeakPower.cpp" line="342"/>
         <source>20 min Peak Power HR</source>
         <translation>20 min Ponto M?ximo de Pot?ncia HR</translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="278"/>
-        <location filename="../PeakPower.cpp" line="279"/>
+        <location filename="../PeakPower.cpp" line="343"/>
+        <location filename="../PeakPower.cpp" line="344"/>
         <source>bpm</source>
         <translation>BPM</translation>
     </message>
@@ -5772,13 +5778,13 @@ Quer continuar?</translation>
 <context>
     <name>PeakPowerHr30m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="291"/>
+        <location filename="../PeakPower.cpp" line="360"/>
         <source>30 min Peak Power HR</source>
         <translation>30 min Ponto M?ximo de Pot?ncia HR</translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="292"/>
-        <location filename="../PeakPower.cpp" line="293"/>
+        <location filename="../PeakPower.cpp" line="361"/>
+        <location filename="../PeakPower.cpp" line="362"/>
         <source>bpm</source>
         <translation>BPM</translation>
     </message>
@@ -5786,23 +5792,9 @@ Quer continuar?</translation>
 <context>
     <name>PeakPowerHr5m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="249"/>
+        <location filename="../PeakPower.cpp" line="306"/>
         <source>5 min Peak Power HR</source>
         <translation>5 min de pot?ncia pico m?xima HR</translation>
-    </message>
-    <message>
-        <location filename="../PeakPower.cpp" line="250"/>
-        <location filename="../PeakPower.cpp" line="251"/>
-        <source>bpm</source>
-        <translation>BPM</translation>
-    </message>
-</context>
-<context>
-    <name>PeakPowerHr60m</name>
-    <message>
-        <location filename="../PeakPower.cpp" line="306"/>
-        <source>60 min Peak Power HR</source>
-        <translation>60 min Ponto M?ximo de Pot?ncia HR</translation>
     </message>
     <message>
         <location filename="../PeakPower.cpp" line="307"/>
@@ -5812,10 +5804,24 @@ Quer continuar?</translation>
     </message>
 </context>
 <context>
+    <name>PeakPowerHr60m</name>
+    <message>
+        <location filename="../PeakPower.cpp" line="379"/>
+        <source>60 min Peak Power HR</source>
+        <translation>60 min Ponto M?ximo de Pot?ncia HR</translation>
+    </message>
+    <message>
+        <location filename="../PeakPower.cpp" line="380"/>
+        <location filename="../PeakPower.cpp" line="381"/>
+        <source>bpm</source>
+        <translation>BPM</translation>
+    </message>
+</context>
+<context>
     <name>PeakWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="89"/>
-        <location filename="../WattsPerKilogram.cpp" line="90"/>
+        <location filename="../WattsPerKilogram.cpp" line="93"/>
+        <location filename="../WattsPerKilogram.cpp" line="94"/>
         <source>wpk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5823,7 +5829,7 @@ Quer continuar?</translation>
 <context>
     <name>PeakWPK10m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="219"/>
+        <location filename="../WattsPerKilogram.cpp" line="263"/>
         <source>10 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5831,7 +5837,7 @@ Quer continuar?</translation>
 <context>
     <name>PeakWPK10s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="153"/>
+        <location filename="../WattsPerKilogram.cpp" line="173"/>
         <source>10 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5839,7 +5845,7 @@ Quer continuar?</translation>
 <context>
     <name>PeakWPK15s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="164"/>
+        <location filename="../WattsPerKilogram.cpp" line="188"/>
         <source>15 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5847,7 +5853,7 @@ Quer continuar?</translation>
 <context>
     <name>PeakWPK1m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="197"/>
+        <location filename="../WattsPerKilogram.cpp" line="233"/>
         <source>1 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5855,7 +5861,7 @@ Quer continuar?</translation>
 <context>
     <name>PeakWPK1s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="131"/>
+        <location filename="../WattsPerKilogram.cpp" line="143"/>
         <source>1 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5863,7 +5869,7 @@ Quer continuar?</translation>
 <context>
     <name>PeakWPK20m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="230"/>
+        <location filename="../WattsPerKilogram.cpp" line="278"/>
         <source>20 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5871,7 +5877,7 @@ Quer continuar?</translation>
 <context>
     <name>PeakWPK20s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="175"/>
+        <location filename="../WattsPerKilogram.cpp" line="203"/>
         <source>20 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5879,7 +5885,7 @@ Quer continuar?</translation>
 <context>
     <name>PeakWPK30m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="241"/>
+        <location filename="../WattsPerKilogram.cpp" line="293"/>
         <source>30 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5887,7 +5893,7 @@ Quer continuar?</translation>
 <context>
     <name>PeakWPK30s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="186"/>
+        <location filename="../WattsPerKilogram.cpp" line="218"/>
         <source>30 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5895,7 +5901,7 @@ Quer continuar?</translation>
 <context>
     <name>PeakWPK5m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="208"/>
+        <location filename="../WattsPerKilogram.cpp" line="248"/>
         <source>5 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5903,7 +5909,7 @@ Quer continuar?</translation>
 <context>
     <name>PeakWPK5s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="142"/>
+        <location filename="../WattsPerKilogram.cpp" line="158"/>
         <source>5 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5927,22 +5933,22 @@ Quer continuar?</translation>
         <translation type="obsolete">Tens?o di?ria</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="118"/>
+        <location filename="../PerfPlot.cpp" line="147"/>
         <source>Daily</source>
         <translation>Di?rio</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="138"/>
+        <location filename="../PerfPlot.cpp" line="167"/>
         <source>Short Term Stress</source>
         <translation>Tens?o curto prazo</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="152"/>
+        <location filename="../PerfPlot.cpp" line="181"/>
         <source>Long Term Stress</source>
         <translation>Tens?o a longo prazo</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="166"/>
+        <location filename="../PerfPlot.cpp" line="195"/>
         <source>Stress Balance</source>
         <translation>Equilibriu de tens?o</translation>
     </message>
@@ -6054,43 +6060,49 @@ Quer continuar?</translation>
     <name>PowerHist</name>
     <message>
         <location filename="../PowerHist.cpp" line="77"/>
-        <location filename="../PowerHist.cpp" line="902"/>
+        <location filename="../PowerHist.cpp" line="940"/>
         <source>Time (minutes)</source>
         <translation>Tempo (minutos)</translation>
     </message>
     <message>
         <location filename="../PowerHist.cpp" line="77"/>
-        <location filename="../PowerHist.cpp" line="902"/>
+        <location filename="../PowerHist.cpp" line="940"/>
         <source>Time (percent)</source>
         <translation>Tempo (percentagem)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="877"/>
+        <location filename="../PowerHist.cpp" line="910"/>
         <source>Power (watts)</source>
         <translation>Pot?ncia (Watts)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="876"/>
+        <location filename="../PowerHist.cpp" line="909"/>
+        <location filename="../PowerHist.cpp" line="914"/>
         <source>Power zone</source>
         <translation>Zona de pot?ncia</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="882"/>
+        <location filename="../PowerHist.cpp" line="920"/>
         <source>Heartrate (bpm)</source>
         <translation>Frequ?ncia Card?aca (bpm)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="881"/>
+        <location filename="../PowerHist.cpp" line="919"/>
         <source>Heartrate zone</source>
         <translation>Zona de Frequ?ncia Card?aca</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="886"/>
+        <location filename="../PowerHist.cpp" line="915"/>
+        <source>Power (watts/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../PowerHist.cpp" line="924"/>
         <source>Cadence (rpm)</source>
         <translation>Cad?ncia (rpm)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>Speed (%1)</source>
         <translation>Velocidade (%1)</translation>
     </message>
@@ -6099,44 +6111,44 @@ Quer continuar?</translation>
         <translation type="obsolete">km/h</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>mph</source>
         <translation>mph</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>kph</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>Torque (%1)</source>
         <translation>Torque (%1)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>N-m</source>
         <translation>N-m</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>ft-lbf</source>
         <translation>ft-lbf</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="898"/>
+        <location filename="../PowerHist.cpp" line="936"/>
         <source>Unknown data series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="962"/>
-        <location filename="../PowerHist.cpp" line="975"/>
+        <location filename="../PowerHist.cpp" line="1000"/>
+        <location filename="../PowerHist.cpp" line="1013"/>
         <source>minutes</source>
         <translation>minutos</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="962"/>
-        <location filename="../PowerHist.cpp" line="975"/>
+        <location filename="../PowerHist.cpp" line="1000"/>
+        <location filename="../PowerHist.cpp" line="1013"/>
         <source>%</source>
         <translation>%</translation>
     </message>
@@ -6153,27 +6165,27 @@ e que o ecr? exibe &quot;Host&quot;</translation>
 <context>
     <name>ProcessorPage</name>
     <message>
-        <location filename="../Pages.cpp" line="2198"/>
+        <location filename="../Pages.cpp" line="2200"/>
         <source>Processor</source>
         <translation>Processador</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2199"/>
+        <location filename="../Pages.cpp" line="2201"/>
         <source>Apply</source>
         <translation>Aplicar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2200"/>
+        <location filename="../Pages.cpp" line="2202"/>
         <source>Settings</source>
         <translation>Configura??es</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2224"/>
+        <location filename="../Pages.cpp" line="2226"/>
         <source>Manual</source>
         <translation>Manual</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2225"/>
+        <location filename="../Pages.cpp" line="2227"/>
         <source>Auto</source>
         <translation>Autom?tco</translation>
     </message>
@@ -6583,7 +6595,7 @@ e que o ecr? exibe &quot;Host&quot;</translation>
 <context>
     <name>RelativeIntensity</name>
     <message>
-        <location filename="../BikeScore.cpp" line="136"/>
+        <location filename="../BikeScore.cpp" line="147"/>
         <source>Relative Intensity</source>
         <translation>Intensidade relativa</translation>
     </message>
@@ -6591,7 +6603,7 @@ e que o ecr? exibe &quot;Host&quot;</translation>
 <context>
     <name>ResponseIndex</name>
     <message>
-        <location filename="../BikeScore.cpp" line="218"/>
+        <location filename="../BikeScore.cpp" line="237"/>
         <source>Response Index</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6606,7 +6618,7 @@ e que o ecr? exibe &quot;Host&quot;</translation>
 <context>
     <name>RideCount</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="34"/>
+        <location filename="../BasicRideMetrics.cpp" line="37"/>
         <source>Rides</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6614,9 +6626,9 @@ e que o ecr? exibe &quot;Host&quot;</translation>
 <context>
     <name>RideDelegate</name>
     <message>
-        <location filename="../RideImportWizard.cpp" line="995"/>
-        <location filename="../RideImportWizard.cpp" line="1032"/>
-        <location filename="../RideImportWizard.cpp" line="1048"/>
+        <location filename="../RideImportWizard.cpp" line="998"/>
+        <location filename="../RideImportWizard.cpp" line="1035"/>
+        <location filename="../RideImportWizard.cpp" line="1051"/>
         <source>dd MMM yyyy</source>
         <translation>dd MMM yyyy</translation>
     </message>
@@ -7174,9 +7186,9 @@ e que o ecr? exibe &quot;Host&quot;</translation>
     </message>
     <message>
         <location filename="../RideImportWizard.cpp" line="74"/>
-        <location filename="../RideImportWizard.cpp" line="696"/>
-        <location filename="../RideImportWizard.cpp" line="738"/>
-        <location filename="../RideImportWizard.cpp" line="890"/>
+        <location filename="../RideImportWizard.cpp" line="699"/>
+        <location filename="../RideImportWizard.cpp" line="741"/>
+        <location filename="../RideImportWizard.cpp" line="893"/>
         <source>Abort</source>
         <translation>Abortar</translation>
     </message>
@@ -7247,12 +7259,12 @@ e que o ecr? exibe &quot;Host&quot;</translation>
     </message>
     <message>
         <location filename="../RideImportWizard.cpp" line="268"/>
-        <location filename="../RideImportWizard.cpp" line="454"/>
-        <location filename="../RideImportWizard.cpp" line="506"/>
-        <location filename="../RideImportWizard.cpp" line="717"/>
-        <location filename="../RideImportWizard.cpp" line="756"/>
-        <location filename="../RideImportWizard.cpp" line="895"/>
-        <location filename="../RideImportWizard.cpp" line="918"/>
+        <location filename="../RideImportWizard.cpp" line="457"/>
+        <location filename="../RideImportWizard.cpp" line="509"/>
+        <location filename="../RideImportWizard.cpp" line="720"/>
+        <location filename="../RideImportWizard.cpp" line="759"/>
+        <location filename="../RideImportWizard.cpp" line="898"/>
+        <location filename="../RideImportWizard.cpp" line="921"/>
         <source>Error</source>
         <translation>Erro</translation>
     </message>
@@ -7262,157 +7274,157 @@ e que o ecr? exibe &quot;Host&quot;</translation>
         <translation>A analisar...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="378"/>
+        <location filename="../RideImportWizard.cpp" line="381"/>
         <source>Validated</source>
         <translation>Validar</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="380"/>
+        <location filename="../RideImportWizard.cpp" line="383"/>
         <source>Warning - </source>
         <translation>AVISO - </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="380"/>
-        <location filename="../RideImportWizard.cpp" line="432"/>
+        <location filename="../RideImportWizard.cpp" line="383"/>
+        <location filename="../RideImportWizard.cpp" line="435"/>
         <source> </source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="394"/>
-        <location filename="../RideImportWizard.cpp" line="619"/>
-        <location filename="../RideImportWizard.cpp" line="765"/>
+        <location filename="../RideImportWizard.cpp" line="397"/>
+        <location filename="../RideImportWizard.cpp" line="622"/>
+        <location filename="../RideImportWizard.cpp" line="768"/>
         <source>dd MMM yyyy</source>
         <translation>dd MMM yyyy</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="395"/>
+        <location filename="../RideImportWizard.cpp" line="398"/>
         <source>hh:mm:ss ap</source>
         <translation>hh:mm:ss ap</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="432"/>
+        <location filename="../RideImportWizard.cpp" line="435"/>
         <source>Error - </source>
         <translation>Erro - </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="447"/>
+        <location filename="../RideImportWizard.cpp" line="450"/>
         <source>Step 3 of 4: Confirm Date and Time</source>
         <translation>Passo 3 de 5: A confirmar data e tempo</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="464"/>
+        <location filename="../RideImportWizard.cpp" line="467"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="573"/>
-        <location filename="../RideImportWizard.cpp" line="623"/>
+        <location filename="../RideImportWizard.cpp" line="576"/>
+        <location filename="../RideImportWizard.cpp" line="626"/>
         <source>hh:mm:ss</source>
         <translation>hh:mm:ss</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="582"/>
+        <location filename="../RideImportWizard.cpp" line="585"/>
         <source>Invalid Selection</source>
         <translation>Sele??o inv?lida</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="582"/>
+        <location filename="../RideImportWizard.cpp" line="585"/>
         <source>More than 24hrs of rides to fit into a day</source>
         <translation>Mais de 24 horas de percurso para caber num dia</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="627"/>
-        <location filename="../RideImportWizard.cpp" line="766"/>
+        <location filename="../RideImportWizard.cpp" line="630"/>
+        <location filename="../RideImportWizard.cpp" line="769"/>
         <source>hh:mm:ss a</source>
         <translation>hh:mm:ss a</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="704"/>
-        <location filename="../RideImportWizard.cpp" line="928"/>
+        <location filename="../RideImportWizard.cpp" line="707"/>
+        <location filename="../RideImportWizard.cpp" line="931"/>
         <source>Finish</source>
         <translation>Acabar</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="736"/>
+        <location filename="../RideImportWizard.cpp" line="739"/>
         <source>Step 4 of 4: Save to Library</source>
         <translation>Passo 4 de 5: Guardar para a biblioteca</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="758"/>
+        <location filename="../RideImportWizard.cpp" line="761"/>
         <source>Saving...</source>
         <translation>A guardar...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="790"/>
-        <location filename="../RideImportWizard.cpp" line="862"/>
+        <location filename="../RideImportWizard.cpp" line="793"/>
+        <location filename="../RideImportWizard.cpp" line="865"/>
         <source>Error - File exists</source>
         <translation>Erro - Ficheiro j? existe</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="821"/>
-        <location filename="../RideImportWizard.cpp" line="854"/>
+        <location filename="../RideImportWizard.cpp" line="824"/>
+        <location filename="../RideImportWizard.cpp" line="857"/>
         <source>File Overwritten</source>
         <translation>Ficheiro foi reescrito</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="823"/>
-        <location filename="../RideImportWizard.cpp" line="868"/>
+        <location filename="../RideImportWizard.cpp" line="826"/>
+        <location filename="../RideImportWizard.cpp" line="871"/>
         <source>File Saved</source>
         <translation>Ficheiro guardado</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="834"/>
+        <location filename="../RideImportWizard.cpp" line="837"/>
         <source>Error - Source is Target</source>
         <translation>Erro - fonte ? alvo</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="845"/>
+        <location filename="../RideImportWizard.cpp" line="848"/>
         <source>Overwriting file...</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="847"/>
+        <location filename="../RideImportWizard.cpp" line="850"/>
         <source>/</source>
         <translation>/</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="847"/>
+        <location filename="../RideImportWizard.cpp" line="850"/>
         <source>.tmp</source>
         <translation>.tmp</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="857"/>
-        <location filename="../RideImportWizard.cpp" line="859"/>
+        <location filename="../RideImportWizard.cpp" line="860"/>
+        <location filename="../RideImportWizard.cpp" line="862"/>
         <source>Error - overwrite failed</source>
         <translation>Erro - sobresrever falhou</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="865"/>
+        <location filename="../RideImportWizard.cpp" line="868"/>
         <source>Saving file...</source>
         <translation>A guardar ficheiro...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="877"/>
+        <location filename="../RideImportWizard.cpp" line="880"/>
         <source>Error - copy failed</source>
         <translation>Erro - copiar falhou</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="888"/>
+        <location filename="../RideImportWizard.cpp" line="891"/>
         <source>Step 5 of 5: Calculating Critical Powers</source>
         <translation>Passo 5 de 5: A calcular pot?ncias cr?ticas</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="896"/>
+        <location filename="../RideImportWizard.cpp" line="899"/>
         <source>Calculating...</source>
         <translation>A calcular...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="905"/>
+        <location filename="../RideImportWizard.cpp" line="908"/>
         <source>Completed.</source>
         <translation>Conclu?do.</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="923"/>
+        <location filename="../RideImportWizard.cpp" line="926"/>
         <source>Import Complete. %1 of %2 successful.</source>
         <translation>Importa??o est? completo. %1 a %2 bem sucedido.</translation>
     </message>
@@ -7420,22 +7432,22 @@ e que o ecr? exibe &quot;Host&quot;</translation>
 <context>
     <name>RideNavigator</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="540"/>
+        <location filename="../RideNavigator.cpp" line="542"/>
         <source>Remove Column</source>
         <translation type="unfinished">Remover coluna</translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="546"/>
+        <location filename="../RideNavigator.cpp" line="548"/>
         <source>Column Chooser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="551"/>
+        <location filename="../RideNavigator.cpp" line="553"/>
         <source>Do Not Show in Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="551"/>
+        <location filename="../RideNavigator.cpp" line="553"/>
         <source>Show In Groups</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7816,32 +7828,32 @@ Quer continuar?</translation>
 <context>
     <name>SchemePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2295"/>
+        <location filename="../Pages.cpp" line="2297"/>
         <source>Add</source>
         <translation>Adicionar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2296"/>
+        <location filename="../Pages.cpp" line="2298"/>
         <source>Rename</source>
         <translation>Renomear</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2297"/>
+        <location filename="../Pages.cpp" line="2299"/>
         <source>Delete</source>
         <translation>Apagar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2306"/>
+        <location filename="../Pages.cpp" line="2308"/>
         <source>Short</source>
         <translation>Curto</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2307"/>
+        <location filename="../Pages.cpp" line="2309"/>
         <source>Long</source>
         <translation>Comprido</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2308"/>
+        <location filename="../Pages.cpp" line="2310"/>
         <source>Percent of CP</source>
         <translation>Percentagem do CP</translation>
     </message>
@@ -7926,42 +7938,42 @@ Quer continuar?</translation>
 <context>
     <name>SeasonsPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3673"/>
+        <location filename="../Pages.cpp" line="3675"/>
         <source>Move up</source>
         <translation type="unfinished">Mover para cima</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3674"/>
+        <location filename="../Pages.cpp" line="3676"/>
         <source>Move down</source>
         <translation type="unfinished">Mover para baixo</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3675"/>
+        <location filename="../Pages.cpp" line="3677"/>
         <source>Add</source>
         <translation type="unfinished">Adicionar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3676"/>
+        <location filename="../Pages.cpp" line="3678"/>
         <source>Delete</source>
         <translation type="unfinished">Apagar</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3685"/>
+        <location filename="../Pages.cpp" line="3687"/>
         <source>Name</source>
         <translation type="unfinished">Nome</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3686"/>
+        <location filename="../Pages.cpp" line="3688"/>
         <source>Type</source>
         <translation type="unfinished">Tipo</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3687"/>
+        <location filename="../Pages.cpp" line="3689"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3688"/>
+        <location filename="../Pages.cpp" line="3690"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7969,7 +7981,7 @@ Quer continuar?</translation>
 <context>
     <name>SessionRPE</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="302"/>
+        <location filename="../TRIMPPoints.cpp" line="316"/>
         <source>Session RPE</source>
         <translation type="unfinished">Sess?o RPE</translation>
     </message>
@@ -8001,91 +8013,142 @@ Quer continuar?</translation>
 <context>
     <name>SpecialFields</name>
     <message>
+        <location filename="../SpecialFields.cpp" line="26"/>
         <source>Start Date</source>
-        <translation type="obsolete">Data de in?cio</translation>
+        <translation type="unfinished">Data de in?cio</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="27"/>
         <source>Start Time</source>
-        <translation type="obsolete">Tempo de in?cio</translation>
+        <translation type="unfinished">Tempo de in?cio</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="28"/>
+        <source>Identifier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="29"/>
         <source>Workout Code</source>
-        <translation type="obsolete">C?digo do treino</translation>
+        <translation type="unfinished">C?digo do treino</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="30"/>
         <source>Sport</source>
-        <translation type="obsolete">Desporto</translation>
+        <translation type="unfinished">Desporto</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="31"/>
         <source>Objective</source>
-        <translation type="obsolete">Objectivo</translation>
+        <translation type="unfinished">Objectivo</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="32"/>
+        <source>Summary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="33"/>
         <source>Notes</source>
-        <translation type="obsolete">Notas</translation>
+        <translation type="unfinished">Notas</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="34"/>
         <source>Keywords</source>
-        <translation type="obsolete">Palavra-chave</translation>
+        <translation type="unfinished">Palavra-chave</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="35"/>
         <source>Recording Interval</source>
-        <translation type="obsolete">Intervalo de grava??o</translation>
+        <translation type="unfinished">Intervalo de grava??o</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="36"/>
         <source>Weight</source>
-        <translation type="obsolete">Peso</translation>
+        <translation type="unfinished">Peso</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="37"/>
         <source>Device</source>
-        <translation type="obsolete">Dispositivo</translation>
+        <translation type="unfinished">Dispositivo</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="38"/>
         <source>Device Info</source>
-        <translation type="obsolete">Informa??es sobre o dispositivo</translation>
+        <translation type="unfinished">Informa??es sobre o dispositivo</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="39"/>
         <source>Dropouts</source>
-        <translation type="obsolete">Desist?ncia</translation>
+        <translation type="unfinished">Desist?ncia</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="40"/>
         <source>Dropout Time</source>
-        <translation type="obsolete">Dura??o da desist?ncia</translation>
+        <translation type="unfinished">Dura??o da desist?ncia</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="41"/>
         <source>Spikes</source>
-        <translation type="obsolete">Picos</translation>
+        <translation type="unfinished">Picos</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="42"/>
         <source>Spike Time</source>
-        <translation type="obsolete">Dura??o do pico</translation>
+        <translation type="unfinished">Dura??o do pico</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="43"/>
         <source>Torque Adjust</source>
-        <translation type="obsolete">Ajustamento de torque</translation>
+        <translation type="unfinished">Ajustamento de torque</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="44"/>
         <source>Filename</source>
-        <translation type="obsolete">Nome do Ficheiro</translation>
+        <translation type="unfinished">Nome do Ficheiro</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="45"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="46"/>
         <source>Change History</source>
-        <translation type="obsolete">Modificar a hist?ria</translation>
+        <translation type="unfinished">Modificar a hist?ria</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="47"/>
+        <source>Calendar Text</source>
+        <translation type="unfinished">Texto no calend?rio</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="48"/>
+        <source>Data</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>SpecialTabs</name>
     <message>
+        <location filename="../SpecialFields.cpp" line="130"/>
         <source>Workout</source>
-        <translation type="obsolete">Treino</translation>
+        <translation type="unfinished">Treino</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="131"/>
         <source>Notes</source>
-        <translation type="obsolete">Notas</translation>
+        <translation type="unfinished">Notas</translation>
     </message>
     <message>
+        <location filename="../SpecialFields.cpp" line="132"/>
         <source>Metric</source>
-        <translation type="obsolete">M?trico</translation>
+        <translation type="unfinished">M?trico</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="133"/>
+        <source>Extra</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -8502,22 +8565,22 @@ Quer continuar?</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="388"/>
+        <location filename="../StravaDialog.cpp" line="389"/>
         <source>Upload ride... Sending</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="398"/>
+        <location filename="../StravaDialog.cpp" line="399"/>
         <source>Upload finished.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="430"/>
+        <location filename="../StravaDialog.cpp" line="431"/>
         <source>Ride processing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="501"/>
+        <location filename="../StravaDialog.cpp" line="502"/>
         <source>Searching corresponding Ride</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8786,7 +8849,7 @@ Quer continuar?</translation>
 <context>
     <name>TRIMP100Points</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="114"/>
+        <location filename="../TRIMPPoints.cpp" line="120"/>
         <source>TRIMP(100) Points</source>
         <translation>TRIMP(100) Pontos</translation>
     </message>
@@ -8794,7 +8857,7 @@ Quer continuar?</translation>
 <context>
     <name>TRIMPPoints</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="47"/>
+        <location filename="../TRIMPPoints.cpp" line="49"/>
         <source>TRIMP Points</source>
         <translation>TRIMP pontos</translation>
     </message>
@@ -8806,7 +8869,7 @@ Quer continuar?</translation>
 <context>
     <name>TRIMPZonalPoints</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="180"/>
+        <location filename="../TRIMPPoints.cpp" line="190"/>
         <source>TRIMP Zonal Points</source>
         <translation>TRIMP pontos zonal</translation>
     </message>
@@ -8814,13 +8877,13 @@ Quer continuar?</translation>
 <context>
     <name>TimeRiding</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="94"/>
+        <location filename="../BasicRideMetrics.cpp" line="105"/>
         <source>Time Riding</source>
         <translation>Dura??o do percurso</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="95"/>
-        <location filename="../BasicRideMetrics.cpp" line="96"/>
+        <location filename="../BasicRideMetrics.cpp" line="106"/>
+        <location filename="../BasicRideMetrics.cpp" line="107"/>
         <source>seconds</source>
         <translation>segundos</translation>
     </message>
@@ -8904,17 +8967,17 @@ Quer continuar?</translation>
 <context>
     <name>TotalDistance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="129"/>
+        <location filename="../BasicRideMetrics.cpp" line="144"/>
         <source>Distance</source>
         <translation>Dist?ncia</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="131"/>
+        <location filename="../BasicRideMetrics.cpp" line="146"/>
         <source>km</source>
         <translation>km</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="132"/>
+        <location filename="../BasicRideMetrics.cpp" line="147"/>
         <source>miles</source>
         <translation>milhas</translation>
     </message>
@@ -8922,13 +8985,13 @@ Quer continuar?</translation>
 <context>
     <name>TotalWork</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="213"/>
+        <location filename="../BasicRideMetrics.cpp" line="236"/>
         <source>Work</source>
         <translation>Trabalho</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="214"/>
-        <location filename="../BasicRideMetrics.cpp" line="215"/>
+        <location filename="../BasicRideMetrics.cpp" line="237"/>
+        <location filename="../BasicRideMetrics.cpp" line="238"/>
         <source>kJ</source>
         <translation>kJ</translation>
     </message>
@@ -9002,6 +9065,14 @@ Press F3 on Controller when done.</source>
         <location filename="../TrainTool.cpp" line="1279"/>
         <source>Done</source>
         <translation type="unfinished">Conclu?do</translation>
+    </message>
+</context>
+<context>
+    <name>TreeMapWindow</name>
+    <message>
+        <location filename="../TreeMapWindow.cpp" line="100"/>
+        <source>Metric</source>
+        <translation type="unfinished">M?trico</translation>
     </message>
 </context>
 <context>
@@ -9296,7 +9367,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>VAM</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="722"/>
+        <location filename="../BasicRideMetrics.cpp" line="811"/>
         <source>VAM</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9304,7 +9375,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>VariabilityIndex</name>
     <message>
-        <location filename="../BikeScore.cpp" line="102"/>
+        <location filename="../BikeScore.cpp" line="109"/>
         <source>Skiba VI</source>
         <translation>Skiba VI</translation>
     </message>
@@ -9336,13 +9407,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>Vo2max</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="252"/>
+        <location filename="../WattsPerKilogram.cpp" line="308"/>
         <source>Estimated VO2MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="254"/>
-        <location filename="../WattsPerKilogram.cpp" line="255"/>
+        <location filename="../WattsPerKilogram.cpp" line="310"/>
+        <location filename="../WattsPerKilogram.cpp" line="311"/>
         <source>ml/min/kg</source>
         <translation type="unfinished"></translation>
     </message>
@@ -9488,13 +9559,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WorkoutTime</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="60"/>
+        <location filename="../BasicRideMetrics.cpp" line="67"/>
         <source>Duration</source>
         <translation>Dura??o</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="61"/>
-        <location filename="../BasicRideMetrics.cpp" line="62"/>
+        <location filename="../BasicRideMetrics.cpp" line="68"/>
+        <location filename="../BasicRideMetrics.cpp" line="69"/>
         <source>seconds</source>
         <translation>segundos</translation>
     </message>
@@ -9530,13 +9601,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>XPower</name>
     <message>
-        <location filename="../BikeScore.cpp" line="45"/>
+        <location filename="../BikeScore.cpp" line="48"/>
         <source>xPower</source>
         <translation>xPot?ncia</translation>
     </message>
     <message>
-        <location filename="../BikeScore.cpp" line="47"/>
-        <location filename="../BikeScore.cpp" line="48"/>
+        <location filename="../BikeScore.cpp" line="50"/>
+        <location filename="../BikeScore.cpp" line="51"/>
         <source>watts</source>
         <translation>watts</translation>
     </message>
@@ -9559,12 +9630,12 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZonePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2278"/>
+        <location filename="../Pages.cpp" line="2280"/>
         <source>Critical Power History</source>
         <translation>Hist?ria da pot?ncia cr?tica</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2279"/>
+        <location filename="../Pages.cpp" line="2281"/>
         <source>Default Zones</source>
         <translation>Zonas padr?o</translation>
     </message>
@@ -9572,7 +9643,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime1</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="74"/>
+        <location filename="../TimeInZone.cpp" line="79"/>
         <source>L1 Time in Zone</source>
         <translation>L1 Tempo na zona</translation>
     </message>
@@ -9580,7 +9651,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime10</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="182"/>
+        <location filename="../TimeInZone.cpp" line="232"/>
         <source>L10 Time in Zone</source>
         <translation>L10 Tempo na zona</translation>
     </message>
@@ -9588,7 +9659,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime2</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="86"/>
+        <location filename="../TimeInZone.cpp" line="96"/>
         <source>L2 Time in Zone</source>
         <translation>L2 Tempo na zona</translation>
     </message>
@@ -9596,7 +9667,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime3</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="98"/>
+        <location filename="../TimeInZone.cpp" line="113"/>
         <source>L3 Time in Zone</source>
         <translation>L3 Tempo na zona</translation>
     </message>
@@ -9604,7 +9675,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime4</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="110"/>
+        <location filename="../TimeInZone.cpp" line="130"/>
         <source>L4 Time in Zone</source>
         <translation>L4 Tempo na zona</translation>
     </message>
@@ -9612,7 +9683,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime5</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="122"/>
+        <location filename="../TimeInZone.cpp" line="147"/>
         <source>L5 Time in Zone</source>
         <translation>L5 Tempo na zona</translation>
     </message>
@@ -9620,7 +9691,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime6</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="134"/>
+        <location filename="../TimeInZone.cpp" line="164"/>
         <source>L6 Time in Zone</source>
         <translation>L6 Tempo na zona</translation>
     </message>
@@ -9628,7 +9699,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime7</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="146"/>
+        <location filename="../TimeInZone.cpp" line="181"/>
         <source>L7 Time in Zone</source>
         <translation>L7 Tempo na zona</translation>
     </message>
@@ -9636,7 +9707,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime8</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="158"/>
+        <location filename="../TimeInZone.cpp" line="198"/>
         <source>L8 Time in Zone</source>
         <translation>L8 Tempo na zona</translation>
     </message>
@@ -9644,7 +9715,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime9</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="170"/>
+        <location filename="../TimeInZone.cpp" line="215"/>
         <source>L9 Time in Zone</source>
         <translation>L9 Tempo na zona</translation>
     </message>

--- a/src/translations/gc_ru.ts
+++ b/src/translations/gc_ru.ts
@@ -254,13 +254,13 @@
 <context>
     <name>AerobicDecoupling</name>
     <message>
-        <location filename="../AerobicDecoupling.cpp" line="50"/>
+        <location filename="../AerobicDecoupling.cpp" line="52"/>
         <source>Aerobic Decoupling</source>
         <translation>Aerobic Decoupling</translation>
     </message>
     <message>
-        <location filename="../AerobicDecoupling.cpp" line="52"/>
-        <location filename="../AerobicDecoupling.cpp" line="53"/>
+        <location filename="../AerobicDecoupling.cpp" line="54"/>
+        <location filename="../AerobicDecoupling.cpp" line="55"/>
         <source>%</source>
         <translation>%</translation>
     </message>
@@ -394,42 +394,42 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="916"/>
+        <location filename="../AllPlot.cpp" line="909"/>
         <source>KPH</source>
         <translation>км/ч</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="916"/>
+        <location filename="../AllPlot.cpp" line="909"/>
         <source>MPH</source>
         <translation>миль/ч</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="932"/>
+        <location filename="../AllPlot.cpp" line="925"/>
         <source>Nm</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="932"/>
+        <location filename="../AllPlot.cpp" line="925"/>
         <source>ftLb</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="945"/>
+        <location filename="../AllPlot.cpp" line="938"/>
         <source>Meters</source>
         <translation>Метры</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="945"/>
+        <location filename="../AllPlot.cpp" line="938"/>
         <source>Feet</source>
         <translation>Футы</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="971"/>
+        <location filename="../AllPlot.cpp" line="981"/>
         <source>Distance </source>
         <translation>Дистанция</translation>
     </message>
     <message>
-        <location filename="../AllPlot.cpp" line="973"/>
+        <location filename="../AllPlot.cpp" line="983"/>
         <source>Time (Hours:Minutes)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -559,13 +559,13 @@
 <context>
     <name>AverageWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="55"/>
+        <location filename="../WattsPerKilogram.cpp" line="58"/>
         <source>Watts Per Kilogram</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="57"/>
-        <location filename="../WattsPerKilogram.cpp" line="58"/>
+        <location filename="../WattsPerKilogram.cpp" line="60"/>
+        <location filename="../WattsPerKilogram.cpp" line="61"/>
         <source>wpk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -573,13 +573,13 @@
 <context>
     <name>AvgCadence</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="433"/>
+        <location filename="../BasicRideMetrics.cpp" line="488"/>
         <source>Average Cadence</source>
         <translation>Средний каденс</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="434"/>
-        <location filename="../BasicRideMetrics.cpp" line="435"/>
+        <location filename="../BasicRideMetrics.cpp" line="489"/>
+        <location filename="../BasicRideMetrics.cpp" line="490"/>
         <source>rpm</source>
         <translation>об/мин</translation>
     </message>
@@ -587,13 +587,13 @@
 <context>
     <name>AvgHeartRate</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="399"/>
+        <location filename="../BasicRideMetrics.cpp" line="448"/>
         <source>Average Heart Rate</source>
         <translation>Средняя ЧСС</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="400"/>
-        <location filename="../BasicRideMetrics.cpp" line="401"/>
+        <location filename="../BasicRideMetrics.cpp" line="449"/>
+        <location filename="../BasicRideMetrics.cpp" line="450"/>
         <source>bpm</source>
         <translation>уд/мин</translation>
     </message>
@@ -601,13 +601,13 @@
 <context>
     <name>AvgPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="331"/>
+        <location filename="../BasicRideMetrics.cpp" line="368"/>
         <source>Average Power</source>
         <translation>Средняя мощность</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="332"/>
-        <location filename="../BasicRideMetrics.cpp" line="333"/>
+        <location filename="../BasicRideMetrics.cpp" line="369"/>
+        <location filename="../BasicRideMetrics.cpp" line="370"/>
         <source>watts</source>
         <translation>ватт</translation>
     </message>
@@ -615,17 +615,17 @@
 <context>
     <name>AvgSpeed</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="244"/>
+        <location filename="../BasicRideMetrics.cpp" line="271"/>
         <source>Average Speed</source>
         <translation>Средняя скорость</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="245"/>
+        <location filename="../BasicRideMetrics.cpp" line="272"/>
         <source>kph</source>
         <translation>км/ч</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="246"/>
+        <location filename="../BasicRideMetrics.cpp" line="273"/>
         <source>mph</source>
         <translation>миль/ч</translation>
     </message>
@@ -633,17 +633,17 @@
 <context>
     <name>AvgTemp</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="467"/>
+        <location filename="../BasicRideMetrics.cpp" line="528"/>
         <source>Average Temp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="468"/>
+        <location filename="../BasicRideMetrics.cpp" line="529"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="469"/>
+        <location filename="../BasicRideMetrics.cpp" line="530"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
@@ -747,7 +747,7 @@
 <context>
     <name>BikeScore</name>
     <message>
-        <location filename="../BikeScore.cpp" line="181"/>
+        <location filename="../BikeScore.cpp" line="196"/>
         <source>BikeScore&amp;#8482;</source>
         <translation>BikeScore&amp;#8482;</translation>
     </message>
@@ -755,54 +755,54 @@
 <context>
     <name>CPPage</name>
     <message>
-        <location filename="../Pages.cpp" line="2455"/>
+        <location filename="../Pages.cpp" line="2457"/>
         <source>Add CP</source>
         <translation>Добавить CP</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2456"/>
+        <location filename="../Pages.cpp" line="2458"/>
         <source>Delete CP</source>
         <translation>Удалить CP</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2457"/>
+        <location filename="../Pages.cpp" line="2459"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2460"/>
+        <location filename="../Pages.cpp" line="2462"/>
         <source>Add Zone</source>
         <translation>Добавить уровень</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2461"/>
+        <location filename="../Pages.cpp" line="2463"/>
         <source>Delete Zone</source>
         <translation>Удалить уровень</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2475"/>
-        <location filename="../Pages.cpp" line="2493"/>
+        <location filename="../Pages.cpp" line="2477"/>
+        <location filename="../Pages.cpp" line="2495"/>
         <source>From Date</source>
         <translation>От даты</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2476"/>
-        <location filename="../Pages.cpp" line="2494"/>
+        <location filename="../Pages.cpp" line="2478"/>
+        <location filename="../Pages.cpp" line="2496"/>
         <source>Critical Power</source>
         <translation>Критическая мощность (CP)</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2523"/>
+        <location filename="../Pages.cpp" line="2525"/>
         <source>Short</source>
         <translation>Краткое</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2524"/>
+        <location filename="../Pages.cpp" line="2526"/>
         <source>Long</source>
         <translation>Полное </translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2525"/>
+        <location filename="../Pages.cpp" line="2527"/>
         <source>From Watts</source>
         <translation>От ватт</translation>
     </message>
@@ -810,7 +810,7 @@
 <context>
     <name>CPWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="120"/>
+        <location filename="../WattsPerKilogram.cpp" line="128"/>
         <source>60 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -905,7 +905,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../ChartSettings.cpp" line="42"/>
+        <location filename="../ChartSettings.cpp" line="41"/>
         <source>Done</source>
         <translation type="unfinished">Готово</translation>
     </message>
@@ -1485,7 +1485,7 @@ This may take a while.
 <context>
     <name>CriticalPower</name>
     <message>
-        <location filename="../PeakPower.cpp" line="63"/>
+        <location filename="../PeakPower.cpp" line="67"/>
         <source>60 min Peak Power</source>
         <translation>Пиковая мощность за 60 минут</translation>
     </message>
@@ -1637,12 +1637,12 @@ This may take a while.
 <context>
     <name>DBAccess</name>
     <message>
-        <location filename="../DBAccess.cpp" line="112"/>
+        <location filename="../DBAccess.cpp" line="113"/>
         <source>Cannot open database</source>
         <translation>Невозможно открыть базу данных</translation>
     </message>
     <message>
-        <location filename="../DBAccess.cpp" line="113"/>
+        <location filename="../DBAccess.cpp" line="114"/>
         <source>Unable to establish a database connection.
 This feature requires SQLite support. Please read the Qt SQL driver documentation for information how to build it.
 
@@ -1656,13 +1656,13 @@ Click Cancel to exit.</source>
 <context>
     <name>DanielsEquivalentPower</name>
     <message>
-        <location filename="../DanielsPoints.cpp" line="110"/>
+        <location filename="../DanielsPoints.cpp" line="116"/>
         <source>Daniels EqP</source>
         <translation>Daniels EqP</translation>
     </message>
     <message>
-        <location filename="../DanielsPoints.cpp" line="111"/>
-        <location filename="../DanielsPoints.cpp" line="112"/>
+        <location filename="../DanielsPoints.cpp" line="117"/>
+        <location filename="../DanielsPoints.cpp" line="118"/>
         <source>watts</source>
         <translation>ватт</translation>
     </message>
@@ -1670,7 +1670,7 @@ Click Cancel to exit.</source>
 <context>
     <name>DanielsPoints</name>
     <message>
-        <location filename="../DanielsPoints.cpp" line="49"/>
+        <location filename="../DanielsPoints.cpp" line="51"/>
         <source>Daniels Points</source>
         <translation>Daniels Points</translation>
     </message>
@@ -1975,52 +1975,17 @@ then click &quot;Rescan&quot; to check again.</source>
 <context>
     <name>EditMetricDetailDialog</name>
     <message>
-        <location filename="../LTMTool.cpp" line="638"/>
+        <location filename="../LTMTool.cpp" line="701"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="662"/>
-        <source>Filter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="664"/>
-        <source>No filter</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="665"/>
-        <source>Include</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="666"/>
-        <source>Exclude</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="668"/>
-        <source>From</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="673"/>
-        <source>To</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="678"/>
-        <source>Show on plot</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../LTMTool.cpp" line="780"/>
+        <location filename="../LTMTool.cpp" line="814"/>
         <source>&amp;OK</source>
         <translation>&amp;ОК</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="781"/>
+        <location filename="../LTMTool.cpp" line="815"/>
         <source>&amp;Cancel</source>
         <translation>&amp;Отмена</translation>
     </message>
@@ -2064,7 +2029,7 @@ then click &quot;Rescan&quot; to check again.</source>
 <context>
     <name>EfficiencyFactor</name>
     <message>
-        <location filename="../Coggan.cpp" line="198"/>
+        <location filename="../Coggan.cpp" line="217"/>
         <source>Efficiency Factor</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2072,17 +2037,17 @@ then click &quot;Rescan&quot; to check again.</source>
 <context>
     <name>ElevationGain</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="170"/>
+        <location filename="../BasicRideMetrics.cpp" line="189"/>
         <source>Elevation Gain</source>
         <translation>Набор высоты</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="172"/>
+        <location filename="../BasicRideMetrics.cpp" line="191"/>
         <source>meters</source>
         <translation>метров</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="173"/>
+        <location filename="../BasicRideMetrics.cpp" line="192"/>
         <source>feet</source>
         <translation>футов</translation>
     </message>
@@ -2349,7 +2314,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>FormField</name>
     <message>
-        <location filename="../RideMetadata.cpp" line="545"/>
+        <location filename="../RideMetadata.cpp" line="546"/>
         <source>You entered &apos;%1&apos; which is not an expected value.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2447,7 +2412,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>Gradient</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="758"/>
+        <location filename="../BasicRideMetrics.cpp" line="851"/>
         <source>Gradient</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2463,7 +2428,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>GroupByModel</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="724"/>
+        <location filename="../RideNavigator.cpp" line="726"/>
         <source>Date</source>
         <translation type="unfinished">Дата</translation>
     </message>
@@ -2546,12 +2511,12 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HomeWindow</name>
     <message>
-        <location filename="../HomeWindow.cpp" line="712"/>
+        <location filename="../HomeWindow.cpp" line="713"/>
         <source>Are you sure you want to remove the chart?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../HomeWindow.cpp" line="713"/>
+        <location filename="../HomeWindow.cpp" line="714"/>
         <source>Remove</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2595,38 +2560,38 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrSchemePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2826"/>
+        <location filename="../Pages.cpp" line="2828"/>
         <source>Add</source>
         <translation>Добавить</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2827"/>
+        <location filename="../Pages.cpp" line="2829"/>
         <source>Rename</source>
         <translation>Переименовать</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2828"/>
+        <location filename="../Pages.cpp" line="2830"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2837"/>
+        <location filename="../Pages.cpp" line="2839"/>
         <source>Short</source>
         <translation>Краткое</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2838"/>
+        <location filename="../Pages.cpp" line="2840"/>
         <source>Long</source>
         <translation>Полное</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2839"/>
+        <location filename="../Pages.cpp" line="2841"/>
         <source>Percent of LT</source>
         <translatorcomment>いまいち</translatorcomment>
         <translation>Процент от ЛП</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2840"/>
+        <location filename="../Pages.cpp" line="2842"/>
         <source>Trimp k</source>
         <translatorcomment>でいいのかな？</translatorcomment>
         <translation>TRIMP k</translation>
@@ -2635,12 +2600,12 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZonePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2809"/>
+        <location filename="../Pages.cpp" line="2811"/>
         <source>Lactic Threshold History</source>
         <translation>История лактатного порога</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2810"/>
+        <location filename="../Pages.cpp" line="2812"/>
         <source>Default Zones</source>
         <translation>Уровни по умолчанию</translation>
     </message>
@@ -2648,7 +2613,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime1</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="72"/>
+        <location filename="../HrTimeInZone.cpp" line="77"/>
         <source>H1 Time in Zone</source>
         <translation>Время на уровне H1</translation>
     </message>
@@ -2656,7 +2621,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime2</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="84"/>
+        <location filename="../HrTimeInZone.cpp" line="94"/>
         <source>H2 Time in Zone</source>
         <translation>Время на уровне H2</translation>
     </message>
@@ -2664,7 +2629,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime3</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="96"/>
+        <location filename="../HrTimeInZone.cpp" line="111"/>
         <source>H3 Time in Zone</source>
         <translation>Время на уровне H3</translation>
     </message>
@@ -2672,7 +2637,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime4</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="108"/>
+        <location filename="../HrTimeInZone.cpp" line="128"/>
         <source>H4 Time in Zone</source>
         <translation>Время на уровне H4</translation>
     </message>
@@ -2680,7 +2645,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime5</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="120"/>
+        <location filename="../HrTimeInZone.cpp" line="145"/>
         <source>H5 Time in Zone</source>
         <translation>Время на уровне H5</translation>
     </message>
@@ -2688,7 +2653,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime6</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="132"/>
+        <location filename="../HrTimeInZone.cpp" line="162"/>
         <source>H6 Time in Zone</source>
         <translation>Время на уровне H6</translation>
     </message>
@@ -2696,7 +2661,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime7</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="144"/>
+        <location filename="../HrTimeInZone.cpp" line="179"/>
         <source>H7 Time in Zone</source>
         <translation>Время на уровне H7</translation>
     </message>
@@ -2704,7 +2669,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>HrZoneTime8</name>
     <message>
-        <location filename="../HrTimeInZone.cpp" line="156"/>
+        <location filename="../HrTimeInZone.cpp" line="196"/>
         <source>H8 Time in Zone</source>
         <translation>Время на уровне H8</translation>
     </message>
@@ -2914,7 +2879,8 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LTMPlot</name>
     <message>
-        <location filename="../LTMPlot.cpp" line="1120"/>
+        <location filename="../LTMPlot.cpp" line="731"/>
+        <location filename="../LTMPlot.cpp" line="1123"/>
         <source>watts</source>
         <translation>ватт</translation>
     </message>
@@ -2936,33 +2902,33 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="253"/>
-        <location filename="../LTMSidebar.cpp" line="289"/>
+        <location filename="../LTMSidebar.cpp" line="257"/>
+        <location filename="../LTMSidebar.cpp" line="293"/>
         <source>Edit details</source>
         <translation type="unfinished">Изменить информацию</translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="254"/>
+        <location filename="../LTMSidebar.cpp" line="258"/>
         <source>Delete range</source>
         <translation type="unfinished">Удалить диапазон</translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="255"/>
+        <location filename="../LTMSidebar.cpp" line="259"/>
         <source>Add Event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="290"/>
+        <location filename="../LTMSidebar.cpp" line="294"/>
         <source>Delete event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="300"/>
+        <location filename="../LTMSidebar.cpp" line="304"/>
         <source>Add event</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LTMSidebar.cpp" line="537"/>
+        <location filename="../LTMSidebar.cpp" line="541"/>
         <source>^(Average|Max) </source>
         <translation type="unfinished"></translation>
     </message>
@@ -2974,7 +2940,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="obsolete">Диапазон дат</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="69"/>
+        <location filename="../LTMTool.cpp" line="124"/>
         <source>Metric</source>
         <translation>Показатель</translation>
     </message>
@@ -3019,8 +2985,8 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="obsolete">Последние 12 месяцев</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="511"/>
-        <location filename="../LTMTool.cpp" line="519"/>
+        <location filename="../LTMTool.cpp" line="574"/>
+        <location filename="../LTMTool.cpp" line="582"/>
         <source>Unknown Metric</source>
         <translation>Неизветсный показатель</translation>
     </message>
@@ -3037,12 +3003,47 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="obsolete">Удалить диапазон</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="544"/>
+        <location filename="../LTMTool.cpp" line="59"/>
+        <source>Filter</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="69"/>
+        <source>Chart</source>
+        <translation type="unfinished">График</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="101"/>
+        <source>Add</source>
+        <translation type="unfinished">Добавить</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="102"/>
+        <source>Manage</source>
+        <translation type="unfinished">Управление</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="518"/>
+        <source>Basic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="519"/>
+        <source>Preset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="520"/>
+        <source>Custom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="607"/>
         <source>Pick Color</source>
         <translation>Выбрать цвет</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="545"/>
+        <location filename="../LTMTool.cpp" line="608"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
@@ -3050,19 +3051,16 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LTMWindow</name>
     <message>
-        <location filename="../LTMWindow.cpp" line="135"/>
         <source>Add</source>
-        <translation>Добавить</translation>
+        <translation type="obsolete">Добавить</translation>
     </message>
     <message>
-        <location filename="../LTMWindow.cpp" line="137"/>
         <source>Manage</source>
-        <translation>Управление</translation>
+        <translation type="obsolete">Управление</translation>
     </message>
     <message>
-        <location filename="../LTMWindow.cpp" line="105"/>
         <source>Chart</source>
-        <translation>График</translation>
+        <translation type="obsolete">График</translation>
     </message>
     <message>
         <source>Days</source>
@@ -3088,71 +3086,71 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LTPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3001"/>
+        <location filename="../Pages.cpp" line="3003"/>
         <source>Add LT</source>
         <translation>Добавить ЛП</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3002"/>
+        <location filename="../Pages.cpp" line="3004"/>
         <source>Delete LT</source>
         <translation>Удалить ЛП</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3003"/>
+        <location filename="../Pages.cpp" line="3005"/>
         <source>Default</source>
         <translation>По умолчанию</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3006"/>
+        <location filename="../Pages.cpp" line="3008"/>
         <source>Add Zone</source>
         <translation>Добавить уровень</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3007"/>
+        <location filename="../Pages.cpp" line="3009"/>
         <source>Delete Zone</source>
         <translation>Удалить уровень</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3021"/>
-        <location filename="../Pages.cpp" line="3061"/>
+        <location filename="../Pages.cpp" line="3023"/>
+        <location filename="../Pages.cpp" line="3063"/>
         <source>From Date</source>
         <translation>От даты</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3022"/>
-        <location filename="../Pages.cpp" line="3062"/>
+        <location filename="../Pages.cpp" line="3024"/>
+        <location filename="../Pages.cpp" line="3064"/>
         <source>Lactic Threshold</source>
         <translation>Лактатный порог</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3039"/>
-        <location filename="../Pages.cpp" line="3063"/>
+        <location filename="../Pages.cpp" line="3041"/>
+        <location filename="../Pages.cpp" line="3065"/>
         <source>Rest HR</source>
         <translation>ЧСС в покое</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3040"/>
-        <location filename="../Pages.cpp" line="3064"/>
+        <location filename="../Pages.cpp" line="3042"/>
+        <location filename="../Pages.cpp" line="3066"/>
         <source>Max HR</source>
         <translation>Максимальная ЧСС</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3101"/>
+        <location filename="../Pages.cpp" line="3103"/>
         <source>Short</source>
         <translation>Краткое</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3102"/>
+        <location filename="../Pages.cpp" line="3104"/>
         <source>Long</source>
         <translation>Полное</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3103"/>
+        <location filename="../Pages.cpp" line="3105"/>
         <source>From BPM</source>
         <translation>От уд/мин</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3104"/>
+        <location filename="../Pages.cpp" line="3106"/>
         <source>Trimp k</source>
         <translation>Trimp k</translation>
     </message>
@@ -3160,13 +3158,13 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
 <context>
     <name>LeftRightBalance</name>
     <message>
-        <location filename="../LeftRightBalance.cpp" line="33"/>
+        <location filename="../LeftRightBalance.cpp" line="36"/>
         <source>Left/Right Balance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../LeftRightBalance.cpp" line="34"/>
-        <location filename="../LeftRightBalance.cpp" line="35"/>
+        <location filename="../LeftRightBalance.cpp" line="37"/>
+        <location filename="../LeftRightBalance.cpp" line="38"/>
         <source>%</source>
         <translation type="unfinished">%</translation>
     </message>
@@ -3178,7 +3176,7 @@ Torque Adjust - this defines an absolute value in poinds per square inch or newt
         <translation type="obsolete">Неверное имя файла тренировки</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2210"/>
+        <location filename="../MainWindow.cpp" line="2216"/>
         <source>Invalid date/time in filename:
 %1
 Skipping file...</source>
@@ -3188,13 +3186,13 @@ Skipping file...</source>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="281"/>
-        <location filename="../MainWindow.cpp" line="2230"/>
+        <location filename="../MainWindow.cpp" line="2236"/>
         <source>Zones File Error</source>
         <translation>Ошибка файла уровней</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="284"/>
-        <location filename="../MainWindow.cpp" line="2234"/>
+        <location filename="../MainWindow.cpp" line="2240"/>
         <source>Reading Zones File</source>
         <translation>Чтение файла уровней</translation>
     </message>
@@ -3204,7 +3202,7 @@ Skipping file...</source>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="565"/>
-        <location filename="../MainWindow.cpp" line="1209"/>
+        <location filename="../MainWindow.cpp" line="1215"/>
         <source>Intervals</source>
         <translation>Интервалы</translation>
     </message>
@@ -3229,22 +3227,22 @@ Skipping file...</source>
         <translation type="obsolete">&amp;Велосипедист</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="743"/>
+        <location filename="../MainWindow.cpp" line="747"/>
         <source>&amp;New...</source>
         <translation>&amp;Новый...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="743"/>
+        <location filename="../MainWindow.cpp" line="747"/>
         <source>Ctrl+N</source>
         <translation>Ctrl+N</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="744"/>
+        <location filename="../MainWindow.cpp" line="748"/>
         <source>&amp;Open...</source>
         <translation>&amp;Открыть...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="744"/>
+        <location filename="../MainWindow.cpp" line="748"/>
         <source>Ctrl+O</source>
         <translation>Ctrl+O</translation>
     </message>
@@ -3253,7 +3251,7 @@ Skipping file...</source>
         <translation type="obsolete">&amp;Выход</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="746"/>
+        <location filename="../MainWindow.cpp" line="750"/>
         <source>Ctrl+Q</source>
         <translation>Ctrl+Q</translation>
     </message>
@@ -3262,24 +3260,24 @@ Skipping file...</source>
         <translation type="obsolete">&amp;Тренировка</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="775"/>
+        <location filename="../MainWindow.cpp" line="779"/>
         <source>Ctrl+S</source>
         <translation>Ctrl+S</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="749"/>
+        <location filename="../MainWindow.cpp" line="753"/>
         <source>&amp;Download from device...</source>
         <translation>&amp;Загрузить с устройства...</translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="291"/>
-        <location filename="../MainWindow.cpp" line="2241"/>
+        <location filename="../MainWindow.cpp" line="2247"/>
         <source>HR Zones File Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="294"/>
-        <location filename="../MainWindow.cpp" line="2245"/>
+        <location filename="../MainWindow.cpp" line="2251"/>
         <source>Reading HR Zones File</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3300,210 +3298,210 @@ Skipping file...</source>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="454"/>
-        <location filename="../MainWindow.cpp" line="845"/>
+        <location filename="../MainWindow.cpp" line="849"/>
         <source>Home</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="461"/>
-        <location filename="../MainWindow.cpp" line="848"/>
+        <location filename="../MainWindow.cpp" line="852"/>
         <source>Diary</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="468"/>
-        <location filename="../MainWindow.cpp" line="844"/>
+        <location filename="../MainWindow.cpp" line="848"/>
         <source>Analysis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="474"/>
-        <location filename="../MainWindow.cpp" line="846"/>
+        <location filename="../MainWindow.cpp" line="850"/>
         <source>Train</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../MainWindow.cpp" line="524"/>
-        <location filename="../MainWindow.cpp" line="1160"/>
+        <location filename="../MainWindow.cpp" line="1166"/>
         <source>All Activities</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="742"/>
+        <location filename="../MainWindow.cpp" line="746"/>
         <source>&amp;Athlete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="745"/>
+        <location filename="../MainWindow.cpp" line="749"/>
         <source>&amp;Close Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="745"/>
+        <location filename="../MainWindow.cpp" line="749"/>
         <source>Ctrl+W</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="746"/>
+        <location filename="../MainWindow.cpp" line="750"/>
         <source>&amp;Quit All Windows</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="748"/>
+        <location filename="../MainWindow.cpp" line="752"/>
         <source>A&amp;ctivity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="749"/>
+        <location filename="../MainWindow.cpp" line="753"/>
         <source>Ctrl+D</source>
         <translation>Ctrl+D</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="751"/>
+        <location filename="../MainWindow.cpp" line="755"/>
         <source>&amp;Manual activity entry...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="753"/>
+        <location filename="../MainWindow.cpp" line="757"/>
         <source>&amp;Export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="754"/>
+        <location filename="../MainWindow.cpp" line="758"/>
         <source>&amp;Batch export...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="755"/>
+        <location filename="../MainWindow.cpp" line="759"/>
         <source>Export Metrics as CSV...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="758"/>
+        <location filename="../MainWindow.cpp" line="762"/>
         <source>&amp;Upload to TrainingPeaks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="758"/>
+        <location filename="../MainWindow.cpp" line="762"/>
         <source>Ctrl+U</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="759"/>
+        <location filename="../MainWindow.cpp" line="763"/>
         <source>Down&amp;load from TrainingPeaks...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="759"/>
+        <location filename="../MainWindow.cpp" line="763"/>
         <source>Ctrl+L</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="775"/>
+        <location filename="../MainWindow.cpp" line="779"/>
         <source>&amp;Save activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="776"/>
+        <location filename="../MainWindow.cpp" line="780"/>
         <source>D&amp;elete activity...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="777"/>
+        <location filename="../MainWindow.cpp" line="781"/>
         <source>Split &amp;activity...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="782"/>
+        <location filename="../MainWindow.cpp" line="786"/>
         <source>Critical Power Calculator...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="783"/>
+        <location filename="../MainWindow.cpp" line="787"/>
         <source>Air Density (Rho) Estimator...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="786"/>
+        <location filename="../MainWindow.cpp" line="790"/>
         <source>Get &amp;Withings Data...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="788"/>
+        <location filename="../MainWindow.cpp" line="792"/>
         <source>Get &amp;Zeo Data...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="791"/>
+        <location filename="../MainWindow.cpp" line="795"/>
         <source>Workout Wizard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="792"/>
+        <location filename="../MainWindow.cpp" line="796"/>
         <source>Get Workouts from ErgDB</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="796"/>
-        <location filename="../MainWindow.cpp" line="1197"/>
+        <location filename="../MainWindow.cpp" line="800"/>
+        <location filename="../MainWindow.cpp" line="1203"/>
         <source>Upload Activity to Calendar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="797"/>
+        <location filename="../MainWindow.cpp" line="801"/>
         <source>Import Calendar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="798"/>
+        <location filename="../MainWindow.cpp" line="802"/>
         <source>Export Calendar...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="799"/>
+        <location filename="../MainWindow.cpp" line="803"/>
         <source>Refresh Calendar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="802"/>
+        <location filename="../MainWindow.cpp" line="806"/>
         <source>Find intervals...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1692"/>
+        <location filename="../MainWindow.cpp" line="1698"/>
         <source>Select Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1692"/>
-        <location filename="../MainWindow.cpp" line="1778"/>
-        <location filename="../MainWindow.cpp" line="1786"/>
+        <location filename="../MainWindow.cpp" line="1698"/>
+        <location filename="../MainWindow.cpp" line="1784"/>
+        <location filename="../MainWindow.cpp" line="1792"/>
         <source>No activity selected!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1703"/>
+        <location filename="../MainWindow.cpp" line="1709"/>
         <source>Export Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1716"/>
+        <location filename="../MainWindow.cpp" line="1722"/>
         <source>Export Failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1717"/>
+        <location filename="../MainWindow.cpp" line="1723"/>
         <source>Failed to export ride, please check permissions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2188"/>
+        <location filename="../MainWindow.cpp" line="2194"/>
         <source>Range from %1 to %2
 Athlete CP set to %3 watts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2209"/>
+        <location filename="../MainWindow.cpp" line="2215"/>
         <source>Invalid Activity File Name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3512,12 +3510,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">&amp;Экспорт в CSV...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="753"/>
+        <location filename="../MainWindow.cpp" line="757"/>
         <source>Ctrl+E</source>
         <translation>Ctrl+E</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="750"/>
+        <location filename="../MainWindow.cpp" line="754"/>
         <source>Ctrl+I</source>
         <translation>Ctrl+I</translation>
     </message>
@@ -3526,7 +3524,7 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Найти лучшие интервалы...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="754"/>
+        <location filename="../MainWindow.cpp" line="758"/>
         <source>Ctrl+B</source>
         <translation>Ctrl+B</translation>
     </message>
@@ -3595,12 +3593,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Редактор</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="750"/>
+        <location filename="../MainWindow.cpp" line="754"/>
         <source>&amp;Import from file...</source>
         <translation>&amp;Импорт из файла...</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="751"/>
+        <location filename="../MainWindow.cpp" line="755"/>
         <source>Ctrl+M</source>
         <translation>Ctrl+M</translation>
     </message>
@@ -3621,12 +3619,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">&amp;Сохранить тренировку</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="780"/>
+        <location filename="../MainWindow.cpp" line="784"/>
         <source>&amp;Tools</source>
         <translation>&amp;Инструменты</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="781"/>
+        <location filename="../MainWindow.cpp" line="785"/>
         <source>&amp;Options...</source>
         <translation>&amp;Параметры ...</translation>
     </message>
@@ -3635,89 +3633,89 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Калькулятор критической мощности</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="825"/>
+        <location filename="../MainWindow.cpp" line="829"/>
         <source>&amp;View</source>
         <translation>&amp;Вид</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="827"/>
+        <location filename="../MainWindow.cpp" line="831"/>
         <source>Toggle Full Screen</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="829"/>
+        <location filename="../MainWindow.cpp" line="833"/>
         <source>Show Left Sidebar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="833"/>
+        <location filename="../MainWindow.cpp" line="837"/>
         <source>Show Toolbar</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="838"/>
+        <location filename="../MainWindow.cpp" line="842"/>
         <source>Tabbed View</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="852"/>
+        <location filename="../MainWindow.cpp" line="856"/>
         <source>Reset Layout</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="854"/>
+        <location filename="../MainWindow.cpp" line="858"/>
         <source>&amp;Window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="861"/>
+        <location filename="../MainWindow.cpp" line="865"/>
         <source>&amp;Help</source>
         <translation>&amp;Помощь</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="862"/>
+        <location filename="../MainWindow.cpp" line="866"/>
         <source>&amp;User Guide</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="863"/>
+        <location filename="../MainWindow.cpp" line="867"/>
         <source>&amp;Log a bug or feature request</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="865"/>
+        <location filename="../MainWindow.cpp" line="869"/>
         <source>&amp;About GoldenCheetah</source>
         <translation>&amp;О GoldenCheetah</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1164"/>
+        <location filename="../MainWindow.cpp" line="1170"/>
         <source>Save Changes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1167"/>
+        <location filename="../MainWindow.cpp" line="1173"/>
         <source>Revert to Saved version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1170"/>
-        <location filename="../MainWindow.cpp" line="1786"/>
+        <location filename="../MainWindow.cpp" line="1176"/>
+        <location filename="../MainWindow.cpp" line="1792"/>
         <source>Delete Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1179"/>
-        <location filename="../MainWindow.cpp" line="1778"/>
+        <location filename="../MainWindow.cpp" line="1185"/>
+        <location filename="../MainWindow.cpp" line="1784"/>
         <source>Split Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1192"/>
+        <location filename="../MainWindow.cpp" line="1198"/>
         <source>Tweet Activity</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1612"/>
+        <location filename="../MainWindow.cpp" line="1618"/>
         <source>Can&apos;t rename %1 to %2</source>
         <translation>Невозможно переименовать %1 в %2</translation>
     </message>
@@ -3786,42 +3784,42 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Невозможно открыть файл %1 для записи</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1739"/>
+        <location filename="../MainWindow.cpp" line="1745"/>
         <source>Import from File</source>
         <translation>Импорт из файла</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1756"/>
+        <location filename="../MainWindow.cpp" line="1762"/>
         <source>No Activity To Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1757"/>
+        <location filename="../MainWindow.cpp" line="1763"/>
         <source>There is no currently selected ride to save.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1791"/>
+        <location filename="../MainWindow.cpp" line="1797"/>
         <source>Are you sure you want to delete the activity:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1845"/>
+        <location filename="../MainWindow.cpp" line="1851"/>
         <source>Export Metrics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1845"/>
+        <location filename="../MainWindow.cpp" line="1851"/>
         <source>Comma Separated Variables (*.csv)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1920"/>
+        <location filename="../MainWindow.cpp" line="1926"/>
         <source>Workout Directory Invalid</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1977"/>
+        <location filename="../MainWindow.cpp" line="1983"/>
         <source> (%1 watts)</source>
         <translation> (%1 ватт)</translation>
     </message>
@@ -3838,12 +3836,12 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Удалить тренировку</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1173"/>
+        <location filename="../MainWindow.cpp" line="1179"/>
         <source>Find Best Intervals</source>
         <translation>Найти лучшие интервалы</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1176"/>
+        <location filename="../MainWindow.cpp" line="1182"/>
         <source>Find Power Peaks</source>
         <translation>Найти пиковую мощность</translation>
     </message>
@@ -3852,27 +3850,27 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Отправить на Twitter</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1214"/>
+        <location filename="../MainWindow.cpp" line="1220"/>
         <source>Rename interval</source>
         <translation>Переименовать интервал</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1215"/>
+        <location filename="../MainWindow.cpp" line="1221"/>
         <source>Delete interval</source>
         <translation>Удалить интервал</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1216"/>
+        <location filename="../MainWindow.cpp" line="1222"/>
         <source>Zoom to interval</source>
         <translation>Интервал на весь экран</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1217"/>
+        <location filename="../MainWindow.cpp" line="1223"/>
         <source>Bring to Front</source>
         <translation>На передний план</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1218"/>
+        <location filename="../MainWindow.cpp" line="1224"/>
         <source>Send to back</source>
         <translation>На задний план</translation>
     </message>
@@ -3907,7 +3905,7 @@ Athlete CP set to %3 watts</source>
         <translation type="obsolete">Невозможно записать заметки файла %1</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="2187"/>
+        <location filename="../MainWindow.cpp" line="2193"/>
         <source>CP saved</source>
         <translation>CP сохранена</translation>
     </message>
@@ -3930,7 +3928,7 @@ CP велосипедиста установлена в %3 ватт</translation
         <translation type="obsolete">Вы уверены, что хотите удалить тренировку:</translation>
     </message>
     <message>
-        <location filename="../MainWindow.cpp" line="1793"/>
+        <location filename="../MainWindow.cpp" line="1799"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
@@ -4151,13 +4149,13 @@ CP велосипедиста установлена в %3 ватт</translation
 <context>
     <name>MaxCadence</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="606"/>
+        <location filename="../BasicRideMetrics.cpp" line="683"/>
         <source>Max Cadence</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="607"/>
-        <location filename="../BasicRideMetrics.cpp" line="608"/>
+        <location filename="../BasicRideMetrics.cpp" line="684"/>
+        <location filename="../BasicRideMetrics.cpp" line="685"/>
         <source>rpm</source>
         <translation type="unfinished">об/мин</translation>
     </message>
@@ -4165,13 +4163,13 @@ CP велосипедиста установлена в %3 ватт</translation
 <context>
     <name>MaxHr</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="538"/>
+        <location filename="../BasicRideMetrics.cpp" line="607"/>
         <source>Max Heartrate</source>
         <translation>Максимальная ЧСС</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="539"/>
-        <location filename="../BasicRideMetrics.cpp" line="540"/>
+        <location filename="../BasicRideMetrics.cpp" line="608"/>
+        <location filename="../BasicRideMetrics.cpp" line="609"/>
         <source>bpm</source>
         <translation>уд/мин</translation>
     </message>
@@ -4179,13 +4177,13 @@ CP велосипедиста установлена в %3 ватт</translation
 <context>
     <name>MaxPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="509"/>
+        <location filename="../BasicRideMetrics.cpp" line="574"/>
         <source>Max Power</source>
         <translation>Максимальная мощность</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="510"/>
-        <location filename="../BasicRideMetrics.cpp" line="511"/>
+        <location filename="../BasicRideMetrics.cpp" line="575"/>
+        <location filename="../BasicRideMetrics.cpp" line="576"/>
         <source>watts</source>
         <translation>ватт</translation>
     </message>
@@ -4193,7 +4191,7 @@ CP велосипедиста установлена в %3 ватт</translation
 <context>
     <name>MaxPowerVariance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="848"/>
+        <location filename="../BasicRideMetrics.cpp" line="949"/>
         <source>Max Power Variance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4201,17 +4199,17 @@ CP велосипедиста установлена в %3 ватт</translation
 <context>
     <name>MaxSpeed</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="567"/>
+        <location filename="../BasicRideMetrics.cpp" line="640"/>
         <source>Max Speed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="568"/>
+        <location filename="../BasicRideMetrics.cpp" line="641"/>
         <source>kph</source>
         <translation type="unfinished">км/ч</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="569"/>
+        <location filename="../BasicRideMetrics.cpp" line="642"/>
         <source>mph</source>
         <translation type="unfinished">миль/ч</translation>
     </message>
@@ -4219,17 +4217,17 @@ CP велосипедиста установлена в %3 ватт</translation
 <context>
     <name>MaxTemp</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="643"/>
+        <location filename="../BasicRideMetrics.cpp" line="724"/>
         <source>Max Temp</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="644"/>
+        <location filename="../BasicRideMetrics.cpp" line="725"/>
         <source>C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="645"/>
+        <location filename="../BasicRideMetrics.cpp" line="726"/>
         <source>F</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4237,7 +4235,7 @@ CP велосипедиста установлена в %3 ватт</translation
 <context>
     <name>MeanPowerVariance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="801"/>
+        <location filename="../BasicRideMetrics.cpp" line="898"/>
         <source>Average Power Variance</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4245,42 +4243,42 @@ CP велосипедиста установлена в %3 ватт</translation
 <context>
     <name>MeasuresPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3395"/>
+        <location filename="../Pages.cpp" line="3397"/>
         <source>Move up</source>
         <translation type="unfinished">Вверх</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3396"/>
+        <location filename="../Pages.cpp" line="3398"/>
         <source>Move down</source>
         <translation type="unfinished">Вниз</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3397"/>
+        <location filename="../Pages.cpp" line="3399"/>
         <source>Insert</source>
         <translation type="unfinished">Вставить</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3398"/>
+        <location filename="../Pages.cpp" line="3400"/>
         <source>Rename</source>
         <translation type="unfinished">Переименовать</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3399"/>
+        <location filename="../Pages.cpp" line="3401"/>
         <source>Delete</source>
         <translation type="unfinished">Удалить</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3410"/>
+        <location filename="../Pages.cpp" line="3412"/>
         <source>Screen Tab</source>
         <translation type="unfinished">Вкладка</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3411"/>
+        <location filename="../Pages.cpp" line="3413"/>
         <source>Measure</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3412"/>
+        <location filename="../Pages.cpp" line="3414"/>
         <source>Type</source>
         <translation type="unfinished">Тип</translation>
     </message>
@@ -4499,17 +4497,17 @@ Elapsed: %1
 <context>
     <name>NavigatorCellDelegate</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="941"/>
+        <location filename="../RideNavigator.cpp" line="944"/>
         <source>Date</source>
         <translation type="unfinished">Дата</translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="944"/>
+        <location filename="../RideNavigator.cpp" line="947"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="947"/>
+        <location filename="../RideNavigator.cpp" line="950"/>
         <source>Last updated</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4636,13 +4634,13 @@ Elapsed: %1
 <context>
     <name>NinetyFivePercentHeartRate</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="688"/>
+        <location filename="../BasicRideMetrics.cpp" line="773"/>
         <source>95% Heartrate</source>
         <translation>95% ЧСС</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="689"/>
-        <location filename="../BasicRideMetrics.cpp" line="690"/>
+        <location filename="../BasicRideMetrics.cpp" line="774"/>
+        <location filename="../BasicRideMetrics.cpp" line="775"/>
         <source>bpm</source>
         <translation>уд/мин</translation>
     </message>
@@ -4650,13 +4648,13 @@ Elapsed: %1
 <context>
     <name>NonZeroPower</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="365"/>
+        <location filename="../BasicRideMetrics.cpp" line="408"/>
         <source>Nonzero Average Power</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="366"/>
-        <location filename="../BasicRideMetrics.cpp" line="367"/>
+        <location filename="../BasicRideMetrics.cpp" line="409"/>
+        <location filename="../BasicRideMetrics.cpp" line="410"/>
         <source>watts</source>
         <translation type="unfinished">ватт</translation>
     </message>
@@ -4664,17 +4662,17 @@ Elapsed: %1
 <context>
     <name>Pace</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="288"/>
+        <location filename="../BasicRideMetrics.cpp" line="319"/>
         <source>Pace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="290"/>
+        <location filename="../BasicRideMetrics.cpp" line="321"/>
         <source>min/km</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="291"/>
+        <location filename="../BasicRideMetrics.cpp" line="322"/>
         <source>min/mile</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4867,7 +4865,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower10m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="162"/>
+        <location filename="../PeakPower.cpp" line="202"/>
         <source>10 min Peak Power</source>
         <translation>Пиковая мощность за 10 мин</translation>
     </message>
@@ -4875,7 +4873,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower10s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="96"/>
+        <location filename="../PeakPower.cpp" line="112"/>
         <source>10 sec Peak Power</source>
         <translation>Пиковая мощность за 10 сек</translation>
     </message>
@@ -4883,7 +4881,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower15s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="107"/>
+        <location filename="../PeakPower.cpp" line="127"/>
         <source>15 sec Peak Power</source>
         <translation>Пиковая мощность за 15 сек</translation>
     </message>
@@ -4891,7 +4889,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower1m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="140"/>
+        <location filename="../PeakPower.cpp" line="172"/>
         <source>1 min Peak Power</source>
         <translation>Пиковая мощность за 1 мин</translation>
     </message>
@@ -4899,7 +4897,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower1s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="74"/>
+        <location filename="../PeakPower.cpp" line="82"/>
         <source>1 sec Peak Power</source>
         <translation>Пиковая мощность за 10 сек</translation>
     </message>
@@ -4907,7 +4905,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower20m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="173"/>
+        <location filename="../PeakPower.cpp" line="217"/>
         <source>20 min Peak Power</source>
         <translation>Пиковая мощность за 20 мин</translation>
     </message>
@@ -4915,7 +4913,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower20s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="118"/>
+        <location filename="../PeakPower.cpp" line="142"/>
         <source>20 sec Peak Power</source>
         <translation>Пиковая мощность за 20 сек</translation>
     </message>
@@ -4923,7 +4921,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower30m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="184"/>
+        <location filename="../PeakPower.cpp" line="232"/>
         <source>30 min Peak Power</source>
         <translation>Пиковая мощность за 30 мин</translation>
     </message>
@@ -4931,7 +4929,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower30s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="129"/>
+        <location filename="../PeakPower.cpp" line="157"/>
         <source>30 sec Peak Power</source>
         <translation>Пиковая мощность за 30 сек</translation>
     </message>
@@ -4939,7 +4937,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower5m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="151"/>
+        <location filename="../PeakPower.cpp" line="187"/>
         <source>5 min Peak Power</source>
         <translation>Пиковая мощность за 5 мин</translation>
     </message>
@@ -4947,7 +4945,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakPower5s</name>
     <message>
-        <location filename="../PeakPower.cpp" line="85"/>
+        <location filename="../PeakPower.cpp" line="97"/>
         <source>5 sec Peak Power</source>
         <translation>Пиковая мощность за 5 сек</translation>
     </message>
@@ -4955,13 +4953,13 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr10m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="263"/>
+        <location filename="../PeakPower.cpp" line="324"/>
         <source>10 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="264"/>
-        <location filename="../PeakPower.cpp" line="265"/>
+        <location filename="../PeakPower.cpp" line="325"/>
+        <location filename="../PeakPower.cpp" line="326"/>
         <source>bpm</source>
         <translation type="unfinished">уд/мин</translation>
     </message>
@@ -4969,13 +4967,13 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr1m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="235"/>
+        <location filename="../PeakPower.cpp" line="288"/>
         <source>1 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="236"/>
-        <location filename="../PeakPower.cpp" line="237"/>
+        <location filename="../PeakPower.cpp" line="289"/>
+        <location filename="../PeakPower.cpp" line="290"/>
         <source>bpm</source>
         <translation type="unfinished">уд/мин</translation>
     </message>
@@ -4983,13 +4981,13 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr20m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="277"/>
+        <location filename="../PeakPower.cpp" line="342"/>
         <source>20 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="278"/>
-        <location filename="../PeakPower.cpp" line="279"/>
+        <location filename="../PeakPower.cpp" line="343"/>
+        <location filename="../PeakPower.cpp" line="344"/>
         <source>bpm</source>
         <translation type="unfinished">уд/мин</translation>
     </message>
@@ -4997,13 +4995,13 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr30m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="291"/>
+        <location filename="../PeakPower.cpp" line="360"/>
         <source>30 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PeakPower.cpp" line="292"/>
-        <location filename="../PeakPower.cpp" line="293"/>
+        <location filename="../PeakPower.cpp" line="361"/>
+        <location filename="../PeakPower.cpp" line="362"/>
         <source>bpm</source>
         <translation type="unfinished">уд/мин</translation>
     </message>
@@ -5011,22 +5009,8 @@ Do you want to continue?</source>
 <context>
     <name>PeakPowerHr5m</name>
     <message>
-        <location filename="../PeakPower.cpp" line="249"/>
-        <source>5 min Peak Power HR</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../PeakPower.cpp" line="250"/>
-        <location filename="../PeakPower.cpp" line="251"/>
-        <source>bpm</source>
-        <translation type="unfinished">уд/мин</translation>
-    </message>
-</context>
-<context>
-    <name>PeakPowerHr60m</name>
-    <message>
         <location filename="../PeakPower.cpp" line="306"/>
-        <source>60 min Peak Power HR</source>
+        <source>5 min Peak Power HR</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -5037,10 +5021,24 @@ Do you want to continue?</source>
     </message>
 </context>
 <context>
+    <name>PeakPowerHr60m</name>
+    <message>
+        <location filename="../PeakPower.cpp" line="379"/>
+        <source>60 min Peak Power HR</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../PeakPower.cpp" line="380"/>
+        <location filename="../PeakPower.cpp" line="381"/>
+        <source>bpm</source>
+        <translation type="unfinished">уд/мин</translation>
+    </message>
+</context>
+<context>
     <name>PeakWPK</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="89"/>
-        <location filename="../WattsPerKilogram.cpp" line="90"/>
+        <location filename="../WattsPerKilogram.cpp" line="93"/>
+        <location filename="../WattsPerKilogram.cpp" line="94"/>
         <source>wpk</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5048,7 +5046,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK10m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="219"/>
+        <location filename="../WattsPerKilogram.cpp" line="263"/>
         <source>10 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5056,7 +5054,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK10s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="153"/>
+        <location filename="../WattsPerKilogram.cpp" line="173"/>
         <source>10 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5064,7 +5062,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK15s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="164"/>
+        <location filename="../WattsPerKilogram.cpp" line="188"/>
         <source>15 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5072,7 +5070,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK1m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="197"/>
+        <location filename="../WattsPerKilogram.cpp" line="233"/>
         <source>1 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5080,7 +5078,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK1s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="131"/>
+        <location filename="../WattsPerKilogram.cpp" line="143"/>
         <source>1 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5088,7 +5086,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK20m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="230"/>
+        <location filename="../WattsPerKilogram.cpp" line="278"/>
         <source>20 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5096,7 +5094,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK20s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="175"/>
+        <location filename="../WattsPerKilogram.cpp" line="203"/>
         <source>20 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5104,7 +5102,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK30m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="241"/>
+        <location filename="../WattsPerKilogram.cpp" line="293"/>
         <source>30 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5112,7 +5110,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK30s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="186"/>
+        <location filename="../WattsPerKilogram.cpp" line="218"/>
         <source>30 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5120,7 +5118,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK5m</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="208"/>
+        <location filename="../WattsPerKilogram.cpp" line="248"/>
         <source>5 min Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5128,7 +5126,7 @@ Do you want to continue?</source>
 <context>
     <name>PeakWPK5s</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="142"/>
+        <location filename="../WattsPerKilogram.cpp" line="158"/>
         <source>5 sec Peak WPK</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5140,22 +5138,22 @@ Do you want to continue?</source>
         <translation type="obsolete">Performance Manager</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="118"/>
+        <location filename="../PerfPlot.cpp" line="147"/>
         <source>Daily</source>
         <translation>В день</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="138"/>
+        <location filename="../PerfPlot.cpp" line="167"/>
         <source>Short Term Stress</source>
         <translation>Краткосрочная нагрузка (Short Term Stress)</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="152"/>
+        <location filename="../PerfPlot.cpp" line="181"/>
         <source>Long Term Stress</source>
         <translation>Долгосрочная нагрузка (Long Term Stress)</translation>
     </message>
     <message>
-        <location filename="../PerfPlot.cpp" line="166"/>
+        <location filename="../PerfPlot.cpp" line="195"/>
         <source>Stress Balance</source>
         <translation>Баланс нагрузки (Stress Balance)</translation>
     </message>
@@ -5267,85 +5265,91 @@ Do you want to continue?</source>
     <name>PowerHist</name>
     <message>
         <location filename="../PowerHist.cpp" line="77"/>
-        <location filename="../PowerHist.cpp" line="902"/>
+        <location filename="../PowerHist.cpp" line="940"/>
         <source>Time (minutes)</source>
         <translation>Время (минуты)</translation>
     </message>
     <message>
         <location filename="../PowerHist.cpp" line="77"/>
-        <location filename="../PowerHist.cpp" line="902"/>
+        <location filename="../PowerHist.cpp" line="940"/>
         <source>Time (percent)</source>
         <translation>Время (проценты)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="877"/>
+        <location filename="../PowerHist.cpp" line="910"/>
         <source>Power (watts)</source>
         <translation>Мощность (ватт)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="876"/>
+        <location filename="../PowerHist.cpp" line="909"/>
+        <location filename="../PowerHist.cpp" line="914"/>
         <source>Power zone</source>
         <translation>Уровень можности</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="882"/>
+        <location filename="../PowerHist.cpp" line="920"/>
         <source>Heartrate (bpm)</source>
         <translation>ЧСС (уд/мин)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="881"/>
+        <location filename="../PowerHist.cpp" line="919"/>
         <source>Heartrate zone</source>
         <translation>Уровень ЧСС</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="886"/>
+        <location filename="../PowerHist.cpp" line="915"/>
+        <source>Power (watts/kg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../PowerHist.cpp" line="924"/>
         <source>Cadence (rpm)</source>
         <translation>Каденс (об/мин)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>Speed (%1)</source>
         <translation>Скорость (%1)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>kph</source>
         <translation>км/ч</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="890"/>
+        <location filename="../PowerHist.cpp" line="928"/>
         <source>mph</source>
         <translation>миль/ч</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>Torque (%1)</source>
         <translation>Крутящий момент (%1)</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>N-m</source>
         <translation>Н-м</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="894"/>
+        <location filename="../PowerHist.cpp" line="932"/>
         <source>ft-lbf</source>
         <translation>ft-lbf</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="898"/>
+        <location filename="../PowerHist.cpp" line="936"/>
         <source>Unknown data series</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="962"/>
-        <location filename="../PowerHist.cpp" line="975"/>
+        <location filename="../PowerHist.cpp" line="1000"/>
+        <location filename="../PowerHist.cpp" line="1013"/>
         <source>minutes</source>
         <translation>минут</translation>
     </message>
     <message>
-        <location filename="../PowerHist.cpp" line="962"/>
-        <location filename="../PowerHist.cpp" line="975"/>
+        <location filename="../PowerHist.cpp" line="1000"/>
+        <location filename="../PowerHist.cpp" line="1013"/>
         <source>%</source>
         <translation>%</translation>
     </message>
@@ -5353,27 +5357,27 @@ Do you want to continue?</source>
 <context>
     <name>ProcessorPage</name>
     <message>
-        <location filename="../Pages.cpp" line="2198"/>
+        <location filename="../Pages.cpp" line="2200"/>
         <source>Processor</source>
         <translation>Processor</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2199"/>
+        <location filename="../Pages.cpp" line="2201"/>
         <source>Apply</source>
         <translation>Применить</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2200"/>
+        <location filename="../Pages.cpp" line="2202"/>
         <source>Settings</source>
         <translation>Настройки</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2224"/>
+        <location filename="../Pages.cpp" line="2226"/>
         <source>Manual</source>
         <translation>Ручной</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2225"/>
+        <location filename="../Pages.cpp" line="2227"/>
         <source>Auto</source>
         <translation>Автоматический</translation>
     </message>
@@ -5783,7 +5787,7 @@ Do you want to continue?</source>
 <context>
     <name>RelativeIntensity</name>
     <message>
-        <location filename="../BikeScore.cpp" line="136"/>
+        <location filename="../BikeScore.cpp" line="147"/>
         <source>Relative Intensity</source>
         <translation>Относительная интенсивность</translation>
     </message>
@@ -5791,7 +5795,7 @@ Do you want to continue?</source>
 <context>
     <name>ResponseIndex</name>
     <message>
-        <location filename="../BikeScore.cpp" line="218"/>
+        <location filename="../BikeScore.cpp" line="237"/>
         <source>Response Index</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5799,7 +5803,7 @@ Do you want to continue?</source>
 <context>
     <name>RideCount</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="34"/>
+        <location filename="../BasicRideMetrics.cpp" line="37"/>
         <source>Rides</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5807,9 +5811,9 @@ Do you want to continue?</source>
 <context>
     <name>RideDelegate</name>
     <message>
-        <location filename="../RideImportWizard.cpp" line="995"/>
-        <location filename="../RideImportWizard.cpp" line="1032"/>
-        <location filename="../RideImportWizard.cpp" line="1048"/>
+        <location filename="../RideImportWizard.cpp" line="998"/>
+        <location filename="../RideImportWizard.cpp" line="1035"/>
+        <location filename="../RideImportWizard.cpp" line="1051"/>
         <source>dd MMM yyyy</source>
         <translation>dd MMM yyyy</translation>
     </message>
@@ -6370,9 +6374,9 @@ Do you want to continue?</source>
     </message>
     <message>
         <location filename="../RideImportWizard.cpp" line="74"/>
-        <location filename="../RideImportWizard.cpp" line="696"/>
-        <location filename="../RideImportWizard.cpp" line="738"/>
-        <location filename="../RideImportWizard.cpp" line="890"/>
+        <location filename="../RideImportWizard.cpp" line="699"/>
+        <location filename="../RideImportWizard.cpp" line="741"/>
+        <location filename="../RideImportWizard.cpp" line="893"/>
         <source>Abort</source>
         <translation>Прервать</translation>
     </message>
@@ -6443,12 +6447,12 @@ Do you want to continue?</source>
     </message>
     <message>
         <location filename="../RideImportWizard.cpp" line="268"/>
-        <location filename="../RideImportWizard.cpp" line="454"/>
-        <location filename="../RideImportWizard.cpp" line="506"/>
-        <location filename="../RideImportWizard.cpp" line="717"/>
-        <location filename="../RideImportWizard.cpp" line="756"/>
-        <location filename="../RideImportWizard.cpp" line="895"/>
-        <location filename="../RideImportWizard.cpp" line="918"/>
+        <location filename="../RideImportWizard.cpp" line="457"/>
+        <location filename="../RideImportWizard.cpp" line="509"/>
+        <location filename="../RideImportWizard.cpp" line="720"/>
+        <location filename="../RideImportWizard.cpp" line="759"/>
+        <location filename="../RideImportWizard.cpp" line="898"/>
+        <location filename="../RideImportWizard.cpp" line="921"/>
         <source>Error</source>
         <translation>Ошибка</translation>
     </message>
@@ -6458,157 +6462,157 @@ Do you want to continue?</source>
         <translation>Анализ...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="378"/>
+        <location filename="../RideImportWizard.cpp" line="381"/>
         <source>Validated</source>
         <translation>Проверено</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="380"/>
+        <location filename="../RideImportWizard.cpp" line="383"/>
         <source>Warning - </source>
         <translation>Предупреждение - </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="394"/>
-        <location filename="../RideImportWizard.cpp" line="619"/>
-        <location filename="../RideImportWizard.cpp" line="765"/>
+        <location filename="../RideImportWizard.cpp" line="397"/>
+        <location filename="../RideImportWizard.cpp" line="622"/>
+        <location filename="../RideImportWizard.cpp" line="768"/>
         <source>dd MMM yyyy</source>
         <translation>dd MMM yyyy</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="395"/>
+        <location filename="../RideImportWizard.cpp" line="398"/>
         <source>hh:mm:ss ap</source>
         <translation>hh:mm:ss ap</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="432"/>
+        <location filename="../RideImportWizard.cpp" line="435"/>
         <source>Error - </source>
         <translation>Ошибка - </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="380"/>
-        <location filename="../RideImportWizard.cpp" line="432"/>
+        <location filename="../RideImportWizard.cpp" line="383"/>
+        <location filename="../RideImportWizard.cpp" line="435"/>
         <source> </source>
         <translation> </translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="447"/>
+        <location filename="../RideImportWizard.cpp" line="450"/>
         <source>Step 3 of 4: Confirm Date and Time</source>
         <translation>Шаг 3 из 4: Подтверждение даты и времени</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="464"/>
+        <location filename="../RideImportWizard.cpp" line="467"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="573"/>
-        <location filename="../RideImportWizard.cpp" line="623"/>
+        <location filename="../RideImportWizard.cpp" line="576"/>
+        <location filename="../RideImportWizard.cpp" line="626"/>
         <source>hh:mm:ss</source>
         <translation>hh:mm:ss</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="582"/>
+        <location filename="../RideImportWizard.cpp" line="585"/>
         <source>Invalid Selection</source>
         <translation>Неправильный выбор</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="582"/>
+        <location filename="../RideImportWizard.cpp" line="585"/>
         <source>More than 24hrs of rides to fit into a day</source>
         <translation>Более 24 часов тренировок в сутки о_О</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="627"/>
-        <location filename="../RideImportWizard.cpp" line="766"/>
+        <location filename="../RideImportWizard.cpp" line="630"/>
+        <location filename="../RideImportWizard.cpp" line="769"/>
         <source>hh:mm:ss a</source>
         <translation>hh:mm:ss a</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="736"/>
+        <location filename="../RideImportWizard.cpp" line="739"/>
         <source>Step 4 of 4: Save to Library</source>
         <translation>Шаг 4 из 4: Сохранить в библиотеку</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="758"/>
+        <location filename="../RideImportWizard.cpp" line="761"/>
         <source>Saving...</source>
         <translation>Сохранение...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="834"/>
+        <location filename="../RideImportWizard.cpp" line="837"/>
         <source>Error - Source is Target</source>
         <translation>Error - Source is Target</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="845"/>
+        <location filename="../RideImportWizard.cpp" line="848"/>
         <source>Overwriting file...</source>
         <translation>Перезапись файла ...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="847"/>
+        <location filename="../RideImportWizard.cpp" line="850"/>
         <source>/</source>
         <translation>/</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="847"/>
+        <location filename="../RideImportWizard.cpp" line="850"/>
         <source>.tmp</source>
         <translation>.tmp</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="821"/>
-        <location filename="../RideImportWizard.cpp" line="854"/>
+        <location filename="../RideImportWizard.cpp" line="824"/>
+        <location filename="../RideImportWizard.cpp" line="857"/>
         <source>File Overwritten</source>
         <translation>Файл перезаписан</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="857"/>
-        <location filename="../RideImportWizard.cpp" line="859"/>
+        <location filename="../RideImportWizard.cpp" line="860"/>
+        <location filename="../RideImportWizard.cpp" line="862"/>
         <source>Error - overwrite failed</source>
         <translation>Ошибка - перезапись не удалась</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="790"/>
-        <location filename="../RideImportWizard.cpp" line="862"/>
+        <location filename="../RideImportWizard.cpp" line="793"/>
+        <location filename="../RideImportWizard.cpp" line="865"/>
         <source>Error - File exists</source>
         <translation>Ошибка - Файл существует</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="865"/>
+        <location filename="../RideImportWizard.cpp" line="868"/>
         <source>Saving file...</source>
         <translation>Сохранение файла...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="823"/>
-        <location filename="../RideImportWizard.cpp" line="868"/>
+        <location filename="../RideImportWizard.cpp" line="826"/>
+        <location filename="../RideImportWizard.cpp" line="871"/>
         <source>File Saved</source>
         <translation>Файл сохранен</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="877"/>
+        <location filename="../RideImportWizard.cpp" line="880"/>
         <source>Error - copy failed</source>
         <translation>Ошибка - копирование не удалось</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="888"/>
+        <location filename="../RideImportWizard.cpp" line="891"/>
         <source>Step 5 of 5: Calculating Critical Powers</source>
         <translation>Шаг 5 из 5: Расчет критической мощности</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="896"/>
+        <location filename="../RideImportWizard.cpp" line="899"/>
         <source>Calculating...</source>
         <translation>Расчет...</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="905"/>
+        <location filename="../RideImportWizard.cpp" line="908"/>
         <source>Completed.</source>
         <translation>Завершено.</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="923"/>
+        <location filename="../RideImportWizard.cpp" line="926"/>
         <source>Import Complete. %1 of %2 successful.</source>
         <translation>Импорт завершен. %1 %2 успешен.</translation>
     </message>
     <message>
-        <location filename="../RideImportWizard.cpp" line="704"/>
-        <location filename="../RideImportWizard.cpp" line="928"/>
+        <location filename="../RideImportWizard.cpp" line="707"/>
+        <location filename="../RideImportWizard.cpp" line="931"/>
         <source>Finish</source>
         <translation>Готово</translation>
     </message>
@@ -6616,22 +6620,22 @@ Do you want to continue?</source>
 <context>
     <name>RideNavigator</name>
     <message>
-        <location filename="../RideNavigator.cpp" line="540"/>
+        <location filename="../RideNavigator.cpp" line="542"/>
         <source>Remove Column</source>
         <translation type="unfinished">Удалить столбец</translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="546"/>
+        <location filename="../RideNavigator.cpp" line="548"/>
         <source>Column Chooser</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="551"/>
+        <location filename="../RideNavigator.cpp" line="553"/>
         <source>Do Not Show in Groups</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../RideNavigator.cpp" line="551"/>
+        <location filename="../RideNavigator.cpp" line="553"/>
         <source>Show In Groups</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6998,32 +7002,32 @@ native format. Should we do so?
 <context>
     <name>SchemePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2295"/>
+        <location filename="../Pages.cpp" line="2297"/>
         <source>Add</source>
         <translation>Добавить</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2296"/>
+        <location filename="../Pages.cpp" line="2298"/>
         <source>Rename</source>
         <translation>Переименовать</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2297"/>
+        <location filename="../Pages.cpp" line="2299"/>
         <source>Delete</source>
         <translation>Удалить</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2306"/>
+        <location filename="../Pages.cpp" line="2308"/>
         <source>Short</source>
         <translation>Краткое</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2307"/>
+        <location filename="../Pages.cpp" line="2309"/>
         <source>Long</source>
         <translation>Полное</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2308"/>
+        <location filename="../Pages.cpp" line="2310"/>
         <source>Percent of CP</source>
         <translation>Процент от CP</translation>
     </message>
@@ -7108,42 +7112,42 @@ native format. Should we do so?
 <context>
     <name>SeasonsPage</name>
     <message>
-        <location filename="../Pages.cpp" line="3673"/>
+        <location filename="../Pages.cpp" line="3675"/>
         <source>Move up</source>
         <translation type="unfinished">Вверх</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3674"/>
+        <location filename="../Pages.cpp" line="3676"/>
         <source>Move down</source>
         <translation type="unfinished">Вниз</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3675"/>
+        <location filename="../Pages.cpp" line="3677"/>
         <source>Add</source>
         <translation type="unfinished">Добавить</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3676"/>
+        <location filename="../Pages.cpp" line="3678"/>
         <source>Delete</source>
         <translation type="unfinished">Удалить</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3685"/>
+        <location filename="../Pages.cpp" line="3687"/>
         <source>Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3686"/>
+        <location filename="../Pages.cpp" line="3688"/>
         <source>Type</source>
         <translation type="unfinished">Тип</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3687"/>
+        <location filename="../Pages.cpp" line="3689"/>
         <source>From</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="3688"/>
+        <location filename="../Pages.cpp" line="3690"/>
         <source>To</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7151,7 +7155,7 @@ native format. Should we do so?
 <context>
     <name>SessionRPE</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="302"/>
+        <location filename="../TRIMPPoints.cpp" line="316"/>
         <source>Session RPE</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7179,6 +7183,147 @@ native format. Should we do so?
         <location filename="../SmallPlot.cpp" line="237"/>
         <source>Time (minutes)</source>
         <translation type="unfinished">Время (минуты)</translation>
+    </message>
+</context>
+<context>
+    <name>SpecialFields</name>
+    <message>
+        <location filename="../SpecialFields.cpp" line="26"/>
+        <source>Start Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="27"/>
+        <source>Start Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="28"/>
+        <source>Identifier</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="29"/>
+        <source>Workout Code</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="30"/>
+        <source>Sport</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="31"/>
+        <source>Objective</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="32"/>
+        <source>Summary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="33"/>
+        <source>Notes</source>
+        <translation type="unfinished">Заметки</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="34"/>
+        <source>Keywords</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="35"/>
+        <source>Recording Interval</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="36"/>
+        <source>Weight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="37"/>
+        <source>Device</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="38"/>
+        <source>Device Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="39"/>
+        <source>Dropouts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="40"/>
+        <source>Dropout Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="41"/>
+        <source>Spikes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="42"/>
+        <source>Spike Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="43"/>
+        <source>Torque Adjust</source>
+        <translation type="unfinished">Крутящий момент</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="44"/>
+        <source>Filename</source>
+        <translation type="unfinished">Имя файла</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="45"/>
+        <source>Year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="46"/>
+        <source>Change History</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="47"/>
+        <source>Calendar Text</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="48"/>
+        <source>Data</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SpecialTabs</name>
+    <message>
+        <location filename="../SpecialFields.cpp" line="130"/>
+        <source>Workout</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="131"/>
+        <source>Notes</source>
+        <translation type="unfinished">Заметки</translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="132"/>
+        <source>Metric</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../SpecialFields.cpp" line="133"/>
+        <source>Extra</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -7595,22 +7740,22 @@ native format. Should we do so?
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="388"/>
+        <location filename="../StravaDialog.cpp" line="389"/>
         <source>Upload ride... Sending</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="398"/>
+        <location filename="../StravaDialog.cpp" line="399"/>
         <source>Upload finished.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="430"/>
+        <location filename="../StravaDialog.cpp" line="431"/>
         <source>Ride processing...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../StravaDialog.cpp" line="501"/>
+        <location filename="../StravaDialog.cpp" line="502"/>
         <source>Searching corresponding Ride</source>
         <translation type="unfinished"></translation>
     </message>
@@ -7863,7 +8008,7 @@ native format. Should we do so?
 <context>
     <name>TRIMP100Points</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="114"/>
+        <location filename="../TRIMPPoints.cpp" line="120"/>
         <source>TRIMP(100) Points</source>
         <translation>TRIMP(100) Points</translation>
     </message>
@@ -7871,7 +8016,7 @@ native format. Should we do so?
 <context>
     <name>TRIMPPoints</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="47"/>
+        <location filename="../TRIMPPoints.cpp" line="49"/>
         <source>TRIMP Points</source>
         <translation>TRIMP Points</translation>
     </message>
@@ -7879,7 +8024,7 @@ native format. Should we do so?
 <context>
     <name>TRIMPZonalPoints</name>
     <message>
-        <location filename="../TRIMPPoints.cpp" line="180"/>
+        <location filename="../TRIMPPoints.cpp" line="190"/>
         <source>TRIMP Zonal Points</source>
         <translation>TRIMP Zonal Points</translation>
     </message>
@@ -7887,13 +8032,13 @@ native format. Should we do so?
 <context>
     <name>TimeRiding</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="94"/>
+        <location filename="../BasicRideMetrics.cpp" line="105"/>
         <source>Time Riding</source>
         <translation>Время в пути</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="95"/>
-        <location filename="../BasicRideMetrics.cpp" line="96"/>
+        <location filename="../BasicRideMetrics.cpp" line="106"/>
+        <location filename="../BasicRideMetrics.cpp" line="107"/>
         <source>seconds</source>
         <translation>секунд</translation>
     </message>
@@ -7977,17 +8122,17 @@ native format. Should we do so?
 <context>
     <name>TotalDistance</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="129"/>
+        <location filename="../BasicRideMetrics.cpp" line="144"/>
         <source>Distance</source>
         <translation>Дистанция</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="131"/>
+        <location filename="../BasicRideMetrics.cpp" line="146"/>
         <source>km</source>
         <translation>км</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="132"/>
+        <location filename="../BasicRideMetrics.cpp" line="147"/>
         <source>miles</source>
         <translation>миль</translation>
     </message>
@@ -7995,13 +8140,13 @@ native format. Should we do so?
 <context>
     <name>TotalWork</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="213"/>
+        <location filename="../BasicRideMetrics.cpp" line="236"/>
         <source>Work</source>
         <translation>Работа</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="214"/>
-        <location filename="../BasicRideMetrics.cpp" line="215"/>
+        <location filename="../BasicRideMetrics.cpp" line="237"/>
+        <location filename="../BasicRideMetrics.cpp" line="238"/>
         <source>kJ</source>
         <translation>кДж</translation>
     </message>
@@ -8075,6 +8220,14 @@ Press F3 on Controller when done.</source>
         <location filename="../TrainTool.cpp" line="1279"/>
         <source>Done</source>
         <translation type="unfinished">Готово</translation>
+    </message>
+</context>
+<context>
+    <name>TreeMapWindow</name>
+    <message>
+        <location filename="../TreeMapWindow.cpp" line="100"/>
+        <source>Metric</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -8369,7 +8522,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>VAM</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="722"/>
+        <location filename="../BasicRideMetrics.cpp" line="811"/>
         <source>VAM</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8377,7 +8530,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>VariabilityIndex</name>
     <message>
-        <location filename="../BikeScore.cpp" line="102"/>
+        <location filename="../BikeScore.cpp" line="109"/>
         <source>Skiba VI</source>
         <translation>Skiba VI</translation>
     </message>
@@ -8409,13 +8562,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>Vo2max</name>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="252"/>
+        <location filename="../WattsPerKilogram.cpp" line="308"/>
         <source>Estimated VO2MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../WattsPerKilogram.cpp" line="254"/>
-        <location filename="../WattsPerKilogram.cpp" line="255"/>
+        <location filename="../WattsPerKilogram.cpp" line="310"/>
+        <location filename="../WattsPerKilogram.cpp" line="311"/>
         <source>ml/min/kg</source>
         <translation type="unfinished"></translation>
     </message>
@@ -8522,13 +8675,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>WorkoutTime</name>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="60"/>
+        <location filename="../BasicRideMetrics.cpp" line="67"/>
         <source>Duration</source>
         <translation>Продолжительность</translation>
     </message>
     <message>
-        <location filename="../BasicRideMetrics.cpp" line="61"/>
-        <location filename="../BasicRideMetrics.cpp" line="62"/>
+        <location filename="../BasicRideMetrics.cpp" line="68"/>
+        <location filename="../BasicRideMetrics.cpp" line="69"/>
         <source>seconds</source>
         <translation>секунд</translation>
     </message>
@@ -8564,13 +8717,13 @@ Press F3 on Controller when done.</source>
 <context>
     <name>XPower</name>
     <message>
-        <location filename="../BikeScore.cpp" line="45"/>
+        <location filename="../BikeScore.cpp" line="48"/>
         <source>xPower</source>
         <translation>xPower</translation>
     </message>
     <message>
-        <location filename="../BikeScore.cpp" line="47"/>
-        <location filename="../BikeScore.cpp" line="48"/>
+        <location filename="../BikeScore.cpp" line="50"/>
+        <location filename="../BikeScore.cpp" line="51"/>
         <source>watts</source>
         <translation>ватт</translation>
     </message>
@@ -8593,12 +8746,12 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZonePage</name>
     <message>
-        <location filename="../Pages.cpp" line="2278"/>
+        <location filename="../Pages.cpp" line="2280"/>
         <source>Critical Power History</source>
         <translation>История критической мощности</translation>
     </message>
     <message>
-        <location filename="../Pages.cpp" line="2279"/>
+        <location filename="../Pages.cpp" line="2281"/>
         <source>Default Zones</source>
         <translation>Уровни по умолчанию</translation>
     </message>
@@ -8606,7 +8759,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime1</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="74"/>
+        <location filename="../TimeInZone.cpp" line="79"/>
         <source>L1 Time in Zone</source>
         <translation>Время на уровне L1</translation>
     </message>
@@ -8614,7 +8767,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime10</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="182"/>
+        <location filename="../TimeInZone.cpp" line="232"/>
         <source>L10 Time in Zone</source>
         <translation>Время на уровне L10</translation>
     </message>
@@ -8622,7 +8775,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime2</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="86"/>
+        <location filename="../TimeInZone.cpp" line="96"/>
         <source>L2 Time in Zone</source>
         <translation>Время на уровне L2</translation>
     </message>
@@ -8630,7 +8783,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime3</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="98"/>
+        <location filename="../TimeInZone.cpp" line="113"/>
         <source>L3 Time in Zone</source>
         <translation>Время на уровне L3</translation>
     </message>
@@ -8638,7 +8791,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime4</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="110"/>
+        <location filename="../TimeInZone.cpp" line="130"/>
         <source>L4 Time in Zone</source>
         <translation>Время на уровне L4</translation>
     </message>
@@ -8646,7 +8799,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime5</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="122"/>
+        <location filename="../TimeInZone.cpp" line="147"/>
         <source>L5 Time in Zone</source>
         <translation>Время на уровне L5</translation>
     </message>
@@ -8654,7 +8807,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime6</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="134"/>
+        <location filename="../TimeInZone.cpp" line="164"/>
         <source>L6 Time in Zone</source>
         <translation>Время на уровне L6</translation>
     </message>
@@ -8662,7 +8815,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime7</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="146"/>
+        <location filename="../TimeInZone.cpp" line="181"/>
         <source>L7 Time in Zone</source>
         <translation>Время на уровне L7</translation>
     </message>
@@ -8670,7 +8823,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime8</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="158"/>
+        <location filename="../TimeInZone.cpp" line="198"/>
         <source>L8 Time in Zone</source>
         <translation>Время на уровне L8</translation>
     </message>
@@ -8678,7 +8831,7 @@ Press F3 on Controller when done.</source>
 <context>
     <name>ZoneTime9</name>
     <message>
-        <location filename="../TimeInZone.cpp" line="170"/>
+        <location filename="../TimeInZone.cpp" line="215"/>
         <source>L9 Time in Zone</source>
         <translation>Время на уровне L9</translation>
     </message>


### PR DESCRIPTION
This patch keeps the original english name for SpecialFields and SpecialTabs
as internalName, to preserve compatibility, while it uses a translated
displayName for user interfase in other languages.
