### PR TITLE
Auto/Stealth Ride Import when opening an Athlete

### DIFF
--- a/src/Athlete.cpp
+++ b/src/Athlete.cpp
@@ -45,6 +45,8 @@
 #include "LTMSettings.h"
 #include "Route.h"
 #include "RouteWindow.h"
+#include "RideImportWizard.h"
+
 
 #include "GcUpgrade.h" // upgrade wizard
 #include "GcCrashDialog.h" // recovering from a crash?
@@ -499,5 +501,43 @@ Athlete::configChanged()
             rideItem->ride(false)->setWeight(0);
             rideItem->ride(false)->getWeight();
         }
+    }
+}
+
+void
+Athlete::importFilesWithoutDialog() {
+
+    int importSettings = appsettings->cvalue(context->athlete->cyclist, GC_IMPORTSETTINGS).toInt(); // default/unset = 0
+    if (importSettings == 0) return; // no autoimport requested
+
+    QVariant importDirQV = appsettings->cvalue(context->athlete->cyclist, GC_IMPORTDIR, "");
+    QString importDirectory = importDirQV.toString();
+    if (importDirectory == "") return; // no implicit assumptions on the directory - only explicite is allowed
+
+    // now get the files formats
+    const RideFileFactory &rff = RideFileFactory::instance();
+    QStringList suffixList = rff.suffixes();
+    suffixList.replaceInStrings(QRegExp("^"), "*.");
+    QStringList allFormats;
+    QFileInfoList fileInfos;
+    foreach(QString suffix, rff.suffixes())
+        allFormats << QString("*.%1").arg(suffix);
+
+    // and now the files for the GC formats / no SubDirs considered
+    QDir *importDir = new QDir (importDirectory);
+    if (!importDir->exists()) return;    // directory might not be available (USB,..)
+    if (!importDir->isReadable()) return; // check if directory is readable,
+
+    // now get the files with their full names
+    fileInfos = importDir->entryInfoList(allFormats, QDir::Files, QDir::NoSort);
+    if (!fileInfos.isEmpty()) {
+        QStringList fileNames;
+        foreach(QFileInfo f, fileInfos) {
+            fileNames.append(f.absoluteFilePath());
+        }
+        RideImportWizard *import = new RideImportWizard(fileNames, context->athlete->home, context);
+        if (importSettings == 1) import->setDialogMode(RideImportWizard::allButDupFileErrors);
+        if (importSettings == 2) import->setDialogMode(RideImportWizard::allErrors);
+        import->process();
     }
 }

--- a/src/Athlete.h
+++ b/src/Athlete.h
@@ -124,6 +124,9 @@ class Athlete : public QObject
         void notifySeasonsChanged() { seasonsChanged(); }
         void notifyNamedSearchesChanged() { namedSearchesChanged(); }
 
+        // import rides from athlete specific directory
+        void importFilesWithoutDialog();
+
     signals:
         void zonesChanged();
         void seasonsChanged();
@@ -135,6 +138,7 @@ class Athlete : public QObject
         void checkCPX(RideItem*ride);
         void updateRideFileIntervals();
         void configChanged();
+
 
 };
 #endif

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1387,6 +1387,7 @@ MainWindow::openWindow(QString name)
     // main window will register itself
     MainWindow *main = new MainWindow(home);
     main->show();
+    main->ridesAutoImport();
 }
 
 void
@@ -1437,6 +1438,9 @@ MainWindow::openTab(QString name)
     showTabbar(true);
 
     setUpdatesEnabled(true);
+
+    // now do the automatic ride file import
+    context->athlete->importFilesWithoutDialog();
 }
 
 void
@@ -1945,5 +1949,12 @@ void
 MainWindow::addIntervals()
 {
     currentTab->addIntervals();
+}
+
+void
+MainWindow::ridesAutoImport() {
+
+    currentTab->context->athlete->importFilesWithoutDialog();
+
 }
 

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -189,6 +189,9 @@ class MainWindow : public QMainWindow
         void revertRide();
         bool saveRideExitDialog(Context *);              // save dirty rides on exit dialog
 
+        // autoload rides from athlete specific directory (preferences)
+        void ridesAutoImport();
+
         // save and restore state to context
         void saveGCState(Context *);
         void restoreGCState(Context *);

--- a/src/Pages.cpp
+++ b/src/Pages.cpp
@@ -780,6 +780,20 @@ RiderPage::RiderPage(QWidget *parent, Context *context) : QWidget(parent), conte
     avatarButton->setFixedHeight(140);
     avatarButton->setFixedWidth(140);
 
+    QVariant importDir = appsettings->cvalue(context->athlete->cyclist, GC_IMPORTDIR, "");
+
+    importLabel = new QLabel(tr("Auto Import from"));
+    importDirectory = new QLineEdit;
+    importDirectory->setText(importDir.toString());
+    importBrowseButton = new QPushButton(tr("Browse"));
+    importBrowseButton->setFixedWidth(120);
+
+    importSetting = new QComboBox();
+    importSetting->addItem("No auto import");
+    importSetting->addItem("No duplicate file errors");
+    importSetting->addItem("All errors");
+    importSetting->setCurrentIndex(appsettings->cvalue(context->athlete->cyclist, GC_IMPORTSETTINGS).toInt()); // default/unset = 0
+
     Qt::Alignment alignment = Qt::AlignLeft|Qt::AlignVCenter;
 
     grid->addWidget(nicklabel, 0, 0, alignment);
