### PR TITLE
Fix crash at shutdown.

### DIFF
--- a/src/Context.cpp
+++ b/src/Context.cpp
@@ -19,9 +19,8 @@
 #include "Context.h"
 #include "Athlete.h"
 
-Context::Context(MainWindow *mainWindow)
+Context::Context(MainWindow *mainWindow): mainWindow(mainWindow)
 {
-    this->mainWindow = mainWindow;
     ride = NULL;
     workout = NULL;
     isfiltered = ishomefiltered = false;

--- a/src/Context.h
+++ b/src/Context.h
@@ -56,7 +56,7 @@ class Context : public QObject
         DateRange currentDateRange() { return dr_; }
 
         // current selections
-        MainWindow *mainWindow;
+        MainWindow * const mainWindow;
         Tab *tab;
         Athlete *athlete;
         RideItem *ride;  // the currently selected ride

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -145,7 +145,7 @@ MainWindow::MainWindow(const QDir &home)
     static const QIcon fullIcon(":images/toolbar/main/togglefull.png");
 
 #ifndef Q_OS_MAC
-    fullScreen = new QTFullScreen(context);
+    fullScreen = new QTFullScreen(this);
 #endif
 
     // if no workout directory is configured, default to the

--- a/src/QTFullScreen.cpp
+++ b/src/QTFullScreen.cpp
@@ -17,34 +17,26 @@
 */
 
 #include "QTFullScreen.h"
-#include "Context.h"
 #include "MainWindow.h"
 
-QTFullScreen::QTFullScreen(Context *context) : QObject(context->mainWindow), context(context), isFull(false)
+QTFullScreen::QTFullScreen(MainWindow* mainWindow) : QObject(mainWindow), mainWindow(mainWindow), isFull(false)
 {
     // watch for ESC key being hit when in full screen
-    context->mainWindow->installEventFilter(this);
+    mainWindow->installEventFilter(this);
 }
 
 bool
 QTFullScreen::eventFilter(QObject *obj, QEvent *event)
 {
-    if (obj != context->mainWindow) return false;
-
-    // F11 toggle full screen
-    if (event->type() == QEvent::KeyPress && static_cast<QKeyEvent *>(event)->key() == Qt::Key_F11) {
-        toggle();
-    }
-
-    // ESC cancels fullscreen
-    if (event->type() == QEvent::KeyPress && static_cast<QKeyEvent *>(event)->key() == Qt::Key_Escape) {
-
-        // if in full screen then toggle, otherwise do nothing
-        if (isFull) {
-            context->mainWindow->showNormal();
+    if (obj == mainWindow && event->type() == QEvent::KeyPress) {
+        QKeyEvent* keyEvent = static_cast<QKeyEvent*>(event);
+        // F11 toggle full screen
+        if (keyEvent->key() == Qt::Key_F11) {
+            toggle();
+        } else if (keyEvent->key() == Qt::Key_Escape && isFull) {
+            mainWindow->showNormal();
             isFull = false;
         }
-        return false;
     }
     return false; // always pass thru, just in case
 }
@@ -54,9 +46,9 @@ void
 QTFullScreen::toggle()
 {
     if (isFull) {
-        context->mainWindow->showNormal();
+        mainWindow->showNormal();
     } else {
-        context->mainWindow->showFullScreen();
+        mainWindow->showFullScreen();
     }
     isFull = !isFull;
 }

--- a/src/QTFullScreen.h
+++ b/src/QTFullScreen.h
@@ -20,18 +20,17 @@
 #ifndef _GC_QTFullScreen_h
 #define _GC_QTFullScreen_h 1
 
-#include "GoldenCheetah.h"
-
 // QT stuff etc
 #include <QtGui>
 
+class MainWindow;
 class QTFullScreen : public QObject
 {
-    Q_OBJECT;
+    Q_OBJECT
 
     public:
 
-        QTFullScreen(Context *context);
+        QTFullScreen(MainWindow* mainWindow);
 
         // found in the supplied directory
         void toggle();
@@ -40,7 +39,7 @@ class QTFullScreen : public QObject
         bool eventFilter(QObject *obj, QEvent *event);
 
     private:
-        Context *context;
+        MainWindow* const mainWindow;
         bool isFull;
 };
 


### PR DESCRIPTION
The context pointer was dereferenced after the context object was deleted. This is fixed by storing a pointer to the MainWindow in QTFullScreen, so context does not have to be dereferenced.

The logic in QTFullScreen::eventFilter is also simplified a bit.

I found this bug after I noticed that GoldenCheetah started with the crash recovery dialog every time. I compiled with  address sanitizer (a gcc 4.8 feature copied from clang. See http://blog.qt.digia.com/blog/2013/04/17/using-gccs-4-8-0-address-sanitizer-with-qt/) and found where it crashed.
