### PR TITLE
New Metrics for MTB(mainly) - Bike - Time Carrying / Elevation Gain Carrying

### DIFF
--- a/src/DBAccess.cpp
+++ b/src/DBAccess.cpp
@@ -101,8 +101,9 @@
 // 80  13  Jul 2014 Mark Liversedge    W' work + Below CP work = Work
 // 81  16  Aug 2014 Joern Rischmueller Added 'Elevation Loss'
 // 82  23  Aug 2014 Mark Liversedge    Added W'bal Matches
+// 83  05  Sep 2014 Joern Rischmueler  Added 'Time Carrying' and 'Elevation Gain Carrying'
 
-int DBSchemaVersion = 82;
+int DBSchemaVersion = 83;
 
 DBAccess::DBAccess(Context* context) : context(context), db(NULL)
 {


### PR DESCRIPTION
... 2 new metrics (derived) mainly relevant for MTB or Race bike steep passes
... a) Time Carrying = moving < 8kph, gaining height, no power, no cadence
... b) Elevation Gain carrying = same criteria, but adding up the elevation gain

Since there is a certain level of variance in interpreting the data, the metrics is named as "Est".
