### PR TITLE
Added error message for unsupported Lap Swimming FIT files

### DIFF
--- a/src/FitRideFile.cpp
+++ b/src/FitRideFile.cpp
@@ -960,6 +960,11 @@ struct FitFileReaderState
                 case 23: /*decodeDeviceInfo(def, time_offset, values);*/ break; /* device info */
                 case 18: decodeSession(def, time_offset, values); break; /* session */
 
+                case 101: /* lap swimming length */
+                    errors << "Unsupported Lap Swimming FIT File - Use .tcx or .pwx formats";
+                    stop = true;
+                    break;
+
                 case 2: /* DEVICE_SETTINGS */
                 case 3: /* USER_PROFILE */
                 case 7: /* ZONES_TARGET12 */


### PR DESCRIPTION
Until proper handling is added better to give an error message,
otherwise an activity with no data is created causing confusion.

I think it is a good idea to try to prevent a flow error reports due to this.