### PR TITLE
Fix - .JSON not updated with man.l changes directly after Import or Download

### DIFF
--- a/src/DownloadRideDialog.cpp
+++ b/src/DownloadRideDialog.cpp
@@ -25,6 +25,7 @@
 #include "Settings.h"
 #include "JsonRideFile.h"
 #include "HelpWhatsThis.h"
+#include "RideItem.h"
 #include <assert.h>
 #include <errno.h>
 #include <QtGui>
@@ -469,6 +470,8 @@ DownloadRideDialog::downloadClicked()
         // now rename
         QFile targetFileTmpActivities(targetFileTmpActivitiesName);
         targetFileTmpActivities.rename(targetFileActivitiesName);
+        // and correct the path locally stored in Ride Item
+        context->ride->setFileName(context->athlete->home->activities().canonicalPath(), targetFileName);
     }
 
     if( ! failures )

--- a/src/RideImportWizard.cpp
+++ b/src/RideImportWizard.cpp
@@ -974,6 +974,8 @@ RideImportWizard::abortClicked()
                 // rideCache is successfully updated, let's move the file to the real /activities
                 if (moveFile(tmpActivitiesFulltarget, finalActivitiesFulltarget)) {
                     tableWidget->item(i,5)->setText(tr("File Saved"));
+                    // and correct the path locally stored in Ride Item
+                    context->ride->setFileName(homeActivities.canonicalPath(), activitiesTarget);
                 }  else {
                     tableWidget->item(i,5)->setText(tr("Error - Moving %1 to activities folder").arg(activitiesTarget));
                 }


### PR DESCRIPTION
... correct the path in RideItem after updating RideCache to the final
path (since RideItem has a local buffer for the path - which is e.g.
used at "Save Ride") any manual changes after the import will create a
new .JSON in /tmpActivities and not update the original .JSON in
/activities

(Problem only occurs when using the in-memory data after an Import or
Download)