### PR TITLE
Fix crash when opening Speed histogram for the first time, on a file without speed info.

### DIFF
--- a/src/PowerHist.cpp
+++ b/src/PowerHist.cpp
@@ -899,7 +899,7 @@ PowerHist::binData(HistData &standard, QVector<double>&x, // x-axis for data
 
         // we add a bin on the end since the last "incomplete" bin
         // will be dropped otherwise
-        int count = int(ceil((arrayLength - 1) / (binw)))+1;
+        int count = qMax(0, int(ceil((arrayLength - 1) / (binw)))+1);
 
         // allocate space for data, plus beginning and ending point
         x.resize(count+2);


### PR DESCRIPTION
I had a trainer file as the second file in my history. Opening this ride, and selecting the speed histogram made GC crash.

I narrowed it down to line 905 in src/PowerHist.cpp. The code was trying to do a resize on a QVector with a negative value. count was -7.

```
int count = int(ceil((arrayLength - 1) / (binw)))+1; 
// allocate space for data, plus beginning and ending point
x.resize(count+2);
```

Making sure that count is always 0 or greater fixed the crash.

Note that opening another ride file, with speed information before this one, selecting the speed histogram and only after that selecting the ride without speed information, did not crash the application. I'm suspecting that there might be some resetting of values, perhaps in the "standards" arrays, that is not done when a data series is missing.

BTW, the trainer file was recorded on a Garmin Edge 800. I had power, cadence and heart rate, but no speed, given I was our shed.

cheers,
Ilja
