### PR TITLE
Enable Context Help (Shift+F1) using "QT's - What's This"

### DIFF
--- a/src/AddIntervalDialog.cpp
+++ b/src/AddIntervalDialog.cpp
@@ -24,6 +24,7 @@
 #include "RideFile.h"
 #include "RideItem.h"
 #include "WPrime.h"
+#include "HelpWhatsThis.h"
 #include <QMap>
 #include <math.h>
 
@@ -35,6 +36,8 @@ AddIntervalDialog::AddIntervalDialog(Context *context) :
 {
     setAttribute(Qt::WA_DeleteOnClose);
     setWindowTitle(tr("Find Intervals"));
+    HelpWhatsThis *help = new HelpWhatsThis(this);
+    this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::FindIntervals));
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
 
     intervalMethodWidget = new QWidget();

--- a/src/AerolabWindow.cpp
+++ b/src/AerolabWindow.cpp
@@ -24,6 +24,7 @@
 #include "IntervalItem.h"
 #include "RideItem.h"
 #include "Colors.h"
+#include "HelpWhatsThis.h"
 #include <QtGui>
 #include <qwt_plot_zoomer.h>
 
@@ -37,6 +38,9 @@ AerolabWindow::AerolabWindow(Context *context) :
 
   // Plot:
   aerolab = new Aerolab(this, context);
+
+  HelpWhatsThis *help = new HelpWhatsThis(aerolab);
+  aerolab->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::ChartRides_Aerolab));
 
   // Left controls layout:
   QVBoxLayout *leftControls  =  new QVBoxLayout;

--- a/src/AllPlotWindow.cpp
+++ b/src/AllPlotWindow.cpp
@@ -55,6 +55,9 @@
 // tooltip
 #include "LTMWindow.h"
 
+// help
+#include "HelpWhatsThis.h"
+
 // overlay helper
 #include "GcOverlayWidget.h"
 #include "IntervalSummaryWindow.h"
@@ -67,6 +70,8 @@ AllPlotWindow::AllPlotWindow(Context *context) :
     // basic setup
     setContentsMargins(0,0,0,0);
     QWidget *c = new QWidget;
+    HelpWhatsThis *helpConfig = new HelpWhatsThis(c);
+    c->setWhatsThis(helpConfig->getWhatsThisText(HelpWhatsThis::ChartRides_Performance));
     setControls(c);
     QVBoxLayout *clv = new QVBoxLayout(c);
 
@@ -87,6 +92,9 @@ AllPlotWindow::AllPlotWindow(Context *context) :
     basicControls->addStretch();
     st->addTab(basic, tr("Basic"));
 
+    HelpWhatsThis *basicHelp = new HelpWhatsThis(basic);
+    basic->setWhatsThis(basicHelp->getWhatsThisText(HelpWhatsThis::ChartRides_Performance_Config_Basic));
+
     // data series
     QWidget *series = new QWidget(this); // data series selection
     QHBoxLayout *seriesControls = new QHBoxLayout(series);
@@ -94,8 +102,10 @@ AllPlotWindow::AllPlotWindow(Context *context) :
     QFormLayout *seriesRight = new QFormLayout(); // ride side series
     seriesControls->addLayout(seriesLeft);
     seriesControls->addLayout(seriesRight); // ack I swapped them around !
-
     st->addTab(series, tr("Curves"));
+
+    HelpWhatsThis *seriesHelp = new HelpWhatsThis(series);
+    series->setWhatsThis(seriesHelp->getWhatsThisText(HelpWhatsThis::ChartRides_Performance_Config_Series));
 
     // Main layout
     //QGridLayout *mainLayout = new QGridLayout();
@@ -360,6 +370,9 @@ AllPlotWindow::AllPlotWindow(Context *context) :
     allStack->addWidget(allPlot);
     allStack->setCurrentIndex(0);
 
+    HelpWhatsThis *help = new HelpWhatsThis(allPlot);
+    allPlot->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::ChartRides_Performance));
+
     // sort out default values
     smoothSlider->setValue(allPlot->smooth);
     smoothLineEdit->setText(QString("%1").arg(allPlot->smooth));
@@ -557,12 +570,18 @@ AllPlotWindow::AllPlotWindow(Context *context) :
     fullPlot->setWantAxis(false);
     fullPlot->setContentsMargins(0,0,0,0);
 
+    HelpWhatsThis *helpFull = new HelpWhatsThis(fullPlot);
+    fullPlot->setWhatsThis(helpFull->getWhatsThisText(HelpWhatsThis::ChartRides_Performance));
+
     // allPlotStack contains the allPlot and the stack by series
     // because both want the optional fullplot at the bottom
     allPlotStack = new QStackedWidget(this);
     allPlotStack->addWidget(allStack);
     allPlotStack->addWidget(seriesstackFrame);
     allPlotStack->setCurrentIndex(0);
+
+    HelpWhatsThis *helpStack = new HelpWhatsThis(allPlotStack);
+    allPlotStack->setWhatsThis(helpStack->getWhatsThisText(HelpWhatsThis::ChartRides_Performance));
 
     allPlotLayout->addWidget(allPlotStack);
     allPlotFrame->setLayout(allPlotLayout);

--- a/src/AnalysisSidebar.cpp
+++ b/src/AnalysisSidebar.cpp
@@ -22,6 +22,7 @@
 #include "Athlete.h"
 #include "Settings.h"
 #include "Units.h"
+#include "HelpWhatsThis.h"
 #include <QtGui>
 
 // metadata support
@@ -50,6 +51,9 @@ AnalysisSidebar::AnalysisSidebar(Context *context) : QWidget(context->mainWindow
     calendarWidget = new GcMultiCalendar(context);
     calendarItem = new GcSplitterItem(tr("Calendar"), iconFromPNG(":images/sidebar/calendar.png"), this);
     calendarItem->addWidget(calendarWidget);
+
+    HelpWhatsThis *helpCalendar = new HelpWhatsThis(calendarWidget);
+    calendarWidget->setWhatsThis(helpCalendar->getWhatsThisText(HelpWhatsThis::SideBarRidesView_Calendar));
 
     // Activity History
     rideNavigator = new RideNavigator(context, true);
@@ -84,6 +88,9 @@ AnalysisSidebar::AnalysisSidebar(Context *context) : QWidget(context->mainWindow
     // INTERVALS
     intervalSummaryWindow = new IntervalSummaryWindow(context);
 
+    HelpWhatsThis *helpSummaryWindow = new HelpWhatsThis(intervalSummaryWindow);
+    intervalSummaryWindow->setWhatsThis(helpSummaryWindow->getWhatsThisText(HelpWhatsThis::SideBarRidesView_Intervals));
+
     intervalSplitter = new QSplitter(this);
     intervalSplitter->setHandleWidth(1);
     intervalSplitter->setOrientation(Qt::Vertical);
@@ -93,6 +100,9 @@ AnalysisSidebar::AnalysisSidebar(Context *context) : QWidget(context->mainWindow
     intervalSplitter->setFrameStyle(QFrame::NoFrame);
     intervalSplitter->setCollapsible(0, false);
     intervalSplitter->setCollapsible(1, false);
+
+    HelpWhatsThis *helpIntervalSplitter = new HelpWhatsThis(intervalSplitter);
+    intervalSplitter->setWhatsThis(helpIntervalSplitter->getWhatsThisText(HelpWhatsThis::SideBarRidesView_Intervals));
 
     intervalItem = new GcSplitterItem(tr("Intervals"), iconFromPNG(":images/mac/stop.png"), this);
     QAction *moreIntervalAct = new QAction(iconFromPNG(":images/sidebar/extra.png"), tr("Menu"), this);

--- a/src/BatchExportDialog.cpp
+++ b/src/BatchExportDialog.cpp
@@ -22,12 +22,15 @@
 #include "Context.h"
 #include "Athlete.h"
 #include "RideCache.h"
+#include "HelpWhatsThis.h"
 
 BatchExportDialog::BatchExportDialog(Context *context) : QDialog(context->mainWindow), context(context)
 {
     setAttribute(Qt::WA_DeleteOnClose);
     //setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint); // must stop using this flag!
     setWindowTitle(tr("Ride Batch Export"));
+    HelpWhatsThis *help = new HelpWhatsThis(this);
+    this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Activity_BatchExport));
 
     // make the dialog a resonable size
     setMinimumWidth(550);

--- a/src/BestIntervalDialog.cpp
+++ b/src/BestIntervalDialog.cpp
@@ -22,6 +22,7 @@
 #include "IntervalItem.h"
 #include "RideFile.h"
 #include "RideItem.h"
+#include "HelpWhatsThis.h"
 #include <QMap>
 #include <math.h>
 
@@ -30,6 +31,9 @@ BestIntervalDialog::BestIntervalDialog(Context *context) :
 {
     setAttribute(Qt::WA_DeleteOnClose);
     setWindowTitle("Find Intervals");
+    HelpWhatsThis *help = new HelpWhatsThis(this);
+    this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::FindIntervals));
+
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
 
     QHBoxLayout *intervalLengthLayout = new QHBoxLayout;

--- a/src/BingMap.cpp
+++ b/src/BingMap.cpp
@@ -28,12 +28,14 @@
 #include "Colors.h"
 #include "Units.h"
 #include "TimeUtils.h"
+#include "HelpWhatsThis.h"
 
 #include <QDebug>
 
 BingMap::BingMap(Context *context) : GcChartWindow(context), context(context), range(-1), current(NULL)
 {
     setControls(NULL);
+
     setContentsMargins(0,0,0,0);
     layout = new QVBoxLayout();
     layout->setSpacing(0);
@@ -46,6 +48,9 @@ BingMap::BingMap(Context *context) : GcChartWindow(context), context(context), r
     view->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     view->setAcceptDrops(false);
     layout->addWidget(view);
+
+    HelpWhatsThis *help = new HelpWhatsThis(view);
+    view->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::ChartRides_Map));
 
     webBridge = new BWebBridge(context, this);
 

--- a/src/ConfigDialog.cpp
+++ b/src/ConfigDialog.cpp
@@ -26,6 +26,7 @@
 #include "Pages.h"
 #include "Settings.h"
 #include "Zones.h"
+#include "HelpWhatsThis.h"
 
 #include "AddDeviceWizard.h"
 #include "MainWindow.h"
@@ -114,26 +115,39 @@ ConfigDialog::ConfigDialog(QDir _home, Zones *_zones, Context *context) :
 
     // create those config pages
     general = new GeneralConfig(_home, _zones, context);
+    HelpWhatsThis *generalHelp = new HelpWhatsThis(general);
+    general->setWhatsThis(generalHelp->getWhatsThisText(HelpWhatsThis::Preferences_General));
     pagesWidget->addWidget(general);
 
     athlete = new AthleteConfig(_home, _zones, context);
+    HelpWhatsThis *athleteHelp = new HelpWhatsThis(athlete);
+    athlete->setWhatsThis(athleteHelp->getWhatsThisText(HelpWhatsThis::Preferences_Athlete_About));
     pagesWidget->addWidget(athlete);
 
     password = new PasswordConfig(_home, _zones, context);
+    HelpWhatsThis *passwordHelp = new HelpWhatsThis(password);
+    password->setWhatsThis(passwordHelp->getWhatsThisText(HelpWhatsThis::Preferences_Passwords));
     pagesWidget->addWidget(password);
 
     appearance = new AppearanceConfig(_home, _zones, context);
+    HelpWhatsThis *appearanceHelp = new HelpWhatsThis(appearance);
+    appearance->setWhatsThis(appearanceHelp->getWhatsThisText(HelpWhatsThis::Preferences_Appearance));
     pagesWidget->addWidget(appearance);
 
     data = new DataConfig(_home, _zones, context);
+    HelpWhatsThis *dataHelp = new HelpWhatsThis(data);
+    data->setWhatsThis(dataHelp->getWhatsThisText(HelpWhatsThis::Preferences_DataFields));
     pagesWidget->addWidget(data);
 
     metric = new MetricConfig(_home, _zones, context);
