### PR TITLE
Translation Enablement + Check on temporary Seasons

### DIFF
--- a/src/LTMSidebar.cpp
+++ b/src/LTMSidebar.cpp
@@ -937,6 +937,11 @@ LTMSidebar::editRange()
     if (dateRangeTree->selectedItems().count() != 1) return;
 
     int index = allDateRanges->indexOfChild(dateRangeTree->selectedItems().first());
+
+    if (seasons->seasons[index].getType() == Season::temporary) {
+        QMessageBox::warning(this, tr("Edit Season"), tr("You can only edit user defined seasons. Please select a season you have created for editing."));
+        return; // must be a user season
+    }
     EditSeasonDialog dialog(context, &seasons->seasons[index]);
 
     if (dialog.exec()) {
@@ -958,6 +963,11 @@ LTMSidebar::deleteRange()
 {
     if (dateRangeTree->selectedItems().count() != 1) return;
     int index = allDateRanges->indexOfChild(dateRangeTree->selectedItems().first());
+
+    if (seasons->seasons[index].getType() == Season::temporary) {
+        QMessageBox::warning(this, tr("Delete Season"), tr("You can only delete user defined seasons. Please select a season you have created for deletion."));
+        return; // must be a user season
+    }
 
     // now delete!
     delete allDateRanges->takeChild(index);

--- a/src/Season.cpp
+++ b/src/Season.cpp
@@ -108,9 +108,9 @@ EditSeasonDialog::EditSeasonDialog(Context *context, Season *season) :
     nameEdit->setText(season->getName());
 
     typeEdit = new QComboBox;
-    typeEdit->addItem("Season", Season::season);
-    typeEdit->addItem("Cycle", Season::cycle);
-    typeEdit->addItem("Adhoc", Season::adhoc);
+    typeEdit->addItem(tr("Season"), Season::season);
+    typeEdit->addItem(tr("Cycle"), Season::cycle);
+    typeEdit->addItem(tr("Adhoc"), Season::adhoc);
     typeEdit->setCurrentIndex(typeEdit->findData(season->getType()));
 
     fromEdit = new QDateEdit(this);


### PR DESCRIPTION
... Translation for Season Types
... Do not allow Temporary Seasons to be edited or deleted through the
main seasons menu (in right click Popup this was already blocked by not
offering the function)

(cherry picked from commit cc7a0a7f8d0b74ca4b9d64d61291206ea58d3f94)
