### PR TITLE
[PATCH] Fix for slightly different Strava export Format

### DIFF
--- a/src/GpxParser.cpp
+++ b/src/GpxParser.cpp
@@ -131,11 +131,11 @@ bool
     {
         hr = buffer.toDouble(); // on suunto ambit export file, there are sometimes double values
     }
-    else if (qName == "gpxdata:temp")
+    else if (qName == "gpxdata:temp" || (qName == "gpxtpx:atemp"))
     {
         temp = buffer.toDouble();
     }
-    else if (qName == "gpxdata:cadence")
+    else if ((qName == "gpxdata:cadence") || (qName == "gpxtpx:cad"))
     {
         cad = buffer.toDouble();
     }


### PR DESCRIPTION
Strava used other slightly other tags for it's gpx files.
Added those tags to the GpxParser.
Tested and verified.
As I don't have a Power Meter I can't verify Power is correctly imported.

Signed-off-by: Simon Egli smn.egli@gmail.com