+    HelpWhatsThis *metricHelp = new HelpWhatsThis(metric);
+    metric->setWhatsThis(metricHelp->getWhatsThisText(HelpWhatsThis::Preferences_Metrics));
     pagesWidget->addWidget(metric);
 
     device = new DeviceConfig(_home, _zones, context);
+    HelpWhatsThis *deviceHelp = new HelpWhatsThis(device);
+    device->setWhatsThis(deviceHelp->getWhatsThisText(HelpWhatsThis::Preferences_TrainDevices));
     pagesWidget->addWidget(device);
-
 
     closeButton = new QPushButton(tr("Close"));
     saveButton = new QPushButton(tr("Save"));
@@ -262,10 +276,24 @@ AthleteConfig::AthleteConfig(QDir home, Zones *zones, Context *context) :
 {
     // the widgets
     athletePage = new RiderPage(this, context);
+    HelpWhatsThis *athleteHelp = new HelpWhatsThis(athletePage);
+    athletePage->setWhatsThis(athleteHelp->getWhatsThisText(HelpWhatsThis::Preferences_Athlete_About));
+
     zonePage = new ZonePage(context);
+    HelpWhatsThis *zoneHelp = new HelpWhatsThis(zonePage);
+    zonePage->setWhatsThis(zoneHelp->getWhatsThisText(HelpWhatsThis::Preferences_Athlete_TrainingZones_Power));
+
     hrZonePage = new HrZonePage(context);
+    HelpWhatsThis *hrZoneHelp = new HelpWhatsThis(hrZonePage);
+    hrZonePage->setWhatsThis(hrZoneHelp->getWhatsThisText(HelpWhatsThis::Preferences_Athlete_TrainingZones_HR));
+
     paceZonePage = new PaceZonePage(context);
+    HelpWhatsThis *paceZoneHelp = new HelpWhatsThis(paceZonePage);
+    paceZonePage->setWhatsThis(paceZoneHelp->getWhatsThisText(HelpWhatsThis::Preferences_Athlete_TrainingZones_Pace));
+
     autoImportPage = new AutoImportPage(context);
+    HelpWhatsThis *autoImportHelp = new HelpWhatsThis(autoImportPage);
+    autoImportPage->setWhatsThis(autoImportHelp->getWhatsThisText(HelpWhatsThis::Preferences_Athlete_Autoimport));
 
     setContentsMargins(0,0,0,0);
     QHBoxLayout *mainLayout = new QHBoxLayout(this);

--- a/src/CriticalPowerWindow.cpp
+++ b/src/CriticalPowerWindow.cpp
@@ -32,6 +32,7 @@
 #include "IntervalItem.h"
 #include "GcOverlayWidget.h"
 #include "MUWidget.h"
+#include "HelpWhatsThis.h"
 #include <qwt_picker.h>
 #include <qwt_picker_machine.h>
 #include <qwt_plot_picker.h>
@@ -91,6 +92,9 @@ CriticalPowerWindow::CriticalPowerWindow(Context *context, bool rangemode) :
 
     cpPlot = new CPPlot(this, context, rangemode);
     mainLayout->addWidget(cpPlot);
+    HelpWhatsThis *help = new HelpWhatsThis(cpPlot);
+    if (rangemode) cpPlot->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::ChartTrends_Critical_MM));
+    else cpPlot->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::ChartRides_Critical_MM));
 
     //
     // Chart settings
@@ -98,10 +102,17 @@ CriticalPowerWindow::CriticalPowerWindow(Context *context, bool rangemode) :
 
     // controls widget and layout
     QTabWidget *settingsTabs = new QTabWidget(this);
+    HelpWhatsThis *helpTabs = new HelpWhatsThis(settingsTabs);
+    if (rangemode) settingsTabs->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::ChartTrends_Critical_MM));
+    else settingsTabs->setWhatsThis(helpTabs->getWhatsThisText(HelpWhatsThis::ChartRides_Critical_MM));
+
 
     QWidget *settingsWidget = new QWidget(this);
     settingsWidget->setContentsMargins(0,0,0,0);
     settingsTabs->addTab(settingsWidget, tr("Basic"));
+    HelpWhatsThis *helpSettings = new HelpWhatsThis(settingsWidget);
+    if (rangemode) settingsWidget->setWhatsThis(helpSettings->getWhatsThisText(HelpWhatsThis::ChartTrends_Critical_MM_Config_Settings));
+    else settingsWidget->setWhatsThis(helpSettings->getWhatsThisText(HelpWhatsThis::ChartRides_Critical_MM_Config_Settings));
 
     QFormLayout *cl = new QFormLayout(settingsWidget);;
     cl->setFieldGrowthPolicy(QFormLayout::FieldsStayAtSizeHint);
@@ -109,6 +120,9 @@ CriticalPowerWindow::CriticalPowerWindow(Context *context, bool rangemode) :
     QWidget *modelWidget = new QWidget(this);
     modelWidget->setContentsMargins(0,0,0,0);
     settingsTabs->addTab(modelWidget, tr("CP/CV Model"));
+    HelpWhatsThis *helpModel = new HelpWhatsThis(modelWidget);
+    if (rangemode) modelWidget->setWhatsThis(helpModel->getWhatsThisText(HelpWhatsThis::ChartTrends_Critical_MM_Config_Model));
+    else modelWidget->setWhatsThis(helpModel->getWhatsThisText(HelpWhatsThis::ChartRides_Critical_MM_Config_Model));
 
     QFormLayout *mcl = new QFormLayout(modelWidget);;
     mcl->setFieldGrowthPolicy(QFormLayout::FieldsStayAtSizeHint);
@@ -129,6 +143,8 @@ CriticalPowerWindow::CriticalPowerWindow(Context *context, bool rangemode) :
     connect(searchBox, SIGNAL(searchResults(QStringList)), this, SLOT(filterChanged()));
     cl->addRow(new QLabel(tr("Filter")), searchBox);
     cl->addWidget(new QLabel("")); //spacing
+    HelpWhatsThis *searchHelp = new HelpWhatsThis(searchBox);
+    searchBox->setWhatsThis(searchHelp->getWhatsThisText(HelpWhatsThis::SearchFilterBox));
 #endif
 
     // series
@@ -147,6 +163,8 @@ CriticalPowerWindow::CriticalPowerWindow(Context *context, bool rangemode) :
     }
     cl->addRow(label2, cComboSeason);
     dateSetting = new DateSettingsEdit(this);
+    HelpWhatsThis *dateSettingHelp = new HelpWhatsThis(dateSetting);
+    dateSetting->setWhatsThis(dateSettingHelp->getWhatsThisText(HelpWhatsThis::ChartTrends_DateRange));
     cl->addRow(label, dateSetting);
     if (rangemode == false) {
         dateSetting->hide();

--- a/src/DiarySidebar.cpp
+++ b/src/DiarySidebar.cpp
@@ -22,6 +22,7 @@
 #include "Context.h"
 #include "GcWindowLayout.h"
 #include "Settings.h"
+#include "HelpWhatsThis.h"
 #include <QWebSettings>
 #include <QWebFrame>
 #include "TimeUtils.h"
@@ -59,6 +60,9 @@ DiarySidebar::DiarySidebar(Context *context) : context(context)
     layout->setContentsMargins(0,0,0,0);
     calendarItem->addWidget(calWidget);
 
+    HelpWhatsThis *helpCalendarItem = new HelpWhatsThis(calendarItem);
+    calendarItem->setWhatsThis(helpCalendarItem->getWhatsThisText(HelpWhatsThis::SideBarDiaryView_Calendar));
+
     // summary widget
     summaryWidget = new QWidget(this);
     summaryWidget->setContentsMargins(0,0,0,0);
@@ -68,6 +72,9 @@ DiarySidebar::DiarySidebar(Context *context) : context(context)
     slayout->setSpacing(0);
     slayout->setContentsMargins(0,0,0,0);
     summaryItem->addWidget(summaryWidget);
+
+    HelpWhatsThis *helpSummaryItem = new HelpWhatsThis(summaryItem);
+    summaryItem->setWhatsThis(helpSummaryItem->getWhatsThisText(HelpWhatsThis::SideBarDiaryView_Summary));
 
     splitter->addWidget(calendarItem);
     splitter->addWidget(summaryItem);

--- a/src/DiaryWindow.cpp
+++ b/src/DiaryWindow.cpp
@@ -22,6 +22,7 @@
 #include "Athlete.h"
 #include "Context.h"
 #include "TabView.h"
+#include "HelpWhatsThis.h"
 
 DiaryWindow::DiaryWindow(Context *context) :
     GcWindow(context), context(context), active(false)
@@ -77,6 +78,9 @@ DiaryWindow::DiaryWindow(Context *context) :
     monthlyView->viewport()->installEventFilter(this);
     monthlyView->setGridStyle(Qt::DotLine);
     monthlyView->setFrameStyle(QFrame::NoFrame);
+
+    HelpWhatsThis *helpView = new HelpWhatsThis(monthlyView);
+    monthlyView->setWhatsThis(helpView->getWhatsThisText(HelpWhatsThis::ChartDiary_Calendar));
 
     allViews = new QStackedWidget(this);
     allViews->addWidget(monthlyView);

--- a/src/DownloadRideDialog.cpp
+++ b/src/DownloadRideDialog.cpp
@@ -24,6 +24,7 @@
 #include "Athlete.h"
 #include "Settings.h"
 #include "JsonRideFile.h"
+#include "HelpWhatsThis.h"
 #include <assert.h>
 #include <errno.h>
 #include <QtGui>
@@ -34,6 +35,9 @@ DownloadRideDialog::DownloadRideDialog(Context *context, bool embedded) :
 {
     setAttribute(Qt::WA_DeleteOnClose);
     setWindowTitle(tr("Download Ride Data"));
+
+    HelpWhatsThis *help = new HelpWhatsThis(this);
+    this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Activity_Download));
 
     deviceCombo = new QComboBox(this);
     QList<QString> deviceTypes = Devices::typeNames();

--- a/src/ErgDBDownloadDialog.cpp
+++ b/src/ErgDBDownloadDialog.cpp
@@ -19,12 +19,17 @@
 #include "ErgDBDownloadDialog.h"
 #include "MainWindow.h"
 #include "TrainDB.h"
+#include "HelpWhatsThis.h"
 
 ErgDBDownloadDialog::ErgDBDownloadDialog(Context *context) : QDialog(context->mainWindow), context(context)
 {
     setAttribute(Qt::WA_DeleteOnClose);
     setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
     setWindowTitle(tr("Download workouts from ErgDB"));
+
+    // help
+    HelpWhatsThis *help = new HelpWhatsThis(this);
+    this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Tools_Download_ERGDB));
 
     // make the dialog a resonable size
     setMinimumWidth(650);

--- a/src/FixDerivePower.cpp
+++ b/src/FixDerivePower.cpp
@@ -20,6 +20,7 @@
 #include "LTMOutliers.h"
 #include "Settings.h"
 #include "Units.h"
+#include "HelpWhatsThis.h"
 #include <algorithm>
 #include <QVector>
 
@@ -37,6 +38,9 @@ class FixDerivePowerConfig : public DataProcessorConfig
 
     public:
         FixDerivePowerConfig(QWidget *parent) : DataProcessorConfig(parent) {
+
+            HelpWhatsThis *help = new HelpWhatsThis(parent);
+            parent->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Edit_EstimatePowerValues));
 
             //layout = new QHBoxLayout(this);
 

--- a/src/FixDeriveTorque.cpp
+++ b/src/FixDeriveTorque.cpp
@@ -20,6 +20,7 @@
 #include "LTMOutliers.h"
 #include "Settings.h"
 #include "Units.h"
+#include "HelpWhatsThis.h"
 #include <algorithm>
 #include <QVector>
 
@@ -37,6 +38,9 @@ class FixDeriveTorqueConfig : public DataProcessorConfig
 
     public:
         FixDeriveTorqueConfig(QWidget *parent) : DataProcessorConfig(parent) {
+
+            HelpWhatsThis *help = new HelpWhatsThis(parent);
+            parent->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Edit_AddTorqueValues));
 
             //layout = new QHBoxLayout(this);
 

