### PR TITLE
Add Gear Ratio related functions in multiple areas

### DIFF
--- a/src/AllPlot.cpp
+++ b/src/AllPlot.cpp
@@ -308,6 +308,8 @@ AllPlotObject::AllPlotObject(AllPlot *plot) : plot(plot)
     gearCurve = new QwtPlotCurve(tr("Gear Ratio"));
     gearCurve->setPaintAttribute(QwtPlotCurve::FilterPoints, true);
     gearCurve->setYAxis(QwtAxisId(QwtAxis::yLeft, 0));
+    gearCurve->setStyle(QwtPlotCurve::Steps);
+    gearCurve->setCurveAttribute(QwtPlotCurve::Inverted);
 
     smo2Curve = new QwtPlotCurve(tr("SmO2"));
     smo2Curve->setPaintAttribute(QwtPlotCurve::FilterPoints, true);
@@ -1291,18 +1293,18 @@ AllPlot::setHighlightIntervals(bool state)
 
 struct DataPoint {
 
-    double time, hr, watts, atiss, antiss, np, rv, rcad, rgct, gear,
+    double time, hr, watts, atiss, antiss, np, rv, rcad, rgct,
            smo2, thb, ap, xp, speed, cad, 
            alt, temp, wind, torque, lrbalance, lte, rte, lps, rps,
            kphd, wattsd, cadd, nmd, hrd, slope;
 
     DataPoint(double t, double h, double w, double at, double an, double n, double rv, double rcad, double rgct,
-              double gear, double smo2, double thb, double l, double x, double s, double c, 
+              double smo2, double thb, double l, double x, double s, double c,
               double a, double te, double wi, double tq, double lrb, double lte, double rte, double lps, double rps,
               double kphd, double wattsd, double cadd, double nmd, double hrd, double sl) :
 
               time(t), hr(h), watts(w), atiss(at), antiss(an), np(n), rv(rv), rcad(rcad), rgct(rgct),
-              gear(gear), smo2(smo2), thb(thb), ap(l), xp(x), speed(s), cad(c), 
+              smo2(smo2), thb(thb), ap(l), xp(x), speed(s), cad(c),
               alt(a), temp(te), wind(wi), torque(tq), lrbalance(lrb), lte(lte), rte(rte), lps(lps), rps(rps),
               kphd(kphd), wattsd(wattsd), cadd(cadd), nmd(nmd), hrd(hrd), slope(sl) {}
 };
@@ -1476,7 +1478,6 @@ AllPlot::recalc(AllPlotObject *objects)
         double totalRCad = 0.0;
         double totalRV = 0.0;
         double totalRGCT = 0.0;
-        double totalGear = 0.0;
         double totalSmO2 = 0.0;
         double totaltHb = 0.0;
         double totalATISS = 0.0;
@@ -1510,7 +1511,6 @@ AllPlot::recalc(AllPlotObject *objects)
         objects->smoothRV.resize(rideTimeSecs + 1);
         objects->smoothRCad.resize(rideTimeSecs + 1);
         objects->smoothRGCT.resize(rideTimeSecs + 1);
-        objects->smoothGear.resize(rideTimeSecs + 1);
         objects->smoothSmO2.resize(rideTimeSecs + 1);
         objects->smoothtHb.resize(rideTimeSecs + 1);
         objects->smoothAT.resize(rideTimeSecs + 1);
@@ -1554,7 +1554,6 @@ AllPlot::recalc(AllPlotObject *objects)
                              (!objects->rvArray.empty() ? objects->rvArray[i] : 0),
                              (!objects->rcadArray.empty() ? objects->rcadArray[i] : 0),
                              (!objects->rgctArray.empty() ? objects->rgctArray[i] : 0),
-                             (!objects->gearArray.empty() ? objects->gearArray[i] : 0),
                              (!objects->smo2Array.empty() ? objects->smo2Array[i] : 0),
                              (!objects->thbArray.empty() ? objects->thbArray[i] : 0),
                              (!objects->apArray.empty() ? objects->apArray[i] : 0),
