### PR TITLE
Fixed wrong caching when CPPlot is filtered by activity type

### DIFF
--- a/src/CPPlot.cpp
+++ b/src/CPPlot.cpp
@@ -1533,7 +1533,7 @@ CPPlot::setRide(RideItem *rideItem)
     // first make sure the bests cache is up to date as we may need it
     // if plotting in percentage mode, so get data and plot it now
     // delete if sport changed
-    if (!rangemode && (rideItem->isRun != isRun || rideItem->isSwim != isSwim)) {
+    if (!rangemode) {
         setSport(rideItem->isRun, rideItem->isSwim);
         delete bestsCache;
         bestsCache = NULL;


### PR DESCRIPTION
The problem can be seen while changing the model in Activities view after having selected an activity of different type.