--- a/src/FixElevation.cpp
+++ b/src/FixElevation.cpp
@@ -19,6 +19,7 @@
 #include "DataProcessor.h"
 #include "Settings.h"
 #include "Units.h"
+#include "HelpWhatsThis.h"
 #include <algorithm>
 #include <QVector>
 #include <QNetworkAccessManager>
@@ -42,7 +43,11 @@ class FixElevationConfig : public DataProcessorConfig
     protected:
     public:
         // there is no config
-        FixElevationConfig(QWidget *parent) : DataProcessorConfig(parent) {}
+        FixElevationConfig(QWidget *parent) : DataProcessorConfig(parent) {
+
+            HelpWhatsThis *help = new HelpWhatsThis(parent);
+            parent->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Edit_FixElevationErrors));
+        }
 
         QString explain() {
             return(QString(tr("Fix or add elevation data. If elevation data is "

--- a/src/FixGPS.cpp
+++ b/src/FixGPS.cpp
@@ -19,6 +19,7 @@
 #include "DataProcessor.h"
 #include "Settings.h"
 #include "Units.h"
+#include "HelpWhatsThis.h"
 #include <algorithm>
 #include <QVector>
 
@@ -31,7 +32,11 @@ class FixGPSConfig : public DataProcessorConfig
     protected:
     public:
         // there is no config
-        FixGPSConfig(QWidget *parent) : DataProcessorConfig(parent) {}
+        FixGPSConfig(QWidget *parent) : DataProcessorConfig(parent) {
+
+            HelpWhatsThis *help = new HelpWhatsThis(parent);
+            parent->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Edit_FixGPSErrors));
+        }
 
         QString explain() {
             return(QString(tr("Remove GPS errors and interpolate positional "

--- a/src/FixGaps.cpp
+++ b/src/FixGaps.cpp
@@ -19,6 +19,7 @@
 #include "DataProcessor.h"
 #include "Settings.h"
 #include "Units.h"
+#include "HelpWhatsThis.h"
 #include <algorithm>
 #include <QVector>
 
@@ -37,6 +38,9 @@ class FixGapsConfig : public DataProcessorConfig
 
     public:
         FixGapsConfig(QWidget *parent) : DataProcessorConfig(parent) {
+
+            HelpWhatsThis *help = new HelpWhatsThis(parent);
+            parent->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Edit_FixGapsInRecording));
 
             layout = new QHBoxLayout(this);
 

--- a/src/FixHRSpikes.cpp
+++ b/src/FixHRSpikes.cpp
@@ -23,6 +23,7 @@
 #include "LTMOutliers.h"
 #include "Settings.h"
 #include "Units.h"
+#include "HelpWhatsThis.h"
 #include <algorithm>
 #include <QVector>
 
@@ -41,6 +42,9 @@ class FixHRSpikesConfig : public DataProcessorConfig
 
     public:
         FixHRSpikesConfig(QWidget *parent) : DataProcessorConfig(parent) {
+
+            HelpWhatsThis *help = new HelpWhatsThis(parent);
+            parent->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Edit_FixHRSpikes));
 
             layout = new QHBoxLayout(this);
 

--- a/src/FixPower.cpp
+++ b/src/FixPower.cpp
@@ -20,6 +20,7 @@
 #include "LTMOutliers.h"
 #include "Settings.h"
 #include "Units.h"
+#include "HelpWhatsThis.h"
 #include <algorithm>
 #include <QVector>
 
@@ -38,6 +39,9 @@ class FixPowerConfig : public DataProcessorConfig
 
     public:
         FixPowerConfig(QWidget *parent) : DataProcessorConfig(parent) {
+
+            HelpWhatsThis *help = new HelpWhatsThis(parent);
+            parent->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Edit_AdjustPowerValues));
 
             layout = new QHBoxLayout(this);
 

--- a/src/FixSpikes.cpp
+++ b/src/FixSpikes.cpp
@@ -20,6 +20,7 @@
 #include "LTMOutliers.h"
 #include "Settings.h"
 #include "Units.h"
+#include "HelpWhatsThis.h"
 #include <algorithm>
 #include <QVector>
 
@@ -38,6 +39,9 @@ class FixSpikesConfig : public DataProcessorConfig
 
     public:
         FixSpikesConfig(QWidget *parent) : DataProcessorConfig(parent) {
+
+            HelpWhatsThis *help = new HelpWhatsThis(parent);
+            parent->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Edit_FixPowerSpikes));
 
             layout = new QHBoxLayout(this);
 

--- a/src/FixTorque.cpp
+++ b/src/FixTorque.cpp
@@ -20,6 +20,7 @@
 #include "LTMOutliers.h"
 #include "Settings.h"
 #include "Units.h"
+#include "HelpWhatsThis.h"
 #include <algorithm>
 #include <QVector>
 
@@ -37,6 +38,9 @@ class FixTorqueConfig : public DataProcessorConfig
 
     public:
         FixTorqueConfig(QWidget *parent) : DataProcessorConfig(parent) {
+
+            HelpWhatsThis *help = new HelpWhatsThis(parent);
+            parent->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Edit_AdjustTorqueValues));
 
             layout = new QHBoxLayout(this);
 

--- a/src/GcScopeBar.cpp
+++ b/src/GcScopeBar.cpp
@@ -21,6 +21,7 @@
 #include "DiarySidebar.h"
 #include "Context.h"
 #include "QtMacButton.h"
+#include "HelpWhatsThis.h"
 
 GcScopeBar::GcScopeBar(Context *context) : QWidget(context->mainWindow), context(context)
 {
@@ -78,10 +79,17 @@ GcScopeBar::GcScopeBar(Context *context) : QWidget(context->mainWindow), context
     layout->addWidget(home);
     connect(home, SIGNAL(clicked(bool)), this, SLOT(clickedHome()));
 
+    HelpWhatsThis *helpHome = new HelpWhatsThis(home);
+    home->setWhatsThis(helpHome->getWhatsThisText(HelpWhatsThis::ScopeBar_Trends));
+
 #ifdef GC_HAVE_ICAL
     diary->setText(tr("Diary"));
     layout->addWidget(diary);
     connect(diary, SIGNAL(clicked(bool)), this, SLOT(clickedDiary()));
+
+    HelpWhatsThis *helpDiary = new HelpWhatsThis(diary);
+    diary->setWhatsThis(helpDiary->getWhatsThisText(HelpWhatsThis::ScopeBar_Diary));
+
 #endif
 
     anal->setText(tr("Rides"));
@@ -90,16 +98,29 @@ GcScopeBar::GcScopeBar(Context *context) : QWidget(context->mainWindow), context
     layout->addWidget(anal);
     connect(anal, SIGNAL(clicked(bool)), this, SLOT(clickedAnal()));
 
+    HelpWhatsThis *helpAnal = new HelpWhatsThis(anal);
+    anal->setWhatsThis(helpAnal->getWhatsThisText(HelpWhatsThis::ScopeBar_Rides));
+
+
 #ifdef GC_HAVE_INTERVALS
     interval->setText(tr("Intervals"));
     interval->setWidth(70);
     layout->addWidget(interval);
     connect(interval, SIGNAL(clicked(bool)), this, SLOT(clickedInterval()));
+
+    HelpWhatsThis *helpIntervals = new HelpWhatsThis(interval);
+    interval->setWhatsThis(helpIntervals->getWhatsThisText(HelpWhatsThis::ScopeBar_Intervals));
+
+
 #endif
 
     train->setText(tr("Train"));
     layout->addWidget(train);
     connect(train, SIGNAL(clicked(bool)), this, SLOT(clickedTrain()));
+
+    HelpWhatsThis *helpTrain = new HelpWhatsThis(train);
+    train->setWhatsThis(helpTrain->getWhatsThisText(HelpWhatsThis::ScopeBar_Train));
+
 
     //layout->addWidget(traintool); //XXX!!! eek
 

--- a/src/GenerateHeatMapDialog.cpp
+++ b/src/GenerateHeatMapDialog.cpp
@@ -22,12 +22,15 @@
 #include "Context.h"
 #include "Athlete.h"
 #include "RideCache.h"
+#include "HelpWhatsThis.h"
 
 GenerateHeatMapDialog::GenerateHeatMapDialog(Context *context) : QDialog(context->mainWindow), context(context)
 {
     setAttribute(Qt::WA_DeleteOnClose);
     //setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint); // must stop using this flag!
     setWindowTitle(tr("Ride Heat Map Generator"));
+    HelpWhatsThis *help = new HelpWhatsThis(this);
+    this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Tools_CreateHeatMap));
 
     // make the dialog a resonable size
     setMinimumWidth(550);

--- a/src/GoogleMapControl.cpp
+++ b/src/GoogleMapControl.cpp
@@ -30,6 +30,7 @@
 #include "Colors.h"
 #include "Units.h"
 #include "TimeUtils.h"
+#include "HelpWhatsThis.h"
 
 // overlay helper
 #include "TabView.h"
@@ -41,6 +42,7 @@ GoogleMapControl::GoogleMapControl(Context *context) : GcChartWindow(context), c
                                                        range(-1), current(NULL), firstShow(true)
 {
     setControls(NULL);
+
     setContentsMargins(0,0,0,0);
     layout = new QVBoxLayout();
     layout->setSpacing(0);
@@ -54,6 +56,9 @@ GoogleMapControl::GoogleMapControl(Context *context) : GcChartWindow(context), c
     view->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     view->setAcceptDrops(false);
     layout->addWidget(view);
+
+    HelpWhatsThis *help = new HelpWhatsThis(view);
+    view->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::ChartRides_Map));
 
     webBridge = new WebBridge(context, this);
 

