### PR TITLE
ColumnChooser - Drag&Drop problem with special Characters and QT 4.6.8

### DIFF
--- a/src/SearchBox.cpp
+++ b/src/SearchBox.cpp
@@ -290,7 +290,12 @@ SearchBox::dragEnterEvent(QDragEnterEvent *event)
 void
 SearchBox::dropEvent(QDropEvent *event)
 {
-    QString name = event->mimeData()->data("application/x-columnchooser");
+    QByteArray rawData = event->mimeData()->data("application/x-columnchooser");
+    QDataStream stream(&rawData, QIODevice::ReadOnly);
+    stream.setVersion(QDataStream::Qt_4_6);
+    QString name;
+    stream >> name;
+
     // fugly, but it works for BikeScore with the (TM) in it... so...
     // independent of Latin1 or UTF-8 coming from "Column Chooser" the "TM" special sign is not recognized by the parser,
     // so strip the "TM" off for this case (only)


### PR DESCRIPTION
... the .toUTF8() conversion (introduced in 3.1 based on QT5.x.x to handle special characters (e.g. german Umlaute) in Column Chooser does not work for QT 4.8.6 (at least not for the Windows) - as a result (Drag&Drop from those fields into Columns or Search Field is not working)
... following the approach other location for "Drag&Drop", approach is changed to "serialization" of the data for "Drag&Drop" - so to work independent on any QT String/ByteArray conversions (which seem to depend on other conditions - as as noticed change over time) 
