### PR TITLE
Periodically refresh Tacx Vortex load setpoint to avoid dropouts

### DIFF
--- a/src/ANT.cpp
+++ b/src/ANT.cpp
@@ -266,6 +266,15 @@ ANT::setLoad(double load)
         sendMessage(ANTMessage::tacxVortexSetPower(vortexChannel, vortexID, (int)load));
     }
 }
+
+void ANT::refreshVortexLoad()
+{
+    if (vortexChannel == -1)
+        return;
+
+    sendMessage(ANTMessage::tacxVortexSetPower(vortexChannel, vortexID, (int)load));
+}
+
 void
 ANT::setGradient(double gradient)
 {

--- a/src/ANT.h
+++ b/src/ANT.h
@@ -415,6 +415,7 @@ public:
     }
 
     void setVortexData(int channel, int id);
+    void refreshVortexLoad();
 
 private:
 

--- a/src/ANTChannel.cpp
+++ b/src/ANTChannel.cpp
@@ -661,6 +661,11 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
             // Tacx Vortex trainer
             case CHANNEL_TYPE_TACX_VORTEX:
             {
+               static int loadRefreshCounter = 1;
+
+               if (((loadRefreshCounter++) % 10) == 0)
+                   parent->refreshVortexLoad();
+
                 if (antMessage.vortexPage == TACX_VORTEX_DATA_CALIBRATION)
                     parent->setVortexData(number, antMessage.vortexId);
                 else if (antMessage.vortexPage == TACX_VORTEX_DATA_SPEED)


### PR DESCRIPTION
This periodically refreshs the power setpoint when a Tacx Vortex trainer is connected.

I've previously had problems where the trainer would initially adjust the resistance but then drop back, creating these spikes and making it hard to follow the workout without speeding up ridiculously (since resistance stays low):

![image](https://cloud.githubusercontent.com/assets/104132/5728569/95898686-9b6b-11e4-958f-2a6b2096d196.png)

Since the fix, it's pretty much a cheap Erg mode:

![image](https://cloud.githubusercontent.com/assets/104132/5728605/cf30419a-9b6b-11e4-8422-e271a060db48.png)
