### PR TITLE
Add error reporting to Estimate CdA and Crr

### DIFF
--- a/src/Aerolab.cpp
+++ b/src/Aerolab.cpp
@@ -774,19 +774,22 @@ void Aerolab::refreshIntervalMarkers()
 /*
  * Estimate CdA and Crr usign energy balance in segments defined by
  * non-zero altitude.
+ * Returns an explanatory error message ff it fails to do the estimation,
+ * otherwise it updates cda and crr and returns an empty error message.
  * Author: Alejandro Martinez
  * Date: 23-aug-2012
  */
-bool Aerolab::estimateCdACrr(RideItem *rideItem)
+QString Aerolab::estimateCdACrr(RideItem *rideItem)
 {
     // HARD-CODED DATA: p1->kph
     const double vfactor = 3.600;
     const double g = 9.80665;
     RideFile *ride = rideItem->ride();
+    QString errMsg;
 
     if(ride) {
         const RideFileDataPresent *dataPresent = ride->areDataPresent();
-        if(dataPresent->alt && dataPresent->alt) {
+        if(dataPresent->alt && dataPresent->watts) {
             double dt = ride->recIntSecs();
             int npoints = ride->dataPoints().size();
             double X1[npoints], X2[npoints], Egain[npoints];
@@ -877,11 +880,21 @@ bool Aerolab::estimateCdACrr(RideItem *rideItem)
                     if (cda >= 0.001 and cda <= 1.0 and crr >= 0.0001 and crr <= 0.1) {
                         this->cda = cda;
                         this->crr = crr;
-                        return true;
+                        errMsg = ""; // No error
+                    } else {
+                        errMsg = tr("Estimates out-of-range");
                     }
+                } else {
+                    errMsg = tr("At least two segments must be independent");
                 }
+            } else {
+                errMsg = tr("At least two segments must be defined");
             }
+        } else {
+            errMsg = tr("Altitude and Power data must be present");
         }
+    } else {
+        errMsg = tr("No ride selected");
     }
-    return false;
+    return errMsg;
 }

--- a/src/Aerolab.h
+++ b/src/Aerolab.h
@@ -135,7 +135,7 @@ class Aerolab : public QwtPlot {
   int      intRho() const { return (int)( rho * 10000); }
   int      intEta() const { return (int)( eta * 10000); }
   int      intEoffset() const { return (int)( eoffset * 100); }
-  bool     estimateCdACrr(RideItem* rideItem);
+  QString  estimateCdACrr(RideItem* rideItem);
 
 };
 

--- a/src/AerolabWindow.cpp
+++ b/src/AerolabWindow.cpp
@@ -475,7 +475,8 @@ AerolabWindow::doEstCdACrr()
 {
     RideItem *ride = mainWindow->rideItem();
     /* Estimate Crr&Cda */
-    if (aerolab->estimateCdACrr(ride)) {
+    const QString errMsg = aerolab->estimateCdACrr(ride);
+    if (errMsg.isEmpty()) {
         /* Update Crr/Cda values values in UI */
         crrLineEdit->setText(QString("%1").arg(aerolab->getCrr()) );
         crrSlider->setValue(aerolab->intCrr());
@@ -485,6 +486,7 @@ AerolabWindow::doEstCdACrr()
         aerolab->setData(ride, false);
     } else {
         /* report error: insufficient data to estimate Cda&Crr */
+        QMessageBox::warning(this, tr("Estimate Cda and Crr"), errMsg);
     }
 }
 


### PR DESCRIPTION
This patch got lost in the migration to github, it completes the CdA and Crr estimation code to inform the user the cause when the estimation cannot be done, previous version just does nothing in that case.
