### PR TITLE
Translation Enablement / Corrections

### DIFF
--- a/src/AboutDialog.cpp
+++ b/src/AboutDialog.cpp
@@ -137,7 +137,7 @@ ContributorsPage::ContributorsPage(Context *context, QDir home) : context(contex
     contributors.append("Jaime Jofre");
     contributors.append("Jamie Kimberley");
     contributors.append("Jim Ley");
-    contributors.append("Jörn Rischmüller");
+    contributors.append("J&#246;rn Rischm&#252;ller");
     contributors.append("John Ehrlinger");
     contributors.append("Jon Escombe");
     contributors.append("Josef Gebel");

--- a/src/HrTimeInZone.cpp
+++ b/src/HrTimeInZone.cpp
@@ -36,8 +36,8 @@ public:
     HrZoneTime() : level(0), seconds(0.0)
     {
         setType(RideMetric::Total);
-        setMetricUnits("seconds");
-        setImperialUnits("seconds");
+        setMetricUnits(tr("seconds"));
+        setImperialUnits(tr("seconds"));
         setPrecision(0);
         setConversion(1.0);
     }
@@ -75,6 +75,8 @@ public:
     void initialize ()
     {
         setName(tr("H1 Time in Zone"));
+        setMetricUnits(tr("seconds"));
+        setImperialUnits(tr("seconds"));
     }
     RideMetric *clone() const { return new HrZoneTime1(*this); }
 };
@@ -92,6 +94,8 @@ public:
     void initialize ()
     {
         setName(tr("H2 Time in Zone"));
+        setMetricUnits(tr("seconds"));
+        setImperialUnits(tr("seconds"));
     }
     RideMetric *clone() const { return new HrZoneTime2(*this); }
 };
@@ -109,6 +113,8 @@ public:
     void initialize ()
     {
         setName(tr("H3 Time in Zone"));
+        setMetricUnits(tr("seconds"));
+        setImperialUnits(tr("seconds"));
     }
     RideMetric *clone() const { return new HrZoneTime3(*this); }
 };
@@ -126,6 +132,8 @@ public:
     void initialize ()
     {
         setName(tr("H4 Time in Zone"));
+        setMetricUnits(tr("seconds"));
+        setImperialUnits(tr("seconds"));
     }
     RideMetric *clone() const { return new HrZoneTime4(*this); }
 };
@@ -143,6 +151,8 @@ public:
     void initialize ()
     {
         setName(tr("H5 Time in Zone"));
+        setMetricUnits(tr("seconds"));
+        setImperialUnits(tr("seconds"));
     }
     RideMetric *clone() const { return new HrZoneTime5(*this); }
 };
@@ -160,6 +170,8 @@ public:
     void initialize ()
     {
         setName(tr("H6 Time in Zone"));
+        setMetricUnits(tr("seconds"));
+        setImperialUnits(tr("seconds"));
     }
     RideMetric *clone() const { return new HrZoneTime6(*this); }
 };
@@ -177,6 +189,8 @@ public:
     void initialize ()
     {
         setName(tr("H7 Time in Zone"));
+        setMetricUnits(tr("seconds"));
+        setImperialUnits(tr("seconds"));
     }
     RideMetric *clone() const { return new HrZoneTime7(*this); }
 };
@@ -194,6 +208,8 @@ public:
     void initialize ()
     {
         setName(tr("H8 Time in Zone"));
+        setMetricUnits(tr("seconds"));
+        setImperialUnits(tr("seconds"));
     }
     RideMetric *clone() const { return new HrZoneTime8(*this); }
 };

