### PR TITLE
fix for #457

### DIFF
--- a/src/PowerTapUtil.cpp
+++ b/src/PowerTapUtil.cpp
@@ -131,6 +131,9 @@ PowerTapUtil::unpack_data(unsigned char *buf, double rec_int_secs,
         else
         {
             *watts = ((buf[2] & 0x0f) << 8) | buf[3];
+            if(*watts >= 4000.00)
+                *watts = 0.0;
+            
             *cad = buf[4];
             if (*cad == 0xff)
                 *cad = 0;


### PR DESCRIPTION
This caps the wattage at 4kW, and hence the torque values also. It's fairly safe to assume that no-one will be producing 4kW on a PowerTap

Without a better debugger I'm unable to see what is going on with the wattage, this might be an imperfect fix for the time being, but make GC usable for me again. 
