### PR TITLE
Support Metric Names with "special characters" for Column Chooser Drag&D...

### DIFF
--- a/src/RideNavigator.cpp
+++ b/src/RideNavigator.cpp
@@ -908,7 +908,8 @@ RideNavigator::dropEvent(QDropEvent *event)
 {
     QString name = event->mimeData()->data("application/x-columnchooser");
     // fugly, but it works for BikeScore with the (TM) in it...
-    if (name == "BikeScore?") name = QTextEdit("BikeScore&#8482;").toPlainText();
+    // when MIME object is UTF-8 and not Latin-1 - this seems not to be required any more
+    //    if (name == "BikeScore?") name = QTextEdit("BikeScore&#8482;").toPlainText();
     tableView->setColumnHidden(logicalHeadings.indexOf(name), false);
     tableView->setColumnWidth(logicalHeadings.indexOf(name), 50);
     tableView->header()->moveSection(tableView->header()->visualIndex(logicalHeadings.indexOf(name)), 1);
@@ -1181,7 +1182,9 @@ ColumnChooser::buttonClicked(QString name)
     // setup the drag data
     QMimeData *mimeData = new QMimeData;
     QByteArray empty;
-    mimeData->setData("application/x-columnchooser", name.toLatin1());
+//    mimeData->setData("application/x-columnchooser", name.toLatin1());
+//  Use UTF-8 in Mime Date to cover also special characters
+    mimeData->setData("application/x-columnchooser", name.toUtf8());
 
     // create a drag event
     QDrag *drag = new QDrag(this);


### PR DESCRIPTION
!!! please check if this right way to do it.
... column names containing special characters (for me in german translation greek "average" sign) did not work in Drag&Drop (even though the charactor is listed to be part of Latin-1 --- after changing in Mime to UTF-8 not only the greek characters, but also "TM" works without special treatment
!!! is this valid for all platforms ?!!!

(cherry picked from commit b4d1a7d3041beec686c7262cfa65bac8cf6e2179)
