### PR TITLE
Allow for extra data in the array of series

### DIFF
--- a/src/JsonRideFile.y
+++ b/src/JsonRideFile.y
@@ -229,7 +229,7 @@ references: REFERENCES ':' '[' reference_list ']'
                                           JsonPoint = RideFilePoint();
                                         }
 reference_list: reference | reference_list ',' reference;
-reference: '{' series_list '}'          { JsonRide->appendReference(JsonPoint);
+reference: '{' series '}'               { JsonRide->appendReference(JsonPoint);
                                           JsonPoint = RideFilePoint();
                                         }
 


### PR DESCRIPTION
When GC imports a json ride file if it encounters an attribute it doesn't support in the series list it will stop importing the file.  This change will allow GC to continue importing the file and skip over the unsupported attributes.