@@ -797,11 +811,18 @@ RiderPage::RiderPage(QWidget *parent, Context *context) : QWidget(parent), conte
     grid->addWidget(bio, 6, 0, 1, 4);
 
     grid->addWidget(avatarButton, 0, 2, 4, 2, Qt::AlignRight|Qt::AlignVCenter);
+
+    grid->addWidget(importLabel, 7,0, alignment);
+    grid->addWidget(importDirectory, 7,1, alignment);
+    grid->addWidget(importBrowseButton, 7,2, alignment);
+    grid->addWidget(importSetting, 7,3, alignment);
+
     all->addLayout(grid);
     all->addStretch();
 
     connect (avatarButton, SIGNAL(clicked()), this, SLOT(chooseAvatar()));
     connect (unitCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(unitChanged(int)));
+    connect (importBrowseButton, SIGNAL(clicked()), this, SLOT(browseImportDir()));
 }
 
 void
@@ -833,6 +854,15 @@ RiderPage::unitChanged(int currentIndex)
 }
 
 void
+RiderPage::browseImportDir()
+{
+    QString dir = QFileDialog::getExistingDirectory(this, tr("Select Import Directory"),
+                            "", QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+    if (dir != "") importDirectory->setText(dir);  //only overwrite current dir, if a new was selected
+}
+
+
+void
 RiderPage::saveClicked()
 {
     appsettings->setCValue(context->athlete->cyclist, GC_NICKNAME, nickname->text());
@@ -847,6 +877,11 @@ RiderPage::saveClicked()
     appsettings->setCValue(context->athlete->cyclist, GC_SEX, sex->currentIndex());
     appsettings->setCValue(context->athlete->cyclist, GC_BIO, bio->toPlainText());
     avatar.save(context->athlete->home.absolutePath() + "/" + "avatar.png", "PNG");
+
+    // save the import settings
+    appsettings->setCValue(context->athlete->cyclist, GC_IMPORTSETTINGS, importSetting->currentIndex());
+    appsettings->setCValue(context->athlete->cyclist, GC_IMPORTDIR, importDirectory->text());
+
 }
 
 //

--- a/src/Pages.h
+++ b/src/Pages.h
@@ -111,6 +111,7 @@ class RiderPage : public QWidget
     public slots:
         void chooseAvatar();
         void unitChanged(int currentIndex);
+        void browseImportDir();
 
     private:
         Context *context;
@@ -124,6 +125,11 @@ class RiderPage : public QWidget
         QTextEdit  *bio;
         QPushButton *avatarButton;
         QPixmap     avatar;
+        QLineEdit *importDirectory;
+        QPushButton *importBrowseButton;
+        QLabel *importLabel;
+        QComboBox *importSetting;
+
 };
 
 class CredentialsPage : public QScrollArea

--- a/src/RideImportWizard.h
+++ b/src/RideImportWizard.h
@@ -46,6 +46,8 @@ public:
     RideImportWizard(QList<QString> files, QDir &home, Context *context, QWidget *parent = 0);
     ~RideImportWizard();
     int process();
+    void setDialogMode(int); // default is fullDialog
+    enum DialogMode { standardDialog, allErrors, allButDupFileErrors };
 
 signals:
 
@@ -62,6 +64,7 @@ private:
     QList <bool> blanks; // record of which have a RideFileReader returned date & time
     QDir home; // target directory
     bool aborted;
+    int dialogMode; // see enum
     QLabel *phaseLabel;
     QTableWidget *tableWidget;
     QProgressBar *progressBar;

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -56,6 +56,8 @@
 #define GC_SEX                      "sex"
 #define GC_BIO                      "bio"
 #define GC_AVATAR                   "avatar"
+#define GC_IMPORTDIR                "importDir"
+#define GC_IMPORTSETTINGS           "importSettings"
 #define GC_SETTINGS_LAST_IMPORT_PATH "mainwindow/lastImportPath"
 #define GC_SETTINGS_LAST_WORKOUT_PATH "mainwindow/lastWorkoutPath"
 #define GC_LAST_DOWNLOAD_DEVICE      "mainwindow/lastDownloadDevice"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -286,6 +286,7 @@ main(int argc, char *argv[])
                 if (home.cd(cyclist)) {
                     MainWindow *mainWindow = new MainWindow(home);
                     mainWindow->show();
+                    mainWindow->ridesAutoImport();
                     home.cdUp();
                     anyOpened = true;
                 }
@@ -314,6 +315,7 @@ main(int argc, char *argv[])
             // .. and open a mainwindow
             MainWindow *mainWindow = new MainWindow(home);
             mainWindow->show();
+            mainWindow->ridesAutoImport();
         }
 
         ret=application->exec();


### PR DESCRIPTION
...  import Ride Files automatically from a defined Directory per Athlete
...  runs silently/without "Import Rides" Widget, if the files can be imported/copied/... without error or warning
...  Preferences->Athlete- defines
      ... the directory - per Athlete and- if the function is active at all (default is OFF)
      ... the error handling options
          a) report back ALL errors and warnings by opening the RideImportWizard popup
          b) report back Errors and Warnings - but ignore the "File exists" warning 
              (so that the import directory can be continuously supplied with new files, 
              without the need to remove the already imported ones)

(screen location of the new preferences input fields might need a tweak - was not sure if to put above or below the text box - so decide not to change the current sequence and add below)