--- a/src/HelpWhatsThis.cpp
+++ b/src/HelpWhatsThis.cpp
@@ -1,0 +1,279 @@
+/*
+ * Copyright (c)  2014 Joern Rischmueller(joern.rm@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <QDesktopServices>
+#include <QWidget>
+#include <QWhatsThis>
+#include "HelpWhatsThis.h"
+
+
+HelpWhatsThis::HelpWhatsThis(QObject *object) : QObject(object) {
+    object->installEventFilter(this);
+}
+
+bool
+HelpWhatsThis::eventFilter ( QObject *object, QEvent *event) {
+
+    if( event->type() == QEvent::WhatsThisClicked )
+    {
+      QWhatsThisClickedEvent *helpEvent = static_cast<QWhatsThisClickedEvent*>(event);
+      QUrl url;
+      url.setUrl(helpEvent->href());
+      if (!QDesktopServices::openUrl( url )) {
+          // if not successful, try default URL
+          QDesktopServices::openUrl(QUrl("https://github.com/GoldenCheetah/GoldenCheetah/wiki"));
+      };
+      // anyway the event was successfully processed - don't go on
+      return true;
+    }
+
+    // pass it on
+    return QObject::eventFilter( object, event );
+
+}
+
+QString
+HelpWhatsThis::getWhatsThisText(GCHelp chapter) {
+    return getText(chapter);
+}
+
+
+// private STATIC function to determine the texts (since the texts and links are fixed values)
+
+QString
+HelpWhatsThis::getText(GCHelp chapter) {
+
+    QString text = "<center>%2<br><a href=\"https://github.com/GoldenCheetah/GoldenCheetah/wiki/UG_310_%1\" target=\"_blank\">" + tr("More Help") + "</a></center>";
+
+    switch (chapter) {
+
+    case Default:
+        return text.arg("Main-Page_Table-of-contents").arg("Table of Contents");
+
+    // Scope Bar
+    case ScopeBar_Trends:
+        return text.arg("ScopeBar_Views#trends").arg("Trends");
+    case ScopeBar_Diary:
+        return text.arg("ScopeBar_Views#diary").arg("Diary");
+    case ScopeBar_Rides:
+        return text.arg("ScopeBar_Views#rides").arg("Rides");
+    case ScopeBar_Intervals:
+        return text.arg("ScopeBar_Views#intervals").arg("Intervals");
+    case ScopeBar_Train:
+        return text.arg("ScopeBar_Views#train").arg("Train");
+
+    // Tool Bar
+    case ToolBar_Download:
+        return text.arg("First-Steps_Download-or-import#downloading-a-ride-from-device").arg("Download from Device");
+    case ToolBar_Manual:
+        return text.arg("Menu%20Bar_Activity").arg("Manual ride/activity entry");
+    case ToolBar_ToggleSidebar:
+        return text.arg("Menu%20Bar_View").arg("Activates / De-activates the Sidebar");
+    case ToolBar_ToggleComparePane:
+        return text.arg("Compare-Pane_General").arg("Activates / De-activates the Compare Pane");
+
+    // Menus
+    case MenuBar_Athlete:
+        return text.arg("Menu%20Bar_Athlete").arg("Menu Bar - Athlete");
+
+    case MenuBar_Activity:
+        return text.arg("Menu%20Bar_Activity").arg("Menu Bar - Activity");
+    case MenuBar_Activity_Download:
+        return text.arg("First-Steps_Download-or-import#downloading-a-ride-from-device").arg("Menu Bar - Download");
+    case MenuBar_Activity_Import:
+        return text.arg("First-Steps_Download-or-import#importing-from-a-file").arg("Menu Bar - Import");
+    case MenuBar_Activity_Manual:
+        return text.arg("Menu%20Bar_Activity").arg("Menu Bar - Manual");
+    case MenuBar_Activity_Share:
+        return text.arg("Special%20Topics_Upload_Download%20to_from%20external%20web-sites#execution").arg("Menu Bar - Share");
+    case MenuBar_Activity_BatchExport:
+        return text.arg("Menu%20Bar_Activity").arg("Menu Bar - Batch Export");
+    case MenuBar_Activity_SplitRide:
+        return text.arg("Menu%20Bar_Activity").arg("Menu Bar - Split Ride");
+    case MenuBar_Activity_CombineRides:
+        return text.arg("Menu%20Bar_Activity").arg("Menu Bar - Combine Rides");
+
+    case MenuBar_Tools:
+        return text.arg("Menu%20Bar_Tools").arg("Menu Bar - Tools");
+    case MenuBar_Tools_CP_EST:
+        return text.arg("Menu%20Bar_Tools").arg("Menu Bar - CP Estimation");
+    case MenuBar_Tools_AirDens_EST:
+        return text.arg("Menu%20Bar_Tools").arg("Menu Bar - Air Density");
+    case MenuBar_Tools_Download_ERGDB:
+        return text.arg("Menu%20Bar_Tools").arg("Menu Bar - Download ERGDB");
+    case MenuBar_Tools_CreateWorkout:
+        return text.arg("Menu%20Bar_Tools").arg("Menu Bar - Create Workout");
+    case MenuBar_Tools_ScanDisk_WorkoutVideo:
+        return text.arg("Menu%20Bar_Tools").arg("Menu Bar - Scan Disk for Workouts/Videos");
+    case MenuBar_Tools_CreateHeatMap:
+        return text.arg("Menu%20Bar_Tools").arg("Menu Bar - Create Heat Map");
+
+    case MenuBar_Edit:
+        return text.arg("Menu%20Bar_Edit").arg("Menu Bar - Edit");
+    case MenuBar_Edit_AddTorqueValues:
+        return text.arg("Menu%20Bar_Tools").arg("Menu Bar - Edit - Add Torque Values");
+    case MenuBar_Edit_AdjustPowerValues:
+        return text.arg("Menu%20Bar_Tools").arg("Menu Bar - Edit - Adjust Power Values");
+    case MenuBar_Edit_AdjustTorqueValues:
+        return text.arg("Menu%20Bar_Tools").arg("Menu Bar - Edit - Adjust Torque Values");
+    case MenuBar_Edit_EstimatePowerValues:
+        return text.arg("Menu%20Bar_Tools").arg("Menu Bar - Edit - Estimate Power Values");
+    case MenuBar_Edit_FixElevationErrors:
+        return text.arg("Menu%20Bar_Tools").arg("Menu Bar - Edit - Fix Elevation Errors");
+    case MenuBar_Edit_FixGapsInRecording:
+        return text.arg("Menu%20Bar_Tools").arg("Menu Bar - Edit - Fix Gaps in Recording");
+    case MenuBar_Edit_FixGPSErrors:
+        return text.arg("Menu%20Bar_Tools").arg("Menu Bar - Edit - Fix GPS Errors");
+    case MenuBar_Edit_FixHRSpikes:
+        return text.arg("Menu%20Bar_Tools").arg("Menu Bar - Edit - Fix HR Spikes");
+    case MenuBar_Edit_FixPowerSpikes:
+        return text.arg("Menu%20Bar_Tools").arg("Menu Bar - Edit - Fix Power Spikes");
+
+    case MenuBar_View:
+        return text.arg("Menu%20Bar_View").arg("Menu Bar - View");
+    case MenuBar_Help:
+        return text.arg("Menu%20Bar_Help").arg("Menu Bar - Help");
+
+    // Charts
+    case ChartTrends_MetricTrends:
+        return text.arg("ChartTypes_Trends#metric-trends").arg("Trends - LTM");
+    case ChartTrends_MetricTrends_Config_Basic:
+        return text.arg("ChartTypes_Trends#basic-settings").arg("Trends - Basic Settings");
+    case ChartTrends_MetricTrends_Config_Preset:
+        return text.arg("ChartTypes_Trends#presets").arg("Trends - Presets");
+    case ChartTrends_MetricTrends_Config_Curves:
+        return text.arg("ChartTypes_Trends#curves").arg("Trends - Curves");
+
+    case ChartTrends_CollectionTreeMap:
+        return text.arg("ChartTypes_Trends#collection-tree-map").arg("Trends - Collection Tree Map");
+
+    case ChartTrends_Critical_MM:
+        return text.arg("ChartTypes_Trends#critical-mean-maximal").arg("Trends - Critical Mean Maximal");
+    case ChartTrends_Critical_MM_Config_Settings:
+        return text.arg("ChartTypes_Trends#critical-mean-maximal").arg("Trends - Critical Mean Maximal - Config - Settings");
+    case ChartTrends_Critical_MM_Config_Model:
+        return text.arg("ChartTypes_Trends#critical-mean-maximal").arg("Trends - Critical Mean Maximal - Config - Model");
+    case ChartTrends_Distribution:
+        return text.arg("ChartTypes_Trends#distribution").arg("Trends - Distribution");
+     case ChartTrends_DateRange:
+        return text.arg("ChartTypes_Trends#date-range-selection").arg("Trends - Date Range");
+    case ChartDiary_Calendar:
+        return text.arg("ChartTypes_Diary#calendar").arg("Diary - Calendar");
+    case ChartDiary_Navigator:
+        return text.arg("ChartTypes_Diary#navigator").arg("Diary - Navigator");
+    case ChartRides_Summary:
+        return text.arg("ChartTypes_Rides#ride-summary").arg("Rides - Summary");
+    case ChartRides_Details:
+        return text.arg("ChartTypes_Rides#details").arg("Rides - Details");
+    case ChartRides_Summary_Details:
+        return text.arg("ChartTypes_Rides#summary-and-details").arg("Rides - Summary/Details");
+    case ChartRides_Editor:
+        return text.arg("ChartTypes_Rides#editor").arg("Rides - Editor");
+
+    case ChartRides_Performance:
+        return text.arg("ChartTypes_Rides#performance").arg("Rides - Performance");
+    case ChartRides_Performance_Config_Basic:
+        return text.arg("ChartTypes_Rides#performance-basic").arg("Rides - Performance - Basic");
+    case ChartRides_Performance_Config_Series:
+        return text.arg("ChartTypes_Rides#performance-series").arg("Rides - Performance - Series");
+
+    case ChartRides_Critical_MM:
+        return text.arg("ChartTypes_Rides#critical-mean-maximals").arg("Rides - Critical Mean Maximals");
+    case ChartRides_Critical_MM_Config_Settings:
+        return text.arg("ChartTypes_Rides#critical-mean-maximal").arg("Rides - Critical Mean Maximal - Config - Settings");
+    case ChartRides_Critical_MM_Config_Model:
+        return text.arg("ChartTypes_Rides#critical-mean-maximal").arg("Rides - Critical Mean Maximal - Config - Model");
+
+    case ChartRides_Histogram:
+        return text.arg("ChartTypes_Rides#histogram").arg("Rides - Histogram");
+    case ChartRides_PFvV:
+        return text.arg("ChartTypes_Rides#pedal-force-vs-velocity").arg("Rides - PFvsV");
+    case ChartRides_HRvsPw:
+        return text.arg("ChartTypes_Rides#heartrate-vs-power").arg("Rides - HRvsPw");
+    case ChartRides_Map:
+        return text.arg("ChartTypes_Rides#google-map--bing-map").arg("Rides - Map");
+    case ChartRides_2D:
+        return text.arg("ChartTypes_Rides#2d-plot").arg("Rides - 2d Plot");
+    case ChartRides_3D:
+        return text.arg("ChartTypes_Rides#3d-plot").arg("Rides - 3d Plot");
+    case ChartRides_Aerolab:
+        return text.arg("ChartTypes_Rides#aerolab-chung-analysis").arg("Rides - Aerolab");
+
+    case Chart_Summary:
+        return text.arg("ChartTypes_Trends#summary").arg("Summary");
+    case Chart_Summary_Config:
+        return text.arg("ChartTypes_Trends#summary-config").arg("Summary Config");
+
+    // Sidebars
+    case SideBarTrendsView_DateRanges:
+        return text.arg("Side-Bar_Trends-view#date-ranges").arg("Date Ranges");
+    case SideBarTrendsView_Events:
+        return text.arg("Side-Bar_Trends-view#events").arg("Events");
+    case SideBarTrendsView_Summary:
+        return text.arg("Side-Bar_Trends-view#summary").arg("Summary");
+    case SideBarTrendsView_Filter:
+        return text.arg("Side-Bar_Trends-view#filters").arg("Filters");
+    case SideBarTrendsView_Charts:
+        return text.arg("Side-Bar_Trends-view#charts").arg("Charts");
+    case SideBarRidesView_Calendar:
+        return text.arg("Side-Bar_Rides-view#calendar").arg("Calendar");
+    case SideBarRidesView_Rides:
+        return text.arg("Side-Bar_Rides-view#rides").arg("Rides");
+    case SideBarRidesView_Intervals:
+        return text.arg("Side-Bar_Rides-view#intervals").arg("Intervals");
+    case SideBarDiaryView_Calendar:
+        return text.arg("Side%20Bar_Diary%20view#calendar").arg("Calendar");
+    case SideBarDiaryView_Summary:
+        return text.arg("Side%20Bar_Diary%20view#summary").arg("Summary");
+
+    // Cross Functions
+    case SearchFilterBox:
+        return text.arg("Special-Topics_SearchFilter").arg("Entry field for Searching and Filtering of activities");
+    case FindIntervals:
+        return text.arg("Side-Bar_Rides-view#intervals").arg("Intervals");
+
+    // Preferences
+    case Preferences_General:
+        return text.arg("Preferences_General").arg("Preferences - General");
+    case Preferences_Athlete_About:
+        return text.arg("Preferences_Athlete").arg("Preferences - Athlete");
+    case Preferences_Athlete_TrainingZones_Power:
+        return text.arg("Preferences_Athlete_Training%20Zones").arg("Preferences - Training Zones");
+    case Preferences_Athlete_TrainingZones_HR:
+        return text.arg("Preferences_Athlete_Training%20Zones").arg("Preferences - Training Zones");
+    case Preferences_Athlete_TrainingZones_Pace:
+        return text.arg("Preferences_Athlete_Training%20Zones").arg("Preferences - Training Zones");
+    case Preferences_Athlete_Autoimport:
+        return text.arg("Preferences_Athlete_Autoimport").arg("Preferences - Autoimport");
+    case Preferences_Passwords:
+        return text.arg("Preferences_Passwords").arg("Preferences - Passwords");
+    case Preferences_Appearance:
+        return text.arg("Preferences_ppearance").arg("Preferences - Appearance");
+    case Preferences_DataFields:
+        return text.arg("Preferences_Data%20Fields").arg("Preferences - Data Fields");
+    case Preferences_Metrics:
+        return text.arg("Preferences_Metrics").arg("Preferences - Metrics");
+    case Preferences_TrainDevices:
+        return text.arg("Preferences_Train Devices").arg("Preferences - Train Devices");
+
+    }
+
+    return text.arg("").arg("Golden Cheetah Wiki");
+
+}
+

--- a/src/HelpWhatsThis.h
+++ b/src/HelpWhatsThis.h
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2014 Joern Rischmueller(joern.rm@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef _GC_HelpWhatsThis_h
+#define _GC_HelpWhatsThis_h
+
+#include <QWhatsThis>
+#include <QEvent>
+#include <QWhatsThisClickedEvent>
+#include <QWidget>
+#include <QAction>
+
+
+class HelpWhatsThis : public QObject
+{
+Q_OBJECT
+
+ public:
+    enum GCHelp{ Default,
+
+                 ScopeBar_Trends,
+                 ScopeBar_Diary,
+                 ScopeBar_Rides,
+                 ScopeBar_Intervals,
+                 ScopeBar_Train,
+
+                 ToolBar_Download,
+                 ToolBar_Manual,
+                 ToolBar_ToggleSidebar,
+                 ToolBar_ToggleComparePane,
+
+                 MenuBar_Athlete,
+
+                 MenuBar_Activity,
+                 MenuBar_Activity_Download,
+                 MenuBar_Activity_Import,
+                 MenuBar_Activity_Manual,
+                 MenuBar_Activity_Share,
+                 MenuBar_Activity_BatchExport,
+                 MenuBar_Activity_SplitRide,
+                 MenuBar_Activity_CombineRides,
+
+                 MenuBar_Tools,
+                 MenuBar_Tools_CP_EST,
+                 MenuBar_Tools_AirDens_EST,
+                 MenuBar_Tools_Download_ERGDB,
+                 MenuBar_Tools_CreateWorkout,
+                 MenuBar_Tools_ScanDisk_WorkoutVideo,
+                 MenuBar_Tools_CreateHeatMap,
+
+                 MenuBar_Edit,
+                 MenuBar_Edit_AddTorqueValues,
+                 MenuBar_Edit_AdjustPowerValues,
+                 MenuBar_Edit_AdjustTorqueValues,
+                 MenuBar_Edit_EstimatePowerValues,
+                 MenuBar_Edit_FixElevationErrors,
+                 MenuBar_Edit_FixGapsInRecording,
+                 MenuBar_Edit_FixGPSErrors,
+                 MenuBar_Edit_FixHRSpikes,
+                 MenuBar_Edit_FixPowerSpikes,
+
+                 MenuBar_View,
+                 MenuBar_Help,
+
+                 ChartTrends_MetricTrends,
+                 ChartTrends_MetricTrends_Config_Basic,
+                 ChartTrends_MetricTrends_Config_Preset,
+                 ChartTrends_MetricTrends_Config_Curves,
+
+                 ChartTrends_CollectionTreeMap,
+                 ChartTrends_Critical_MM,
+                 ChartTrends_Critical_MM_Config_Settings,
+                 ChartTrends_Critical_MM_Config_Model,
+
+                 ChartTrends_Distribution,
+                 ChartTrends_DateRange,
+
+                 ChartDiary_Calendar,
+                 ChartDiary_Navigator,
+
+                 ChartRides_Summary,
+                 ChartRides_Details,
+                 ChartRides_Summary_Details,  //open
+                 ChartRides_Editor,
+                 ChartRides_Performance,
+                 ChartRides_Performance_Config_Basic,
+                 ChartRides_Performance_Config_Series,
+                 ChartRides_Critical_MM,
+                 ChartRides_Critical_MM_Config_Settings,
+                 ChartRides_Critical_MM_Config_Model,
+
+                 ChartRides_Histogram,
+                 ChartRides_PFvV,
+                 ChartRides_HRvsPw,
+                 ChartRides_Map,
+                 ChartRides_2D,
+                 ChartRides_3D,
+                 ChartRides_Aerolab,
+
+                 Chart_Summary,
+                 Chart_Summary_Config,
+
+                 SideBarTrendsView_DateRanges,
+                 SideBarTrendsView_Events,
+                 SideBarTrendsView_Summary,
+                 SideBarTrendsView_Filter,
+                 SideBarTrendsView_Charts,
+                 SideBarRidesView_Calendar,
+                 SideBarRidesView_Rides,
+                 SideBarRidesView_Intervals,
+                 SideBarDiaryView_Calendar,
+                 SideBarDiaryView_Summary,
+
+                 SearchFilterBox,
+                 FindIntervals,
+
+                 Preferences_General,
+                 Preferences_Athlete_About,
+                 Preferences_Athlete_TrainingZones_Power,
+                 Preferences_Athlete_TrainingZones_HR,
+                 Preferences_Athlete_TrainingZones_Pace,
+                 Preferences_Athlete_Autoimport,
+                 Preferences_Passwords,
+                 Preferences_Appearance,
+                 Preferences_DataFields,
+                 Preferences_Metrics,
+                 Preferences_TrainDevices,
+
+                 };
+
+    HelpWhatsThis (QObject *object = 0);
+
+    QString getWhatsThisText(GCHelp chapter);
+
+ protected:
+    bool eventFilter( QObject*, QEvent* );
+
+ private:
+    static QString getText(GCHelp chapter);
+
+};
+
+
+#endif

--- a/src/HistogramWindow.cpp
+++ b/src/HistogramWindow.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "HistogramWindow.h"
+#include "HelpWhatsThis.h"
 
 // predefined deltas for each series
 static const double wattsDelta = 1.0;
@@ -43,8 +44,12 @@ static const int gearDigits  = 2;
 //
 HistogramWindow::HistogramWindow(Context *context, bool rangemode) : GcChartWindow(context), context(context), stale(true), source(NULL), active(false), bactive(false), rangemode(rangemode), compareStale(false), useCustom(false), useToToday(false), precision(99)
 {
+
     QWidget *c = new QWidget;
     c->setContentsMargins(0,0,0,0);
+    HelpWhatsThis *helpConfig = new HelpWhatsThis(c);
+    if (rangemode) c->setWhatsThis(helpConfig->getWhatsThisText(HelpWhatsThis::ChartTrends_Distribution));
+    else c->setWhatsThis(helpConfig->getWhatsThisText(HelpWhatsThis::ChartRides_Histogram));
     QFormLayout *cl = new QFormLayout(c);
     cl->setFieldGrowthPolicy(QFormLayout::ExpandingFieldsGrow);
     cl->setSpacing(5);
@@ -87,6 +92,10 @@ HistogramWindow::HistogramWindow(Context *context, bool rangemode) : GcChartWind
     powerHist = new PowerHist(context, rangemode);
     vlayout->addWidget(powerHist);
 
+    HelpWhatsThis *help = new HelpWhatsThis(powerHist);
+    if (rangemode) powerHist->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::ChartTrends_Distribution));
+    else powerHist->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::ChartRides_Histogram));
+
     setChartLayout(vlayout);
 
 #ifdef GC_HAVE_LUCENE
@@ -100,10 +109,14 @@ HistogramWindow::HistogramWindow(Context *context, bool rangemode) : GcChartWind
         cl->addRow(new QLabel(tr("Filter")), searchBox);
         cl->addWidget(new QLabel(""));
     }
+    HelpWhatsThis *searchHelp = new HelpWhatsThis(searchBox);
+    searchBox->setWhatsThis(searchHelp->getWhatsThisText(HelpWhatsThis::SearchFilterBox));
 #endif
 
     // date selection
     dateSetting = new DateSettingsEdit(this);
+    HelpWhatsThis *dateSettingHelp = new HelpWhatsThis(dateSetting);
+    dateSetting->setWhatsThis(dateSettingHelp->getWhatsThisText(HelpWhatsThis::ChartTrends_DateRange));
 
     if (rangemode) {
 

--- a/src/HrPwWindow.cpp
+++ b/src/HrPwWindow.cpp
@@ -23,6 +23,7 @@
 #include "HrPwPlot.h"
 #include "SmallPlot.h"
 #include "RideItem.h"
+#include "HelpWhatsThis.h"
 #include <math.h>
 #include <stdlib.h>
 #include <QVector>
@@ -86,6 +87,8 @@ HrPwWindow::HrPwWindow(Context *context) :
     // main plot
     hrPwPlot = new HrPwPlot(context, this);
 
+    HelpWhatsThis *help = new HelpWhatsThis(hrPwPlot);
+    hrPwPlot->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::ChartRides_HRvsPw));
 
     // tooltip on hover over point
     hrPwPlot->tooltip = new LTMToolTip(QwtPlot::xBottom, QwtPlot::yLeft,
@@ -122,6 +125,8 @@ HrPwWindow::HrPwWindow(Context *context) :
     // the controls
     //
     QWidget *c = new QWidget(this);
+    HelpWhatsThis *helpConfig = new HelpWhatsThis(c);
+    c->setWhatsThis(helpConfig->getWhatsThisText(HelpWhatsThis::ChartRides_HRvsPw));
     setControls(c);
     QFormLayout *cl = new QFormLayout(c);
 

--- a/src/IntervalNavigator.cpp
+++ b/src/IntervalNavigator.cpp
@@ -24,6 +24,7 @@
 #include "IntervalNavigatorProxy.h"
 #include "SearchFilterBox.h"
 #include "TabView.h"
+#include "HelpWhatsThis.h"
 
 #include <QtGui>
 #include <QString>
@@ -81,6 +82,8 @@ IntervalNavigator::IntervalNavigator(Context *context, QString type, bool mainwi
     if (!mainwindow) {
         searchFilterBox = new SearchFilterBox(this, context, false);
         mainLayout->addWidget(searchFilterBox);
+        HelpWhatsThis *searchHelp = new HelpWhatsThis(searchFilterBox);
+        searchFilterBox->setWhatsThis(searchHelp->getWhatsThisText(HelpWhatsThis::SearchFilterBox));
     }
 #endif
 

--- a/src/LTMSidebar.cpp
+++ b/src/LTMSidebar.cpp
@@ -23,6 +23,7 @@
 #include "RideCache.h"
 #include "Settings.h"
 #include "Units.h"
+#include "HelpWhatsThis.h"
 
 #include <QApplication>
 #include <QWebView>
@@ -87,7 +88,10 @@ LTMSidebar::LTMSidebar(Context *context) : QWidget(context->mainWindow), context
 #endif
     seasonsWidget->addWidget(dateRangeTree);
 
-    // events
+    HelpWhatsThis *helpDateRange = new HelpWhatsThis(dateRangeTree);
+    dateRangeTree->setWhatsThis(helpDateRange->getWhatsThisText(HelpWhatsThis::SideBarTrendsView_DateRanges));
+
+     // events
     eventsWidget = new GcSplitterItem(tr("Events"), iconFromPNG(":images/sidebar/bookmark.png"), this);
     QAction *moreEventAct = new QAction(iconFromPNG(":images/sidebar/extra.png"), tr("Menu"), this);
     eventsWidget->addAction(moreEventAct);
@@ -113,7 +117,11 @@ LTMSidebar::LTMSidebar(Context *context) : QWidget(context->mainWindow), context
     cde = QStyleFactory::create(OS_STYLE);
     eventTree->verticalScrollBar()->setStyle(cde);
 #endif
+
     eventsWidget->addWidget(eventTree);
+
+    HelpWhatsThis *helpEventsTree = new HelpWhatsThis(eventTree);
+    eventTree->setWhatsThis(helpEventsTree->getWhatsThisText(HelpWhatsThis::SideBarTrendsView_Events));
 
     // charts
     chartsWidget = new GcSplitterItem(tr("Charts"), iconFromPNG(":images/sidebar/charts.png"), this);
@@ -143,6 +151,9 @@ LTMSidebar::LTMSidebar(Context *context) : QWidget(context->mainWindow), context
     chartTree->verticalScrollBar()->setStyle(cde);
 #endif
     chartsWidget->addWidget(chartTree);
+
+    HelpWhatsThis *helpChartsTree = new HelpWhatsThis(chartTree);
+    chartTree->setWhatsThis(helpChartsTree->getWhatsThisText(HelpWhatsThis::SideBarTrendsView_Charts));
 
     // setup for first time
     presetsChanged();
@@ -180,6 +191,10 @@ LTMSidebar::LTMSidebar(Context *context) : QWidget(context->mainWindow), context
     // we cast the filter tree and this because we use the same constructor XXX fix this!!!
     filterSplitter = new GcSubSplitter(Qt::Vertical, (GcSplitterControl*)filterTree, (GcSplitter*)this, true);
     filtersWidget->addWidget(filterSplitter);
+
+    HelpWhatsThis *helpFilterTree = new HelpWhatsThis(filterTree);
+    filterTree->setWhatsThis(helpFilterTree->getWhatsThisText(HelpWhatsThis::SideBarTrendsView_Filter));
+
 #endif
 
     seasons = context->athlete->seasons;
@@ -207,6 +222,9 @@ LTMSidebar::LTMSidebar(Context *context) : QWidget(context->mainWindow), context
     summary->setAcceptDrops(false);
 
     summaryWidget->addWidget(summary);
+
+    HelpWhatsThis *helpSummary = new HelpWhatsThis(summary);
+    summary->setWhatsThis(helpSummary->getWhatsThisText(HelpWhatsThis::SideBarTrendsView_Summary));
 
     QFont defaultFont; // mainwindow sets up the defaults.. we need to apply
     summary->settings()->setFontSize(QWebSettings::DefaultFontSize, defaultFont.pointSize());
@@ -631,6 +649,9 @@ LTMSidebar::autoFilterChanged()
 #endif
             item->addWidget(tree);
             filterSplitter->addWidget(item);
+
+            HelpWhatsThis *helpFilterTree = new HelpWhatsThis(tree);
+            tree->setWhatsThis(helpFilterTree->getWhatsThisText(HelpWhatsThis::SideBarTrendsView_Filter));
 
             // Convert field names for Internal to Display (to work with the translated values)
             SpecialFields sp;

--- a/src/LTMTool.cpp
+++ b/src/LTMTool.cpp
@@ -22,8 +22,10 @@
 #include "Athlete.h"
 #include "Settings.h"
 #include "Units.h"
+#include "HelpWhatsThis.h"
 #include <QApplication>
 #include <QtGui>
+
 
 // charts.xml support
 #include "LTMChartParser.h"
@@ -54,11 +56,16 @@ LTMTool::LTMTool(Context *context, LTMSettings *settings) : QWidget(context->mai
 
     QWidget *basicsettings = new QWidget(this);
     mainLayout->addWidget(basicsettings);
+    HelpWhatsThis *basicHelp = new HelpWhatsThis(basicsettings);
+    basicsettings->setWhatsThis(basicHelp->getWhatsThisText(HelpWhatsThis::ChartTrends_MetricTrends_Config_Basic));
+
     QFormLayout *basicsettingsLayout = new QFormLayout(basicsettings);
     basicsettingsLayout->setFieldGrowthPolicy(QFormLayout::ExpandingFieldsGrow);
 
 #ifdef GC_HAVE_LUCENE
     searchBox = new SearchFilterBox(this, context);
+    HelpWhatsThis *searchHelp = new HelpWhatsThis(searchBox);
+    searchBox->setWhatsThis(searchHelp->getWhatsThisText(HelpWhatsThis::SearchFilterBox));
     connect(searchBox, SIGNAL(searchClear()), this, SLOT(clearFilter()));
     connect(searchBox, SIGNAL(searchResults(QStringList)), this, SLOT(setFilter(QStringList)));
 
@@ -69,6 +76,8 @@ LTMTool::LTMTool(Context *context, LTMSettings *settings) : QWidget(context->mai
     // Basic Controls
     QWidget *basic = new QWidget(this);
     basic->setContentsMargins(0,0,0,0);
+    HelpWhatsThis *presetHelp = new HelpWhatsThis(basic);
+    basic->setWhatsThis(presetHelp->getWhatsThisText(HelpWhatsThis::ChartTrends_MetricTrends_Config_Preset));
     QVBoxLayout *basicLayout = new QVBoxLayout(basic);
     basicLayout->setContentsMargins(0,0,0,0);
     basicLayout->setSpacing(5);
@@ -80,6 +89,8 @@ LTMTool::LTMTool(Context *context, LTMSettings *settings) : QWidget(context->mai
 #endif
 
     dateSetting = new DateSettingsEdit(this);
+    HelpWhatsThis *dateSettingHelp = new HelpWhatsThis(dateSetting);
+    dateSetting->setWhatsThis(dateSettingHelp->getWhatsThisText(HelpWhatsThis::ChartTrends_DateRange));
     basicsettingsLayout->addRow(new QLabel(tr("Date range")), dateSetting);
     basicsettingsLayout->addRow(new QLabel(tr(""))); // spacing
 
@@ -247,6 +258,8 @@ LTMTool::LTMTool(Context *context, LTMSettings *settings) : QWidget(context->mai
     // custom widget
     QWidget *custom = new QWidget(this);
     custom->setContentsMargins(20,20,20,20);
+    HelpWhatsThis *curvesHelp = new HelpWhatsThis(custom);
+    custom->setWhatsThis(curvesHelp->getWhatsThisText(HelpWhatsThis::ChartTrends_MetricTrends_Config_Curves));
     QVBoxLayout *customLayout = new QVBoxLayout(custom);
     customLayout->setContentsMargins(0,0,0,0);
     customLayout->setSpacing(5);

--- a/src/LTMWindow.cpp
+++ b/src/LTMWindow.cpp
@@ -30,6 +30,7 @@
 #include "Settings.h"
 #include "math.h"
 #include "Units.h" // for MILES_PER_KM
+#include "HelpWhatsThis.h"
 
 #include <QtGui>
 #include <QString>
@@ -116,6 +117,9 @@ LTMWindow::LTMWindow(Context *context) :
     mainLayout->addWidget(stackWidget);
     setChartLayout(mainLayout);
 
+    HelpWhatsThis *helpStack = new HelpWhatsThis(stackWidget);
+    stackWidget->setWhatsThis(helpStack->getWhatsThisText(HelpWhatsThis::ChartTrends_MetricTrends));
+
     // reveal controls
     QHBoxLayout *revealLayout = new QHBoxLayout;
     revealLayout->setContentsMargins(0,0,0,0);
@@ -153,6 +157,8 @@ LTMWindow::LTMWindow(Context *context) :
     // the controls
     QWidget *c = new QWidget;
     c->setContentsMargins(0,0,0,0);
+    HelpWhatsThis *helpConfig = new HelpWhatsThis(c);
+    c->setWhatsThis(helpConfig->getWhatsThisText(HelpWhatsThis::ChartTrends_MetricTrends));
     QVBoxLayout *cl = new QVBoxLayout(c);
     cl->setContentsMargins(0,0,0,0);
     cl->setSpacing(0);

--- a/src/Library.cpp
+++ b/src/Library.cpp
@@ -22,6 +22,7 @@
 #include "Settings.h"
 #include "LibraryParser.h"
 #include "TrainDB.h"
+#include "HelpWhatsThis.h"
 #include <QVBoxLayout>
 #include <QHeaderView>
 #include <QLabel>
@@ -210,6 +211,8 @@ LibrarySearchDialog::LibrarySearchDialog(Context *context) : context(context)
 {
     setAttribute(Qt::WA_DeleteOnClose);
     setWindowTitle(tr("Search for Workouts and Media"));
+    HelpWhatsThis *help = new HelpWhatsThis(this);
+    this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Tools_ScanDisk_WorkoutVideo));
     setMinimumWidth(600);
 
     searcher = NULL;

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -44,6 +44,7 @@
 #include "LibraryParser.h"
 #include "TrainDB.h"
 #include "GcUpgrade.h"
+#include "HelpWhatsThis.h"
 
 // DIALOGS / DOWNLOADS / UPLOADS
 #include "AboutDialog.h"
@@ -195,6 +196,17 @@ MainWindow::MainWindow(const QDir &home)
     connect(scopebar, SIGNAL(selectTrain()), this, SLOT(selectTrain()));
     connect(scopebar, SIGNAL(selectInterval()), this, SLOT(selectInterval()));
 
+    /*----------------------------------------------------------------------
+     * What's this Context Help
+     *--------------------------------------------------------------------*/
+
+    // Help for the whole window
+    HelpWhatsThis *help = new HelpWhatsThis(this);
+    this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::Default));
+    // add Help Button
+    QAction *myHelper = QWhatsThis::createAction (this);
+    this->addAction(myHelper);
+
 #if 0
     // Add chart is on the scope bar
     chartMenu = new QMenu(this);
