### PR TITLE
Report- File "Open for Write" errors

### DIFF
--- a/src/CalendarDownload.cpp
+++ b/src/CalendarDownload.cpp
@@ -63,7 +63,14 @@ CalendarDownload::downloadFinished(QNetworkReply *reply)
     if (fulltext != "") {
 
         // update remote cache - write to it!
-        remoteCacheFile.open(QFile::ReadWrite | QFile::Text);
+        if (!remoteCacheFile.open(QFile::ReadWrite | QFile::Text)) {
+            QMessageBox msgBox;
+            msgBox.setIcon(QMessageBox::Critical);
+            msgBox.setText(tr("Problem Saving Calendar Download"));
+            msgBox.setInformativeText(tr("File: %1 cannot be opened for 'Writing'. Please check file properties.").arg(remoteCache));
+            msgBox.exec();
+            return;
+        }
         QTextStream out(&remoteCacheFile);
         out << fulltext;
         remoteCacheFile.close();

--- a/src/HomeWindow.cpp
+++ b/src/HomeWindow.cpp
@@ -1171,7 +1171,11 @@ HomeWindow::saveState()
     QString filename = context->athlete->home->config().canonicalPath() + "/" + name + "-layout.xml";
     QFile file(filename);
     if (!file.open(QFile::WriteOnly)) {
-        QMessageBox::critical(this, tr("Problem Saving Charts Configuration"), tr("File: %1 cannot be opened for 'Writing' ! Please check file properties.").arg(filename));
+        QMessageBox msgBox;
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.setText(tr("Problem Saving Chart Bar Layout"));
+        msgBox.setInformativeText(tr("File: %1 cannot be opened for 'Writing'. Please check file properties.").arg(filename));
+        msgBox.exec();
         return;
     };
     file.resize(0);

--- a/src/HrZones.cpp
+++ b/src/HrZones.cpp
@@ -703,6 +703,13 @@ void HrZones::write(QDir home)
         QTextStream stream(&file);
         stream << strzones;
         file.close();
+    } else {
+        QMessageBox msgBox;
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.setText(tr("Problem Saving Heartrate Zones"));
+        msgBox.setInformativeText(tr("File: %1 cannot be opened for 'Writing'. Please check file properties.").arg(home.canonicalPath() + "/hr.zones"));
+        msgBox.exec();
+        return;
     }
 }
 

