### PR TITLE
Use Duration when Time Moving is zero in Session RPE and Daniels EqP

### DIFF
--- a/src/DanielsPoints.cpp
+++ b/src/DanielsPoints.cpp
@@ -132,12 +132,16 @@ class DanielsEquivalentPower : public RideMetric {
         double cp = zones->getCP(zoneRange);
         assert(deps.contains("daniels_points"));
         assert(deps.contains("time_riding"));
+        assert(deps.contains("workout_time"));
         const RideMetric *danielsPoints = deps.value("daniels_points");
         const RideMetric *timeRiding = deps.value("time_riding");
+        const RideMetric *workoutTime = deps.value("workout_time");
         assert(danielsPoints);
         assert(timeRiding);
+        assert(workoutTime);
         double score = danielsPoints->value(true);
-        double secs = timeRiding->value(true);
+        double secs = timeRiding->value(true) ? timeRiding->value(true) :
+                                                workoutTime->value(true);
         watts = secs == 0.0 ? 0.0 : cp * pow(score / DanielsPoints::K / secs, 0.25);
 
         setValue(watts);
@@ -149,6 +153,7 @@ static bool added() {
     RideMetricFactory::instance().addMetric(DanielsPoints());
     QVector<QString> deps;
     deps.append("time_riding");
+    deps.append("workout_time");
     deps.append("daniels_points");
     RideMetricFactory::instance().addMetric(DanielsEquivalentPower(), &deps);
     return true;

--- a/src/TRIMPPoints.cpp
+++ b/src/TRIMPPoints.cpp
@@ -335,8 +335,12 @@ class SessionRPE : public RideMetric {
         assert(deps.contains("time_riding"));
         const RideMetric *timeRidingMetric = deps.value("time_riding");
         assert(timeRidingMetric);
+        assert(deps.contains("workout_time"));
+        const RideMetric *durationMetric = deps.value("workout_time");
+        assert(durationMetric);
 
-        double secs = timeRidingMetric->value(true);
+        double secs = timeRidingMetric->value(true) ? timeRidingMetric->value(true) :
+                                                      durationMetric->value(true);;
 
         // ok lets work the score out
         score = ((secs == 0.0 || rpe == 0) ? 0.0 :  secs/60 *rpe);
@@ -371,6 +375,7 @@ static bool added() {
 
     deps.clear();
     deps.append("time_riding");
+    deps.append("workout_time");
     RideMetricFactory::instance().addMetric(SessionRPE(), &deps);
     return true;
 }


### PR DESCRIPTION
Important for Session RPE, similar to TRIMP points, also fixes #1265