@@ -251,13 +263,18 @@ MainWindow::MainWindow(const QDir &home)
     QPixmap *importImg = new QPixmap(":images/mac/download.png");
     import->setImage(importImg);
     import->setToolTip("Download");
+    HelpWhatsThis *helpImport = new HelpWhatsThis(import);
+    import->setWhatsThis(helpImport->getWhatsThisText(HelpWhatsThis::ToolBar_Download));
     lb->addWidget(import);
     lb->addWidget(new Spacer(this));
+
     compose = new QtMacButton(this, QtMacButton::TexturedRounded);
     QPixmap *composeImg = new QPixmap(":images/mac/compose.png");
     compose->setImage(composeImg);
     compose->setToolTip("Create");
     lb->addWidget(compose);
+    HelpWhatsThis *helpCompose = new HelpWhatsThis(compose);
+    compose->setWhatsThis(helpCompose->getWhatsThisText(HelpWhatsThis::ToolBar_Manual));
 
     // connect to actions
     connect(import, SIGNAL(clicked(bool)), this, SLOT(downloadRide()));
@@ -279,6 +296,8 @@ MainWindow::MainWindow(const QDir &home)
     sidebar->setMaximumSize(25, 25);
     sidebar->setToolTip("Sidebar");
     sidebar->setSelected(true); // assume always start up with sidebar selected
