### PR TITLE
fix timestamps after gaps in SRM files

### DIFF
--- a/src/SrmRideFile.cpp
+++ b/src/SrmRideFile.cpp
@@ -310,7 +310,7 @@ RideFile *SrmFileReader::openRideFile(QFile &file, QStringList &errorStrings, QL
                 ((qint64) end.toTime_t()) * 1000 + end.time().msec();
             qint64 startms =
                 ((qint64) start.toTime_t()) * 1000 + start.time().msec();
-            double diff_secs = (startms - endms) / 1000.0;
+            double diff_secs = (startms - endms + recintms) / 1000.0;
             if (diff_secs < result->recIntSecs()) {
                 errorStrings << QString("ERROR: time goes backwards by %1 s"
                                         " on trans " "to block %2"


### PR DESCRIPTION
"secs" is miscalculated for gaps between blocks: It takes the delta
between last chunks _END_time and next chunks start time - and thereby is
off by RecInt. This error adds up for each block/gap - so, the n'th block
will by off by n seconds.

fixes issue #582.