@@ -1583,7 +1582,6 @@ AllPlot::recalc(AllPlotObject *objects)
                 if (!objects->rvArray.empty()) totalRV += objects->rvArray[i];
                 if (!objects->rcadArray.empty()) totalRCad += objects->rcadArray[i];
                 if (!objects->rgctArray.empty()) totalRGCT += objects->rgctArray[i];
-                if (!objects->gearArray.empty()) totalGear += objects->gearArray[i];
                 if (!objects->smo2Array.empty()) totalSmO2 += objects->smo2Array[i];
                 if (!objects->thbArray.empty()) totaltHb += objects->thbArray[i];
                 if (!objects->atissArray.empty()) totalATISS += objects->atissArray[i];
@@ -1647,7 +1645,6 @@ AllPlot::recalc(AllPlotObject *objects)
                 totalRV -= dp.rv;
                 totalRCad -= dp.rcad;
                 totalRGCT -= dp.rgct;
-                totalGear -= dp.gear;
                 totalSmO2 -= dp.smo2;
                 totaltHb -= dp.thb;
                 totalATISS -= dp.atiss;
@@ -1682,7 +1679,6 @@ AllPlot::recalc(AllPlotObject *objects)
                 objects->smoothRV[secs] = 0.0;
                 objects->smoothRCad[secs] = 0.0;
                 objects->smoothRGCT[secs] = 0.0;
-                objects->smoothGear[secs] = 0.0;
                 objects->smoothSmO2[secs] = 0.0;
                 objects->smoothtHb[secs] = 0.0;
                 objects->smoothAT[secs] = 0.0;
@@ -1716,7 +1712,6 @@ AllPlot::recalc(AllPlotObject *objects)
                 objects->smoothRV[secs]    = totalRV / list.size();
                 objects->smoothRCad[secs]    = totalRCad / list.size();
                 objects->smoothRGCT[secs]    = totalRGCT / list.size();
-                objects->smoothGear[secs]    = totalGear / list.size();
                 objects->smoothSmO2[secs]    = totalSmO2 / list.size();
                 objects->smoothtHb[secs]    = totaltHb / list.size();
                 objects->smoothAT[secs]    = totalATISS / list.size();
@@ -1769,7 +1764,6 @@ AllPlot::recalc(AllPlotObject *objects)
         objects->smoothRV.resize(0);
         objects->smoothRCad.resize(0);
         objects->smoothRGCT.resize(0);
-        objects->smoothGear.resize(0);
         objects->smoothSmO2.resize(0);
         objects->smoothtHb.resize(0);
         objects->smoothAT.resize(0);
@@ -1853,6 +1847,13 @@ AllPlot::recalc(AllPlotObject *objects)
 
         }
     }
+
+    // and now set data series which MUST not be smoothed AT ALL (e.g. gear ratio)
+    objects->smoothGear.resize(0);
+    foreach (RideFilePoint *dp, rideItem->ride()->dataPoints()) {
+        objects->smoothGear.append(dp->gear);
+    }
+
 
     QVector<double> &xaxis = bydist ? objects->smoothDistance : objects->smoothTime;
     int startingIndex = qMin(smooth, xaxis.count());

--- a/src/HistogramWindow.cpp
+++ b/src/HistogramWindow.cpp
@@ -26,6 +26,7 @@ static const double nmDelta    = 0.1;
 static const double hrDelta    = 1.0;
 static const double kphDelta   = 0.1;
 static const double cadDelta   = 1.0;
+static const double gearDelta  = 0.01; //RideFileCache creates POW(10) * decimals sections
 
 // digits for text entry validator
 static const int wattsDigits = 0;
@@ -34,6 +35,7 @@ static const int nmDigits    = 1;
 static const int hrDigits    = 0;
 static const int kphDigits   = 1;
 static const int cadDigits   = 0;
+static const int gearDigits  = 2;
 
 
 //
@@ -832,7 +834,8 @@ void HistogramWindow::addSeries()
                << RideFile::kph
                << RideFile::cad
                << RideFile::nm
-               << RideFile::aPower;
+               << RideFile::aPower
+               << RideFile::gear;
 
     foreach (RideFile::SeriesType x, seriesList) 
         seriesCombo->addItem(RideFile::seriesName(x), static_cast<int>(x));
@@ -1087,6 +1090,7 @@ HistogramWindow::getDelta()
             case 4: return cadDelta;
             case 5: return nmDelta;
             case 6: return wattsDelta; //aPower
