### PR TITLE
Minor Translation Related Fixes

### DIFF
--- a/src/Pages.cpp
+++ b/src/Pages.cpp
@@ -4743,7 +4743,7 @@ CVPage::CVPage(PaceZonePage* zonePage) : zonePage(zonePage)
     cvEdit->setDisplayFormat("mm:ss");
 
     per = new QLabel(this);
-    metric = new QCheckBox("Metric Pace");
+    metric = new QCheckBox(tr("Metric Pace"));
     metric->setChecked(appsettings->value(this, zonePage->zones->paceSetting(), true).toBool());
     per->setText(zonePage->zones->paceUnits(metric->isChecked()));
     if (!metric->isChecked()) metricChanged(); // default is metric

--- a/src/RideCacheModel.cpp
+++ b/src/RideCacheModel.cpp
@@ -91,7 +91,7 @@ RideCacheModel::data(const QModelIndex &index, int role) const
                 // bit of a kludge, but will return stuff with no decimal places
                 // as a number, but not if unit is seconds or high precision which means
                 // metrics with high precision don't sort this is crap XXX
-                if (m->units(true) != "km" && (m->units(true) == "seconds" || m->precision() > 0)) {
+                if (m->units(true) != "km" && (m->isTime() || m->precision() > 0)) {
                     m->setValue(rideCache->rides().at(index.row())->metrics_[m->index()]);
                     return m->toString(context->athlete->useMetricUnits); // string
                 } else {

--- a/src/translations/gc_es.ts
+++ b/src/translations/gc_es.ts
@@ -4297,6 +4297,11 @@ ddd, dd MMM yyyy</source>
         <translation>Velocidad Crítica</translation>
     </message>
     <message>
+        <location filename="../Pages.cpp" line="4746"/>
+        <source>Metric Pace</source>
+        <translation>Ritmo en unidades métricas</translation>
+    </message>
+    <message>
         <location filename="../Pages.cpp" line="4789"/>
         <location filename="../Pages.cpp" line="4865"/>
         <source>MMM d, yyyy</source>


### PR DESCRIPTION
"Metric Pace" translatable
Format for time columns in Navigator

Actually sorting by time columns doesn't work because hours are absent when value < 1h, perhaps it can be temporarily solved formating time as hh:mm:ss even when it is < 1h