### PR TITLE
fix "Time Riding" for rides without kph

### DIFF
--- a/src/BasicRideMetrics.cpp
+++ b/src/BasicRideMetrics.cpp
@@ -114,7 +114,7 @@ class TimeRiding : public RideMetric {
                  const Context *) {
 
         secsMovingOrPedaling = 0;
-        if (ride->areDataPresent()->kph) {
+        if (ride->areDataPresent()->kph || ride->areDataPresent()->cad ) {
             foreach (const RideFilePoint *point, ride->dataPoints()) {
                 if ((point->kph > 0.0) || (point->cad > 0.0))
                     secsMovingOrPedaling += ride->recIntSecs();


### PR DESCRIPTION
"Time Riding" was only calculated when the ride had kph values - although
it's then also including time without kph but cadence. This caused it to
skip all time spent on the trainer (... if there's no sensor on the rear
wheel).

This patch makes it consistently calculate "Time Riding" if there's kph or
cad... might be worth to count time with pwr or similar running metrics,
too.
