### PR TITLE
FIT File Read - Exception not catched

### DIFF
--- a/src/FitRideFile.cpp
+++ b/src/FitRideFile.cpp
@@ -1008,8 +1008,14 @@ struct FitFileReaderState
         }
         else {
             if (!truncated) {
-                int crc = read_uint16( false ); // always littleEndian
-                (void) crc;
+                try {
+                    int crc = read_uint16( false ); // always littleEndian
+                    (void) crc;
+                }
+                catch (TruncatedRead &e) {
+                    errors << "truncated file body";
+                    return NULL;
+                }
             }
 
             foreach(int num, unknown_global_msg_nums)


### PR DESCRIPTION
... exception "Truncated" for the "final" read call of the FIT file reader was not catched, causing termination of the program (problem reported with an example file being truncated at the end)