### PR TITLE
Pre-work for coastdown calibration

### DIFF
--- a/src/ANT.cpp
+++ b/src/ANT.cpp
@@ -185,9 +185,6 @@ void ANT::run()
 
     if (openPort() == 0) {
 
-        antlog.setFileName("antlog.bin");
-        antlog.open(QIODevice::WriteOnly | QIODevice::Truncate);
-
         sendMessage(ANTMessage::resetSystem());
         sendMessage(ANTMessage::setNetworkKey(1, key));
 
@@ -312,8 +309,8 @@ ANT::stop()
     Status = 0; // Terminate it!
     pvars.unlock();
 
-    // close debug file
-    antlog.close();
+    // Signal to stop logging
+    emit receivedAntMessage(NULL, NULL);
     return 0;
 }
 
@@ -691,10 +688,9 @@ ANT::processMessage(void) {
 //for(int i=0; i<m.length+3; i++) fprintf(stderr, "%02x ", m.data[i]);
 //fprintf(stderr, "\n");
 
-    QDataStream out(&antlog);
-    for (int i=0; i<ANT_MAX_MESSAGE_SIZE; i++)
-        out<<rxMessage[i];
-    
+    struct timeval timestamp;
+    gettimeofday (&timestamp, NULL);
+    emit receivedAntMessage(&m, &timestamp);
 
     switch (rxMessage[ANT_OFFSET_ID]) {
         case ANT_ACK_DATA:

--- a/src/ANT.h
+++ b/src/ANT.h
@@ -257,6 +257,7 @@ signals:
     void searchTimeout(int channel);         // searchTimeount
     void searchComplete(int channel);         // searchComplete
     void signalStrength(int channel, double reliability);
+    void receivedAntMessage(const ANTMessage *message, const struct timeval *timestamp);
 
 public slots:
 
@@ -391,8 +392,6 @@ private:
 
     QQueue<setChannelAtom> channelQueue; // messages for configuring channels from controller
 
-    // antlog.bin ant message stream
-    QFile antlog;
 };
 
 #endif

--- a/src/ANTLogger.cpp
+++ b/src/ANTLogger.cpp
@@ -1,0 +1,31 @@
+#include "ANTLogger.h"
+
+ANTLogger::ANTLogger(QObject *parent) : QObject(parent)
+{
+    isLogging=false;
+}
+
+void ANTLogger::logRawAntMessage(const ANTMessage *message, const struct timeval *timestamp)
+{
+    if (message==NULL && timestamp==NULL) {
+        if (isLogging) {
+            // close debug file
+            antlog.close();
+        }
+        return;
+    }
+
+    if (!isLogging) {
+        antlog.setFileName("antlog.bin");
+        antlog.open(QIODevice::WriteOnly | QIODevice::Truncate);
+        isLogging = true;
+    }
+
+    QDataStream out(&antlog);
+
+    for (int i=0; i<ANT_MAX_MESSAGE_SIZE; i++)
+        out<<message->data[i];
+
+
+}
+

--- a/src/ANTLogger.h
+++ b/src/ANTLogger.h
@@ -1,0 +1,26 @@
+#include <sys/time.h>
+#include <QObject>
+#include "ANTMessage.h"
+
+#ifndef ANTLOGGER_H
+#define ANTLOGGER_H
+
+class ANTLogger : public QObject
+{
+    Q_OBJECT
+public:
+    explicit ANTLogger(QObject *parent = 0);
+    
+signals:
+    
+public slots:
+    void logRawAntMessage(const ANTMessage *message, const struct timeval *timestamp);
+
+private:
+    // antlog.bin ant message stream
+    QFile antlog;
+    bool isLogging;
+
+};
+
+#endif // ANTLOGGER_H

--- a/src/ANTlocalController.cpp
+++ b/src/ANTlocalController.cpp
@@ -20,6 +20,7 @@
 #include <QProgressDialog>
 #include "ANTlocalController.h"
 #include "ANT.h"
+#include "ANTLogger.h"
 #include "RealtimeData.h"
 
 ANTlocalController::ANTlocalController(TrainTool *parent, DeviceConfiguration *dc) : RealtimeController(parent, dc)
@@ -28,6 +29,9 @@ ANTlocalController::ANTlocalController(TrainTool *parent, DeviceConfiguration *d
     connect(myANTlocal, SIGNAL(foundDevice(int,int,int)), this, SIGNAL(foundDevice(int,int,int)));
     connect(myANTlocal, SIGNAL(lostDevice(int)), this, SIGNAL(lostDevice(int)));
     connect(myANTlocal, SIGNAL(searchTimeout(int)), this, SIGNAL(searchTimeout(int)));
+
+    // Connect a logger
+    connect(myANTlocal, SIGNAL(receivedAntMessage(const ANTMessage *,const timeval *)), &logger, SLOT(logRawAntMessage(const ANTMessage *,const timeval *)));
 }
 
 void

--- a/src/ANTlocalController.h
+++ b/src/ANTlocalController.h
@@ -20,6 +20,7 @@
 #include "RealtimeController.h"
 #include "DeviceConfiguration.h"
 #include "ANT.h"
+#include "ANTLogger.h"
 #include "ConfigDialog.h"
 
 // Abstract base class for Realtime device controllers
@@ -65,6 +66,8 @@ signals:
 
 private:
     QQueue<setChannelAtom> channelQueue;
+    ANTLogger logger;
+
     
 };
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -225,6 +225,7 @@ HEADERS += \
         AllPlotWindow.h \
         ANT.h \
         ANTChannel.h \
+        ANTLogger.h \
         ANTMessage.h \
         ANTMessages.h \
         ANTlocalController.h \
@@ -410,6 +411,7 @@ SOURCES += \
         AthleteTool.cpp \
         ANT.cpp \
         ANTChannel.cpp \
+        ANTLogger.cpp \
         ANTMessage.cpp \
         ANTlocalController.cpp \
         ANTplusController.cpp \


### PR DESCRIPTION
ANT.cpp now emits a signal for each ANTMessage
ANTlocalController wires up this signal to a slot in ANTLogger which
writes the message to antlog.bin

Signed-off-by: dhague darren.hague@fortybeans.com
