### PR TITLE
VAM CP x-axis bug #1085

### DIFF
--- a/src/CPPlot.cpp
+++ b/src/CPPlot.cpp
@@ -1012,6 +1012,9 @@ CPPlot::plotBests()
     if (criticalSeries == CriticalPowerWindow::work) {
         int i = std::lower_bound(time.begin(), time.end(), 60.0) - time.begin();
         ymax = 10 * ceil(work[i] / 10);
+    } else if (criticalSeries == CriticalPowerWindow::vam) {
+        double yVam = bestsCache->meanMaxArray(RideFile::vam).value(296);
+        ymax = 100 * ceil(yVam / 100); // index of xMin for Time
     } else {
         ymax = 100 * ceil(values[0] / 100);
         if (ymax == 100) ymax = 5 * ceil(values[0] / 5);
@@ -1029,7 +1032,10 @@ CPPlot::plotBests()
     else if (criticalSeries == CriticalPowerWindow::veloclinicplot) {
         setAxisScale(yLeft, 0, 1.5*pdModel->WPrime());
     }
-    else {
+    else if (criticalSeries == CriticalPowerWindow::vam) {
+        // VAM is very big anyway - so just 5% headroom
+        setAxisScale(yLeft, 0, 1.05*ymax);
+    } else {
 
         // or just add 10% headroom
         setAxisScale(yLeft, 0, 1.1*values[0]);
@@ -1875,9 +1881,25 @@ CPPlot::calculateForDateRanges(QList<CompareDateRange> compareDateRanges)
                 if (rideSeries == RideFile::watts || rideSeries == RideFile::wattsKg)
                     plotModel(cache->meanMaxArray(rideSeries), range.color, NULL);
 
+                int xCount = 0;
+                double vamYMax = 0;
                 foreach(double v, cache->meanMaxArray(rideSeries)) {
+                    // get the biggest y-Axes value
                     if (v > ymax) ymax = v;
+
+                    // VAM x-Axis starts at 4.993 seconds = x-time array point 296 -
+                    // so skip the values upto that point in x-Axis time
+                    if (rideSeries == RideFile::vam) {
+                       // VAM x-Axis starts at 4.993 seconds = x-time array point 296 -
+                       // so skip the values upto that point in x-Axis time
+                       if (xCount >= 296) {
+                           if (v > vamYMax) vamYMax = v;
+                       }
+                     }
+                     xCount++;
                 }
+                // overwrite ymax for VAM - if a proper value was found
+                if (rideSeries == RideFile::vam && vamYMax > 0) ymax = vamYMax;
             }
         }
     }
@@ -1997,9 +2019,25 @@ CPPlot::calculateForIntervals(QList<CompareInterval> compareIntervals)
                 plotCache(interval.rideFileCache()->meanMaxArray(rideSeries), interval.color);
 
                 // whats ymax ?
+                int xCount = 0;
+                double vamYMax = 0;
                 foreach(double v, interval.rideFileCache()->meanMaxArray(rideSeries)) {
+                    // get the biggest y-Axes value
                     if (v > ymax) ymax = v;
+
+                    // VAM x-Axis starts at 4.993 seconds = x-time array point 296 -
+                    // so skip the values upto that point in x-Axis time
+                    if (rideSeries == RideFile::vam) {
+                       // VAM x-Axis starts at 4.993 seconds = x-time array point 296 -
+                       // so skip the values upto that point in x-Axis time
+                       if (xCount >= 296) {
+                           if (v > vamYMax) vamYMax = v;
+                       }
+                     }
+                     xCount++;
                 }
+                // overwrite ymax for VAM - if a proper value was found
+                if (rideSeries == RideFile::vam && vamYMax > 0) ymax = vamYMax;
 
                 double mins = interval.rideFileCache()->meanMaxArray(rideSeries).count() / 60.00f;
                 if (mins > xmax) xmax = mins;


### PR DESCRIPTION
... fixed by not considering Y-Axis values in the 0 to 4.993 minutes range which are not shown for VAM anyway
... both in standard view and in compare view / intervals and date ranges
... handle intervals below 4.993 minutes properly (since they are not shown in CP VAM)
