### PR TITLE
LTM Popup - further enhancements

### DIFF
--- a/src/LTMPlot.h
+++ b/src/LTMPlot.h
@@ -186,6 +186,7 @@ class LTMScaleDraw: public QwtScaleDraw
 
         case LTM_TOD:
             break;
+
         }
     }
 
@@ -197,13 +198,13 @@ class LTMScaleDraw: public QwtScaleDraw
         switch (groupBy) {
         case LTM_DAY:
             upTime = baseTime.addDays((int)v);
-            label = upTime.toString("MMM dd\nyyyy");
+            label = upTime.toString(QObject::tr("MMM dd\nyyyy")); /* 2 line display of date - keep \n in translation */
             break;
 
         case LTM_WEEK:
             {
             QDate week = baseTime.date().addDays((int)v*7);
-            label = week.toString("MMM dd\nyyyy");
+            label = week.toString(QObject::tr("MMM dd\nyyyy")); /* 2 line display of date - keep \n in translation */
             }
             break;
 
@@ -223,6 +224,11 @@ class LTMScaleDraw: public QwtScaleDraw
         case LTM_TOD:
             label = QString("%1:00").arg((int)v);
             break;
+
+        case LTM_ALL:
+            label = QString(QObject::tr("All"));
+            break;
+
         }
         return label;
     }

--- a/src/LTMPopup.h
+++ b/src/LTMPopup.h
@@ -48,8 +48,8 @@ class LTMPopup : public QWidget
         LTMPopup(Context *context);
         void setTitle(QString);
 
-        // when called from LTM chart
-        void setData(LTMSettings &settings, QDate start, QDate end);
+        // when called from LTM chart (time only relevant for LTM_TOD)
+        void setData(LTMSettings &settings, QDate start, QDate end, QTime time);
 
         // when called from a TreeMap chart
         void setData(QList<SummaryMetrics>data, const RideMetric *metric, QString title);

--- a/src/LTMWindow.cpp
+++ b/src/LTMWindow.cpp
@@ -860,13 +860,24 @@ LTMWindow::groupForDate(QDate date)
 void
 LTMWindow::pointClicked(QwtPlotCurve*curve, int index)
 {
-    // get the date range for this point
-    QDate start, end;
-    LTMScaleDraw *lsd = new LTMScaleDraw(settings.start,
-                        groupForDate(settings.start.date()),
-                        settings.groupBy);
-    lsd->dateRange((int)round(curve->sample(index).x()), start, end);
-    ltmPopup->setData(settings, start, end);
+    // initialize date and time to sensefull boundaries
+    QDate start = QDate(1900,1,1);
+    QDate end   = QDate(2999,12,31);
+    QTime time = QTime(0, 0, 0, 0);
+
+    // now fill the correct values for context
+    if (settings.groupBy != LTM_TOD) {
+      // get the date range for this point (for all date-dependent grouping)
+      LTMScaleDraw *lsd = new LTMScaleDraw(settings.start,
+                          groupForDate(settings.start.date()),
+                          settings.groupBy);
+      lsd->dateRange((int)round(curve->sample(index).x()), start, end); }
+    else {
+      // special treatment for LTM_TOD as time dependent grouping
+      time = QTime((int)round(curve->sample(index).x()), 0, 0, 0);
+    }
+    // feed the popup with data
+    ltmPopup->setData(settings, start, end, time);
     popup->show();
 }
 

--- a/src/RideSummaryWindow.cpp
+++ b/src/RideSummaryWindow.cpp
@@ -917,7 +917,7 @@ RideSummaryWindow::htmlSummary()
 
             // "n of x activities" shown in header of list when filtered
             summary += ("<p><h3>" + 
-                        QString("%1 of %2").arg(activities).arg(data.count()) 
+                        QString(tr("%1 of %2")).arg(activities).arg(data.count())
                                            + (data.count() == 1 ? tr(" ride") : tr(" rides")) +
                         "</h3><p>");
         } else {


### PR DESCRIPTION
... make window "minimumSize" instead of "fixedSize" - so that resize in case of many columns works 
... handle LTM_TOD when called from LTM-Chart (list the rides in the hour, considering DateRange)
... consider HomeFilter and Search/Filter in result list (add info text if list is filtered)
... also show Rides of only 1 ride is selected (since Rides contain Date/Time) and the Metrics (which mostly are not part of the Summary HTML)
... do not allow MouseSelection of only 1 Ride is shown
... some more tr()
... remove "artefact" # Includes from previous pull request 