+    HelpWhatsThis *helpSideBar = new HelpWhatsThis(sidebar);
+    sidebar->setWhatsThis(helpSideBar->getWhatsThisText(HelpWhatsThis::ToolBar_ToggleSidebar));
 
     lowbar = new QtMacButton(this, QtMacButton::TexturedRounded);
     QPixmap *lowbarImg = new QPixmap(":images/mac/lowbar.png");
@@ -287,6 +306,8 @@ MainWindow::MainWindow(const QDir &home)
     lowbar->setMaximumSize(25, 25);
     lowbar->setToolTip("Compare");
     lowbar->setSelected(false); // assume always start up with lowbar deselected
+    HelpWhatsThis *helpLowBar = new HelpWhatsThis(lowbar);
+    lowbar->setWhatsThis(helpLowBar->getWhatsThisText(HelpWhatsThis::ToolBar_ToggleComparePane));
 
     actbuttons = new QtMacSegmentedButton(3, acts);
     actbuttons->setWidth(115);
@@ -382,6 +403,8 @@ MainWindow::MainWindow(const QDir &home)
     import->setStyle(toolStyle);
     import->setToolTip(tr("Download from Device"));
     import->setPalette(metal);
+    HelpWhatsThis *helpImport = new HelpWhatsThis(import);
+    import->setWhatsThis(helpImport->getWhatsThisText(HelpWhatsThis::ToolBar_Download));
     connect(import, SIGNAL(clicked(bool)), this, SLOT(downloadRide()));
 
     compose = new QPushButton(this);
@@ -392,6 +415,8 @@ MainWindow::MainWindow(const QDir &home)
     compose->setToolTip(tr("Create Manual Ride"));
     compose->setPalette(metal);
     connect(compose, SIGNAL(clicked(bool)), this, SLOT(manualRide()));
+    HelpWhatsThis *helpCompose = new HelpWhatsThis(compose);
+    compose->setWhatsThis(helpCompose->getWhatsThisText(HelpWhatsThis::ToolBar_Manual));
 
     lowbar = new QPushButton(this);
     lowbar->setIcon(lowbarIcon);
@@ -401,6 +426,8 @@ MainWindow::MainWindow(const QDir &home)
     lowbar->setToolTip(tr("Toggle Compare Pane"));
     lowbar->setPalette(metal);
     connect(lowbar, SIGNAL(clicked(bool)), this, SLOT(toggleLowbar()));
