### PR TITLE
Fix error about missing qtsolutions/config.pri with Qt 5

### DIFF
--- a/qtsolutions/common.pri
+++ b/qtsolutions/common.pri
@@ -1,4 +1,4 @@
-infile(config.pri, SOLUTIONS_LIBRARY, yes): CONFIG += qtsoap-uselib
+exists(config.pri):infile(config.pri, SOLUTIONS_LIBRARY, yes): CONFIG += qtsoap-uselib
 TEMPLATE += fakelib
 QTSOAP_LIBNAME = $$qtLibraryTarget(QtSolutions_SOAP-2.7)
 TEMPLATE -= fakelib


### PR DESCRIPTION
I had an error about missing qtsolutions/config.pri when calling qmake on my new laptop with Qt5 on Ubuntu 14.04 x64
I don't know how it should be solved properly with Qt5, below I found a solution that works:
https://qt.gitorious.org/qt-solutions/ov3r1oads-qt-solutions/commit/8c2c3f0bde67e64c627c903b718bec92ace28680?diffmode=sidebyside

Goldencheetah works great for me, thanks!
