### PR TITLE
Details - Metrics Tab (UI Nit)

### DIFF
--- a/src/RideMetadata.cpp
+++ b/src/RideMetadata.cpp
@@ -427,6 +427,9 @@ FormField::FormField(FieldDefinition field, RideMetadata *meta) : definition(fie
     if (meta->sp.isMetric(field.name)) {
         field.type = FIELD_DOUBLE; // whatever they say, we want a double!
         units = meta->sp.rideMetric(field.name)->units(meta->context->athlete->useMetricUnits);
+        // remove "seconds", since the field will be a QTimeEdit field
+        if (units == "seconds" || units == tr("seconds")) units = "";
+        // layout units name for screen
         if (units != "") units = QString(" (%1)").arg(units);
     }
 


### PR DESCRIPTION
... for metrics / time fields with unit ("seconds") don't show unit in field texts, since the field is QTimeEdit (in hours)

result after this change: 
![seconds](https://cloud.githubusercontent.com/assets/7491731/3423009/dc21ee10-ff78-11e3-9d21-27d0ea858a48.JPG)
