### PR TITLE
AllPlot - Smoothing also for "Left Border"

### DIFF
--- a/src/AllPlot.cpp
+++ b/src/AllPlot.cpp
@@ -1247,40 +1247,11 @@ AllPlot::recalc(AllPlotObject *objects)
         objects->smoothRTE.resize(rideTimeSecs + 1);
         objects->smoothLPS.resize(rideTimeSecs + 1);
         objects->smoothRPS.resize(rideTimeSecs + 1);
-
-        for (int secs = 0; ((secs < applysmooth)
-                            && (secs < rideTimeSecs)); ++secs) {
-            objects->smoothWatts[secs] = 0.0;
-            objects->smoothNP[secs] = 0.0;
-            objects->smoothAT[secs] = 0.0;
-            objects->smoothANT[secs] = 0.0;
-            objects->smoothXP[secs] = 0.0;
-            objects->smoothAP[secs] = 0.0;
-            objects->smoothHr[secs]    = 0.0;
-            objects->smoothSpeed[secs] = 0.0;
-            objects->smoothAccel[secs] = 0.0;
-            objects->smoothWattsD[secs] = 0.0;
-            objects->smoothCadD[secs] = 0.0;
-            objects->smoothNmD[secs] = 0.0;
-            objects->smoothHrD[secs] = 0.0;
-            objects->smoothCad[secs]   = 0.0;
-            objects->smoothTime[secs]  = secs / 60.0;
-            objects->smoothDistance[secs]  = 0.0;
-            objects->smoothAltitude[secs]  = 0.0;
-            objects->smoothTemp[secs]  = 0.0;
-            objects->smoothWind[secs]  = 0.0;
-            objects->smoothRelSpeed[secs] = QwtIntervalSample();
-            objects->smoothTorque[secs]  = 0.0;
-            objects->smoothLTE[secs]  = 0.0;
-            objects->smoothRTE[secs]  = 0.0;
-            objects->smoothLPS[secs]  = 0.0;
-            objects->smoothRPS[secs]  = 0.0;
-            objects->smoothBalanceL[secs]  = 50;
-            objects->smoothBalanceR[secs]  = 50;
-        }
-
+        // do the smoothing by caculating the average of the "applysmooth" values left
+        // of the current data point - for points in time smaller than "applysmooth"
+        // only the available datapoints left are used to build the average
         int i = 0;
-        for (int secs = applysmooth; secs <= rideTimeSecs; ++secs) {
+        for (int secs = 0; secs <= rideTimeSecs; ++secs) {
             while ((i < objects->timeArray.count()) && (objects->timeArray[i] <= secs)) {
                 DataPoint dp(objects->timeArray[i],
                              (!objects->hrArray.empty() ? objects->hrArray[i] : 0),
@@ -1406,7 +1377,7 @@ AllPlot::recalc(AllPlotObject *objects)
                 objects->smoothNmD[secs] = 0.0;
                 objects->smoothHrD[secs] = 0.0;
                 objects->smoothCad[secs]   = 0.0;
-                objects->smoothAltitude[secs]   = objects->smoothAltitude[secs - 1];
+                objects->smoothAltitude[secs]   = ((secs > 0) ? objects->smoothAltitude[secs - 1] : objects->altArray[secs] ) ;
                 objects->smoothTemp[secs]   = 0.0;
                 objects->smoothWind[secs] = 0.0;
                 objects->smoothRelSpeed[secs] =  QwtIntervalSample();


### PR DESCRIPTION
Problem:
... data points of "Smoothing" settings are set to Zero in result data samples (first x data points)
... this cause e.g. Zero Altitude Values when Plot Smoothing is active
Solution:
... also most left values are using the same "smoothing" approach now (by using the data points left of them to create the average)

Tested - both in normal/compare mode and also after removing data points from the ride (using the GC Editor) - by removing at beginning, middle and end of ride file.

For more details check previous pull request - which was canceled since the patch did not work for the test cases listed above:

https://github.com/GoldenCheetah/GoldenCheetah/pull/1058
