### PR TITLE
GC Upgrade 3.11 enhancements

### DIFF
--- a/src/GcUpgrade.h
+++ b/src/GcUpgrade.h
@@ -74,6 +74,7 @@ class GcUpgradeLogDialog : public QDialog
 
     public slots:
         void saveAs();
+        void checkAndAccept();
 
     private:
         QWebView *report;
@@ -115,6 +116,15 @@ class GcUpgradeExecuteDialog : public QDialog
 
     public:
         GcUpgradeExecuteDialog(QString);
+
+    public slots:
+        void checkVerticalScroll(int value);
+
+    private:
+        QScrollArea *scrollText;
+        QScrollBar *vertical;
+        QPushButton *proceedButton;
+        QPushButton *abortButton;
 
 };
 


### PR DESCRIPTION
... make Upgrade Check Window smaller (with scrollable Text Box)
    ... only allow to proceed if Text is scrolled down to end (full read)
... in Upgrade Log, only allow to proceed to athlete if Log has been scrolled down to the end
