### PR TITLE
Metric to Imperial conversion applied twice in Trends->RideSummary

### DIFF
--- a/src/RideCache.cpp
+++ b/src/RideCache.cpp
@@ -425,12 +425,6 @@ RideCache::getAggregate(QString name, Specification spec, bool useMetricUnits, b
         // check values are bounded, just in case
         if (std::isnan(value) || std::isinf(value)) value = 0;
 
-        // imperial / metric conversion
-        if (useMetricUnits == false) {
-            value *= metric->conversion();
-            value += metric->conversionSum();
-        }
-
         // do we aggregate zero values ?
         bool aggZero = metric->aggregateZero();
 


### PR DESCRIPTION
Now it is done by RideMetric::toString. Fixes #1424 

I'm afraid I introduced this bug when used toString to format pace metrics without removing the existing conversion, sorry.