### PR TITLE
LTM Popup - cosmetics

### DIFF
--- a/src/LTMPopup.cpp
+++ b/src/LTMPopup.cpp
@@ -65,7 +65,7 @@ LTMPopup::LTMPopup(Context *context) : QWidget(context->mainWindow), context(con
                      "background-color: rgba(255,255,255,0);"
                      "border: 0px;"
                      "margin: 0px;"
-                     "font-size: 8px; }";
+                     "font-size: 10px; }";
     rides->horizontalHeader()->setStyleSheet(styleSheet);
     rides->verticalHeader()->hide();
     rides->setShowGrid(false);


### PR DESCRIPTION
... Font-Size for Header Texts increased to 10px (since the 8px font is very ugly - at least on Windows 7) - since the Screen can be resized, bigger header texts can still be read after resizing.

(if this is looking better for other OS, just close / don't merge and let me know / then I will make the change OS dependent for Win only).
