### PR TITLE
Adding hr,cad,power,temp of the watch "Suunto Ambit2" Export gpx files

### DIFF
--- a/src/GpxParser.h
+++ b/src/GpxParser.h
@@ -42,22 +42,25 @@ public:
 
 private:
 
-    RideFile*	rideFile;
+    RideFile*   rideFile;
 
-    QString	buffer;
+    QString     buffer;
     QVariant    isGarminSmartRecording;
     QVariant    GarminHWM;
 
-    QDateTime	start_time;
-    QDateTime	last_time;
-    QDateTime	time;
-    double	distance;
+    QDateTime   start_time;
+    QDateTime   last_time;
+    QDateTime   time;
+    double      distance;
     double      lastLat, lastLon;
 
     double      alt;
     double      lat;
     double      lon;
-    int         hr;
+    double      hr;
+    double      temp;
+    double      cad;
+    double      watts;
 
     // set to false after the first time element is seen (not in metadata)
     bool firstTime;


### PR DESCRIPTION
Added support for the Export .gpx datafile of the watch "Suunto Ambit2", where the heart rate, temperature and cadence are saved in <extensions> with the tag name "gpxdata:hr", ...
added the "gpxdata:bikepower" as well, which I hope Suunto will add it in future as well into the export gpx file.
I got the name bikepower from the download file of the moveslink application.

Exporting GPX data from http://www.movescount.com/ is currently the only way for me to have the ride data of the great watch "Suunto Ambit2" in GC.