--- a/src/LTMChartParser.cpp
+++ b/src/LTMChartParser.cpp
@@ -103,7 +103,14 @@ LTMChartParser::serialize(QString filename, QList<LTMSettings> charts)
 {
     // open file - truncate contents
     QFile file(filename);
-    file.open(QFile::WriteOnly);
+    if (!file.open(QFile::WriteOnly)) {
+        QMessageBox msgBox;
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.setText(QObject::tr("Problem Saving Charts Configuration"));
+        msgBox.setInformativeText(QObject::tr("File: %1 cannot be opened for 'Writing'. Please check file properties.").arg(filename));
+        msgBox.exec();
+        return;
+    };
     file.resize(0);
     QTextStream out(&file);
     out.setCodec("UTF-8");

--- a/src/LibraryParser.cpp
+++ b/src/LibraryParser.cpp
@@ -19,6 +19,7 @@
 #include "Library.h"
 #include "LibraryParser.h"
 #include <QDebug>
+#include <QMessageBox>
 
 bool LibraryParser::startDocument()
 {
@@ -72,7 +73,14 @@ LibraryParser::serialize(QDir home)
     // open file - truncate contents
     QString filename = home.canonicalPath() + "/library.xml";
     QFile file(filename);
-    file.open(QFile::WriteOnly);
+    if (!file.open(QFile::WriteOnly)) {
+        QMessageBox msgBox;
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.setText(QObject::tr("Problem Saving Workout Library"));
+        msgBox.setInformativeText(QObject::tr("File: %1 cannot be opened for 'Writing'. Please check file properties.").arg(filename));
+        msgBox.exec();
+        return false;
+    };
     file.resize(0);
     QTextStream out(&file);
     out.setCodec("UTF-8");

--- a/src/NamedSearch.cpp
+++ b/src/NamedSearch.cpp
@@ -22,6 +22,8 @@
 #include "Athlete.h"
 #include "GcSideBarItem.h" // for iconFromPNG
 
+#include <QMessageBox>
+
 // Escape special characters (JSON compliance & XML)
 static QString protect(const QString string)
 {
@@ -173,6 +175,14 @@ NamedSearchParser::serialize(QString filename, QList<NamedSearch>NamedSearches)
     // open file - truncate contents
     QFile file(filename);
     file.open(QFile::WriteOnly);
+    if (!file.open(QFile::WriteOnly)) {
+        QMessageBox msgBox;
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.setText(QObject::tr("Problem Saving Named Search Configuration"));
+        msgBox.setInformativeText(QObject::tr("File: %1 cannot be opened for 'Writing'. Please check file properties.").arg(filename));
+        msgBox.exec();
+        return false;
+    };
     file.resize(0);
     QTextStream out(&file);
     out.setCodec("UTF-8");

--- a/src/PaceZones.cpp
+++ b/src/PaceZones.cpp
@@ -813,10 +813,16 @@ void PaceZones::write(QDir home)
 
     QFile file(home.canonicalPath() + "/" + fileName_);
     if (file.open(QFile::WriteOnly)) {
-
         QTextStream stream(&file);
         stream << strzones;
         file.close();
+    } else {
+        QMessageBox msgBox;
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.setText(tr("Problem Saving Pace Zones"));
+        msgBox.setInformativeText(tr("File: %1 cannot be opened for 'Writing'. Please check file properties.").arg(home.canonicalPath() + "/" + fileName_));
+        msgBox.exec();
+        return;
     }
 }
 

--- a/src/RideAutoImportConfig.cpp
+++ b/src/RideAutoImportConfig.cpp
@@ -20,6 +20,8 @@
 #include "Context.h"
 #include "Athlete.h"
 
+#include <QMessageBox>
+
 
 // Class: RideAutoImportRule
 
@@ -141,7 +143,14 @@ RideAutoImportConfigParser::serialize(QString filename, QList<RideAutoImportRule
 {
     // open file - truncate contents
     QFile file(filename);
-    file.open(QFile::WriteOnly);
+    if (!file.open(QFile::WriteOnly)) {
+        QMessageBox msgBox;
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.setText(QObject::tr("Problem Saving Autoimport Configuration"));
+        msgBox.setInformativeText(QObject::tr("File: %1 cannot be opened for 'Writing'. Please check file properties.").arg(filename));
+        msgBox.exec();
+        return false;
+    };
     file.resize(0);
     QTextStream out(&file);
     out.setCodec("UTF-8");

--- a/src/RideCache.cpp
+++ b/src/RideCache.cpp
@@ -308,7 +308,14 @@ RideCache::writeAsCSV(QString filename)
 
     // open file.. truncate if exists already
     QFile file(filename);
-    file.open(QFile::WriteOnly);
+    if (!file.open(QFile::WriteOnly)) {
+        QMessageBox msgBox;
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.setText(tr("Problem Saving Ride Cache"));
+        msgBox.setInformativeText(tr("File: %1 cannot be opened for 'Writing'. Please check file properties.").arg(filename));
+        msgBox.exec();
+        return;
+    };
     file.resize(0);
     QTextStream out(&file);
 

--- a/src/RideMetadata.cpp
+++ b/src/RideMetadata.cpp
@@ -1032,7 +1032,14 @@ RideMetadata::serialize(QString filename, QList<KeywordDefinition>keywordDefinit
 {
     // open file - truncate contents
     QFile file(filename);
-    file.open(QFile::WriteOnly);
+    if (!file.open(QFile::WriteOnly)) {
+        QMessageBox msgBox;
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.setText(tr("Problem Saving Meta Data"));
+        msgBox.setInformativeText(tr("File: %1 cannot be opened for 'Writing'. Please check file properties.").arg(filename));
+        msgBox.exec();
+        return;
+    };
     file.resize(0);
     QTextStream out(&file);
     out.setCodec("UTF-8");

--- a/src/RouteParser.cpp
+++ b/src/RouteParser.cpp
@@ -97,7 +97,14 @@ RouteParser::serialize(QString filename, QList<RouteSegment>routes)
 {
     // open file - truncate contents
     QFile file(filename);
-    file.open(QFile::WriteOnly);
+    if (!file.open(QFile::WriteOnly)) {
+        QMessageBox msgBox;
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.setText(QObject::tr("Problem Saving Route Data"));
+        msgBox.setInformativeText(QObject::tr("File: %1 cannot be opened for 'Writing'. Please check file properties.").arg(filename));
+        msgBox.exec();
+        return false;
+    };
     file.resize(0);
     QTextStream out(&file);
 

--- a/src/SeasonParser.cpp
+++ b/src/SeasonParser.cpp
@@ -19,6 +19,7 @@
 #include "SeasonParser.h"
 #include <QDate>
 #include <QDebug>
+#include <QMessageBox>
 
 static inline QString unquote(QString quoted)
 {
@@ -133,7 +134,14 @@ SeasonParser::serialize(QString filename, QList<Season>Seasons)
 {
     // open file - truncate contents
     QFile file(filename);
-    file.open(QFile::WriteOnly);
+    if (!file.open(QFile::WriteOnly)) {
+        QMessageBox msgBox;
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.setText(QObject::tr("Problem Saving Seasons"));
+        msgBox.setInformativeText(QObject::tr("File: %1 cannot be opened for 'Writing'. Please check file properties.").arg(filename));
+        msgBox.exec();
+        return false;
+    };
     file.resize(0);
     QTextStream out(&file);
     out.setCodec("UTF-8");

--- a/src/Zones.cpp
+++ b/src/Zones.cpp
@@ -796,6 +796,13 @@ void Zones::write(QDir home)
         QTextStream stream(&file);
         stream << strzones;
         file.close();
+    } else {
+        QMessageBox msgBox;
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.setText(tr("Problem Saving Power Zones"));
+        msgBox.setInformativeText(tr("File: %1 cannot be opened for 'Writing'. Please check file properties.").arg(home.canonicalPath() + "/power.zones"));
+        msgBox.exec();
+        return;
     }
 }
 


### PR DESCRIPTION
... for all config files, which need to be written, show error Popup, if file cannot be opened in "Write" mode
(now all locations with "openFile" in "write-mode" which did not yet have an error handling are covered)