### PR TITLE
Bikescore (TM) unique Handling (Part 2)

### DIFF
--- a/src/Colors.cpp
+++ b/src/Colors.cpp
@@ -82,7 +82,7 @@ void GCColor::setupColors()
         { tr("Long Term Stress"), "COLORLTS", Qt::green },
         { tr("Stress Balance"), "COLORSB", Qt::black },
         { tr("Daily Stress"), "COLORDAILYSTRESS", Qt::red },
-        { tr("Bike Score"), "COLORBIKESCORE", Qt::gray },
+        { "Bike Score (TM)", "COLORBIKESCORE", Qt::gray },
         { tr("Calendar Text"), "COLORCALENDARTEXT", Qt::black },
         { tr("Power Zone 1 Shading"), "COLORZONE1", QColor(255,0,255) },
         { tr("Power Zone 2 Shading"), "COLORZONE2", QColor(42,0,255) },

--- a/src/ComparePane.cpp
+++ b/src/ComparePane.cpp
@@ -195,8 +195,9 @@ ComparePane::refreshTable()
                 // check for both original and translated
                 if (!(m->units(context->athlete->useMetricUnits) == "seconds" || m->units(context->athlete->useMetricUnits) == tr("seconds")))
                     units = m->units(context->athlete->useMetricUnits);
-                if (units != "") list << QString("%1 (%2)").arg(m->name()).arg(units);
-                else list << QString("%1").arg(m->name());
+                QTextEdit name(m->name()); // process html encoding of(TM)
+                if (units != "") list << QString("%1 (%2)").arg(name.toPlainText()).arg(units);
+                else list << QString("%1").arg(name.toPlainText());
             }
         }
 
@@ -367,8 +368,9 @@ ComparePane::refreshTable()
                 QString units;
                 if (!(m->units(context->athlete->useMetricUnits) == "seconds" || m->units(context->athlete->useMetricUnits) == tr("seconds")))
                     units = m->units(context->athlete->useMetricUnits);
-                if (units != "") list << QString("%1 (%2)").arg(m->name()).arg(units);
-                else list << QString("%1").arg(m->name());
+                QTextEdit name(m->name()); // process html encoding of(TM)
+                if (units != "") list << QString("%1 (%2)").arg(name.toPlainText()).arg(units);
+                else list << QString("%1").arg(name.toPlainText());
             }
         }
 

--- a/src/DataFilter.cpp
+++ b/src/DataFilter.cpp
@@ -276,9 +276,6 @@ void DataFilter::configUpdate()
         QString symbol = factory.metricName(i);
         QString name = context->specialFields.internalName(factory.rideMetric(symbol)->name());
 
-        //special Treatment for BikeScore
-        if (name.startsWith("BikeScore")) name = "BikeScore&#8482;";
-
         lookupMap.insert(name.replace(" ","_"), symbol);
         lookupType.insert(name.replace(" ","_"), true);
     }

--- a/src/LTMPopup.cpp
+++ b/src/LTMPopup.cpp
@@ -121,8 +121,9 @@ LTMPopup::setData(QList<SummaryMetrics>data, const RideMetric *metric, QString t
     QTableWidgetItem *h = new QTableWidgetItem(tr("Date & Time"), QTableWidgetItem::Type);
     rides->setHorizontalHeaderItem(0,h);
 
-    // value & special Treatment for (TM)
-    h = new QTableWidgetItem(metric->name().replace("&#8482;", " (TM)"), QTableWidgetItem::Type);
+    // value & process html encoding of(TM)
+    QTextEdit name(metric->name());
+    h = new QTableWidgetItem(name.toPlainText(), QTableWidgetItem::Type);
 
     rides->setHorizontalHeaderItem(1,h);
 

--- a/src/Pages.cpp
+++ b/src/Pages.cpp
@@ -1543,9 +1543,8 @@ IntervalMetricsPage::IntervalMetricsPage(QWidget *parent) :
         if (selectedMetrics.contains(symbol))
             continue;
         QSharedPointer<RideMetric> m(factory.newMetric(symbol));
-        QString name = m->name();
-        name.replace("&#8482;", " (TM)"); //Don't allow translation
-        QListWidgetItem *item = new QListWidgetItem(name);
+        QTextEdit name(m->name()); // process html encoding of(TM)
+        QListWidgetItem *item = new QListWidgetItem(name.toPlainText());
         item->setData(Qt::UserRole, symbol);
         availList->addItem(item);
     }
@@ -1553,9 +1552,8 @@ IntervalMetricsPage::IntervalMetricsPage(QWidget *parent) :
         if (!factory.haveMetric(symbol))
             continue;
         QSharedPointer<RideMetric> m(factory.newMetric(symbol));