--- a/src/LTMSettings.cpp
+++ b/src/LTMSettings.cpp
@@ -67,14 +67,14 @@ EditChartDialog::okClicked()
 {
     // mustn't be blank
     if (chartName->text() == "") {
-        QMessageBox::warning( 0, "Entry Error", "Name is blank");
+        QMessageBox::warning( 0, tr("Entry Error"), tr("Name is blank"));
         return;
     }
 
     // does it already exist?
     foreach (LTMSettings chart, presets) {
         if (chart.name == chartName->text()) {
-            QMessageBox::warning( 0, "Entry Error", "Chart already exists");
+            QMessageBox::warning( 0, tr("Entry Error"), tr("Chart already exists"));
             return;
         }
     }

--- a/src/LTMTool.cpp
+++ b/src/LTMTool.cpp
@@ -147,7 +147,7 @@ LTMTool::LTMTool(Context *context, LTMSettings *settings) : QWidget(context->mai
 #ifdef Q_OS_MAC
     charts->setAttribute(Qt::WA_MacShowFocusRect, 0);
 #endif
-    charts->headerItem()->setText(0, "Charts");
+    charts->headerItem()->setText(0, tr("Charts"));
     charts->setColumnCount(1);
     charts->setSelectionMode(QAbstractItemView::SingleSelection);
     charts->setEditTriggers(QAbstractItemView::SelectedClicked); // allow edit
@@ -1317,11 +1317,11 @@ EditMetricDetailDialog::estimateName()
         case 3 : name = "p-Max"; break;
         case 4 : 
             {
-                name = QString("Estimate %1 %2 Power").arg(estimateDuration->value())
+                name = QString(tr("Estimate %1 %2 Power")).arg(estimateDuration->value())
                                                   .arg(estimateDurationUnits->currentText());
             }
             break;
-        case 5 : name = "Endurance Index"; break;
+        case 5 : name = tr("Endurance Index"); break;
     }
 
     // now the model
@@ -1747,10 +1747,10 @@ EditMetricDetailDialog::bestName()
     // set uname from current parms
     QString desc = QString(tr("Peak %1")).arg(duration->value());
     switch (durationUnits->currentIndex()) {
-    case 0 : desc += " second "; break;
-    case 1 : desc += " minute "; break;
+    case 0 : desc += tr(" second "); break;
+    case 1 : desc += tr(" minute "); break;
     default:
-    case 2 : desc += " hour "; break;
+    case 2 : desc += tr(" hour "); break;
     }
     desc += RideFile::seriesName(seriesList.at(dataSeries->currentIndex()));
     userName->setText(desc);
@@ -2072,7 +2072,7 @@ LTMTool::importClicked()
 
         } else {
             // oops non existant - does this ever happen?
-            QMessageBox::warning( 0, "Entry Error", QString("Selected file (%1) does not exist").arg(filenames[0]));
+            QMessageBox::warning( 0, tr("Entry Error"), QString(tr("Selected file (%1) does not exist")).arg(filenames[0]));
         }
     }
 }
