### PR TITLE
Fixed conversion errors in pace units

### DIFF
--- a/src/AllPlot.cpp
+++ b/src/AllPlot.cpp
@@ -6463,13 +6463,12 @@ AllPlot::pointHover(QwtPlotCurve *curve, int index)
         if (curve->title() == tr("Speed") && rideItem && rideItem->isRun) {
             bool metricPace = appsettings->value(this, GC_PACE, true).toBool();
             QString paceunit = metricPace ? tr("min/km") : tr("min/mile");
-            paceStr = tr("\n%1 %2").arg(context->athlete->useMetricUnits ? kphToPace(yvalue, metricPace) : mphToPace(yvalue, metricPace)).arg(paceunit);
+            paceStr = tr("\n%1 %2").arg(context->athlete->useMetricUnits ? kphToPace(yvalue, metricPace, false) : mphToPace(yvalue, metricPace, false)).arg(paceunit);
         }
         if (curve->title() == tr("Speed") && rideItem && rideItem->isSwim) {
             bool metricPace = appsettings->value(this, GC_SWIMPACE, true).toBool();
             QString paceunit = metricPace ? tr("min/100m") : tr("min/100yd");
-            double swimSpeed = yvalue * 10.00f * (metricPace ? 1.00f : METERS_PER_YARD);
-            paceStr = tr("\n%1 %2").arg(context->athlete->useMetricUnits ? kphToPace(swimSpeed, true) : mphToPace(swimSpeed, true)).arg(paceunit);
+            paceStr = tr("\n%1 %2").arg(context->athlete->useMetricUnits ? kphToPace(yvalue, metricPace, true) : mphToPace(yvalue, metricPace, true)).arg(paceunit);
         }
 
         bool isHB= curve->title().text().contains("Hb");

--- a/src/BasicRideMetrics.cpp
+++ b/src/BasicRideMetrics.cpp
@@ -276,7 +276,7 @@ class TotalDistance : public RideMetric {
         setType(RideMetric::Total);
         setMetricUnits(tr("km"));
         setImperialUnits(tr("miles"));
-        setPrecision(2);
+        setPrecision(3);
         setConversion(MILES_PER_KM);
     }
     void compute(const RideFile *ride, const Zones *, int,

--- a/src/LapsEditor.cpp
+++ b/src/LapsEditor.cpp
@@ -46,9 +46,9 @@ LapsEditor::LapsEditor(bool isSwim) : isSwim(isSwim)
     HelpWhatsThis *help = new HelpWhatsThis(this);
     this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Activity_Manual_LapsEditor));
 #ifdef Q_OS_MAC
-    setFixedSize(615,415);
+    setFixedSize(625,415);
 #else
-    setFixedSize(620,420);
+    setFixedSize(630,420);
 #endif
 
     //
@@ -57,7 +57,7 @@ LapsEditor::LapsEditor(bool isSwim) : isSwim(isSwim)
 
     // Laps table
     const int nCols = 7;
-    const int nRows = 10;
+    const int nRows = 100;
     tableWidget = new QTableWidget(nRows, nCols, this);
     QStringList hLabels;
     tableWidget->setColumnWidth(0,  48);

--- a/src/PaceZones.cpp
+++ b/src/PaceZones.cpp
@@ -993,10 +993,7 @@ PaceZones::kphFromTime(QTimeEdit *cvedit, bool metric) const
 QString
 PaceZones::kphToPaceString(double kph, bool metric) const
 {
-    if (swim)
-        return kphToPace(kph * 10.00f * (metric ? 1.00f : METERS_PER_YARD), true);
-    else
-        return kphToPace(kph, metric);
+    return kphToPace(kph, metric, swim);
 }
 
 QString

