### PR TITLE
Estimates Plot - some fixes

### DIFF
--- a/src/LTMPlot.cpp
+++ b/src/LTMPlot.cpp
@@ -2583,8 +2583,30 @@ LTMPlot::createEstimateData(Context *context, LTMSettings *settings, MetricDetai
     x.resize(maxdays+3); // one for start from zero plus two for 0 value added at head and tail
     y.resize(maxdays+3); // one for start from zero plus two for 0 value added at head and tail
 
-    // what is the first date
-    int firstDay = groupForDate(settings->start.date(), settings->groupBy);
+    // data vectors for averaging in case on Monthly/Yearly/Total grouping
+    QVector<double> xCount;
+    QVector<double> yTotal;
+
+    xCount.resize(maxdays+3);
+    yTotal.resize(maxdays+3);
+
+    // what is the first period
+    int firstPeriod = groupForDate(settings->start.date(), settings->groupBy);
+
+    // get first PDEstimate / fillup X/Y with missing time range
+    if (!context->athlete->PDEstimates.isEmpty()) {
+      PDEstimate firstEst = context->athlete->PDEstimates.first();
+      if ((settings->start.date() < firstEst.from) &&
+          (settings->end.date() > firstEst.from)){
+        int timeforward = groupForDate(firstEst.from, settings->groupBy)
+                - groupForDate(settings->start.date(), settings->groupBy);
+        for (int i = 0; i < timeforward; i++) {
+            x[n] = n;
+            y[n] = 0;
+            n++;
+        }
+      }
+    }
 
     // loop through all the estimate data
     foreach(PDEstimate est, context->athlete->PDEstimates) {
@@ -2646,22 +2668,84 @@ LTMPlot::createEstimateData(Context *context, LTMSettings *settings, MetricDetai
             break;
         }
 
-        if (n <= maxdays && value > 0) {
-            int currentDay = groupForDate(from, settings->groupBy);
-            x[n] = currentDay - firstDay;
-            y[n] = value;
-            n++;
+        // PDE estimates are created in Weekly Buckets - so we need to aggregate and average or data fillup
+        // depending on the different groupings (day, week, month, year, all)
+        switch(settings->groupBy) {
 
-            int nextDay = groupForDate(to, settings->groupBy);
-            while (n <= maxdays && nextDay > currentDay) { // i.e. not the same day
-                x[n] = 1 + currentDay - firstDay;
+        case LTM_MONTH:
+        case LTM_YEAR:
+        case LTM_ALL:
+
+           // for month, year, all - aggregate the weekly values and build averages
+           if (n <= maxdays) {
+             int currentPeriod =  groupForDate(from, settings->groupBy);
+             if (n != (currentPeriod - firstPeriod)) {
+                 // data of next period of estimates is available,
+                 // so calcuated the current period and switch forward to next
+                 x[n] = n;
+                 if (xCount[n]> 0) {
+                    y[n] = yTotal[n] / xCount[n];
+                 } else {
+                    y[n] = 0;
+                 }
+                 n++;
+             };
+             // store for calcuation
+             yTotal[n] += value;
+             xCount[n]++;
+           }
+           break;
+
+        case LTM_DAY:
+            if (n <= maxdays) {
+
+                // for days - take estimate data from first day and fill the days to end of week
+                // since there is no more estimate data available until next week
+                x[n] = n;
                 y[n] = value;
                 n++;
-                currentDay++;
+                int currentDay = groupForDate(from, settings->groupBy);
+                int nextDay = groupForDate(to, settings->groupBy);
+                while (n <= maxdays && nextDay > currentDay) { // i.e. not the same day
+                    x[n] = n;
+                    y[n] = value;
+                    n++;
+                    currentDay++;
+                }
             }
+            break;
+
+        case LTM_WEEK:
+        default:
+
+            // for weeks - just take the data available - no fill,...
+            if (n <= maxdays) {
+
+                x[n] = n;
+                y[n] = value;
+                n++;
+            }
+            break;
         }
     }
 
+    // just check if we had data at all
+    if (!context->athlete->PDEstimates.isEmpty()) {
+        // add the last average value to the output
+        switch(settings->groupBy) {
+
+        case LTM_MONTH:
+        case LTM_YEAR:
+        case LTM_ALL:
+            x[n] = n;
+            if (xCount[n]> 0) {
+               y[n] = yTotal[n] / xCount[n];
+            } else {
+               y[n] = 0;
+            }
+            n++;
+        }
+    }
     // always seems to be one too many ...
     if (n>0)n--;
 }

--- a/src/RideCache.cpp
+++ b/src/RideCache.cpp
@@ -647,12 +647,13 @@ RideCache::refreshCPModelMetrics()
     models << &extmodel;
 
 
-    // run backwards stopping when date is at 1990 or first ride date with data
-    QDate date = from.addDays(-84);
-    while (date < to.addDays(7)) {
+    // from has first ride with Power data / looking at the next 7 days of data with Power
+    // calculate Estimates for all data per week including the week of the last Power recording
+    QDate date = from;
+    while (date < to) {
 
         QDate begin = date;
-        QDate end = date.addDays(7);
+        QDate end = date.addDays(6);
 
         // let others know where we got to...
         emit modelProgress(date.year(), date.month());
@@ -709,7 +710,7 @@ RideCache::refreshCPModelMetrics()
             //qDebug()<<add.from<<model->code()<< "KG W'="<< model->WPrime() <<"CP="<< model->CP() <<"pMax="<<model->PMax();
         }
 
-        // go back a week
+        // go forward a week
         date = date.addDays(7);
     }
 


### PR DESCRIPTION
... shift plot if start date is earlier than any Power Estimates exist
... enhance grouping (calculation of averages for month/years/all grouping)
... adjust estimates calculation
    ... to calculate non-overlapping weeks data
    ... to not create any "infinite" data for weeks before the first Power based actitivity exists