### PR TITLE
Fix - .JSON import of chars > 127 on QT5 problem (leading to ? in text fields)

### DIFF
--- a/src/JsonRideFile.y
+++ b/src/JsonRideFile.y
@@ -82,9 +82,9 @@ static QString protect(const QString string)
 }
 
 // Un-Escape special characters (JSON compliance)
-static QString unprotect(const QString string)
+static QString unprotect(const char * string)
 {
-    QString string2 = QString::fromLocal8Bit(string.toLatin1().data());
+    QString string2 = QString::fromLocal8Bit(string);
 
     // this is a lexer string so it will be enclosed
     // in quotes. Lets strip those first


### PR DESCRIPTION
... on QT5 the conversion of chars > 127 did not work (substituting characters with "?") when loading a .JSON ride file which had such character in their text (e.g. in TAGS)
... by this change the implicite type cast (char to QString) when calling "unprotect" does not take place any more, but the lexer result string is converted directly from 'Local8Bit' to QString to what is has been converted when setting the file-string for lex
... again QT has changed behavior of locale related processing in QT5 (all this worked fine in QT4)
