### PR TITLE
Introducing /quarantine for acvitities cause RideCache to crash/dump

### DIFF
--- a/src/Athlete.cpp
+++ b/src/Athlete.cpp
@@ -73,6 +73,12 @@ Athlete::Athlete(Context *context, const QDir &homeDir)
     }
     appsettings->setCValue(cyclist, GC_SAFEEXIT, false); // will be set to true on exit
 
+    // make sure that the latest folder structure exists in Athlete Directory -
+    // e.g. Cache could be deleted by mistake or empty folders are not copied
+    // later GC expects the folders are available
+
+    if (!this->home->subDirsExist()) this->home->createAllSubdirs();
+
     // Before we initialise we need to run the upgrade wizard for this athlete
     GcUpgrade v3;
     int returnCode = v3.upgrade(home->root());
@@ -310,9 +316,9 @@ Athlete::updateRideFileIntervals()
 }
 
 void
-Athlete::addRide(QString name, bool dosignal)
+Athlete::addRide(QString name, bool dosignal, bool useTempActivities)
 {
-    rideCache->addRide(name, dosignal);
+    rideCache->addRide(name, dosignal, useTempActivities);
 }
 
 void
@@ -423,6 +429,7 @@ AthleteDirectoryStructure::AthleteDirectoryStructure(const QDir home){
     myhome = home;
 
     athlete_activities = "activities";
+    athlete_tmp_activities = "tempActivities";
     athlete_imports = "imports";
     athlete_records = "records";
     athlete_downloads = "downloads";
@@ -433,6 +440,7 @@ AthleteDirectoryStructure::AthleteDirectoryStructure(const QDir home){
     athlete_workouts = "workouts";
     athlete_temp = "temp";
     athlete_logs = "logs";
+    athlete_quarantine = "quarantine";
 
 
 }
@@ -447,6 +455,7 @@ void
 AthleteDirectoryStructure::createAllSubdirs() {
 
     myhome.mkdir(athlete_activities);
+    myhome.mkdir(athlete_tmp_activities);
     myhome.mkdir(athlete_imports);
     myhome.mkdir(athlete_records);
     myhome.mkdir(athlete_downloads);
@@ -457,6 +466,8 @@ AthleteDirectoryStructure::createAllSubdirs() {
     myhome.mkdir(athlete_workouts);
     myhome.mkdir(athlete_logs);
     myhome.mkdir(athlete_temp);
+    myhome.mkdir(athlete_quarantine);
+
 
 
 }
@@ -465,6 +476,7 @@ bool
 AthleteDirectoryStructure::subDirsExist() {
 
     return (activities().exists() &&
+            tmpActivities().exists() &&
             imports().exists() &&
             records().exists() &&
             downloads().exists() &&
@@ -474,7 +486,8 @@ AthleteDirectoryStructure::subDirsExist() {
             calendar().exists() &&
             workouts().exists() &&
             logs().exists() &&
-            temp().exists()
+            temp().exists() &&
+            quarantine().exists()
             );
 }
 

--- a/src/Athlete.h
+++ b/src/Athlete.h
@@ -140,7 +140,7 @@ class Athlete : public QObject
 
         // ride collection
         void selectRideFile(QString);
-        void addRide(QString name, bool bSelect=true);
+        void addRide(QString name, bool bSelect=true, bool useTempActivities=false);
         void removeCurrentRide();
 
         // interval selection
@@ -182,6 +182,7 @@ class AthleteDirectoryStructure : public QObject {
             ~AthleteDirectoryStructure();
 
             QDir activities() { return QDir(myhome.absolutePath()+"/"+athlete_activities); }
+            QDir tmpActivities() { return QDir(myhome.absolutePath()+"/"+athlete_tmp_activities); }
             QDir imports(){ return QDir(myhome.absolutePath()+"/"+athlete_imports);}
             QDir records(){ return QDir(myhome.absolutePath()+"/"+athlete_records);}
             QDir downloads() { return QDir(myhome.absolutePath()+"/"+athlete_downloads);}
@@ -192,17 +193,8 @@ class AthleteDirectoryStructure : public QObject {
             QDir workouts() { return QDir(myhome.absolutePath()+"/"+athlete_workouts);}
             QDir logs() { return QDir(myhome.absolutePath()+"/"+athlete_logs);}
             QDir temp() { return QDir(myhome.absolutePath()+"/"+athlete_temp);}
+            QDir quarantine() { return QDir(myhome.absolutePath()+"/"+athlete_quarantine);}
             QDir root() { return myhome; }
-
-            QString getActivitiesSubDir() {return athlete_activities; }
-            QString getImportsSubDir() {return athlete_imports; }
-            QString getDownloadsSubDir() {return athlete_downloads; }
-            QString getFileBackupSubDir() {return athlete_fileBackup;}
-            QString getConfigSubDir() {return athlete_config; }
-            QString getCacheSubDir() {return athlete_cache; }
-            QString getWorkoutsSubDir() {return athlete_workouts; }
-            QString getLogsSubDir() {return athlete_logs; }
-            QString getTempSubDir() {return athlete_temp; }
 
             // supporting functions to work with the subDirs
             void createAllSubdirs();
@@ -214,6 +206,7 @@ class AthleteDirectoryStructure : public QObject {
             QDir myhome;
 
             QString athlete_activities;
+            QString athlete_tmp_activities;
             QString athlete_imports;
             QString athlete_records;
             QString athlete_downloads;
@@ -224,6 +217,7 @@ class AthleteDirectoryStructure : public QObject {
             QString athlete_workouts;
             QString athlete_logs;
             QString athlete_temp;
+            QString athlete_quarantine;
 
 
 };

--- a/src/GcCrashDialog.h
+++ b/src/GcCrashDialog.h
@@ -41,6 +41,8 @@ class GcCrashDialog : public QDialog
 
     private:
         QWebView *report;
+        bool newFilesInQuarantine;
+        QStringList files;
 };
 
 #endif

--- a/src/GcUpgrade.cpp
+++ b/src/GcUpgrade.cpp
@@ -337,6 +337,7 @@ GcUpgrade::upgrade(const QDir &home)
     // 3.11 new subfolder introduction and upgrade processing
     //----------------------------------------------------------------------
 
+
     // now the special "folder structure" upgrade - which is tracked separately on success
 
     bool folderUpgradeSuccess =  appsettings->cvalue(home.dirName(), GC_UPGRADE_311_FOLDER_SUCCESS, false).toBool();
@@ -733,7 +734,11 @@ GcUpgradeExecuteDialog::GcUpgradeExecuteDialog(QString athlete) : QDialog(NULL, 
                      "-> Cache files: <samp>/cache</samp><br>"
                      "-> Calendar files: <samp>/calendar</samp><br>"
                      "-> Log files: <samp>/logs</samp><br>"
-                     "-> Temp files: <samp>/temp</samp><br><br>"
+                     "-> Temp files: <samp>/temp</samp><br>"
+                     "-> Temp for Activities: <samp>/tempActivities</samp><br>"
+                     "-> Train View recordings: <samp>/recordings</samp><br>"
+                     "-> Quarantined files: <samp>/quarantine</samp><br><br>"
+
                      "The upgrade process will create the new directory structure and move "
                      "the existing files to the new directories as needed. During the upgrade "
                      "all activity/ride files will be converted to GoldenCheetah's native "

--- a/src/RideCache.cpp
+++ b/src/RideCache.cpp
@@ -150,14 +150,18 @@ RideCache::itemChanged()
 
 // add a new ride
 void
-RideCache::addRide(QString name, bool dosignal)
+RideCache::addRide(QString name, bool dosignal, bool useTempActivities)
 {
     // ignore malformed names
     QDateTime dt;
     if (!RideFile::parseRideFileName(name, &dt)) return;
 
     // new ride item
-    RideItem *last = new RideItem(context->athlete->home->activities().canonicalPath(), name, dt, context);
+    RideItem *last;
+    if (useTempActivities)
+       last = new RideItem(context->athlete->home->tmpActivities().canonicalPath(), name, dt, context);
+    else
+       last = new RideItem(context->athlete->home->activities().canonicalPath(), name, dt, context);
 
     connect(last, SIGNAL(rideDataChanged()), this, SLOT(itemChanged()));
     connect(last, SIGNAL(rideMetadataChanged()), this, SLOT(itemChanged()));

--- a/src/RideCache.h
+++ b/src/RideCache.h
@@ -77,7 +77,7 @@ class RideCache : public QObject
 	    QVector<RideItem*>&rides() { return rides_; } 
 
         // add/remove a ride to the list
-        void addRide(QString name, bool dosignal);
+        void addRide(QString name, bool dosignal, bool useTempActivities);
         void removeCurrentRide();
 
         // export metrics in CSV format

--- a/src/RideImportWizard.h
+++ b/src/RideImportWizard.h
@@ -62,11 +62,14 @@ private slots:
 
 private:
     void init(QList<QString> files, Context *context);
+    bool moveFile(const QString &source, const QString &target);
+
     QList <QString> filenames; // list of filenames passed
     int numberOfFiles; // number of files to be processed
     QList <bool> blanks; // record of which have a RideFileReader returned date & time
     QDir homeImports; // target directory for source files
     QDir homeActivities; // target directory for .JSON
+    QDir tmpActivities; // activitiy .JSON is stored here until rideCache() update was successfull
     bool aborted;
     bool autoImportMode;
     QLabel *phaseLabel;
@@ -82,6 +85,8 @@ private:
     RideAutoImportConfig *importConfig;
 
     QStringList deleteMe; // list of temp files created during import
+
+
 };
 
 // Item Delegate for Editing Date and Time of Ride inside the


### PR DESCRIPTION
... for RideImport and RideDownload the created .JSON files are firstly
stored in /tempActivities and only moved to /activities after
successful updating RideCache (with this approach files with "bad data" causing
RideCache calculations to crash can be identified when starting GC again)

... in GC CrashDialog the /tempActivities are documented in the Crash
Log and moved to /quarantine for further analysis

... small addition - the existence of the new directory structure is
verified when opening an Athlete - missing directories are added to
ensure a consistent structure being in place at all times