### PR TITLE
Using milliseconds for speed calculation, needed for Suunto Ambit gpx datafiles

### DIFF
--- a/src/GpxParser.cpp
+++ b/src/GpxParser.cpp
@@ -170,7 +170,8 @@ bool
 
         // compute the elapsed time and distance traveled since the
         // last recorded trackpoint
-        double delta_t = last_time.secsTo(time);
+        // use msec in case there are msec in QDateTime
+        double delta_t_ms = last_time.msecsTo(time);
         if (delta_d<0)
         {
             delta_d=0;
@@ -181,9 +182,9 @@ bool
         // for the first trackpoint -- so set speed to 0.0 instead of
         // dividing by zero.
         double speed = 0.0;
-        if (delta_t > 0.0)
+        if (delta_t_ms > 0.0)
         {
-            speed=delta_d / delta_t * 3600.0;
+            speed= 1000.0 * delta_d / delta_t_ms * 3600.0;
         }
 
         // Time from beginning of activity


### PR DESCRIPTION
I had speed spikes when importing Suunto Ambit gpx files. I figured out that these files have milliseconds in the timestamp and in QDateTime this is already available, so the changes above work fine for my files.
Sample:
2014-01-16T18:48:44.340Z
and the following timestamp could be:
2014-01-16T18:48:46.870Z
