### PR TITLE
Prevent crashed in PMC by checking if start and end date of seasons are ...

### DIFF
--- a/src/SeasonParser.cpp
+++ b/src/SeasonParser.cpp
@@ -63,7 +63,9 @@ bool SeasonParser::endElement( const QString&, const QString&, const QString &qN
             if (seasons[seasons.size()-1].getEnd() == QDate())
                 seasons[seasons.size()-1].setEnd(season.getStart());
         }
-        seasons.append(season);
+        if (season.getStart().isValid() && season.getEnd().isValid()) {
+            seasons.append(season);
+        }
     }
     return true;
 }


### PR DESCRIPTION
Hi,

I've had crashes lately, when using HEAD from master and 3.0.2 when switching to the 'Trends' tab. GoldenCheetah was crashing somewhere inside StressCalculator::max(). 

``` cpp
double StressCalculator::max(void) {
    double max = 0.0;
    for(int i = 0; i < days; i++) {
    if (stsvalues[i] > max)  max = stsvalues[i];
    if (ltsvalues[i] > max)  max = ltsvalues[i]; // unlikely..
    if (sbvalues[i] > max)  max = sbvalues[i]; // really unlikely.
    }
    return max;
}
```

This was because the size of stsvalues was only 2. This was caused by the fact that StressCalculator::startDate was invalid, so maxarray, in the line 124, was 2.

``` cpp
foreach(Season x, context->athlete->seasons->seasons)
     if (x.getStart() < startDate.date())
            startDate = QDateTime(x.getStart(), QTime(0,0,0));

int maxarray = startDate.daysTo(endDate) +2; // from zero plus tomorrows SB!
```

The problem, in my case, was triggered by the fact that one of the seasons in my seasons.xml had an empty startDate. The 'if' in the piece of code above will than initialize startDate to an invalid (null) date. Of course, that should never be the case, but somehow it happened. I cannot remember editing this file, but that doesn't mean I didn't do it.. Anyway, I guess the program shouldn't just crash on a "user-error" like that. 

My fix was to make sure that SeasonParser drops seasons without a valid start and end date. After this fix, I could view the PMC (in all it's low-number glory in my case..) again.

cheers,
Ilja
