### PR TITLE
50 min peaks

### DIFF
--- a/src/PeakPower.cpp
+++ b/src/PeakPower.cpp
@@ -256,6 +256,23 @@ class PeakPower30m : public PeakPower {
         RideMetric *clone() const { return new PeakPower30m(*this); }
 };
 
+class PeakPower50m : public PeakPower {
+    Q_DECLARE_TR_FUNCTIONS(PeakPower50m)
+    public:
+        PeakPower50m()
+        {
+            setSecs(3000);
+            setSymbol("50m_critical_power");
+            setInternalName("50 min Peak Power");
+        }
+        void initialize () {
+            setName(tr("50 min Peak Power"));
+            setMetricUnits(tr("watts"));
+            setImperialUnits(tr("watts"));
+        }
+        RideMetric *clone() const { return new PeakPower50m(*this); }
+};
+
 class PeakPowerHr : public RideMetric {
     Q_DECLARE_TR_FUNCTIONS(PeakPowerHr)
 
@@ -386,6 +403,24 @@ class PeakPowerHr30m : public PeakPowerHr {
         RideMetric *clone() const { return new PeakPowerHr30m(*this); }
 };
 
+class PeakPowerHr50m : public PeakPowerHr {
+    Q_DECLARE_TR_FUNCTIONS(PeakPowerHr50m)
+
+    public:
+        PeakPowerHr50m()
+        {
+            setSecs(3000);
+            setSymbol("50m_critical_power_hr");
+            setInternalName("50 min Peak Power HR");
+        }
+        void initialize () {
+            setName(tr("50 min Peak Power HR"));
+            setMetricUnits(tr("bpm"));
+            setImperialUnits(tr("bpm"));
+        }
+        RideMetric *clone() const { return new PeakPowerHr50m(*this); }
+};
+
 
 class PeakPowerHr60m : public PeakPowerHr {
     Q_DECLARE_TR_FUNCTIONS(PeakPowerHr60m)
@@ -417,12 +452,14 @@ static bool addAllPeaks() {
     RideMetricFactory::instance().addMetric(PeakPower10m());
     RideMetricFactory::instance().addMetric(PeakPower20m());
     RideMetricFactory::instance().addMetric(PeakPower30m());
+    RideMetricFactory::instance().addMetric(PeakPower50m());
     RideMetricFactory::instance().addMetric(CriticalPower());
     RideMetricFactory::instance().addMetric(PeakPowerHr1m());
     RideMetricFactory::instance().addMetric(PeakPowerHr5m());
     RideMetricFactory::instance().addMetric(PeakPowerHr10m());
     RideMetricFactory::instance().addMetric(PeakPowerHr20m());
     RideMetricFactory::instance().addMetric(PeakPowerHr30m());
+    RideMetricFactory::instance().addMetric(PeakPowerHr50m());
     RideMetricFactory::instance().addMetric(PeakPowerHr60m());
     return true;
 }

--- a/src/WattsPerKilogram.cpp
+++ b/src/WattsPerKilogram.cpp
@@ -295,6 +295,21 @@ class PeakWPK30m : public PeakWPK {
         RideMetric *clone() const { return new PeakWPK30m(*this); }
 };
 
+class PeakWPK50m : public PeakWPK {
+    Q_DECLARE_TR_FUNCTIONS(PeakWPK50m)
+    public:
+        PeakWPK50m()
+        {
+            setSecs(3000);
+            setSymbol("50m_peak_wpk");
+            setInternalName("50 min Peak WPK");
+        }
+        void initialize () {
+            setName(tr("50 min Peak WPK"));
+        }
+        RideMetric *clone() const { return new PeakWPK50m(*this); }
+};
+
 class Vo2max : public RideMetric {
     Q_DECLARE_TR_FUNCTIONS(Vo2max)
     public:
@@ -335,6 +350,7 @@ static bool addAllWPK() {
     RideMetricFactory::instance().addMetric(PeakWPK10m());
     RideMetricFactory::instance().addMetric(PeakWPK20m());
     RideMetricFactory::instance().addMetric(PeakWPK30m());
+    RideMetricFactory::instance().addMetric(PeakWPK50m());
     RideMetricFactory::instance().addMetric(CPWPK());
     QVector<QString> deps;
     deps.append("5m_peak_wpk");


### PR DESCRIPTION
I'm not sure it's useful to anyone else, but as my best FTPish efforts are in crits or 25m TTs, 60 min peak misses them, so I like to track my best 50 min efforts.

I don't mind if this isn't wanted, I'm happy enough to have it in my own fork. Note that metricsDBv3 needs to be reset.
