### PR TITLE
Fix x-axis missing label issues with Qt 5 

### DIFF
--- a/src/ErgFilePlot.cpp
+++ b/src/ErgFilePlot.cpp
@@ -246,6 +246,7 @@ ErgFilePlot::ErgFilePlot(Context *context) : context(context)
     ergFile = NULL;
 
     setAutoReplot(false);
+	setData(ergFile);
 }
 
 void

--- a/src/ErgFilePlot.h
+++ b/src/ErgFilePlot.h
@@ -116,7 +116,7 @@ public:
 
     virtual QwtText label(double v) const { 
         v /= 1000;
-        QTime t = QTime().addSecs(v);
+        QTime t = QTime(0,0,0,0).addSecs(v);
         if (scaleMap().sDist() > 5)
             return t.toString("hh:mm");
         return t.toString("hh:mm:ss");


### PR DESCRIPTION
Fixes issue #750 with Qt5 by 1) making sure the QTime object is initialized so that it is valid and not null (calls to isValid returns true and isNull returns False) and voce a call to setData() in ErgFilePlot so that the initial, default axis is drawn.
