### PR TITLE
TreeMap - multi-language enablement

### DIFF
--- a/src/TreeMapPlot.cpp
+++ b/src/TreeMapPlot.cpp
@@ -72,10 +72,10 @@ TreeMapPlot::setData(TMSettings *settings)
         if (context->ishomefiltered && !context->homeFilters.contains(rideMetrics.getFileName())) continue;
 
         double value = rideMetrics.getForSymbol(settings->symbol);
-        QString text1 = rideMetrics.getText(settings->field1, "(unknown)");
-        QString text2 = rideMetrics.getText(settings->field2, "(unknown)");
-        if (text1 == "") text1 = "(unknown)";
-        if (text2 == "") text2 = "(unknown)";
+        QString text1 = rideMetrics.getText(settings->field1, tr("(unknown)"));
+        QString text2 = rideMetrics.getText(settings->field2, tr("(unknown)"));
+        if (text1 == "") text1 = tr("(unknown)");
+        if (text2 == "") text2 = tr("(unknown)");
 
         TreeMap *first = root->insert(text1, 0.0);
         first->insert(text2, value);

--- a/src/TreeMapPlot.h
+++ b/src/TreeMapPlot.h
@@ -73,7 +73,7 @@ class TreeMap
                 delete x;
             }
             children.clear();
-            name = "(unknown)";
+            name = "tr((unknown))";
             value = 0.00;
         }
 

--- a/src/TreeMapWindow.cpp
+++ b/src/TreeMapWindow.cpp
@@ -115,8 +115,6 @@ TreeMapWindow::TreeMapWindow(Context *context) :
         add->setText(0, title.toPlainText()); // long name
         add->setText(1, factory.metricName(i)); // symbol (hidden)
 
-        // sort by title
-        add->sortChildren(0, Qt::DescendingOrder);
         // by default use workout_time
         if (factory.metricName(i) == "workout_time") allMetrics->child(i)->setSelected(true);
     }
@@ -227,8 +225,9 @@ TreeMapWindow::refresh()
             settings.from = myDateRange.from;
             settings.to = myDateRange.to;
         }
-        settings.field1 = field1->currentText();
-        settings.field2 = field2->currentText();
+        SpecialFields sp;
+        settings.field1 = sp.internalName(field1->currentText());
+        settings.field2 = sp.internalName(field2->currentText());
         settings.data = &results;
 
         // get the data
@@ -267,8 +266,13 @@ TreeMapWindow::cellClicked(QString f1, QString f2)
     // create a list of activities in this cell
     int count = 0;
     foreach(SummaryMetrics x, results) {
-        if (x.getText(settings.field1, tr("(unknown)")) == f1 &&
-            x.getText(settings.field2, tr("(unknown)")) == f2) {
+        // text may either not exists, then "unknown" or just be "" but f1, f2 don't know ""
+        QString x1 = x.getText(settings.field1, tr("(unknown)"));
+        QString x2 = x.getText(settings.field2, tr("(unknown)"));
+        if (x1 == "") x1 = tr("(unknown)");
+        if (x2 == "") x2 = tr("(unknown)");
+        // now we can compare and append
+        if (x1 == f1 && x2 == f2) {
             cell.append(x);
             count++;
         }
@@ -285,8 +289,10 @@ TreeMapWindow::cellClicked(QString f1, QString f2)
 void
 TreeMapWindow::addTextFields(QComboBox *combo)
 {
-    combo->addItem(tr("None"));
+    combo->addItem(tr("None")); // if "None" is changed to not being first any more, adjust public methods f1,f2,setf1,setf2
+    SpecialFields sp;
     foreach (FieldDefinition x, fieldDefinitions) {
-        if (x.type < 4) combo->addItem(x.name);
+        if (x.type < 4) combo->addItem(sp.displayName(x.name));
     }
 }
+

--- a/src/TreeMapWindow.h
+++ b/src/TreeMapWindow.h
@@ -28,6 +28,7 @@
 #include "Season.h"
 #include "LTMPopup.h"
 #include "GcPane.h"
+#include "SpecialFields.h"
 
 #include <math.h>
 
@@ -69,10 +70,40 @@ class TreeMapWindow : public GcWindow
 #ifdef GC_HAVE_LUCENE
         bool isFiltered() const { return context->ishomefiltered || context->isfiltered; }
 #endif
-        QString f1() const { return field1->currentText(); }
-        void setf1(QString x) const { field1->setCurrentIndex(field1->findText(x)); }
-        QString f2() const { return field2->currentText(); }
-        void setf2(QString x) const { field2->setCurrentIndex(field1->findText(x)); }
+        QString f1 ()
+        {   // consider translation on Screen, but Store only in EN
+            if (field1->currentIndex() == 0) {
+               return "None"; // dont' translate
+            } else {
+               SpecialFields sp;
+               return ( sp.internalName(field1->currentText()));
+            }
+        }
+
+        QString f2()
+        {   // consider translation on Screen, but Store only in EN
+            if (field2->currentIndex() == 0) {
+               return "None"; // dont' translate
+            } else {
+               SpecialFields sp;
+               return ( sp.internalName(field2->currentText()));
+            }
+        }
+
+        void setf1(QString x)
+        {   // consider translation on Screen, but Store only in EN
+            SpecialFields sp;
+            if (x == "None") field1->setCurrentIndex(0); // "None" is the first item in Combo Box
+            else field1->setCurrentIndex(field1->findText(sp.displayName(x)));
+        }
+
+        void setf2(QString x)
+        {   // consider translation on Screen, but Store only in EN
+            SpecialFields sp;
+            if (x == "None") field2->setCurrentIndex(0); // // "None" is the first item in Combo Box
+            else field2->setCurrentIndex(field2->findText(sp.displayName(x)));
+        }
+
         int useSelected() { return dateSetting->mode(); }
         void setUseSelected(int x) { dateSetting->setMode(x); }
 


### PR DESCRIPTION
... use translated Metadata terms for Tree Dimensions (via Special Fields)
... store the Metadaten information in Home-Layout.XML in "EN/Original Language" and convert back/forth as needed
... fixed an issue, that Rides for a Cell (for the ltmPopup) are not selected in case the resp. Metadata field in the Rides is ""/empty
