### PR TITLE
Power value from Suunto .gpx file and fix with unvalid 0m Altitude in .tcx

### DIFF
--- a/src/GpxParser.cpp
+++ b/src/GpxParser.cpp
@@ -139,7 +139,7 @@ bool
     {
         cad = buffer.toDouble();
     }
-    else if (qName == "gpxdata:bikepower") // hopefully suunto adds bikepower data to gpx export file, as it is on saved moveslink log_.xml
+    else if (qName == "gpxdata:power") // from suunto ambit export file
     {
         watts = buffer.toDouble();
     }

--- a/src/TcxParser.cpp
+++ b/src/TcxParser.cpp
@@ -103,8 +103,12 @@ TcxParser::endElement( const QString&, const QString&, const QString& qName)
     else if (qName == "Speed" || qName == "ns3:Speed") { speed = buffer.toDouble() * 3.6; }
     else if (qName == "Value") { hr = buffer.toDouble(); }
     else if (qName == "Cadence") { cadence = buffer.toDouble(); }
-    else if (qName == "AltitudeMeters") { alt = buffer.toDouble(); }
-    else if (qName == "LongitudeDegrees") {
+    else if (qName == "AltitudeMeters") {
+        // on Suunto TCX files there are lots of 0 values between valid ones, skip these
+        if (buffer.toDouble() != 0) {
+            alt = buffer.toDouble();
+        }
+    } else if (qName == "LongitudeDegrees") {
 
         char *p; 
         setlocale(LC_NUMERIC,"C"); // strtod is locale dependent!


### PR DESCRIPTION
This week I noticed that Suunto http://www.movescount.com has updated their Export functionality.
The .gpx file contains now Power values, it is named "gpxdata:power" an not as I first expected bikepower.
A .tcx files is now available as well which contains "Watts", but there are lots of 0 "AltitudeMeters", that's why I adjusted the tcx Parser as well.
The new .fit file has a lot more problems, I better wait, maybe Suunto will change it anyway.

If you like, I send you some sample Files.

Regards Walter
