### PR TITLE
Changes to build on OS X with spaces in path

### DIFF
--- a/qwt/src/src.pro
+++ b/qwt/src/src.pro
@@ -17,7 +17,7 @@ include( $${QWT_ROOT}/qwtfunctions.pri )
 TEMPLATE          = lib
 TARGET            = $$qwtLibraryTarget(qwt)
 
-DESTDIR           = $${OUT_PWD}/../lib
+DESTDIR           = $$replace($${OUT_PWD}/../lib," ","\\ ")
 
 contains(QWT_CONFIG, QwtDll) {
 

--- a/src/application.qrc
+++ b/src/application.qrc
@@ -75,15 +75,6 @@
         <file>images/settings.png</file>
         <file>images/addchart.png</file>
         <file>images/library.png</file>
-        <file>translations/gc_fr.qm</file>
-        <file>translations/gc_ja.qm</file>
-        <file>translations/gc_it.qm</file>
-        <file>translations/gc_pt-br.qm</file>
-        <file>translations/gc_de.qm</file>
-        <file>translations/gc_ru.qm</file>
-        <file>translations/gc_cs.qm</file>
-        <file>translations/gc_es.qm</file>
-        <file>translations/gc_pt.qm</file>
         <file>xml/charts.xml</file>
         <file>xml/metadata.xml</file>
         <file>xml/train-layout.xml</file>

--- a/src/application.qrc
+++ b/src/application.qrc
@@ -75,6 +75,15 @@
         <file>images/settings.png</file>
         <file>images/addchart.png</file>
         <file>images/library.png</file>
+        <file>translations/gc_fr.qm</file>
+        <file>translations/gc_ja.qm</file>
+        <file>translations/gc_it.qm</file>
+        <file>translations/gc_pt-br.qm</file>
+        <file>translations/gc_de.qm</file>
+        <file>translations/gc_ru.qm</file>
+        <file>translations/gc_cs.qm</file>
+        <file>translations/gc_es.qm</file>
+        <file>translations/gc_pt.qm</file>
         <file>xml/charts.xml</file>
         <file>xml/metadata.xml</file>
         <file>xml/train-layout.xml</file>


### PR DESCRIPTION
Needed to escape the spaces in $$(OUT_PWD) and $$quote(…) did not work.

Also qmake failed to complete initially because the translation files I have now removed from src/application.qrc are not present.