### PR TITLE
Fixed NaN in xPower when there are no samples

### DIFF
--- a/src/BikeScore.cpp
+++ b/src/BikeScore.cpp
@@ -85,7 +85,7 @@ class XPower : public RideMetric {
             total += pow(weighted, 4.0);
             count++;
         }
-        xpower = pow(total / count, 0.25);
+        xpower = count ? pow(total / count, 0.25) : 0.0;
         secs = count * secsDelta;
 
         setValue(xpower);

--- a/src/SwimScore.cpp
+++ b/src/SwimScore.cpp
@@ -107,7 +107,7 @@ class XPowerSwim : public RideMetric {
             total += pow(weighted, 3.0);
             count++;
         }
-        xpower = pow(total / count, 1/3.0);
+        xpower = count ? pow(total / count, 1/3.0) : 0.0;
         secs = count * secsDelta;
 
         setValue(xpower);


### PR DESCRIPTION
It propagates to Bike/SwimScore and plays havoc with PMC