### PR TITLE
Don't reset ANT channel settings on search timeout

### DIFF
--- a/src/ANTChannel.cpp
+++ b/src/ANTChannel.cpp
@@ -174,11 +174,13 @@ void ANTChannel::channelEvent(unsigned char *ant_message) {
 
             emit lostInfo(number);
 
-            channel_type=CHANNEL_TYPE_UNUSED;
-            channel_type_flags=0;
-            device_number=0;
-            value2=value=0;
-            setId();
+            // Don't wipe out the channel settings when the search times out,
+            // else can not reconnect to the device once back in range..
+            //channel_type=CHANNEL_TYPE_UNUSED;
+            //channel_type_flags=0;
+            //device_number=0;
+            //value2=value=0;
+            //setId();
 
             parent->sendMessage(ANTMessage::unassignChannel(number));
         }


### PR DESCRIPTION
Wiping out these settings prevents a successful reconnection
of the device if it comes back into range

Fixes #514

---

This fixes the issue of walking away from a training view session, and subsequently losing HR data for the remainder of the session - even when back in range. This can be easily reproduced by taking the HR strap into another room for one minute.

Because the ANT channel type is reset, when the code next passes through the state machine in ANTChannel::attemptTransition(), it assigns the channel to network 0 (the default public network) instead of network 1 (the ANT sport network).

Maybe someone more familiar with the ANT code should cast an eye over this, but I haven't seen any unwanted side effects? The channel type is still unset in ANT::removeDevice() when the training session is ended.
