### PR TITLE
Fixed CP chart title blanking out after first showing

### DIFF
--- a/src/CpintPlot.cpp
+++ b/src/CpintPlot.cpp
@@ -79,6 +79,7 @@ CpintPlot::CpintPlot(MainWindow *main, QString p, const Zones *zones) :
     curveTitle.attach(this);
     curveTitle.setXValue(5);
     curveTitle.setYValue(20);
+    curveTitle.setLabel(QwtText("", QwtText::PlainText)); // default to no title
 
     zoomer = new penTooltip(this->canvas());
     zoomer->setMousePattern(QwtEventPattern::MouseSelect1,
@@ -537,7 +538,6 @@ CpintPlot::calculate(RideItem *rideItem)
     //
     // PLOT MODEL CURVE (DERIVED)
     //
-    curveTitle.setLabel(QwtText("", QwtText::PlainText)); // default to no title
     if (series == RideFile::xPower || series == RideFile::NP || series == RideFile::watts  || series == RideFile::wattsKg || series == RideFile::none) {
 
         if (bests->meanMaxArray(series).size() > 1) {


### PR DESCRIPTION
Trying this again after a git rebase.  Move initialization of curveTitle to CpintPlot constructor from calculate() so the CP chart title doesn't get overriden to blank after its first showing.