+    HelpWhatsThis *helpLowBar = new HelpWhatsThis(lowbar);
+    lowbar->setWhatsThis(helpLowBar->getWhatsThisText(HelpWhatsThis::ToolBar_ToggleComparePane));
 
     sidebar = new QPushButton(this);
     sidebar->setIcon(sidebarIcon);
@@ -410,6 +437,8 @@ MainWindow::MainWindow(const QDir &home)
     sidebar->setToolTip(tr("Toggle Sidebar"));
     sidebar->setPalette(metal);
     connect(sidebar, SIGNAL(clicked(bool)), this, SLOT(toggleSidebar()));
+    HelpWhatsThis *helpSideBar = new HelpWhatsThis(sidebar);
+    sidebar->setWhatsThis(helpSideBar->getWhatsThisText(HelpWhatsThis::ToolBar_ToggleSidebar));
 
     actbuttons = new QtSegmentControl(this);
     actbuttons->setStyle(toolStyle);
@@ -459,6 +488,8 @@ MainWindow::MainWindow(const QDir &home)
     head->addWidget(searchBox);
     connect(searchBox, SIGNAL(searchResults(QStringList)), this, SLOT(setFilter(QStringList)));
     connect(searchBox, SIGNAL(searchClear()), this, SLOT(clearFilter()));
+    HelpWhatsThis *helpSearchBox = new HelpWhatsThis(searchBox);
+    searchBox->setWhatsThis(helpSearchBox->getWhatsThisText(HelpWhatsThis::SearchFilterBox));
 #endif
     Spacer *spacer = new Spacer(this);
     spacer->setFixedWidth(5);
@@ -548,6 +579,9 @@ MainWindow::MainWindow(const QDir &home)
     fileMenu->addAction(tr("&Close Tab"), this, SLOT(closeTab()));
     fileMenu->addAction(tr("&Quit All Windows"), this, SLOT(closeAll()), tr("Ctrl+Q"));
 
+    HelpWhatsThis *fileMenuHelp = new HelpWhatsThis(fileMenu);
+    fileMenu->setWhatsThis(fileMenuHelp->getWhatsThisText(HelpWhatsThis::MenuBar_Athlete));
+
     // ACTIVITY MENU
     QMenu *rideMenu = menuBar()->addMenu(tr("A&ctivity"));
     rideMenu->addAction(tr("&Download from device..."), this, SLOT(downloadRide()), tr("Ctrl+D"));
@@ -579,6 +613,9 @@ MainWindow::MainWindow(const QDir &home)
     rideMenu->addAction(tr("Combine rides..."), this, SLOT(mergeRide()));
     rideMenu->addSeparator ();
 
+    HelpWhatsThis *helpRideMenu = new HelpWhatsThis(rideMenu);
+    rideMenu->setWhatsThis(helpRideMenu->getWhatsThisText(HelpWhatsThis::MenuBar_Activity));
+
     // TOOLS MENU
     QMenu *optionsMenu = menuBar()->addMenu(tr("&Tools"));
     optionsMenu->addAction(tr("&Options..."), this, SLOT(showOptions()));
@@ -606,6 +643,10 @@ MainWindow::MainWindow(const QDir &home)
     optionsMenu->addSeparator();
     optionsMenu->addAction(tr("Find intervals..."), this, SLOT(addIntervals()), tr (""));
 
+    HelpWhatsThis *optionsMenuHelp = new HelpWhatsThis(optionsMenu);
+    optionsMenu->setWhatsThis(optionsMenuHelp->getWhatsThisText(HelpWhatsThis::MenuBar_Tools));
+
+
     QMenu *editMenu = menuBar()->addMenu(tr("&Edit"));
     // Add all the data processors to the tools menu
     const DataProcessorFactory &factory = DataProcessorFactory::instance();
@@ -627,6 +668,9 @@ MainWindow::MainWindow(const QDir &home)
             toolMapper->setMapping(action, i.key());
         }
     }
+
+    HelpWhatsThis *editMenuHelp = new HelpWhatsThis(editMenu);
+    editMenu->setWhatsThis(editMenuHelp->getWhatsThisText(HelpWhatsThis::MenuBar_Edit));
 
     // VIEW MENU
     QMenu *viewMenu = menuBar()->addMenu(tr("&View"));
@@ -670,6 +714,9 @@ MainWindow::MainWindow(const QDir &home)
     connect(subChartMenu, SIGNAL(aboutToShow()), this, SLOT(setSubChartMenu()));
     connect(subChartMenu, SIGNAL(triggered(QAction*)), this, SLOT(addChart(QAction*)));
 
+    HelpWhatsThis *viewMenuHelp = new HelpWhatsThis(viewMenu);
+    viewMenu->setWhatsThis(viewMenuHelp->getWhatsThisText(HelpWhatsThis::MenuBar_View));
+
     // HELP MENU
     QMenu *helpMenu = menuBar()->addMenu(tr("&Help"));
     helpMenu->addAction(tr("&User Guide"), this, SLOT(helpView()));
@@ -677,6 +724,9 @@ MainWindow::MainWindow(const QDir &home)
     helpMenu->addAction(tr("&Discussion and Support Forum"), this, SLOT(support()));
     helpMenu->addSeparator();
     helpMenu->addAction(tr("&About GoldenCheetah"), this, SLOT(aboutDialog()));
+
+    HelpWhatsThis *helpMenuHelp = new HelpWhatsThis(helpMenu);
+    helpMenu->setWhatsThis(helpMenuHelp->getWhatsThisText(HelpWhatsThis::MenuBar_Help));
 
     /*----------------------------------------------------------------------
      * Lets go, choose latest ride and get GUI up and running
@@ -1042,7 +1092,7 @@ MainWindow::logBug()
 void
 MainWindow::helpView()
 {
-    QDesktopServices::openUrl(QUrl("http://www.goldencheetah.org/wiki.html"));
+    QDesktopServices::openUrl(QUrl("https://github.com/GoldenCheetah/GoldenCheetah/wiki"));
 }
 
 void

--- a/src/ManualRideDialog.cpp
+++ b/src/ManualRideDialog.cpp
@@ -25,6 +25,7 @@
 #include <QtGui>
 #include <math.h>
 #include "Units.h"
+#include "HelpWhatsThis.h"
 
 #include "MetricAggregator.h"
 
@@ -118,6 +119,8 @@ ManualRideDialog::ManualRideDialog(Context *context) : context(context)
 {
     setAttribute(Qt::WA_DeleteOnClose);
     setWindowTitle(tr("Manual Ride Entry"));
+    HelpWhatsThis *help = new HelpWhatsThis(this);
+    this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Activity_Manual));
 #ifdef Q_OS_MAC
     setFixedSize(610,415);
 #else

--- a/src/MergeActivityWizard.cpp
+++ b/src/MergeActivityWizard.cpp
@@ -21,6 +21,7 @@
 #include "Context.h"
 #include "RideCache.h"
 #include "MainWindow.h"
+#include "HelpWhatsThis.h"
 
 // minimum R-squared fit when trying to find offsets to
 // merge ride files. Lower numbers mean happier to take
@@ -59,6 +60,9 @@ MergeActivityWizard::MergeActivityWizard(Context *context) : QWizard(context->ma
     setWizardStyle(QWizard::ModernStyle);
 #endif
     setWindowTitle(tr("Combine Activities"));
+
+    HelpWhatsThis *help = new HelpWhatsThis(this);
+    this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Activity_CombineRides));
 
     setFixedHeight(530);
     setFixedWidth(550);

--- a/src/MetadataWindow.cpp
+++ b/src/MetadataWindow.cpp
@@ -18,6 +18,7 @@
 
 #include "MetadataWindow.h"
 #include "Colors.h"
+#include "HelpWhatsThis.h"
 
 MetadataWindow::MetadataWindow(Context *context) :
     GcChartWindow(context), context(context)
@@ -35,6 +36,10 @@ MetadataWindow::MetadataWindow(Context *context) :
     rideMetadata->setContentsMargins(20,0,20,20);
     vlayout->addWidget(rideMetadata);
     setChartLayout(vlayout);
+
+    HelpWhatsThis *help = new HelpWhatsThis(rideMetadata);
+    rideMetadata->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::ChartRides_Details));
+
 
     connect(this, SIGNAL(rideItemChanged(RideItem*)), this, SLOT(rideItemChanged()));
     connect(context, SIGNAL(configChanged()), this, SLOT(configChanged()));

--- a/src/ModelWindow.cpp
+++ b/src/ModelWindow.cpp
@@ -25,6 +25,7 @@
 #include "math.h"
 #include "Units.h" // for MILES_PER_KM
 #include "Colors.h" // for MILES_PER_KM
+#include "HelpWhatsThis.h"
 
 #include <QtGui>
 #include <QString>
@@ -58,6 +59,8 @@ ModelWindow::ModelWindow(Context *context) :
     GcChartWindow(context), context(context), ride(NULL), current(NULL)
 {
     QWidget *c = new QWidget(this);
+    HelpWhatsThis *helpConfig = new HelpWhatsThis(c);
+    c->setWhatsThis(helpConfig->getWhatsThisText(HelpWhatsThis::ChartRides_3D));
     QFormLayout *cl = new QFormLayout(c);
     setControls(c);
 
@@ -72,6 +75,9 @@ ModelWindow::ModelWindow(Context *context) :
     mainLayout->addWidget(zpane);
     mainLayout->addWidget(modelPlot);
     setChartLayout(mainLayout);
+
+    HelpWhatsThis *help = new HelpWhatsThis(modelPlot);
+    modelPlot->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::ChartRides_3D));
 
     // preset Values
     presetLabel = new QLabel(tr("Analyse"), this);

--- a/src/PfPvWindow.cpp
+++ b/src/PfPvWindow.cpp
@@ -24,6 +24,7 @@
 #include "RideFile.h"
 #include "Settings.h"
 #include "Colors.h"
+#include "HelpWhatsThis.h"
 #include <QtGui>
 
 #define PI M_PI
@@ -75,6 +76,8 @@ PfPvWindow::PfPvWindow(Context *context) :
     GcChartWindow(context), context(context), current(NULL), compareStale(true)
 {
     QWidget *c = new QWidget;
+    HelpWhatsThis *helpConfig = new HelpWhatsThis(c);
+    c->setWhatsThis(helpConfig->getWhatsThisText(HelpWhatsThis::ChartRides_PFvV));
     QVBoxLayout *cl = new QVBoxLayout(c);
     setControls(c);
 
@@ -116,6 +119,8 @@ PfPvWindow::PfPvWindow(Context *context) :
     QVBoxLayout *vlayout = new QVBoxLayout;
     pfPvPlot = new PfPvPlot(context);
     vlayout->addWidget(pfPvPlot);
+    HelpWhatsThis *help = new HelpWhatsThis(pfPvPlot);
+    pfPvPlot->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::ChartRides_PFvV));
 
     setChartLayout(vlayout);
     setAutoFillBackground(true);

--- a/src/RideEditor.cpp
+++ b/src/RideEditor.cpp
@@ -25,6 +25,7 @@
 #include "Settings.h"
 #include "Colors.h"
 #include "TabView.h"
+#include "HelpWhatsThis.h"
 
 #include <QtGui>
 #include <QString>
@@ -92,6 +93,8 @@ RideEditor::RideEditor(Context *context) : GcChartWindow(context), data(NULL), r
     toolbar->addAction(saveAct);
 
     toolbar->addSeparator();
+    HelpWhatsThis *helpToolbar = new HelpWhatsThis(toolbar);
+    toolbar->setWhatsThis(helpToolbar->getWhatsThisText(HelpWhatsThis::ChartRides_Editor));
 
     // undo and redo deliberately at a distance from the
     // save icon, since accidentally hitting the wrong
@@ -134,6 +137,9 @@ RideEditor::RideEditor(Context *context) : GcChartWindow(context), data(NULL), r
     table->setContextMenuPolicy(Qt::CustomContextMenu);
     table->setSelectionMode(QAbstractItemView::ContiguousSelection);
     table->installEventFilter(this);
+
+    HelpWhatsThis *helpTable = new HelpWhatsThis(table);
+    table->setWhatsThis(helpTable->getWhatsThisText(HelpWhatsThis::ChartRides_Editor));
 
     // prettify (and make anomalies more visible)
     table->setGridStyle(Qt::NoPen);

--- a/src/RideImportWizard.cpp
+++ b/src/RideImportWizard.cpp
@@ -32,6 +32,7 @@
 #include "TcxRideFile.h"
 #include "MetricAggregator.h"
 #include "RideAutoImportConfig.h"
+#include "HelpWhatsThis.h"
 
 
 // drag and drop passes urls ... convert to a list of files and call main constructor
@@ -161,6 +162,10 @@ RideImportWizard::RideImportWizard(RideAutoImportConfig *dirs, Context *context,
 void
 RideImportWizard::init(QList<QString> files, Context * /*mainWindow*/)
 {
+
+    // setup Help
+    HelpWhatsThis *help = new HelpWhatsThis(this);
+    this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Activity_Import));
 
     // initialise dialog box
     tableWidget = new QTableWidget(files.count(), 6, this);

