### PR TITLE
Adding Indended Plot Markers for AllPlot

### DIFF
--- a/src/AllPlot.cpp
+++ b/src/AllPlot.cpp
@@ -32,6 +32,7 @@
 #include "Zones.h"
 #include "Colors.h"
 #include "WPrime.h"
+#include "IndendPlotMarker.h"
 
 #include <qwt_plot_curve.h>
 #include <qwt_plot_canvas.h>
@@ -2299,6 +2300,8 @@ AllPlot::recalc(AllPlotObject *objects)
 void
 AllPlot::refreshIntervalMarkers()
 {
+    QwtIndPlotMarker::resetDrawnLabels();
+
     foreach(QwtPlotMarker *mrk, standard->d_mrk) {
         mrk->detach();
         delete mrk;
@@ -2316,7 +2319,7 @@ AllPlot::refreshIntervalMarkers()
             if (interval.isBest() || interval.isPeak() || 
                 interval.isMatch()) nolabel = true;
 
-            QwtPlotMarker *mrk = new QwtPlotMarker;
+            QwtPlotMarker *mrk = new QwtIndPlotMarker;
             standard->d_mrk.append(mrk);
             mrk->attach(this);
             mrk->setLineStyle(QwtPlotMarker::VLine);
@@ -2473,6 +2476,11 @@ AllPlot::plotReferenceLine(const RideFilePoint *referencePoint)
     return referenceLine;
 }
 
+void
+AllPlot::replot() {
+        QwtIndPlotMarker::resetDrawnLabels();
+        QwtPlot::replot();
+    }
 
 void
 AllPlot::setYMax()

--- a/src/AllPlot.h
+++ b/src/AllPlot.h
@@ -538,6 +538,8 @@ class AllPlot : public QwtPlot
         void confirmTmpReference(double value, int axis, bool allowDelete);
         QwtPlotCurve* plotReferenceLine(const RideFilePoint *referencePoint);
 
+        virtual void replot();
+
         // remembering state etc
         CurveColors *curveColors;
 


### PR DESCRIPTION
I intentionally didn't add the IndendPlotMarkers to all markings,
but only to the interval markers at the top of the plot.

NOTE: the height of the spacing is actually what Qwt tells us
is the textheight.
I think this spacing is rather big.
We might want to reduce it somehow in the future.

Signed-off-by: Simon Egli (Silzo) <smn.egli@gmail.com>