+            case 7: return gearDelta;
             default: return 1;
         }
     }
@@ -1115,6 +1119,7 @@ HistogramWindow::getDigits()
             case  4: return cadDigits;
             case  5: return nmDigits;
             case  6: return wattsDigits; // aPower
+            case  7: return gearDigits;
             default: return 1;
         }
     }

--- a/src/PowerHist.h
+++ b/src/PowerHist.h
@@ -94,7 +94,7 @@ class HistData // each curve needs a lot of data (!? this may need refactoring, 
 
         // storage for data counts
         QVector<unsigned int> aPowerArray, wattsArray, wattsZoneArray, wattsCPZoneArray, wattsKgArray, nmArray, hrArray,
-                              hrZoneArray, kphArray, cadArray, metricArray;
+                              hrZoneArray, kphArray, cadArray, gearArray, metricArray;
 
         // storage for data counts in interval selected
         QVector<unsigned int> aPowerSelectedArray, 
@@ -104,7 +104,7 @@ class HistData // each curve needs a lot of data (!? this may need refactoring, 
                               wattsKgSelectedArray,
                               nmSelectedArray, hrSelectedArray,
                               hrZoneSelectedArray, kphSelectedArray,
-                              cadSelectedArray;
+                              cadSelectedArray, gearSelectedArray;
 };
 
 class PowerHist : public QwtPlot

--- a/src/RideFileCache.cpp
+++ b/src/RideFileCache.cpp
@@ -58,6 +58,7 @@ RideFileCache::RideFileCache(Context *context, QString fileName, RideFile *passe
     wattsDistribution.resize(0);
     hrDistribution.resize(0);
     cadDistribution.resize(0);
+    gearDistribution.resize(0);
     nmDistribution.resize(0);
     kphDistribution.resize(0);
     xPowerDistribution.resize(0);
@@ -193,6 +194,7 @@ static long offsetForTiz(RideFileCacheHeader head, RideFile::SeriesType series)
     offset += head.wattsDistCount * sizeof(float);
     offset += head.hrDistCount * sizeof(float);
     offset += head.cadDistCount * sizeof(float);
+    offset += head.gearDistCount * sizeof(float);
     offset += head.nmDistrCount * sizeof(float);
     offset += head.kphDistCount * sizeof(float);
     offset += head.xPowerDistCount * sizeof(float);
@@ -362,6 +364,7 @@ RideFileCache::RideFileCache(RideFile *ride) :
     wattsDistribution.resize(0);
     hrDistribution.resize(0);
     cadDistribution.resize(0);
+    gearDistribution.resize(0);
     nmDistribution.resize(0);
     kphDistribution.resize(0);
     xPowerDistribution.resize(0);
@@ -397,15 +400,16 @@ RideFileCache::RideFileCache(RideFile *ride) :
     doubleArray(wattsKgMeanMaxDouble, wattsKgMeanMax, RideFile::wattsKg);
     doubleArray(aPowerMeanMaxDouble, aPowerMeanMax, RideFile::aPower);
 
-    doubleArray(wattsDistributionDouble, wattsDistribution, RideFile::watts);
-    doubleArray(hrDistributionDouble, hrDistribution, RideFile::hr);
-    doubleArray(cadDistributionDouble, cadDistribution, RideFile::cad);
-    doubleArray(nmDistributionDouble, nmDistribution, RideFile::nm);
-    doubleArray(kphDistributionDouble, kphDistribution, RideFile::kph);
-    doubleArray(xPowerDistributionDouble, xPowerDistribution, RideFile::xPower);
-    doubleArray(npDistributionDouble, npDistribution, RideFile::NP);
-    doubleArray(wattsKgDistributionDouble, wattsKgDistribution, RideFile::wattsKg);
-    doubleArray(aPowerDistributionDouble, aPowerDistribution, RideFile::aPower);
+    doubleArrayForDistribution(wattsDistributionDouble, wattsDistribution);
+    doubleArrayForDistribution(hrDistributionDouble, hrDistribution);
+    doubleArrayForDistribution(cadDistributionDouble, cadDistribution);
+    doubleArrayForDistribution(gearDistributionDouble, gearDistribution);
+    doubleArrayForDistribution(nmDistributionDouble, nmDistribution);
+    doubleArrayForDistribution(kphDistributionDouble, kphDistribution);
+    doubleArrayForDistribution(xPowerDistributionDouble, xPowerDistribution);
+    doubleArrayForDistribution(npDistributionDouble, npDistribution);
+    doubleArrayForDistribution(wattsKgDistributionDouble, wattsKgDistribution);
+    doubleArrayForDistribution(aPowerDistributionDouble, aPowerDistribution);
 }
 
 int
