### PR TITLE
Avoid Dump in Merge Activity Wizard

### DIFF
--- a/src/MergeActivityWizard.cpp
+++ b/src/MergeActivityWizard.cpp
@@ -159,6 +159,8 @@ MergeUpload::importFile(QList<QString> files)
                 ride2Label->setText(tr("Second ride")+" "+ride->startTime().toString(tr("MMM d, yyyy - hh:mm:ss")));
 
                 wizard->ride2 = ride;
+                ride2Loaded = TRUE;
+                emit completeChanged();
             }
 
         } else {
@@ -168,6 +170,13 @@ MergeUpload::importFile(QList<QString> files)
 
     }
 }
+
+
+bool MergeUpload::isComplete() const
+{
+  return ride2Loaded;
+}
+
 
 
 // Synchronise start of files

--- a/src/MergeActivityWizard.h
+++ b/src/MergeActivityWizard.h
@@ -146,6 +146,8 @@ class MergeUpload : public QWizardPage
 
         QPushButton *uploadButton;
         QLabel      *labelSuccess, *ride2Label;
+        bool isComplete() const;
+        bool ride2Loaded = FALSE;
 
     private slots:
         void importFile();


### PR DESCRIPTION
... Only allow "Next" if 2nd file is loaded (otherwise a dump occurs)

(There should more elegant ways to check if 2nd file is loaded - so please adjust for me to learn)

(cherry picked from commit 88b8479cbb90c8306ca32c0d193199ed895db95c)
