### PR TITLE
Ensured compute method call setValue for Run/Swim metrics

### DIFF
--- a/src/BikeScore.cpp
+++ b/src/BikeScore.cpp
@@ -57,6 +57,12 @@ class XPower : public RideMetric {
                  const QHash<QString,RideMetric*> &,
                  const Context *) {
 
+        if (ride->recIntSecs() == 0) {
+            setValue(0.0);
+            setCount(0);
+            return;
+        }
+
         static const double EPSILON = 0.1;
         static const double NEGLIGIBLE = 0.1;
 
@@ -383,8 +389,10 @@ class BikeScore : public RideMetric {
                  const HrZones *, int,
 	    const QHash<QString,RideMetric*> &deps,
                  const Context *) {
-	    if (!zones || zoneRange < 0)
+	    if (!zones || zoneRange < 0) {
+	        setValue(0.0);
 	        return;
+        }
 
         assert(deps.contains("skiba_xpower"));
         assert(deps.contains("skiba_relative_intensity"));

--- a/src/GOVSS.cpp
+++ b/src/GOVSS.cpp
@@ -78,10 +78,12 @@ class LNP : public RideMetric {
                  const QHash<QString,RideMetric*> &,
                  const Context *) {
 
-        if(ride->recIntSecs() == 0) return;
-
-        // LNP only makes sense for running
-        if (!ride->isRun()) return;
+        // LNP only makes sense for running and it needs recIntSecs > 0
+        if (!ride->isRun() || ride->recIntSecs() == 0) {
+            setValue(0.0);
+            setCount(0);
+            return;
+        }
 
         // unconst naughty boy, get athlete's data
         RideFile *uride = const_cast<RideFile*>(ride);
@@ -194,7 +196,11 @@ class XPace : public RideMetric {
                  const QHash<QString,RideMetric*> &deps,
                  const Context *) {
         // xPace only makes sense for running
-        if (!ride->isRun()) return;
+        if (!ride->isRun()) {
+            setValue(0.0);
+            setCount(0);
+            return;
+        }
 
         // unconst naughty boy, get athlete's data
         RideFile *uride = const_cast<RideFile*>(ride);
@@ -225,6 +231,7 @@ class XPace : public RideMetric {
         else xPace = 0.0;
 
         setValue(xPace);
+        setCount(lnp->count());
     }
     bool isRelevantForRide(const RideItem *ride) const { return ride->isRun; }
     RideMetric *clone() const { return new XPace(*this); }
@@ -253,7 +260,10 @@ class RTP : public RideMetric {
                  const QHash<QString,RideMetric*> &,
                  const Context *context) {
         // LNP only makes sense for running
-        if (!ride->isRun()) return;
+        if (!ride->isRun()) {
+            setValue(0.0);
+            return;
+        }
 
         // unconst naughty boy, get athlete's data
         RideFile *uride = const_cast<RideFile*>(ride);
@@ -305,7 +315,11 @@ class IWF : public RideMetric {
                  const QHash<QString,RideMetric*> &deps,
                  const Context *) {
         // IWF only makes sense for running
-        if (!ride->isRun()) return;
+        if (!ride->isRun()) {
+            setValue(0.0);
+            setCount(0);
+            return;
+        }
 
         assert(deps.contains("govss_lnp"));
         LNP *lnp = dynamic_cast<LNP*>(deps.value("govss_lnp"));
@@ -344,7 +358,10 @@ class GOVSS : public RideMetric {
 	    const QHash<QString,RideMetric*> &deps,
                  const Context *) {
         // GOVSS only makes sense for running
-        if (!ride->isRun()) return;
+        if (!ride->isRun()) {
+            setValue(0.0);
+            return;
+        }
 
         assert(deps.contains("govss_lnp"));
         assert(deps.contains("govss_rtp"));

--- a/src/SwimScore.cpp
+++ b/src/SwimScore.cpp
@@ -73,8 +73,12 @@ class XPowerSwim : public RideMetric {
                  const QHash<QString,RideMetric*> &,
                  const Context *) {
 
-        // xPowerSwim only makes sense for running
-        if (!ride->isSwim()) return;
+        // xPowerSwim only makes sense for running and it needs recIntSecs > 0
+        if (!ride->isSwim() || ride->recIntSecs() == 0) {
+            setValue(0.0);
+            setCount(0);
+            return;
+        }
 
         // unconst naughty boy, get athlete's data
         RideFile *uride = const_cast<RideFile*>(ride);
@@ -157,7 +161,11 @@ class XPaceSwim : public RideMetric {
                  const QHash<QString,RideMetric*> &deps,
                  const Context *) {
         // xPaceSwim only makes sense for swimming
-        if (!ride->isSwim()) return;
+        if (!ride->isSwim()) {
+            setValue(0.0);
+            setCount(0);
+            return;
+        }
 
         // unconst naughty boy, get athlete's data
         RideFile *uride = const_cast<RideFile*>(ride);
@@ -173,6 +181,7 @@ class XPaceSwim : public RideMetric {
         xPaceSwim = speed ? (100.0/60.0) / speed : 0.0;
 
         setValue(xPaceSwim);
+        setCount(xPowerSwim->count());
     }
     bool isRelevantForRide(const RideItem *ride) const { return ride->isSwim; }
     RideMetric *clone() const { return new XPaceSwim(*this); }
@@ -201,7 +210,10 @@ class STP : public RideMetric {
                  const QHash<QString,RideMetric*> &,
                  const Context *context) {
         // STP only makes sense for running
-        if (!ride->isSwim()) return;
+        if (!ride->isSwim()) {
+            setValue(0.0);
+            return;
+        }
 
         // unconst naughty boy, get athlete's data
         RideFile *uride = const_cast<RideFile*>(ride);
@@ -252,7 +264,11 @@ class SRI : public RideMetric {
                  const QHash<QString,RideMetric*> &deps,
                  const Context *) {
         // SRI only makes sense for swimming
-        if (!ride->isSwim()) return;
+        if (!ride->isSwim()) {
+            setValue(0.0);
+            setCount(0);
+            return;
+        }
 
         assert(deps.contains("swimscore_xpower"));
         XPowerSwim *xPowerSwim = dynamic_cast<XPowerSwim*>(deps.value("swimscore_xpower"));
@@ -291,7 +307,10 @@ class SwimScore : public RideMetric {
 	    const QHash<QString,RideMetric*> &deps,
                  const Context *) {
         // SwimScore only makes sense for swimming
-        if (!ride->isSwim()) return;
+        if (!ride->isSwim()) {
+            setValue(0.0);
+            return;
+        }
 
         assert(deps.contains("swimscore_xpower"));
         assert(deps.contains("swimscore_ri"));


### PR DESCRIPTION
Fixes #1310
Also for BikeScore and prevents division by zero in XPower when recIntSecs == 0