### PR TITLE
Remove AM/PM from time formatting (to be Locale neutral)

### DIFF
--- a/src/BatchExportDialog.cpp
+++ b/src/BatchExportDialog.cpp
@@ -70,7 +70,7 @@ BatchExportDialog::BatchExportDialog(Context *context) : QDialog(context->mainWi
         // we will wipe the original file
         add->setText(1, rideItem->fileName);
         add->setText(2, rideItem->dateTime.toString(tr("dd MMM yyyy")));
-        add->setText(3, rideItem->dateTime.toString(tr("hh:mm:ss ap")));
+        add->setText(3, rideItem->dateTime.toString("hh:mm:ss"));
 
         // interval action
         add->setText(4, tr("Export"));

--- a/src/MergeActivityWizard.cpp
+++ b/src/MergeActivityWizard.cpp
@@ -81,6 +81,7 @@ MergeUpload::MergeUpload(MergeActivityWizard *parent) : QWizardPage(parent), wiz
     QVBoxLayout *layout = new QVBoxLayout;
     setLayout(layout);
 
+    //: Do not change the time format in translation, keep hh:mm:ss !
     QLabel *ride1Label = new QLabel(tr("Current ride")+" "+parent->ride1->dateTime.toString(tr("MMM d, yyyy - hh:mm:ss")));
     layout->addWidget(ride1Label);
     QSpacerItem* spacer = new QSpacerItem( 20, 20, QSizePolicy::Minimum,QSizePolicy::Expanding );
@@ -155,8 +156,8 @@ MergeUpload::importFile(QList<QString> files)
             if (ride) {
                 //wizard->addRideFile(ride);
                 labelSuccess->setText(tr("File uploaded"));
+                //: Do not change the time format in translation, keep hh:mm:ss !
                 ride2Label->setText(tr("Second ride")+" "+ride->startTime().toString(tr("MMM d, yyyy - hh:mm:ss")));
-
                 wizard->ride2 = ride;
                 emit completeChanged();
             }

--- a/src/RideImportWizard.cpp
+++ b/src/RideImportWizard.cpp
@@ -396,7 +396,7 @@ RideImportWizard::process()
                        // Cool, the date and time was extrcted from the source file
                        blanks[i] = false;
                        tableWidget->item(i,1)->setText(ride->startTime().toString(tr("dd MMM yyyy")));
-                       tableWidget->item(i,2)->setText(ride->startTime().toString(tr("hh:mm:ss ap")));
+                       tableWidget->item(i,2)->setText(ride->startTime().toString("hh:mm:ss"));
                    }
 
                    tableWidget->item(i,1)->setTextAlignment(Qt::AlignRight); // put in the middle
@@ -574,7 +574,7 @@ RideImportWizard::todayClicked(int index)
             tableWidget->item(i,5)->isSelected()) {
             countselected++;
 
-            QTime duration = QTime().fromString(tableWidget->item(i,3)->text(), tr("hh:mm:ss"));
+            QTime duration = QTime().fromString(tableWidget->item(i,3)->text(), "hh:mm:ss");
             totalduration += duration.hour() * 3600 +
                              duration.minute() * 60 +
                              duration.second();
@@ -624,11 +624,11 @@ RideImportWizard::todayClicked(int index)
             // look at rides with missing start time - we need to populate those
 
             // ride duration
-            QTime duration = QTime().fromString(tableWidget->item(i,3)->text(), tr("hh:mm:ss"));
+            QTime duration = QTime().fromString(tableWidget->item(i,3)->text(), "hh:mm:ss");
 
             // ride start time
             QTime time(rstart/3600, rstart%3600/60, rstart%60);
-            tableWidget->item(i,2)->setText(time.toString(tr("hh:mm:ss a")));
+            tableWidget->item(i,2)->setText(time.toString("hh:mm:ss"));
             rstart += duration.hour() * 3600 +
                       duration.minute() * 60 +
                       duration.second();
@@ -767,7 +767,7 @@ RideImportWizard::abortClicked()
 
         // Setup the ridetime as a QDateTime
         QDateTime ridedatetime = QDateTime(QDate().fromString(tableWidget->item(i,1)->text(), tr("dd MMM yyyy")),
-                                 QTime().fromString(tableWidget->item(i,2)->text(), tr("hh:mm:ss a")));
+                                 QTime().fromString(tableWidget->item(i,2)->text(), "hh:mm:ss"));
         QString suffix = QFileInfo(filenames[i]).suffix();
         QString targetnosuffix = QString ( "%1_%2_%3_%4_%5_%6" )
                                .arg ( ridedatetime.date().year(), 4, 10, zero )
@@ -976,7 +976,7 @@ QWidget *RideDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem 
 
         // edit that time
         QTimeEdit *timeEdit = new QTimeEdit(parent);
-        timeEdit->setDisplayFormat("hh:mm:ss a");
+        timeEdit->setDisplayFormat("hh:mm:ss");
         connect(timeEdit, SIGNAL(editingFinished()), this, SLOT(commitAndCloseTimeEditor()));
         return timeEdit;
     } else {
@@ -1010,7 +1010,7 @@ void RideDelegate::setEditorData(QWidget *editor, const QModelIndex &index) cons
         dateEdit->setDate(date);
     } else if (index.column() == dateColumn+1) {
         QTimeEdit *timeEdit = qobject_cast<QTimeEdit *>(editor);
-        QTime time = QTime().fromString(index.model()->data(index, Qt::DisplayRole).toString(), "hh:mm:ss a");;
+        QTime time = QTime().fromString(index.model()->data(index, Qt::DisplayRole).toString(), "hh:mm:ss");;
         timeEdit->setTime(time);
     }
 }
