### PR TITLE
Handle SSL errors when using Google Maps API

### DIFF
--- a/src/GoogleMapControl.cpp
+++ b/src/GoogleMapControl.cpp
@@ -30,6 +30,9 @@
 #include "TimeUtils.h"
 
 #include <QDebug>
+#include <QtNetwork/QSslConfiguration>
+#include <QtNetwork/QSslSocket>
+#include <QtNetwork/QSslError>
 
 GoogleMapControl::GoogleMapControl(MainWindow *mw) : GcChartWindow(mw), main(mw), range(-1), current(NULL)
 {
@@ -60,6 +63,12 @@ GoogleMapControl::GoogleMapControl(MainWindow *mw) : GcChartWindow(mw), main(mw)
     connect(mw, SIGNAL(intervalsChanged()), webBridge, SLOT(intervalsChanged()));
     connect(mw, SIGNAL(intervalSelected()), webBridge, SLOT(intervalsChanged()));
     connect(mw, SIGNAL(intervalZoom(IntervalItem*)), this, SLOT(zoomInterval(IntervalItem*)));
+
+    connect(view->page()->networkAccessManager(), SIGNAL(sslErrors(QNetworkReply*, const QList<QSslError> & )),
+            this, SLOT(sslErrorHandler(QNetworkReply*, const QList<QSslError> & )));
+
+    bool isSSLSupported = QSslSocket::supportsSsl();
+    qDebug() << "SSL Support:" << isSSLSupported ;
 
     first = true;
 }
@@ -475,6 +484,16 @@ GoogleMapControl::createMarkers()
 
     return;
 }
+
+void GoogleMapControl::sslErrorHandler(QNetworkReply* qnr, const QList<QSslError> & errlist)
+{
+
+    qDebug() << "SSL Error(s):" << errlist;
+    qDebug() << "Certificate:" << qnr->sslConfiguration().peerCertificate();
+
+    qnr->ignoreSslErrors();
+}
+
 
 void GoogleMapControl::zoomInterval(IntervalItem *which)
 {

--- a/src/GoogleMapControl.h
+++ b/src/GoogleMapControl.h
@@ -94,6 +94,8 @@ class GoogleMapControl : public GcChartWindow
         void createMarkers();
         void drawShadedRoute();
         void zoomInterval(IntervalItem*);
+        void sslErrorHandler(QNetworkReply* qnr, const QList<QSslError> & errlist);
+
 
     private:
         MainWindow *main;


### PR DESCRIPTION
The default.css location now redirects to an HTTPS URL, causing an
SSL error to be thrown in some builds. This results in the style
sheet not being loaded, and the map height becoming 0 pixels and
therefore not rendering correctly.

This patch displays the state of SSL support, and if any errors are
thrown, the error messages and the peer certificate.

It will then ignore the error, allowing the Google Maps page to be
displayed correctly.
