### PR TITLE
Add FIT file device ID parsing for Zwift.

### DIFF
--- a/src/FitRideFile.cpp
+++ b/src/FitRideFile.cpp
@@ -286,6 +286,9 @@ struct FitFileReaderState
             // does not set product at this point
            rideFile->setDeviceType("Sigmasport ROX");
         
+        } else if (manu == 260) {
+            // Zwift!
+            rideFile->setDeviceType("Zwift");
         } else {
 
             rideFile->setDeviceType(QString("Unknown FIT Device %1:%2").arg(manu).arg(prod));


### PR DESCRIPTION
There is no official proclamation that ID 260:0 is officially assigned
to Zwift; it is simply the value observed in data files downloaded from
Zwift for the author. A support request opened with Zwift requesting
confirmation has gone unanswered.