@@ -1027,7 +1027,7 @@ void RideDelegate::setModelData(QWidget *editor, QAbstractItemModel *model, cons
         model->setData(index, value, Qt::DisplayRole);
     } else if (index.column() == dateColumn+1) {
         QTimeEdit *timeEdit = qobject_cast<QTimeEdit *>(editor);
-        QString value = timeEdit->time().toString("hh:mm:ss a");
+        QString value = timeEdit->time().toString("hh:mm:ss");
         model->setData(index, value, Qt::DisplayRole);
     }
 }

--- a/src/RideMetadata.cpp
+++ b/src/RideMetadata.cpp
@@ -523,7 +523,7 @@ FormField::FormField(FieldDefinition field, RideMetadata *meta) : definition(fie
     case FIELD_TIME : // time
         widget = new QTimeEdit(this);
         //widget->setFixedHeight(18);
-        ((QTimeEdit*)widget)->setDisplayFormat("hh:mm:ss AP");
+        ((QTimeEdit*)widget)->setDisplayFormat("hh:mm:ss");
         connect (widget, SIGNAL(timeChanged(const QTime)), this, SLOT(dataChanged()));
         connect (widget, SIGNAL(editingFinished()), this, SLOT(editFinished()));
         break;

--- a/src/SplitActivityWizard.cpp
+++ b/src/SplitActivityWizard.cpp
@@ -318,7 +318,7 @@ SplitActivityWizard::setFilesList()
 
         add->setText(0, rideItem->fileName);
         add->setText(1, rideItem->ride()->startTime().toString(tr("dd MMM yyyy")));
-        add->setText(2, rideItem->ride()->startTime().toString(tr("hh:mm:ss ap")));
+        add->setText(2, rideItem->ride()->startTime().toString("hh:mm:ss"));
 
         // get duration and distance, yuk, dup of code below, and from RideImportWizard
         int secs=0;
@@ -365,7 +365,7 @@ SplitActivityWizard::setFilesList()
 
         // date and time
         add->setText(1, ride->startTime().toString(tr("dd MMM yyyy")));
-        add->setText(2, ride->startTime().toString(tr("hh:mm:ss ap")));
+        add->setText(2, ride->startTime().toString("hh:mm:ss"));
 
         // get duration and distance
         int secs=0;

--- a/src/TPDownloadDialog.cpp
+++ b/src/TPDownloadDialog.cpp
@@ -364,7 +364,7 @@ TPDownloadDialog::completedWorkout(QList<QMap<QString, QString> >workouts)
 
         add->setText(2, ridedatetime.toString("MMM d, yyyy"));
         add->setTextAlignment(2, Qt::AlignLeft);
-        add->setText(3, ridedatetime.toString("hh:mm:ss ap"));
+        add->setText(3, ridedatetime.toString("hh:mm:ss"));
         add->setTextAlignment(3, Qt::AlignCenter);
 
         long secs = workouts[i].value("TimeTotalInSeconds").toInt();
@@ -414,7 +414,7 @@ TPDownloadDialog::completedWorkout(QList<QMap<QString, QString> >workouts)
             sync->setTextAlignment(1, Qt::AlignCenter);
             sync->setText(2, ridedatetime.toString("MMM d, yyyy"));
             sync->setTextAlignment(2, Qt::AlignLeft);
-            sync->setText(3, ridedatetime.toString("hh:mm:ss ap"));
+            sync->setText(3, ridedatetime.toString("hh:mm:ss"));
             sync->setTextAlignment(3, Qt::AlignCenter);
             sync->setText(4, duration);
             sync->setTextAlignment(4, Qt::AlignCenter);
@@ -448,7 +448,7 @@ TPDownloadDialog::completedWorkout(QList<QMap<QString, QString> >workouts)
 
         add->setText(2, ridedatetime.toString("MMM d, yyyy"));
         add->setTextAlignment(2, Qt::AlignLeft);
-        add->setText(3, ridedatetime.toString("hh:mm:ss ap"));
+        add->setText(3, ridedatetime.toString("hh:mm:ss"));
         add->setTextAlignment(3, Qt::AlignCenter);
 
         long secs = rideMetrics[i].getForSymbol("workout_time");
@@ -494,7 +494,7 @@ TPDownloadDialog::completedWorkout(QList<QMap<QString, QString> >workouts)
             sync->setTextAlignment(1, Qt::AlignCenter);
             sync->setText(2, ridedatetime.toString("MMM d, yyyy"));
             sync->setTextAlignment(2, Qt::AlignLeft);
-            sync->setText(3, ridedatetime.toString("hh:mm:ss ap"));
+            sync->setText(3, ridedatetime.toString("hh:mm:ss"));
             sync->setTextAlignment(3, Qt::AlignCenter);
             sync->setText(4, duration);
             sync->setTextAlignment(4, Qt::AlignCenter);


### PR DESCRIPTION
... sync all format strings for time input/output to 'hh:mm:ss'
... remove any 'AM/PM' time formats
... remove tr() commands from time formats (since 'hh:mm:ss' is reasonable around the globe and should be be translated to avoid the AM/PM problem coming back)

... main reason: QT5 does not follow the pure formatting rules any more (like QT4), but considers the system.locale in formatting as well (so for countries which have no AM/PM, even if the format string is set, the QT routines ignores that - having some side effect on GC - e.g. running in English on a German Windows)
