### PR TITLE
Fix context menu in ride editor (QT5 problem only)

### DIFF
--- a/src/RideEditor.cpp
+++ b/src/RideEditor.cpp
@@ -502,7 +502,8 @@ RideEditor::eventFilter(QObject *object, QEvent *e)
     switch(e->type())
     {
         case QEvent::ContextMenu:
-            borderMenu(((QMouseEvent *)e)->pos());
+            // borderMenu(((QMouseEvent *)e)->pos());
+            borderMenu(table->mapFromGlobal(QCursor::pos()));
             return true; // I'll take that thanks
             break;
 


### PR DESCRIPTION
... same problem as in 'Ride Navigator'  (only QT 5.3.1) (fixed on June 20th - Commit see below)
... tested for 4.8.6 and 5.3.1 on Windows 

https://github.com/GoldenCheetah/GoldenCheetah/commit/88e1dc5745462a752c78c3d8c9ff9cc5d0a393b6