--- a/src/PowerHist.cpp
+++ b/src/PowerHist.cpp
@@ -2293,13 +2293,12 @@ PowerHist::pointHover(QwtPlotCurve *curve, int index)
                 if (series == RideFile::kph && (!rideItem || rideItem->isRun)) {
                     bool metricPace = appsettings->value(this, GC_PACE, true).toBool();
                     QString paceunit = metricPace ? tr("min/km") : tr("min/mile");
-                    runPaceStr = tr("\n%1 Pace (%2)").arg(context->athlete->useMetricUnits ? kphToPace(xvalue, metricPace) : mphToPace(xvalue, metricPace)).arg(paceunit);
+                    runPaceStr = tr("\n%1 Pace (%2)").arg(context->athlete->useMetricUnits ? kphToPace(xvalue, metricPace, false) : mphToPace(xvalue, metricPace, false)).arg(paceunit);
                 }
                 if (series == RideFile::kph && (!rideItem || rideItem->isSwim)) {
                     bool metricPace = appsettings->value(this, GC_SWIMPACE, true).toBool();
                     QString paceunit = metricPace ? tr("min/100m") : tr("min/100yd");
-                    double swimSpeed = xvalue * 10.00f * (metricPace ? 1.00f : METERS_PER_YARD);
-                    swimPaceStr = tr("\n%1 Pace (%2)").arg(context->athlete->useMetricUnits ? kphToPace(swimSpeed, true) : mphToPace(swimSpeed, true)).arg(paceunit);
+                    swimPaceStr = tr("\n%1 Pace (%2)").arg(context->athlete->useMetricUnits ? kphToPace(xvalue, metricPace, true) : mphToPace(xvalue, metricPace, true)).arg(paceunit);
                 }
                 // output the tooltip
                 text = QString("%1 %2%5%6\n%3 %4")

--- a/src/RideItem.cpp
+++ b/src/RideItem.cpp
@@ -107,7 +107,7 @@ RideItem::setFrom(QHash<QString, RideMetricPtr> computed)
     QHashIterator<QString, RideMetricPtr> i(computed);
     while (i.hasNext()) {
         i.next();
-        metrics_[i.value()->index()] = i.value()->value(true);
+        metrics_[i.value()->index()] = i.value()->value();
     }
 }
 
@@ -410,7 +410,7 @@ RideItem::refresh()
         QHashIterator<QString, RideMetricPtr> i(computed);
         while (i.hasNext()) {
             i.next();
-            metrics_[i.value()->index()] = i.value()->value(true);
+            metrics_[i.value()->index()] = i.value()->value();
         }
 
         // clean any bad values

--- a/src/RideMetric.h
+++ b/src/RideMetric.h
@@ -98,6 +98,8 @@ public:
 
     // The actual value of this ride metric, in the units above.
     virtual double value(bool metric) const { return metric ? value_ : (value_ * conversion_); }
+    // The internal value of this ride metric, useful to cache and then setValue.
+    double value() const { return value_; }
 
     // for averages the count of items included in the average
     virtual double count() const { return count_; }

--- a/src/Units.cpp
+++ b/src/Units.cpp
@@ -19,10 +19,10 @@
 #include "Units.h"
 #include <cmath>
 
-QString kphToPace(double kph, bool metric)
+QString kphToPace(double kph, bool metric, bool isSwim)
 {
     // return a min/mile or min/kph string
-    if (!metric) kph /= KM_PER_MILE;
+    if (!metric && !isSwim) kph /= KM_PER_MILE;
 
     // stop silly stuff
     if (kph < 0.1) {
@@ -32,6 +32,9 @@ QString kphToPace(double kph, bool metric)
     if (kph > 99) {
         return "xx:xx";
     }
+
+    // Swim pace is min/100m or min/100y
+    if (isSwim) kph = kph * 10.00f / (metric ? 1.00f : METERS_PER_YARD);
 
     // now how many minutes to do 1 ?
     double pace = 60.00f / kph;
@@ -49,10 +52,10 @@ QString kphToPace(double kph, bool metric)
                   .arg(seconds, 2, 10, QLatin1Char('0'));
 }
 
-QString mphToPace(double mph, bool metric)
+QString mphToPace(double mph, bool metric, bool isSwim)
 {
     // convert to kph and then use kph function
     double kph = mph * KM_PER_MILE;
 
-    return kphToPace(kph, metric);
+    return kphToPace(kph, metric, isSwim);
 }

--- a/src/Units.h
+++ b/src/Units.h
@@ -35,8 +35,8 @@
 #define GPS_COORD_TO_STRING 8
 
 #include <QString>
-extern QString kphToPace(double kph, bool metric);
-extern QString mphToPace(double mph, bool metric);
+extern QString kphToPace(double kph, bool metric, bool isSwim=false);
+extern QString mphToPace(double mph, bool metric, bool isSwim=false);
 
 #endif // _GC_Units_h
 


### PR DESCRIPTION
Pace swimming conversion from kph was reversed, fixed and consolidated in units.cpp
Pace metrics needs to be cached in metric units, added value() method to retrieve the internal value.
Also changed decimals from 2 to 3 for distance to easy visualization of swimming distances and maximum laps in LapsEditor to allow the input of individual laps, not only series.