### PR TITLE
Data Filter - Internal Field Names + Multiple tr()

### DIFF
--- a/src/CriticalPowerWindow.cpp
+++ b/src/CriticalPowerWindow.cpp
@@ -205,11 +205,11 @@ CriticalPowerWindow::CriticalPowerWindow(const QDir &home, Context *context, boo
     // model config
     // 2 or 3 point model ?
     modelCombo= new QComboBox(this);
-    modelCombo->addItem("None");
-    modelCombo->addItem("2 parameter");
-    modelCombo->addItem("3 parameter");
-    modelCombo->addItem("Extended CP");
-    modelCombo->addItem("Multicomponent");
+    modelCombo->addItem(tr("None"));
+    modelCombo->addItem(tr("2 parameter"));
+    modelCombo->addItem(tr("3 parameter"));
+    modelCombo->addItem(tr("Extended CP"));
+    modelCombo->addItem(tr("Multicomponent"));
     modelCombo->setCurrentIndex(1);
 
     mcl->addRow(new QLabel(tr("CP Model")), modelCombo);

--- a/src/DataFilter.l
+++ b/src/DataFilter.l
@@ -61,7 +61,11 @@
 
 "TRIMP(100)_Points"                         return SYMBOL; /* special case */
 "Left/Right_Balance"                        return SYMBOL; /* special case */
-"Minimum_W'_bal"                        return SYMBOL; /* special case */
+"Minimum_W'bal"                             return SYMBOL; /* special case */
+"Maximum_W'bal_Match"                       return SYMBOL; /* special case */
+"Max_W'_Expended"                           return SYMBOL; /* special case */
+"W'_Work"                                   return SYMBOL; /* special case */
+"W'bal_TAU"                                 return SYMBOL; /* special case */
 [a-zA-Z0-9][a-zA-Z0-9_%™]+                  return SYMBOL; /* symbols can start with 0-9 */
 
 

--- a/src/RideNavigator.cpp
+++ b/src/RideNavigator.cpp
@@ -907,9 +907,6 @@ void
 RideNavigator::dropEvent(QDropEvent *event)
 {
     QString name = event->mimeData()->data("application/x-columnchooser");
-    // fugly, but it works for BikeScore with the (TM) in it...
-    // when MIME object is UTF-8 and not Latin-1 - this seems not to be required any more
-    //    if (name == "BikeScore?") name = QTextEdit("BikeScore&#8482;").toPlainText();
     tableView->setColumnHidden(logicalHeadings.indexOf(name), false);
     tableView->setColumnWidth(logicalHeadings.indexOf(name), 50);
     tableView->header()->moveSection(tableView->header()->visualIndex(logicalHeadings.indexOf(name)), 1);
@@ -1182,8 +1179,8 @@ ColumnChooser::buttonClicked(QString name)
     // setup the drag data
     QMimeData *mimeData = new QMimeData;
     QByteArray empty;
-//    mimeData->setData("application/x-columnchooser", name.toLatin1());
-//  Use UTF-8 in Mime Date to cover also special characters
+    //  Use UTF-8 in Mime Date to cover also special characters,
+    //  but the Receiver of the mimeData has to be able to handle Utf8() or translate
     mimeData->setData("application/x-columnchooser", name.toUtf8());
 
     // create a drag event

--- a/src/SearchBox.cpp
+++ b/src/SearchBox.cpp
@@ -231,7 +231,7 @@ void SearchBox::setBad(QStringList errors)
     pal.setColor(QPalette::Text, Qt::red);
     setPalette(pal);
 
-    setToolTip(errors.join(" and "));
+    setToolTip(errors.join(tr(" and ")));
 }
 
 void SearchBox::setGood()
@@ -259,8 +259,13 @@ void
 SearchBox::dropEvent(QDropEvent *event)
 {
     QString name = event->mimeData()->data("application/x-columnchooser");
-    // fugly, but it works for BikeScore with the (TM) in it...
-    if (name == "BikeScore?") name = QString("BikeScore&#8482;").replace("&#8482;", QChar(0x2122));
+    // fugly, but it works for BikeScore with the (TM) in it... so...
+    // independent of Latin1 or UTF-8 coming from "Column Chooser" the "TM" is not recognized by the parser,
+    // when stripping it of, all works fine (Parser add's it internally to find the right metrics)
+    if (name.startsWith("BikeScore")) name = QString("BikeScore");
+    //  Always use the "internalNames" in Filter expressions
+    SpecialFields sp;
+    name = sp.internalName(name);
 
     // we do very little to the name, just space to _ and lower case it for now...
     name.replace(' ', '_');


### PR DESCRIPTION
... allow/use only internal field names (delivered by Column Chooser) in Data Filter expressions
(to overcome problems with special characters in translation an make stored queries working even if the    language is changed) (also tested with own created new fields)

... multipe tr()

Remark: even though BikeScore is working for now - I need to look at that again 

(cherry picked from commit bc4164adab74dd82c0a0307d7d0fbb736f95ef0d)
