### PR TITLE
Allow "Out-Of-Source" Build (Original patch by yarrouye)

### DIFF
--- a/qwt/src/src.pro
+++ b/qwt/src/src.pro
@@ -17,7 +17,7 @@ include( $${QWT_ROOT}/qwtfunctions.pri )
 TEMPLATE          = lib
 TARGET            = $$qwtLibraryTarget(qwt)
 
-DESTDIR           = $${QWT_ROOT}/lib
+DESTDIR           = $${OUT_PWD}/../lib
 
 contains(QWT_CONFIG, QwtDll) {
 


### PR DESCRIPTION
... separated the "out-of-source" patch from Yves from original pull request

... the patch allows to use e.g. QTCreators "Shadow-Build" feature so that GC is build not in source, but in a different directory
.. this is useful when using QTCreator and switch between different QT versions / 32/64 bit builds - since every build resides in a separate directory from GC source

-- since the original commit (at least from GitHub view) is shown in a mixed pull request with other commits - this is a separated version of the single commit
