### PR TITLE
Fix for 'stuck in full screen' issue

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -221,7 +221,15 @@ MainWindow::MainWindow(const QDir &home) :
         font.setPointSize(app.defaultFont);
         QApplication::setFont(font);
 
-    } else setGeometry(geom.toRect());
+    } else {
+        QRect size = desktop->availableGeometry();
+
+        // ensure saved geometry isn't greater than current screen size
+        if ((geom.toRect().height() > size.height()) || (geom.toRect().width() > size.width()))
+            setGeometry(size);
+        else
+            setGeometry(geom.toRect());
+    }
 
 
 #ifdef Q_OS_MAC // MAC NATIVE TOOLBAR


### PR DESCRIPTION
When GC is restarted after being closed full screen, the saved geometry
is larger than the actual screen size - resulting in the title bar being
drawn off screen & not easily reachable.

This patch checks whether the saved geometry is larger than the current
screen size, and resizes to the screen size instead of the saved values.
