### PR TITLE
Upgrade - Folder - verify upgrade demand

### DIFF
--- a/src/Athlete.cpp
+++ b/src/Athlete.cpp
@@ -479,6 +479,19 @@ AthleteDirectoryStructure::subDirsExist() {
             );
 }
 
+bool
+AthleteDirectoryStructure::upgradedDirectoriesHaveData() {
+
+   if ( activities().exists() && config().exists()) {
+       QStringList activityFiles = activities().entryList(QDir::Files);
+       if (!activityFiles.isEmpty()) { return true; }
+       QStringList configFiles = config().entryList(QDir::Files);
+       if (!configFiles.isEmpty()) { return true; }
+   }
+   return false;
+
+}
+
 // working with withings data
 void 
 Athlete::setWithings(QList<WithingsReading>&x)

--- a/src/Athlete.h
+++ b/src/Athlete.h
@@ -193,9 +193,9 @@ class AthleteDirectoryStructure : public QObject {
             QDir root() { return myhome; }
 
             // supporting functions to work with the subDirs
-            void createAllSubdirs();
-            bool subDirsExist();
-
+            void createAllSubdirs();            // create all new SubDirectories (or create only missing ones)
+            bool subDirsExist();                // check for all new SubDirectories
+            bool upgradedDirectoriesHaveData(); // check only for /activities and /config (as the main directories which have to bee there)
 
         private:
 


### PR DESCRIPTION
... check if the  "folder-upgrade" has really taken place - if not reset, Upgrade Flag to force the new folder structure upgrade
... (allows to revert to the pre-upgrade backup of a folder structure - which during test already had be successfully upgraded and therefore marked as being ok).