### PR TITLE
Attempt to fix intermittent segfault at end of workout

### DIFF
--- a/src/ANT.cpp
+++ b/src/ANT.cpp
@@ -344,6 +344,9 @@ ANT::quit(int code)
     // ensure no more messages can arrive and re-open the log file.
     emit receivedAntMessage(NULL, NULL);
 
+    // Give queued messages a chance to be written to the log before thread terminates.
+    msleep(500);
+
     exit(code);
     return 0;
 }


### PR DESCRIPTION
There is an intermittent segfault in ANTLogger::logRawAntMessage() at
the end of a workout. When this occurs it seems that the message data
can not be read. 

This commit just adds a 500ms delay before closing the ANT worker thread,
which should allow any queued messages to be written to the log file
before the thread terminates.

---

This only happens right at the end of the workout when the ANT worker thread is closed, so am assuming the message data is being lost when the thread that posted it is terminated. 

But I must confess I'm not very clear on how Qt signals / slots work, as I thought the data could be dereferenced once sent by the thread that emits it?

Anyway the issue is intermittent enough that I've not been able to prove whether this fixes it conclusively, but it does allow any outstanding messages to be written to the debug log before the ANT thread is terminated.
