### PR TITLE
Chart Settings (show legend and shade zones) do not persist.

### DIFF
--- a/src/LTMWindow.cpp
+++ b/src/LTMWindow.cpp
@@ -96,12 +96,8 @@ LTMWindow::LTMWindow(MainWindow *parent, bool useMetricUnits, const QDir &home) 
     settings.ltmTool = ltmTool;
     settings.data = NULL;
     settings.groupBy = LTM_DAY;
-    settings.legend = true;
-    if (appsettings->value(this, GC_SHADEZONES, true).toBool()==true)
-        settings.shadeZones = true;
-    else
-        settings.shadeZones = false;
-
+    settings.legend = ltmTool->showLegend->isChecked();
+    settings.shadeZones = ltmTool->shadeZones->isChecked();
     cl->addWidget(ltmTool);
 
     connect(this, SIGNAL(dateRangeChanged(DateRange)), this, SLOT(dateRangeChanged(DateRange)));


### PR DESCRIPTION
LTM settings default to: Show Legend = true; Shade Zones = true; 
They should persist.

I'm sure there's a more correct way to do this but I couldn't find it.