@@ -414,6 +418,7 @@ RideFileCache::decimalsFor(RideFile::SeriesType series)
     switch (series) {
         case RideFile::secs : return 0; break;
         case RideFile::cad : return 0; break;
+        case RideFile::gear : return 2; break;
         case RideFile::hr : return 0; break;
         case RideFile::km : return 3; break;
         case RideFile::kph : return 1; break;
@@ -604,6 +609,10 @@ RideFileCache::distributionArray(RideFile::SeriesType series)
             return cadDistributionDouble;
             break;
 
+       case RideFile::gear:
+           return gearDistributionDouble;
+           break;
+
         case RideFile::hr:
             return hrDistributionDouble;
             break;
@@ -726,6 +735,7 @@ void RideFileCache::RideFileCache::compute()
     computeDistribution(wattsDistribution, RideFile::watts);
     computeDistribution(hrDistribution, RideFile::hr);
     computeDistribution(cadDistribution, RideFile::cad);
+    computeDistribution(gearDistribution, RideFile::gear);
     computeDistribution(nmDistribution, RideFile::nm);
     computeDistribution(kphDistribution, RideFile::kph);
     computeDistribution(wattsKgDistribution, RideFile::wattsKg);
@@ -1393,6 +1403,7 @@ RideFileCache::RideFileCache(Context *context, QDate start, QDate end, bool filt
             distAggregate(wattsDistributionDouble, rideCache.wattsDistributionDouble);
             distAggregate(hrDistributionDouble, rideCache.hrDistributionDouble);
             distAggregate(cadDistributionDouble, rideCache.cadDistributionDouble);
+            distAggregate(gearDistributionDouble, rideCache.gearDistributionDouble);
             distAggregate(nmDistributionDouble, rideCache.nmDistributionDouble);
             distAggregate(kphDistributionDouble, rideCache.kphDistributionDouble);
             distAggregate(xPowerDistributionDouble, rideCache.xPowerDistributionDouble);
@@ -1496,6 +1507,7 @@ RideFileCache::serialize(QDataStream *out)
     head.npDistCount = xPowerDistribution.size();
     head.hrDistCount = hrDistribution.size();
     head.cadDistCount = cadDistribution.size();
+    head.gearDistCount = gearDistribution.size();
     head.nmDistrCount = nmDistribution.size();
     head.kphDistCount = kphDistribution.size();
     head.wattsKgDistCount = wattsKgDistribution.size();
@@ -1524,6 +1536,7 @@ RideFileCache::serialize(QDataStream *out)
     out->writeRawData((const char *) wattsDistribution.data(), sizeof(float) * wattsDistribution.size());
     out->writeRawData((const char *) hrDistribution.data(), sizeof(float) * hrDistribution.size());
     out->writeRawData((const char *) cadDistribution.data(), sizeof(float) * cadDistribution.size());
+    out->writeRawData((const char *) gearDistribution.data(), sizeof(float) * gearDistribution.size());
     out->writeRawData((const char *) nmDistribution.data(), sizeof(float) * nmDistribution.size());
     out->writeRawData((const char *) kphDistribution.data(), sizeof(float) * kphDistribution.size());
     out->writeRawData((const char *) xPowerDistribution.data(), sizeof(float) * xPowerDistribution.size());
@@ -1568,6 +1581,7 @@ RideFileCache::readCache()
         wattsDistribution.resize(head.wattsDistCount);
         hrDistribution.resize(head.hrDistCount);
         cadDistribution.resize(head.cadDistCount);
+        gearDistribution.resize(head.gearDistCount);
         nmDistribution.resize(head.nmDistrCount);
         kphDistribution.resize(head.kphDistCount);
         xPowerDistribution.resize(head.xPowerDistCount);
@@ -1597,6 +1611,7 @@ RideFileCache::readCache()
         inFile.readRawData((char *) wattsDistribution.data(), sizeof(float) * wattsDistribution.size());
         inFile.readRawData((char *) hrDistribution.data(), sizeof(float) * hrDistribution.size());
         inFile.readRawData((char *) cadDistribution.data(), sizeof(float) * cadDistribution.size());
+        inFile.readRawData((char *) gearDistribution.data(), sizeof(float) * gearDistribution.size());
         inFile.readRawData((char *) nmDistribution.data(), sizeof(float) * nmDistribution.size());
         inFile.readRawData((char *) kphDistribution.data(), sizeof(float) * kphDistribution.size());
         inFile.readRawData((char *) xPowerDistribution.data(), sizeof(float) * xPowerDistribution.size());
@@ -1626,15 +1641,16 @@ RideFileCache::readCache()
         doubleArray(wattsKgMeanMaxDouble, wattsKgMeanMax, RideFile::wattsKg);
         doubleArray(aPowerMeanMaxDouble, aPowerMeanMax, RideFile::aPower);
 
-        doubleArray(wattsDistributionDouble, wattsDistribution, RideFile::watts);
-        doubleArray(hrDistributionDouble, hrDistribution, RideFile::hr);
-        doubleArray(cadDistributionDouble, cadDistribution, RideFile::cad);
-        doubleArray(nmDistributionDouble, nmDistribution, RideFile::nm);
-        doubleArray(kphDistributionDouble, kphDistribution, RideFile::kph);
-        doubleArray(xPowerDistributionDouble, xPowerDistribution, RideFile::xPower);
-        doubleArray(npDistributionDouble, npDistribution, RideFile::NP);
-        doubleArray(wattsKgDistributionDouble, wattsKgDistribution, RideFile::wattsKg);
-        doubleArray(aPowerDistributionDouble, aPowerDistribution, RideFile::aPower);
+        doubleArrayForDistribution(wattsDistributionDouble, wattsDistribution);
+        doubleArrayForDistribution(hrDistributionDouble, hrDistribution);
+        doubleArrayForDistribution(cadDistributionDouble, cadDistribution);
+        doubleArrayForDistribution(gearDistributionDouble, gearDistribution);
+        doubleArrayForDistribution(nmDistributionDouble, nmDistribution);
+        doubleArrayForDistribution(kphDistributionDouble, kphDistribution);
+        doubleArrayForDistribution(xPowerDistributionDouble, xPowerDistribution);
+        doubleArrayForDistribution(npDistributionDouble, npDistribution);
+        doubleArrayForDistribution(wattsKgDistributionDouble, wattsKgDistribution);
+        doubleArrayForDistribution(aPowerDistributionDouble, aPowerDistribution);
 
         cacheFile.close();
     }
@@ -1646,6 +1662,15 @@ void RideFileCache::doubleArray(QVector<double> &into, QVector<float> &from, Rid
     double divisor = pow(10, decimalsFor(series)); // ? 10 : 1;
     into.resize(from.size());
     for(int i=0; i<from.size(); i++) into[i] = double(from[i]) / divisor;
+
+    return;
+}
+
+// for Distribution Series the values in Long/Float are ALWAYS Seconds (therefor no decimals adjustment calcuation required)
+void RideFileCache::doubleArrayForDistribution(QVector<double> &into, QVector<float> &from)
+{
+    into.resize(from.size());
+    for(int i=0; i<from.size(); i++) into[i] = double(from[i]);
 
     return;
 }

--- a/src/RideFileCache.h
+++ b/src/RideFileCache.h
@@ -40,7 +40,7 @@ typedef double data_t;
 // arrays when plotting CP curves and histograms. It is precoputed
 // to save time and cached in a file .cpx
 //
-static const unsigned int RideFileCacheVersion = 17;
+static const unsigned int RideFileCacheVersion = 18;
 // revision history:
 // version  date         description
 // 1        29-Apr-11    Initial - header, mean-max & distribution data blocks
@@ -59,6 +59,7 @@ static const unsigned int RideFileCacheVersion = 17;
 // 13-15    24-Feb-14    Add hr, cad, watts, nm Δ data series
 // 13-15    24-Feb-14    Add crc to the header
 // 17       09-Jun-14    Move wpk meanmax array next to watts for fast read
+// 18       19-Oct-14    Added gearRatio distribution
 
 // The cache file (.cpx) has a binary format:
 // 1 x Header data - describing the version and contents of the cache
@@ -93,6 +94,7 @@ struct RideFileCacheHeader {
                  wattsDistCount,
                  hrDistCount,
                  cadDistCount,
+                 gearDistCount,
                  nmDistrCount,
                  kphDistCount,
                  xPowerDistCount,
@@ -186,6 +188,7 @@ class RideFileCache
         // we need to return doubles not longs, we just use longs
         // to reduce disk storage
         static void doubleArray(QVector<double> &into, QVector<float> &from, RideFile::SeriesType series);
+        static void doubleArrayForDistribution(QVector<double> &into, QVector<float> &from);
 
     protected:
 
@@ -279,6 +282,7 @@ class RideFileCache
         // RideFile::decimalsFor() then it will be distributed in 0.1 of a unit
         QVector<float> wattsDistribution; // RideFile::watts
         QVector<float> hrDistribution; // RideFile::hr
+        QVector<float> gearDistribution; // RideFile::gear
         QVector<float> cadDistribution; // RideFile::cad
         QVector<float> nmDistribution; // RideFile::nm
         QVector<float> kphDistribution; // RideFile::kph
@@ -290,6 +294,7 @@ class RideFileCache
 
         QVector<double> wattsDistributionDouble; // RideFile::watts
         QVector<double> hrDistributionDouble; // RideFile::hr
+        QVector<double> gearDistributionDouble; // RideFile::gear
         QVector<double> cadDistributionDouble; // RideFile::cad
         QVector<double> nmDistributionDouble; // RideFile::nm
         QVector<double> kphDistributionDouble; // RideFile::kph

--- a/src/ScatterPlot.cpp
+++ b/src/ScatterPlot.cpp
@@ -310,8 +310,13 @@ void ScatterPlot::setData (ScatterSettings *settings)
             double xv = pointType(point, settings->x, side, context->athlete->useMetricUnits, cranklength);
             double yv = pointType(point, settings->y, side, context->athlete->useMetricUnits, cranklength);
 
-            // skip zeroes?
-            if (settings->ignore && (int(xv) == 0 || int(yv) == 0)) continue;
+            // skip zeroes? - special logic for Model Gear, since there value between 0.01 and 1 happen and are relevant
+            if ((settings->x != MODEL_GEAR && settings->y != MODEL_GEAR)
+                 && settings->ignore && (int(xv) == 0 || int(yv) == 0)) continue;
+            if ((settings->x == MODEL_GEAR)
+                 && settings->ignore && (xv == 0.0f || int(yv) == 0)) continue;
+            if ((settings->y == MODEL_GEAR)
+                 && settings->ignore && (int(xv) == 0 || yv == 0.0f)) continue;
 
             // add it 
             x <<xv;
@@ -451,6 +456,10 @@ void ScatterPlot::setData (ScatterSettings *settings)
     else setAxisScale(yLeft, minY, maxY);
     if (settings->x == MODEL_CPV) setAxisScale(xBottom, 0, 3);
     else setAxisScale(xBottom, minX, maxX);
+
+    // gear
+    if (settings->x == MODEL_GEAR) setAxisScale(xBottom, 0, 7);
+    if (settings->y == MODEL_GEAR) setAxisScale(yLeft, 0, 7);
 
 
     // and those interval markers


### PR DESCRIPTION
.. RideFile - add rounding approach for gear values (different rounding depending on value) - leading to discrete GearRatio values 
.. AllPlot - exclude Gear Ratio from Smoothing (to keep the discrete value) - and change curve type to "Steps"
.. ScatterPlot - specific handling for GearRatio since values between 0.01 and 1 are relevant for GearRatio and must not be filtered out
.. RideFileChache - add Distribution Data for Gear Ratio and fix Distribution Cache for DataSeries with > 0 decimalsFor
.. Histogram - add GearRatio to Histograms (both Rides and Trends)
