### PR TITLE
Clean up code to avoid thread race conditions on GC exit

### DIFF
--- a/src/Computrainer.cpp
+++ b/src/Computrainer.cpp
@@ -441,10 +441,6 @@ int Computrainer::stop()
     pvars.lock();
     deviceStatus = 0; // Terminate it!
     pvars.unlock();
-	// Ok, let's wrap it up
-	closePort(); // need to release that file handle!!
-	quit(0);
-	QThread::wait();			// wait to avoid race conditions
     return 0;
 }
 


### PR DESCRIPTION
On Ctrl-Q and Ctrl-W close events, ensure the TrainStops if it is running and in the Computrainer stop() method, clean up the thread and wait for it.  This avoids closing GC while the CT threat is still running and ensures all timers and files are closed properly.
