### PR TITLE
Fix - AllPlot - Smoothing

### DIFF
--- a/src/AllPlot.cpp
+++ b/src/AllPlot.cpp
@@ -1184,8 +1184,8 @@ AllPlot::recalc(AllPlotObject *objects)
         return;
     }
 
-    // if recintsecs is longer than the smoothing there is no point in even trying
-    int applysmooth = smooth < rideItem->ride()->recIntSecs() ? 0 : smooth;
+    // if recintsecs is longer than the smoothing, or equal to the smoothing there is no point in even trying
+    int applysmooth = smooth <= rideItem->ride()->recIntSecs() ? 0 : smooth;
 
     // compare mode breaks
     if (context->isCompareIntervals && applysmooth == 0) applysmooth = 1;


### PR DESCRIPTION
... values in the ride plot deviate from the ride data since smoothing takes place even if the sample time is equal to the smoothing interval (for which the expectation was that the original samples are plotted)

... don't touch comparemode smoothing
