### PR TITLE
Zones class a little more generic, prepare for speed.zones

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -2625,7 +2625,9 @@ MainWindow::setCriticalPower(int cp)
 
   zones_->setCP(range, cp);        // update the CP value
   zones_->setZonesFromCP(range);   // update the zones based on the value of CP
-  zones_->write(home);             // write the output file
+
+  QFile zonesFile(home.absolutePath() + "/power.zones");
+  zones_->write(zonesFile);             // write the output file
 
   QDate startDate = zones_->getStartDate(range);
   QDate endDate   =  zones_->getEndDate(range);

--- a/src/NewCyclistDialog.cpp
+++ b/src/NewCyclistDialog.cpp
@@ -196,7 +196,8 @@ NewCyclistDialog::saveClicked()
                 // Setup Power Zones
                 Zones zones;
                 zones.addZoneRange(QDate(1900, 01, 01), cp->value());
-                zones.write(QDir(home.path() + "/" + name->text()));
+                QFile zonesFile(home.path() + "/" + name->text() + "/power.zones");
+                zones.write(zonesFile);
 
                 // HR Zones too!
                 HrZones hrzones;

--- a/src/Pages.cpp
+++ b/src/Pages.cpp
@@ -2159,7 +2159,8 @@ void
 ZonePage::saveClicked()
 {
     zones.setScheme(schemePage->getScheme());
-    zones.write(main->home);
+    QFile zonesFile(main->home.absolutePath() + "/power.zones");
+    zones.write(zonesFile);
 }
 
 SchemePage::SchemePage(ZonePage* zonePage) : zonePage(zonePage)

--- a/src/Zones.cpp
+++ b/src/Zones.cpp
@@ -615,7 +615,7 @@ QString Zones::summarize(int rnum, QVector<double> &time_in_zone) const
 }
 
 #define USE_SHORT_POWER_ZONES_FORMAT true   /* whether a less redundent format should be used */
-void Zones::write(QDir home)
+void Zones::write(QFile &file)
 {
     QString strzones;
 
@@ -670,7 +670,6 @@ void Zones::write(QDir home)
         #endif
     }
 
-    QFile file(home.absolutePath() + "/power.zones");
     if (file.open(QFile::WriteOnly))
     {
         QTextStream stream(&file);

--- a/src/Zones.h
+++ b/src/Zones.h
@@ -148,7 +148,7 @@ class Zones : public QObject
         // read and write power.zones
         //
         bool read(QFile &file);
-        void write(QDir home);
+        void write(QFile &file);
         const QString &errorString() const { return err; }
         const QString &warningString() const { return warning; }
 


### PR DESCRIPTION
Give file argument for write() like it is for read(). Preparing for 'Critical Speed' zones for running.

Just a little change towards the following issue, which I will try for release 3.1
https://github.com/GoldenCheetah/GoldenCheetah/issues/341