@@ -2090,8 +2090,8 @@ LTMTool::exportClicked()
         // if exists confirm overwrite
         if (QFileInfo(filenames[0]).exists()) {
             QMessageBox msgBox;
-            msgBox.setText(QString("The selected file (%1) exists.").arg(filenames[0]));
-            msgBox.setInformativeText("Do you want to overwrite it?");
+            msgBox.setText(QString(tr("The selected file (%1) exists.")).arg(filenames[0]));
+            msgBox.setInformativeText(tr("Do you want to overwrite it?"));
             msgBox.setStandardButtons(QMessageBox::Ok | QMessageBox::Cancel);
             msgBox.setDefaultButton(QMessageBox::Cancel);
             msgBox.setIcon(QMessageBox::Warning);
@@ -2159,7 +2159,7 @@ LTMTool::deleteClicked()
 {
     // must have at least 1 child
     if (charts->invisibleRootItem()->childCount() == 1) {
-        QMessageBox::warning(0, "Error", "You must have at least one chart");
+        QMessageBox::warning(0, tr("Error"), tr("You must have at least one chart"));
         return;
 
     } else if (charts->currentItem()) {

--- a/src/TimeInZone.cpp
+++ b/src/TimeInZone.cpp
@@ -36,8 +36,8 @@ class ZoneTime : public RideMetric {
     ZoneTime() : level(0), seconds(0.0)
     {
         setType(RideMetric::Total);
-        setMetricUnits("seconds");
-        setImperialUnits("seconds");
+        setMetricUnits(tr("seconds"));
+        setImperialUnits(tr("seconds"));
         setPrecision(0);
         setConversion(1.0);
     }
@@ -77,6 +77,8 @@ class ZoneTime1 : public ZoneTime {
         void initialize ()
         {
             setName(tr("L1 Time in Zone"));
+            setMetricUnits(tr("seconds"));
+            setImperialUnits(tr("seconds"));
         }
         RideMetric *clone() const { return new ZoneTime1(*this); }
 };
@@ -94,6 +96,8 @@ class ZoneTime2 : public ZoneTime {
         void initialize ()
         {
             setName(tr("L2 Time in Zone"));
+            setMetricUnits(tr("seconds"));
+            setImperialUnits(tr("seconds"));
         }
         RideMetric *clone() const { return new ZoneTime2(*this); }
 };
@@ -111,6 +115,8 @@ class ZoneTime3 : public ZoneTime {
         void initialize ()
         {
             setName(tr("L3 Time in Zone"));
+            setMetricUnits(tr("seconds"));
+            setImperialUnits(tr("seconds"));
         }
         RideMetric *clone() const { return new ZoneTime3(*this); }
 };
@@ -124,10 +130,14 @@ class ZoneTime4 : public ZoneTime {
             setLevel(4);
             setSymbol("time_in_zone_L4");
             setInternalName("L4 Time in Zone");
+            setMetricUnits(tr("seconds"));
+            setImperialUnits(tr("seconds"));
         }
         void initialize ()
         {
             setName(tr("L4 Time in Zone"));
+            setMetricUnits(tr("seconds"));
+            setImperialUnits(tr("seconds"));
         }
         RideMetric *clone() const { return new ZoneTime4(*this); }
 };
@@ -145,6 +155,8 @@ class ZoneTime5 : public ZoneTime {
         void initialize ()
         {
             setName(tr("L5 Time in Zone"));
+            setMetricUnits(tr("seconds"));
+            setImperialUnits(tr("seconds"));
         }
         RideMetric *clone() const { return new ZoneTime5(*this); }
 };
@@ -162,6 +174,8 @@ class ZoneTime6 : public ZoneTime {
         void initialize ()
         {
             setName(tr("L6 Time in Zone"));
+            setMetricUnits(tr("seconds"));
+            setImperialUnits(tr("seconds"));
         }
         RideMetric *clone() const { return new ZoneTime6(*this); }
 };
@@ -179,6 +193,8 @@ class ZoneTime7 : public ZoneTime {
         void initialize ()
         {
             setName(tr("L7 Time in Zone"));
+            setMetricUnits(tr("seconds"));
+            setImperialUnits(tr("seconds"));
         }
         RideMetric *clone() const { return new ZoneTime7(*this); }
 };
@@ -196,6 +212,8 @@ class ZoneTime8 : public ZoneTime {
         void initialize ()
         {
             setName(tr("L8 Time in Zone"));
+            setMetricUnits(tr("seconds"));
+            setImperialUnits(tr("seconds"));
         }
         RideMetric *clone() const { return new ZoneTime8(*this); }
 };
@@ -213,6 +231,8 @@ class ZoneTime9 : public ZoneTime {
         void initialize ()
         {
             setName(tr("L9 Time in Zone"));
+            setMetricUnits(tr("seconds"));
+            setImperialUnits(tr("seconds"));
         }
         RideMetric *clone() const { return new ZoneTime9(*this); }
 };
@@ -230,6 +250,8 @@ class ZoneTime10 : public ZoneTime {
         void initialize ()
         {
             setName(tr("L10 Time in Zone"));
+            setMetricUnits(tr("seconds"));
+            setImperialUnits(tr("seconds"));
         }
         RideMetric *clone() const { return new ZoneTime10(*this); }
 };


### PR DESCRIPTION
... some more tr() (LTMTool, LTMSettings)
... for Lx/Hx in Time and unit "seconds" translation not working in constructor, therefore moved to "initialization" for both HR and Power (similar to the translated metric names) (HrTimeInZone, TimeInZone)
... in RC2 - Windows (name with "umlaut") not displayed in official build (adjusted to be handled like the one name with umlauts already defined) (About)