-        QString name = m->name();
-        name.replace("&#8482;", " (TM)");  //Don't allow translation
-        QListWidgetItem *item = new QListWidgetItem(name);
+        QTextEdit name(m->name());  // process html encoding of(TM)
+        QListWidgetItem *item = new QListWidgetItem(name.toPlainText());
         item->setData(Qt::UserRole, symbol);
         selectedList->addItem(item);
     }
@@ -1736,9 +1734,8 @@ BestsMetricsPage::BestsMetricsPage(QWidget *parent) :
         if (selectedMetrics.contains(symbol))
             continue;
         QSharedPointer<RideMetric> m(factory.newMetric(symbol));
-        QString name = m->name();
-        name.replace("&#8482;", " (TM)");  // Dont' allow Translation
-        QListWidgetItem *item = new QListWidgetItem(name);
+        QTextEdit name(m->name()); //  process html encoding of(TM)
+        QListWidgetItem *item = new QListWidgetItem(name.toPlainText());
         item->setData(Qt::UserRole, symbol);
         availList->addItem(item);
     }
@@ -1746,9 +1743,8 @@ BestsMetricsPage::BestsMetricsPage(QWidget *parent) :
         if (!factory.haveMetric(symbol))
             continue;
         QSharedPointer<RideMetric> m(factory.newMetric(symbol));
-        QString name = m->name();
-        name.replace("&#8482;", " (TM)");  // Don't allow translation
-        QListWidgetItem *item = new QListWidgetItem(name);
+        QTextEdit name(m->name()); //  process html encoding of(TM)
+        QListWidgetItem *item = new QListWidgetItem(name.toPlainText());
         item->setData(Qt::UserRole, symbol);
         selectedList->addItem(item);
     }
@@ -1925,9 +1921,8 @@ SummaryMetricsPage::SummaryMetricsPage(QWidget *parent) :
         if (selectedMetrics.contains(symbol))
             continue;
         QSharedPointer<RideMetric> m(factory.newMetric(symbol));
-        QString name = m->name();
-        name.replace("&#8482;", " (TM)"); // Don't allow translation
-        QListWidgetItem *item = new QListWidgetItem(name);
+        QTextEdit name(m->name()); //  process html encoding of(TM)
+        QListWidgetItem *item = new QListWidgetItem(name.toPlainText());
         item->setData(Qt::UserRole, symbol);
         availList->addItem(item);
     }
@@ -1935,9 +1930,8 @@ SummaryMetricsPage::SummaryMetricsPage(QWidget *parent) :
         if (!factory.haveMetric(symbol))
             continue;
         QSharedPointer<RideMetric> m(factory.newMetric(symbol));
-        QString name = m->name();
-        name.replace("&#8482;", " (TM)"); // Don't allow translation
-        QListWidgetItem *item = new QListWidgetItem(name);
+        QTextEdit name(m->name()); //  process html encoding of(TM)
+        QListWidgetItem *item = new QListWidgetItem(name.toPlainText());
         item->setData(Qt::UserRole, symbol);
         selectedList->addItem(item);
     }

--- a/src/SearchBox.cpp
+++ b/src/SearchBox.cpp
@@ -292,9 +292,10 @@ SearchBox::dropEvent(QDropEvent *event)
 {
     QString name = event->mimeData()->data("application/x-columnchooser");
     // fugly, but it works for BikeScore with the (TM) in it... so...
-    // independent of Latin1 or UTF-8 coming from "Column Chooser" the "TM" is not recognized by the parser,
-    // when stripping it of, all works fine (Parser add's it internally to find the right metrics)
+    // independent of Latin1 or UTF-8 coming from "Column Chooser" the "TM" special sign is not recognized by the parser,
+    // so strip the "TM" off for this case (only)
     if (name.startsWith("BikeScore")) name = QString("BikeScore");
+
     //  Always use the "internalNames" in Filter expressions
     SpecialFields sp;
     name = sp.internalName(name);

--- a/src/TreeMapWindow.cpp
+++ b/src/TreeMapWindow.cpp
@@ -111,9 +111,8 @@ TreeMapWindow::TreeMapWindow(Context *context) :
         // I know it is confusing, but changing it will mean changing it absolutely
         // everywhere. Just remember - in the factory "name" refers to symbol and
         // if you want the user friendly metric description you get it via the metric
-        QString title = factory.rideMetric(factory.metricName(i))->name();
-        title.replace("&#8482;", " (TM)");
-        add->setText(0, title); // long name
+        QTextEdit title(factory.rideMetric(factory.metricName(i))->name()); // to handle HTML
+        add->setText(0, title.toPlainText()); // long name
         add->setText(1, factory.metricName(i)); // symbol (hidden)
 
         // sort by title


### PR DESCRIPTION
... have the same consistent handling for (TM) at all visible places (with the same coding logic applied)
... do not allow Translation of BikeScore through tr(), (since it's a TM and should not change)
... Have (TM) sign everwhere visible - only in Searches just use "BikeScore" as Symbol for comparison
