### PR TITLE
Set Pace Zone Shading and Pace units according to sport in CV chart

### DIFF
--- a/src/CPPlot.h
+++ b/src/CPPlot.h
@@ -76,6 +76,7 @@ class CPPlot : public QwtPlot
         void setVeloCP(int x) { veloCP = x; }
         void setDateCP(int x) { dateCP = x; }
         void setDateCV(double x) { dateCV = x; }
+        void setSport(bool run, bool swim) { isRun = run; isSwim = swim; }
         void setSeries(CriticalPowerWindow::CriticalSeriesType);
         void setPlotType(int index);
         void setModel(int sanI1, int sanI2, int anI1, int anI2, 
@@ -123,7 +124,7 @@ class CPPlot : public QwtPlot
 
         // plotters
         void plotRide(RideItem *);
-        void plotBests();
+        void plotBests(RideItem *);
         void plotEfforts();
         void plotModel();
         void plotModel(QVector<double> vector, QColor plotColor, PDModel *baseline); // for compare date range models
@@ -148,6 +149,7 @@ class CPPlot : public QwtPlot
         int veloCP;
         int dateCP;
         double dateCV;
+        bool isRun, isSwim;
         QTime lastupdate;
 
         // settings

--- a/src/RideFileCache.cpp
+++ b/src/RideFileCache.cpp
@@ -1419,7 +1419,7 @@ static void distAggregate(QVector<double> &into, QVector<double> &other)
 
 }
 
-RideFileCache::RideFileCache(Context *context, QDate start, QDate end, bool filter, QStringList files, bool onhome)
+RideFileCache::RideFileCache(Context *context, QDate start, QDate end, bool filter, QStringList files, bool onhome, RideItem *rideItem)
                : start(start), end(end), incomplete(false), context(context), rideFileName(""), ride(0)
 {
 
@@ -1429,7 +1429,7 @@ RideFileCache::RideFileCache(Context *context, QDate start, QDate end, bool filt
     this->onhome = onhome;
 
     // Oh lets get from the cache if we can -- but not if filtered
-    if (!filter && !context->isfiltered) {
+    if (!filter && !context->isfiltered && !rideItem) {
 
         // oh and not if we're onhome and homefiltered
         if ((onhome && !context->ishomefiltered) || !onhome) {
@@ -1496,6 +1496,8 @@ RideFileCache::RideFileCache(Context *context, QDate start, QDate end, bool filt
             // skip globally filtered values
             if (context->isfiltered && !context->filters.contains(item->fileName)) continue;
             if (onhome && context->ishomefiltered && !context->homeFilters.contains(item->fileName)) continue;
+            // skip other sports if rideItem is given
+            if (rideItem && ((rideItem->isRun != item->isRun) || (rideItem->isSwim != item->isSwim))) continue;
 
             // get its cached values (will NOT! refresh if needed...)
             // the true means it will check only

--- a/src/RideFileCache.h
+++ b/src/RideFileCache.h
@@ -154,7 +154,7 @@ class RideFileCache
 
         // Construct a ridefile cache that represents the data
         // across a date range. This is used to provide aggregated data.
-        RideFileCache(Context *context, QDate start, QDate end, bool filter = false, QStringList files = QStringList(), bool onhome = true);
+        RideFileCache(Context *context, QDate start, QDate end, bool filter = false, QStringList files = QStringList(), bool onhome = true, RideItem *rideItem = NULL);
 
         // once a cache is loaded we can refresh from in-memory if needed
         void refresh(RideFile*ride = NULL);


### PR DESCRIPTION
In activities it depends on selected activity, bests are automatically filtered.
In range mode it can be set by sidebar or home filters for single sport

a) Examples in Trends:
a1) Swims:
![image](https://cloud.githubusercontent.com/assets/1444784/8142235/e213b72c-114c-11e5-9b73-7608866e465b.png)
a2) No sport filter (mixed activities or only rides):
![image](https://cloud.githubusercontent.com/assets/1444784/8142234/c45c3772-114c-11e5-9ee7-99fe97acd8ef.png)
a3) Runs:
![image](https://cloud.githubusercontent.com/assets/1444784/8142241/06e596ce-114d-11e5-91ff-e014a6ec9180.png)
b) Examples in Activities:
b1) Swim selected:
![image](https://cloud.githubusercontent.com/assets/1444784/8142258/4ab764c2-114d-11e5-9c25-3fba3462792c.png)
b2) Ride selected:
![image](https://cloud.githubusercontent.com/assets/1444784/8142261/5a9dc804-114d-11e5-91d1-820b7c0143a0.png)
b3) Run selected:
![image](https://cloud.githubusercontent.com/assets/1444784/8142267/6ae17a12-114d-11e5-838f-1c6ca4e5f695.png)
