### PR TITLE
Updated Metrics translation in LTM

### DIFF
--- a/src/HomeWindow.cpp
+++ b/src/HomeWindow.cpp
@@ -1263,11 +1263,6 @@ HomeWindow::restoreState(bool useDefault)
     // translate the metrics, but only if the built-in "default.XML"s are read (and only for LTM charts)
     // and only if the language is not English (i.e. translation is required).
     if (defaultUsed and !english) {
-        // define and fill translation maps
-        QMap<QString, QString> nMap;  // names
-        QMap<QString, QString> uMap;  // unit of measurement
-        LTMTool::getMetricsTranslationMap(nMap, uMap, context->athlete->useMetricUnits);
-
         // check all charts for LTMWindow(s)
         for (int i=0; i<handler.charts.count(); i++) {
             // find out if it's an LTMWindow via dynamic_cast
@@ -1277,16 +1272,8 @@ HomeWindow::restoreState(bool useDefault)
 
                 // now get the LTMMetrics
                 LTMSettings workSettings = ltmW->getSettings();
-                for (int j=0; j<workSettings.metrics.count(); j++){
-                    // now map and substitute
-                    QString n  = nMap.value(workSettings.metrics[j].symbol, workSettings.metrics[j].uname);
-                    QString u  = uMap.value(workSettings.metrics[j].symbol, workSettings.metrics[j].uunits);
-                    // set name, units only if there was a description before
-                    if (workSettings.metrics[j].name != "") workSettings.metrics[j].name = n;
-                    workSettings.metrics[j].uname = n;
-                    if (workSettings.metrics[j].units != "") workSettings.metrics[j].units = u;
-                    workSettings.metrics[j].uunits = u;
-                }
+                // replace name and unit for translated versions
+                workSettings.translateMetrics(context->athlete->useMetricUnits);
                 ltmW->applySettings(workSettings);
             }
         }

--- a/src/LTMPlot.cpp
+++ b/src/LTMPlot.cpp
@@ -224,9 +224,6 @@ LTMPlot::setData(LTMSettings *set)
 
     settings = set;
 
-    // For each metric in chart, translate units and name if default uname
-    //XXX BROKEN XXX LTMTool::translateMetrics(context, settings);
-
     // crop dates to at least within a year of the data available, but only if we have some data
     if (context->athlete->rideCache->rides().count()) {
 

--- a/src/LTMSettings.h
+++ b/src/LTMSettings.h
@@ -170,6 +170,7 @@ class LTMSettings {
 
         void writeChartXML(QDir, QList<LTMSettings>);
         void readChartXML(QDir, bool, QList<LTMSettings>&charts);
+        void translateMetrics(bool useMetricUnits);
 
         QString name;
         QString title;

--- a/src/LTMTool.cpp
+++ b/src/LTMTool.cpp
@@ -1430,30 +1430,6 @@ LTMTool::addCurrent()
     context->notifyPresetsChanged();
 }
 
-void
-LTMTool::getMetricsTranslationMap (QMap<QString, QString> &nMap, QMap<QString, QString> &uMap, bool useMetricUnits) {
-
-    // build up translation maps
-    const RideMetricFactory &factory = RideMetricFactory::instance();
-    for (int i=0; i<factory.metricCount(); i++) {
-        const RideMetric *add = factory.rideMetric(factory.metricName(i));
-        QTextEdit processHTMLname(add->name());
-        // use the .symbol() as key - since only CHART.XML is mapped
-        nMap.insert(add->symbol(), processHTMLname.toPlainText());
-        uMap.insert(add->symbol(), add->units(useMetricUnits));
-
-    }
-    // add mapping for PM metrics (name and unit)
-    QList<MetricDetail> pmMetrics = LTMTool::providePMmetrics();
-    for (int i=0; i<pmMetrics.count(); i++)
-    {
-        nMap.insert(pmMetrics[i].symbol, pmMetrics[i].uname);
-        uMap.insert(pmMetrics[i].symbol, pmMetrics[i].uunits);
-    }
-
-}
-
-
 // set the estimateSelection based upon what is available
 void 
 EditMetricDetailDialog::modelChanged()
@@ -2248,48 +2224,6 @@ LTMTool::setFilter(QStringList files)
         filenames = files;
 
         emit filterChanged();
-}
-
-
-// metricDetails gives access to the metric details catalog by symbol
-MetricDetail*
-LTMTool::metricDetails(QString symbol)
-{
-    for(int i = 0; i < metrics.count(); i++)
-        if (metrics[i].symbol == symbol)
-            return &metrics[i];
-    return NULL;
-}
-
-void
-LTMTool::translateMetrics(Context *context, LTMSettings *settings) // settings override local scope (static function)!!
-{
-    static QMap<QString, QString> unitsMap;
-    // LTMTool instance is created to have access to metrics catalog
-    LTMTool* ltmTool = new LTMTool(context, settings);
-    if (unitsMap.isEmpty()) {
-        foreach(MetricDetail metric, ltmTool->metrics) {
-            if (metric.units != "")  // translate units
-	            unitsMap.insert(metric.units, metric.uunits);
-            if (metric.uunits != "") // keep already translated the same
-	            unitsMap.insert(metric.uunits, metric.uunits);
-        }
-    }
-    for (int j=0; j < settings->metrics.count(); j++) {
-        if (settings->metrics[j].uname == settings->metrics[j].name) {
-            MetricDetail* mdp = ltmTool->metricDetails(settings->metrics[j].symbol);
-            if (mdp != NULL) {
-                // Replace with default translated name
-                settings->metrics[j].name = mdp->name;
-                settings->metrics[j].uname = mdp->uname;
-                // replace with translated units, if available
-                if (settings->metrics[j].uunits != "")
-                    settings->metrics[j].uunits = unitsMap.value(settings->metrics[j].uunits,
-                                                                 mdp->uunits);
-            }
-        }
-    }
-    delete ltmTool;
 }
 
 void

--- a/src/LTMTool.h
+++ b/src/LTMTool.h
@@ -61,7 +61,6 @@ class LTMTool : public QWidget
 
         QList<MetricDetail> metrics;
         MetricDetail* metricDetails(QString symbol);
-        static void translateMetrics(Context *context, LTMSettings *settings);
 
         // apply settings to the metric selector
         void applySettings();
@@ -92,7 +91,6 @@ class LTMTool : public QWidget
         DateSettingsEdit *dateSetting;
 
         static QList<MetricDetail> providePMmetrics();
-        static void getMetricsTranslationMap (QMap<QString, QString>& nMap, QMap<QString, QString>& uMap, bool useMetricUnits);
 
     signals:
 


### PR DESCRIPTION
- Code cleanup, removing deprecated code and refactoring
- Metrics translation is now done in a method for LTMSettings
- User defined metric name (uname) is translated if it matches english name
- User defined units (uunit) is only translated if it matches saved units