--- a/src/RideNavigator.cpp
+++ b/src/RideNavigator.cpp
@@ -25,6 +25,7 @@
 #include "RideNavigatorProxy.h"
 #include "SearchFilterBox.h"
 #include "TabView.h"
+#include "HelpWhatsThis.h"
 
 #include <QtGui>
 #include <QString>
@@ -73,6 +74,8 @@ RideNavigator::RideNavigator(Context *context, bool mainwindow) : context(contex
     if (!mainwindow) {
         searchFilterBox = new SearchFilterBox(this, context, false);
         mainLayout->addWidget(searchFilterBox);
+        HelpWhatsThis *searchHelp = new HelpWhatsThis(searchFilterBox);
+        searchFilterBox->setWhatsThis(searchHelp->getWhatsThisText(HelpWhatsThis::SearchFilterBox));
     }
 #endif
 
@@ -106,6 +109,12 @@ RideNavigator::RideNavigator(Context *context, bool mainwindow) : context(contex
     tableView->setFrameStyle(QFrame::NoFrame);
     tableView->setAcceptDrops(true);
     tableView->setColumnWidth(1, 100);
+
+    HelpWhatsThis *helpTableView = new HelpWhatsThis(tableView);
+    if (mainwindow)
+        tableView->setWhatsThis(helpTableView->getWhatsThisText(HelpWhatsThis::SideBarRidesView_Rides));
+    else
+        tableView->setWhatsThis(helpTableView->getWhatsThisText(HelpWhatsThis::ChartDiary_Navigator));
 
     // good to go
     tableView->show();

--- a/src/RideSummaryWindow.cpp
+++ b/src/RideSummaryWindow.cpp
@@ -31,6 +31,7 @@
 #include "PDModel.h"
 #include "MetricAggregator.h"
 #include "DBAccess.h"
+#include "HelpWhatsThis.h"
 #include <QtGui>
 #include <QtXml/QtXml>
 #include <math.h>
@@ -51,6 +52,8 @@ RideSummaryWindow::RideSummaryWindow(Context *context, bool ridesummary) :
 
         QWidget *c = new QWidget;
         c->setContentsMargins(0,0,0,0);
+        HelpWhatsThis *helpConfig = new HelpWhatsThis(c);
+        c->setWhatsThis(helpConfig->getWhatsThisText(HelpWhatsThis::Chart_Summary_Config));
         QFormLayout *cl = new QFormLayout(c);
         cl->setContentsMargins(0,0,0,0);
         cl->setSpacing(0);
@@ -59,6 +62,8 @@ RideSummaryWindow::RideSummaryWindow(Context *context, bool ridesummary) :
 #ifdef GC_HAVE_LUCENE
         // filter / searchbox
         searchBox = new SearchFilterBox(this, context);
+        HelpWhatsThis *searchHelp = new HelpWhatsThis(searchBox);
+        searchBox->setWhatsThis(searchHelp->getWhatsThisText(HelpWhatsThis::SearchFilterBox));
         connect(searchBox, SIGNAL(searchClear()), this, SLOT(clearFilter()));
         connect(searchBox, SIGNAL(searchResults(QStringList)), this, SLOT(setFilter(QStringList)));
         cl->addRow(new QLabel(tr("Filter")), searchBox);
@@ -79,6 +84,10 @@ RideSummaryWindow::RideSummaryWindow(Context *context, bool ridesummary) :
     rideSummary->page()->view()->setContentsMargins(0,0,0,0);
     rideSummary->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     rideSummary->setAcceptDrops(false);
+
+    HelpWhatsThis *help = new HelpWhatsThis(rideSummary);
+    if (ridesummary) rideSummary->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::ChartRides_Summary));
+    else rideSummary->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::Chart_Summary));
 
     vlayout->addWidget(rideSummary);
 

--- a/src/ScatterWindow.cpp
+++ b/src/ScatterWindow.cpp
@@ -22,6 +22,7 @@
 #include "Athlete.h"
 #include "Context.h"
 #include "Colors.h"
+#include "HelpWhatsThis.h"
 
 #include <QtGui>
 #include <QString>
@@ -122,6 +123,8 @@ ScatterWindow::ScatterWindow(Context *context) :
     setRevealLayout(r);
 
     QWidget *c = new QWidget;
+    HelpWhatsThis *helpConfig = new HelpWhatsThis(c);
+    c->setWhatsThis(helpConfig->getWhatsThisText(HelpWhatsThis::ChartRides_2D));
     QFormLayout *cl = new QFormLayout(c);
     setControls(c);
 
@@ -129,6 +132,8 @@ ScatterWindow::ScatterWindow(Context *context) :
     scatterPlot= new ScatterPlot(context);
     QVBoxLayout *vlayout = new QVBoxLayout;
     vlayout->addWidget(scatterPlot);
+    HelpWhatsThis *help = new HelpWhatsThis(scatterPlot);
+    scatterPlot->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::ChartRides_2D));
 
     setChartLayout(vlayout);
 

--- a/src/ShareDialog.cpp
+++ b/src/ShareDialog.cpp
@@ -26,6 +26,7 @@
 #include "Units.h"
 #include "VeloHeroUploader.h"
 #include "TrainingstagebuchUploader.h"
+#include "HelpWhatsThis.h"
 
 // access to metrics
 #include "MetricAggregator.h"
@@ -89,6 +90,8 @@ ShareDialog::ShareDialog(Context *context, RideItem *item) :
     context(context)
 {
     setWindowTitle(tr("Share your ride"));
+    HelpWhatsThis *help = new HelpWhatsThis(this);
+    this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Activity_Share));
 
     // make the dialog a resonable size
     setMinimumWidth(550);

--- a/src/SplitActivityWizard.cpp
+++ b/src/SplitActivityWizard.cpp
@@ -20,6 +20,7 @@
 #include "MainWindow.h"
 #include "Athlete.h"
 #include "Context.h"
+#include "HelpWhatsThis.h"
 
 // Minimum gap in recording to find a natural break to split
 static const double defaultMinimumGap = 1; // 1 minute
@@ -43,6 +44,10 @@ SplitActivityWizard::SplitActivityWizard(Context *context) : QWizard(context->ma
 
     // title
     setWindowTitle(tr("Split Ride"));
+
+    // help
+    HelpWhatsThis *help = new HelpWhatsThis(this);
+    this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Activity_SplitRide));
 
     // set ride - unconst since we will wipe it away eventually
     rideItem = const_cast<RideItem*>(context->currentRideItem());

--- a/src/ToolsDialog.cpp
+++ b/src/ToolsDialog.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "ToolsDialog.h"
+#include "HelpWhatsThis.h"
 #include <QtGui>
 
 typedef QDoubleSpinBox* QDoubleSpinBoxPtr;
@@ -60,6 +61,10 @@ QHBoxLayout *setupMinsSecs(ToolsDialog *dialog,
 ToolsDialog::ToolsDialog(QWidget *parent) : QDialog(parent)
 {
     setWindowTitle(tr("Critical Power Estimator"));
+
+    HelpWhatsThis *help = new HelpWhatsThis(this);
+    this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Tools_CP_EST));
+
     setAttribute(Qt::WA_DeleteOnClose);
 
     setFixedSize(300, 240);

--- a/src/ToolsRhoEstimator.cpp
+++ b/src/ToolsRhoEstimator.cpp
@@ -23,6 +23,7 @@
 #include "Context.h"
 #include "Athlete.h"
 #include "Units.h"
+#include "HelpWhatsThis.h"
 #include <QtGui>
 #include <sstream>
 #include <cmath>
@@ -33,6 +34,8 @@ ToolsRhoEstimator::ToolsRhoEstimator(Context *context, QWidget *parent) : QDialo
 
   // Set the main window title.
   setWindowTitle(tr("Air Density (Rho) Estimator"));
+  HelpWhatsThis *help = new HelpWhatsThis(this);
+  this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Tools_AirDens_EST));
   setAttribute(Qt::WA_DeleteOnClose);
 
   // Create the main layout box.

--- a/src/TreeMapWindow.cpp
+++ b/src/TreeMapWindow.cpp
@@ -27,6 +27,7 @@
 #include "Settings.h"
 #include "math.h"
 #include "Units.h" // for MILES_PER_KM
+#include "HelpWhatsThis.h"
 
 #include <QtGui>
 #include <QString>
@@ -47,8 +48,13 @@ TreeMapWindow::TreeMapWindow(Context *context) :
     mainLayout->setContentsMargins(0,0,0,0);
     setLayout(mainLayout);
 
+    HelpWhatsThis *helpLTMPlot = new HelpWhatsThis(ltmPlot);
+    ltmPlot->setWhatsThis(helpLTMPlot->getWhatsThisText(HelpWhatsThis::ChartTrends_CollectionTreeMap));
+
     // the controls
     QWidget *c = new QWidget;
+    HelpWhatsThis *helpConfig = new HelpWhatsThis(c);
+    c->setWhatsThis(helpConfig->getWhatsThisText(HelpWhatsThis::ChartTrends_CollectionTreeMap));
     QFormLayout *cl = new QFormLayout(c);
     setControls(c);
 

--- a/src/WorkoutWizard.cpp
+++ b/src/WorkoutWizard.cpp
@@ -20,6 +20,7 @@
 #include "MainWindow.h"
 #include "Context.h"
 #include "Athlete.h"
+#include "HelpWhatsThis.h"
 
 #include "qwt_plot.h"
 #include "qwt_plot_curve.h"
@@ -748,6 +749,9 @@ void ImportPage::SaveWorkout()
 
 WorkoutWizard::WorkoutWizard(Context *context) :QWizard(context->mainWindow)
 {
+    HelpWhatsThis *help = new HelpWhatsThis(this);
+    this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Tools_CreateWorkout));
+
     hackContext = context;
     setPage(WW_WorkoutTypePage, new WorkoutTypePage());
     setPage(WW_AbsWattagePage, new AbsWattagePage());

--- a/src/src.pro
+++ b/src/src.pro
@@ -332,6 +332,7 @@ HEADERS += \
         GpxParser.h \
         GpxRideFile.h \
         HelpWindow.h \
+        HelpWhatsThis.h \
         HistogramWindow.h \
         HomeWindow.h \
         HrZones.h \
@@ -555,6 +556,7 @@ SOURCES += \
         GpxParser.cpp \
         GpxRideFile.cpp \
         HelpWindow.cpp \
+        HelpWhatsThis.cpp \
         HistogramWindow.cpp \
         HomeWindow.cpp \
         HrTimeInZone.cpp \


### PR DESCRIPTION
... adds "What's this" to (hopefully) most of the widgets (please report on missing ones)
... defines draft "Whats' this" texts including a context specific WikiLink

.. How-to-use: Help Key for all platforms is <Shift>+<F1> + in some widgets "RightMouse - Click" as well

... Tested on Win and Mac (On Mac QtMacButton seems not supporting "What's this") - so here <Shift>+<F1> has no result.

... ToDo: Create final texts and links based on the to be updated 3.11 Wiki
