### PR TITLE
Fixes issue #791 - Create new workout Workout Wizard show improperly displayed BikeScore trademark

### DIFF
--- a/src/WorkoutWizard.cpp
+++ b/src/WorkoutWizard.cpp
@@ -168,6 +168,7 @@ void WorkoutMetricsSummary::updateMetrics(QStringList &order, QHash<QString,Ride
         if(!metricMap.contains(name))
         {
             QLabel *label = new QLabel((rmp->name()) + ":");
+			label->setTextFormat(Qt::RichText);
             QLabel *lcd = new QLabel();
             metricMap[name] = QPair<QLabel*,QLabel*>(label,lcd);
             layout->addWidget(label,metricMap.size(),0);


### PR DESCRIPTION
For some reason the QLabel is not displaying correctly the BikeScore label in the create new workout Workout Wizard.  This can be fixed by telling the label the Text Format is RichText.
