### PR TITLE
Translate ":/Charts.XML" during import

### DIFF
--- a/src/Athlete.cpp
+++ b/src/Athlete.cpp
@@ -101,7 +101,7 @@ Athlete::Athlete(Context *context, const QDir &home)
 
     // read athlete's charts.xml and translate etc
     LTMSettings reader;
-    reader.readChartXML(context->athlete->home, presets);
+    reader.readChartXML(context->athlete->home, context->athlete->useMetricUnits, presets);
     translateDefaultCharts(presets);
 
     // Metadata

--- a/src/LTMSettings.cpp
+++ b/src/LTMSettings.cpp
@@ -103,7 +103,7 @@ LTMSettings::writeChartXML(QDir home, QList<LTMSettings> charts)
  *--------------------------------------------------------------------*/
 
 void
-LTMSettings::readChartXML(QDir home, QList<LTMSettings> &charts)
+LTMSettings::readChartXML(QDir home, bool useMetricUnits, QList<LTMSettings> &charts)
 {
     QFileInfo chartFile(home.absolutePath() + "/charts.xml");
     QFile chartsFile;
@@ -129,33 +129,21 @@ LTMSettings::readChartXML(QDir home, QList<LTMSettings> &charts)
 
     // translate only once and only if the built-in version is imported
     if (builtIn) {
+        // create translation maps (for names and units)
         QMap<QString, QString> nMap;  // names
         QMap<QString, QString> uMap;  // unit of measurement
-        // build up translation maps
-        const RideMetricFactory &factory = RideMetricFactory::instance();
-        for (int i=0; i<factory.metricCount(); i++) {
-            const RideMetric *add = factory.rideMetric(factory.metricName(i));
-            QTextEdit processHTMLname(add->name());
-            // use the .symbol() as key - since only CHART.XML is mapped
-            nMap.insert(add->symbol(), processHTMLname.toPlainText());
-            uMap.insert(add->symbol(), add->units(true)); // JR - HERE UNITS Metric... still to be done
+        LTMTool::getMetricsTranslationMap(nMap, uMap, useMetricUnits);
 
-        }
-        // add mapping for PM metrics (name and unit)
-        QList<MetricDetail> pmMetrics = LTMTool::providePMmetrics();
-        for (int i=0; i<pmMetrics.count(); i++)
-        {
-            nMap.insert(pmMetrics[i].symbol, pmMetrics[i].uname);
-            uMap.insert(pmMetrics[i].symbol, pmMetrics[i].uunits);
-        }
-
-        // no run over all chart metrics and map - name and unit
+        // now run over all chart metrics and map - name and unit
         for (int i=0; i<charts.count(); i++) {
             for (int j=0; j<charts[i].metrics.count(); j++){
                 // no map and substitute
                 QString n  = nMap.value(charts[i].metrics[j].symbol, charts[i].metrics[j].uname);
                 QString u  = uMap.value(charts[i].metrics[j].symbol, charts[i].metrics[j].uunits);
-                charts[i].metrics[j].name = charts[i].metrics[j].uname = n;
+                // set name, unit only if there was text before
+                if (charts[i].metrics[j].name != "") charts[i].metrics[j].name = n;
+                charts[i].metrics[j].uname = n;
+                if (charts[i].metrics[j].units != "") charts[i].metrics[j].units = u;
                 charts[i].metrics[j].units = charts[i].metrics[j].uunits = u;
             }
         }

--- a/src/LTMSettings.h
+++ b/src/LTMSettings.h
@@ -153,7 +153,7 @@ class LTMSettings {
         }
 
         void writeChartXML(QDir, QList<LTMSettings>);
-        void readChartXML(QDir, QList<LTMSettings>&charts);
+        void readChartXML(QDir, bool, QList<LTMSettings>&charts);
 
         QString name;
         QString title;

--- a/src/LTMTool.cpp
+++ b/src/LTMTool.cpp
@@ -1283,6 +1283,30 @@ LTMTool::addCurrent()
     context->notifyPresetsChanged();
 }
 
+void
+LTMTool::getMetricsTranslationMap (QMap<QString, QString> &nMap, QMap<QString, QString> &uMap, bool useMetricUnits) {
+
+    // build up translation maps
+    const RideMetricFactory &factory = RideMetricFactory::instance();
+    for (int i=0; i<factory.metricCount(); i++) {
+        const RideMetric *add = factory.rideMetric(factory.metricName(i));
+        QTextEdit processHTMLname(add->name());
+        // use the .symbol() as key - since only CHART.XML is mapped
+        nMap.insert(add->symbol(), processHTMLname.toPlainText());
+        uMap.insert(add->symbol(), add->units(useMetricUnits));
+
+    }
+    // add mapping for PM metrics (name and unit)
+    QList<MetricDetail> pmMetrics = LTMTool::providePMmetrics();
+    for (int i=0; i<pmMetrics.count(); i++)
+    {
+        nMap.insert(pmMetrics[i].symbol, pmMetrics[i].uname);
+        uMap.insert(pmMetrics[i].symbol, pmMetrics[i].uunits);
+    }
+
+}
+
+
 // set the estimateSelection based upon what is available
 void 
 EditMetricDetailDialog::modelChanged()

--- a/src/LTMTool.h
+++ b/src/LTMTool.h
@@ -96,6 +96,7 @@ class LTMTool : public QWidget
         DateSettingsEdit *dateSetting;
 
         static QList<MetricDetail> providePMmetrics();
+        static void getMetricsTranslationMap (QMap<QString, QString>& nMap, QMap<QString, QString>& uMap, bool useMetricUnits);
 
     signals:
 


### PR DESCRIPTION
... a little more explanation here, since the changes in the files are very "optimized":

... LTMTool: - extracted the "RideMetrics" definitions for all the PM settings into an own static routine (which is used as well by the orginal LTMTool (where the code comes from) , but also allows to re-use the MetricsDetail table for PMmetrics for translation of the PMmetrics (used on LTMSettings for now)

... LTMSettings: added that (only) for the DEFAULT "Charts.XML" the translation for field names and units takes place. It currently maps the standard metrics and the PM related metrics, but not measures, or estimates

I have tested in English, German and French - texts available are translated - otherwise EN is still the default. Since the translated settings are stored in the local CHARTS.XML the change is persistent. For users running GC in multiple languages this could be confusing, since with the further changes of GC language, the copied CHARTS.XML is not touched any more. 

What's not translated by this way are any LTMSettings in the "xxx-Layout.XML" charts.

Please decide if you want to add to 3.1 still (I know it's pretty late - and RC2 is alreday out) - we can also push to 3.11 or further.
