### PR TITLE
LTM curves: edit metric on double click

### DIFF
--- a/src/LTMTool.cpp
+++ b/src/LTMTool.cpp
@@ -293,6 +293,8 @@ LTMTool::LTMTool(Context *context, LTMSettings *settings) : QWidget(context->mai
     customTable->setSelectionMode(QAbstractItemView::SingleSelection);
     customTable->setSelectionBehavior(QAbstractItemView::SelectRows);
     customLayout->addWidget(customTable);
+    connect(customTable, SIGNAL(cellDoubleClicked(int, int)), this, SLOT(doubleClicked(int, int)));
+
 
     // custom buttons
     editCustomButton = new QPushButton(tr("Edit"));
@@ -1197,6 +1199,25 @@ LTMTool::editMetric()
 
         // apply!
         settings->metrics[index] = edit;
+
+        // update
+        refreshCustomTable();
+        curvesChanged();
+    }
+}
+
+void
+LTMTool::doubleClicked( int row, int column )
+{
+    (void) column; // ignore, calm down
+
+    MetricDetail edit = settings->metrics[row];
+    EditMetricDetailDialog dialog(context, this, &edit);
+
+    if (dialog.exec()) {
+
+        // apply!
+        settings->metrics[row] = edit;
 
         // update
         refreshCustomTable();

--- a/src/LTMTool.h
+++ b/src/LTMTool.h
@@ -108,6 +108,7 @@ class LTMTool : public QWidget
 
     private slots:
         void editMetric();
+        void doubleClicked( int row, int column );
         void addMetric();
         void deleteMetric();
 


### PR DESCRIPTION
more comfortable alternative to select + click edit button: allow double
clicking on a row in the metric list to edit it's settings.

... I'd also love to be able to reorder the curves... but for now this is beyond my QT skills.
