### PR TITLE
Added GOVSS/SwimScore for manual workouts

### DIFF
--- a/src/ManualRideDialog.cpp
+++ b/src/ManualRideDialog.cpp
@@ -216,7 +216,8 @@ ManualRideDialog::ManualRideDialog(Context *context) : context(context)
     // Restore from last time
     QVariant BSmode = appsettings->value(this, GC_BIKESCOREMODE); // remember from before
     if (BSmode.toString() == "time") byDuration->setChecked(true);
-    else byDistance->setChecked(true);
+    else if (BSmode.toString() == "dist") byDistance->setChecked(true);
+    else byManual->setChecked(true);
 
     // Derived metrics
     QLabel *BSLabel = new QLabel("BikeScore (TM): ", this);
@@ -345,6 +346,14 @@ ManualRideDialog::ManualRideDialog(Context *context) : context(context)
 void
 ManualRideDialog::estimate()
 {
+    QTime time = duration->time();
+    double hours = (time.hour()) + (time.minute() / 60.00) + (time.second() / 3600.00);
+    double dist = distance->value();
+
+    // Estimate average speed
+    if (hours && dist) avgKPH->setValue(dist / hours);
+    else avgKPH->setValue(0.0);
+
     if (byManual->isChecked()) {
         BS->setEnabled(true);
         DP->setEnabled(true);
@@ -364,9 +373,6 @@ ManualRideDialog::estimate()
 
     if (byDuration->isChecked()) {
         // by time
-        QTime time = duration->time();
-        double hours = (time.hour()) + (time.minute() / 60.00) + (time.second() / 3600.00);
-
         BS->setValue(hours * timeBS);
         DP->setValue(hours * timeDP);
         TSS->setValue(hours * timeTSS);
@@ -374,8 +380,6 @@ ManualRideDialog::estimate()
 
     } else {
         // by distance
-        double dist = distance->value();
-
         BS->setValue(dist * distanceBS);
         DP->setValue(dist * distanceDP);
         TSS->setValue(dist * distanceTSS);


### PR DESCRIPTION
Based on average speed and duration, changed ManualRideDialog to calculate average speed as dist/time by default, but it can be overridden for backward compatibility.