### PR TITLE
Detach kernel driver before claiming USB2 ANT+ interface.

### DIFF
--- a/src/LibUsb.cpp
+++ b/src/LibUsb.cpp
@@ -406,9 +406,9 @@ struct usb_dev_handle* LibUsb::OpenAntStick()
 
                         if ((intf = usb_find_interface(&dev->config[0])) != NULL) {
 
-                            if (OperatingSystem == LINUX) {
-                                usb_detach_kernel_driver_np(udev, interface);
-                            }
+#ifdef Q_OS_LINUX
+                            usb_detach_kernel_driver_np(udev, interface);
+#endif
 
                             int rc = usb_set_configuration(udev, 1);
                             if (rc < 0) {


### PR DESCRIPTION
Kernel 3.11 exposes the Suunto ANT+ stick as a USB serial device,
this prevents GC from opening it in training mode unless the
kernel driver is detached first.
