### PR TITLE
JSON char > 127 codepage problem (Issue #1028)

### DIFF
--- a/src/JsonRideFile.l
+++ b/src/JsonRideFile.l
@@ -91,5 +91,8 @@ int JsonRideFilelex_destroy(void) { return 0; }
 
 void JsonRideFile_setString(QString p)
 {
-    JsonRideFile_scan_string(p.toLocal8Bit().data());
+    // internally work with UTF-8 encoding
+    // this works for FLEX, since the multi-byte characters only appear WITHIN a "String",
+    // but not as part of the grammar - this is important since a char in UTF-8 can have up to 4 bytes
+    JsonRideFile_scan_string(p.toUtf8().data());
 }


### PR DESCRIPTION
... on the different platforms/QT version the .JSON ridefile was encoded using different (local) codepages which caused problems with chars > 127 (since the local encoder of QT changed in QT5 for some platform)
... .JSON is now always encoded/decoded with UTF-8 codec
... old files which contain chars > 127 (e.g. German Umlaut, French accent?) are still decoded with Latin1/ISO8859-1) codec if the decoding in UTF-8 failed for some chars
... the UTF-8 files get the respective BOM (Byte order mark) added, so that any editor being able to handle unicode can recognize the code page 
