### PR TITLE
Athlete Subdirs - improvements

### DIFF
--- a/src/Athlete.cpp
+++ b/src/Athlete.cpp
@@ -435,6 +435,7 @@ AthleteDirectoryStructure::AthleteDirectoryStructure(const QDir home){
     athlete_imports = "imports";
     athlete_records = "records";
     athlete_downloads = "downloads";
+    athlete_fileBackup = "bak";
     athlete_config = "config";
     athlete_cache = "cache";
     athlete_calendar = "calendar";
@@ -458,6 +459,7 @@ AthleteDirectoryStructure::createAllSubdirs() {
     myhome.mkdir(athlete_imports);
     myhome.mkdir(athlete_records);
     myhome.mkdir(athlete_downloads);
+    myhome.mkdir(athlete_fileBackup);
     myhome.mkdir(athlete_config);
     myhome.mkdir(athlete_cache);
     myhome.mkdir(athlete_calendar);
@@ -475,6 +477,7 @@ AthleteDirectoryStructure::subDirsExist() {
             imports().exists() &&
             records().exists() &&
             downloads().exists() &&
+            fileBackup().exists() &&
             config().exists() &&
             cache().exists() &&
             calendar().exists() &&

--- a/src/Athlete.h
+++ b/src/Athlete.h
@@ -164,6 +164,7 @@ class AthleteDirectoryStructure : public QObject {
             QDir imports(){ return QDir(myhome.absolutePath()+"/"+athlete_imports);}
             QDir records(){ return QDir(myhome.absolutePath()+"/"+athlete_records);}
             QDir downloads() { return QDir(myhome.absolutePath()+"/"+athlete_downloads);}
+            QDir fileBackup() { return QDir(myhome.absolutePath()+"/"+athlete_fileBackup);}
             QDir config() { return QDir(myhome.absolutePath()+"/"+athlete_config);}
             QDir cache() { return QDir(myhome.absolutePath()+"/"+athlete_cache);}
             QDir calendar() { return QDir(myhome.absolutePath()+"/"+athlete_calendar);}
@@ -175,6 +176,7 @@ class AthleteDirectoryStructure : public QObject {
             QString getActivitiesSubDir() {return athlete_activities; }
             QString getImportsSubDir() {return athlete_imports; }
             QString getDownloadsSubDir() {return athlete_downloads; }
+            QString getFileBackupSubDir() {return athlete_fileBackup;}
             QString getConfigSubDir() {return athlete_config; }
             QString getCacheSubDir() {return athlete_cache; }
             QString getWorkoutsSubDir() {return athlete_workouts; }
@@ -194,6 +196,7 @@ class AthleteDirectoryStructure : public QObject {
             QString athlete_imports;
             QString athlete_records;
             QString athlete_downloads;
+            QString athlete_fileBackup;
             QString athlete_config;
             QString athlete_cache;
             QString athlete_calendar;

--- a/src/GcUpgrade.cpp
+++ b/src/GcUpgrade.cpp
@@ -460,14 +460,14 @@ GcUpgrade::upgrade(const QDir &home)
                   .arg(QString::number(ok)).arg(newHome.activities().dirName()).arg(QString::number(fail)),2);
 
 
-        // 3.6 keep the .BAK files and store in /imports()
+        // 3.6 keep the .BAK files and store in /fileBackup()
         QStringList bakFiles;
         bakFiles << "*.bak";
         upgradeLog->append(tr("Start copying of: Activity files (.BAK)..."),3);
         ok = 0; fail = 0;
         foreach (QString bakFile, newHome.root().entryList(bakFiles, QDir::Files)) {
             bool success = moveFile(QString("%1/%2").arg(newHome.root().canonicalPath()).arg(bakFile),
-                     QString("%1/%2").arg(newHome.imports().canonicalPath()).arg(bakFile));
+                     QString("%1/%2").arg(newHome.fileBackup().canonicalPath()).arg(bakFile));
             if (success) {
                 ok++;
             } else {
@@ -477,7 +477,7 @@ GcUpgrade::upgrade(const QDir &home)
         }
         errorCount += fail;
         upgradeLog->append(QString(tr("%1 activity backup (.BAK) files moved to subdirectory: %2 - %3 failed" ))
-                  .arg(QString::number(ok)).arg(newHome.imports().dirName()).arg(QString::number(fail)),2);
+                  .arg(QString::number(ok)).arg(newHome.fileBackup().dirName()).arg(QString::number(fail)),2);
 
         // 3.6 now sort the rest of the files (extension checks are re-use)
         MediaHelper mediaFile;
@@ -727,6 +727,7 @@ GcUpgradeExecuteDialog::GcUpgradeExecuteDialog(QString athlete) : QDialog(NULL, 
                      "-> Configuration files: <samp>/config</samp><br>"
                      "-> Download files: <samp>/downloads</samp><br>"
                      "-> Import files: <samp>/imports</samp><br>"
+                     "-> Backups of Activity/Ride files: <samp>/bak</samp><br>"
                      "-> Workout related files: <samp>/workouts</samp><br>"
                      "-> Cache files: <samp>/cache</samp><br>"
                      "-> Calendar files: <samp>/calendar</samp><br>"

--- a/src/RideCache.cpp
+++ b/src/RideCache.cpp
@@ -135,31 +135,21 @@ RideCache::removeCurrentRide()
 
     // in case there was an existing bak file, delete it
     // ignore errors since it probably isn't there.
-    QFile::remove(context->athlete->home->activities().canonicalPath() + "/" + strNewName);
+    QFile::remove(context->athlete->home->fileBackup().canonicalPath() + "/" + strNewName);
 
-    if (!file.rename(context->athlete->home->activities().canonicalPath() + "/" + strNewName)) {
+    if (!file.rename(context->athlete->home->fileBackup().canonicalPath() + "/" + strNewName)) {
         QMessageBox::critical(NULL, "Rename Error", tr("Can't rename %1 to %2")
             .arg(strOldFileName).arg(strNewName));
     }
 
-    // remove any other derived/additional files; notes, cpi etc
+    // remove any other derived/additional files; notes, cpi etc (they can only exist in /cache )
     QStringList extras;
     extras << "notes" << "cpi" << "cpx";
     foreach (QString extension, extras) {
 
         QString deleteMe = QFileInfo(strOldFileName).baseName() + "." + extension;
-        QFile::remove(context->athlete->home->activities().canonicalPath() + "/" + deleteMe);
-    }
+        QFile::remove(context->athlete->home->cache().canonicalPath() + "/" + deleteMe);
 
-    // rename also the source files either in /imports or in /downloads to allow a second round of import
-    QString sourceFilename = todelete->ride()->getTag("Source Filename", "");
-    if (sourceFilename != "") {
-        // try to rename in both directories /imports and /downloads
-        // but don't report any errors - files may have been backup already
-        QFile old1 (context->athlete->home->imports().canonicalPath() + "/" + sourceFilename);
-        old1.rename(context->athlete->home->imports().canonicalPath() + "/" + sourceFilename + ".bak");
-        QFile old2 (context->athlete->home->downloads().canonicalPath() + "/" + sourceFilename);
-        old2.rename(context->athlete->home->downloads().canonicalPath() + "/" + sourceFilename + ".bak");
     }
 
     // we don't want the whole delete, select next flicker

--- a/src/SplitActivityWizard.cpp
+++ b/src/SplitActivityWizard.cpp
@@ -402,7 +402,7 @@ SplitActivityWizard::setFilesList()
 QString
 SplitActivityWizard::hasBackup(QString filename)
 {
-    QString backupFilename = context->athlete->home->activities().canonicalPath() + "/" + filename + ".bak";
+    QString backupFilename = context->athlete->home->fileBackup().canonicalPath() + "/" + filename + ".bak";
 
     if (QFile(backupFilename).exists()) {
 


### PR DESCRIPTION
.. added /BAK subdir where all actvities .BAK files are stored
.. do not delete any original files in /imports /downloads when deleting activity
.. copy deleted activity .JSON as .BAK into /BAK subfolder
.. adjust upgrade procedure to copy .BAK files to /BAK
.. do not rename files in /import or /download when importing again from those dirs and the file already exists as imported file
