### PR TITLE
QWT Build

### DIFF
--- a/qwt/src/src.pro
+++ b/qwt/src/src.pro
@@ -14,10 +14,12 @@ include( $${QWT_ROOT}/qwtconfig.pri )
 include( $${QWT_ROOT}/qwtbuild.pri )
 include( $${QWT_ROOT}/qwtfunctions.pri )
 
+QWT_OUT_ROOT = $${OUT_PWD}/..
+
 TEMPLATE          = lib
 TARGET            = $$qwtLibraryTarget(qwt)
 
-DESTDIR           = $$replace($${QWT_ROOT}/lib," ","\\ ")
+DESTDIR           = $${QWT_OUT_ROOT}/lib
 
 contains(QWT_CONFIG, QwtDll) {
 


### PR DESCRIPTION
... remove $$replace and use the latest src.pro code from QWT lib (which
allows in-source and out-of-source/shadow build)

($$replace - for unknown reasons - creates an empty string/fails if the
input string contains mixed Upper and Lower case characters - which it
happening in many file systems)