### PR TITLE
#678: Tcx: fix speed in summary information

### DIFF
--- a/src/TcxRideFile.cpp
+++ b/src/TcxRideFile.cpp
@@ -120,7 +120,8 @@ TcxFileReader::toByteArray(Context *context, const RideFile *ride, bool withAlt,
     lap.appendChild(lap_distance);
 
     QDomElement max_speed = doc.createElement("MaximumSpeed");
-    text = doc.createTextNode(QString("%1").arg(computed.value("max_speed")->value(true)));
+    text = doc.createTextNode(QString("%1")
+        .arg(computed.value("max_speed")->value(true) / 3.6));
     max_speed.appendChild(text);
     lap.appendChild(max_speed);
 
@@ -273,7 +274,8 @@ TcxFileReader::toByteArray(Context *context, const RideFile *ride, bool withAlt,
     extensions.appendChild(lx);
 
     QDomElement avg_speed = doc.createElement("AvgSpeed");
-    text = doc.createTextNode(QString("%1").arg(computed.value("average_speed")->value(true)));
+    text = doc.createTextNode(QString("%1")
+        .arg(computed.value("average_speed")->value(true) / 3.6));
     avg_speed.appendChild(text);
     lx.appendChild(avg_speed);
 


### PR DESCRIPTION
This is fixing 2) in #678:

When exporting files to Tcx, it's writing an ActivityExtension to the end
of the file with calculated AvgSpeed and MaxSpeed. Unfortunatly it's using
the km/h values - while Tcx is using m/sec. Schema is a bit unclear about
this, as the ActivityExtension uses "double" as type for both values, but
original Tcx v2 Schema only uses m/sec, GTC exports as m/sec and some
other software is expecting m/sec, aswell.
