### PR TITLE
LTM Translation Preparation

### DIFF
--- a/src/LTMSettings.cpp
+++ b/src/LTMSettings.cpp
@@ -171,7 +171,7 @@ QDataStream &operator<<(QDataStream &out, const LTMSettings &settings)
     out<<settings.field1;
     out<<settings.field2;
     out<<int(-1);
-    out<<int(12); 
+    out<<int(13);
     out<<settings.metrics.count();
     foreach(MetricDetail metric, settings.metrics) {
         bool discard = false;
@@ -212,6 +212,7 @@ QDataStream &operator<<(QDataStream &out, const LTMSettings &settings)
         out<<metric.estimateDuration_units;
         out<<metric.wpk;
         out<<metric.stressType;
+        out<<metric.units;
     }
     out<<settings.showData;
     out<<settings.stack;
@@ -321,6 +322,9 @@ while(counter-- && !in.atEnd()) {
         }
         if (version >= 12) {
             in >> m.stressType;
+        }
+        if (version >= 13) {
+            in >> m.units;
         }
 
         bool keep=true;

--- a/src/LTMTool.cpp
+++ b/src/LTMTool.cpp
@@ -210,8 +210,8 @@ LTMTool::LTMTool(Context *context, LTMSettings *settings) : QWidget(context->mai
 
         // set default for the user overiddable fields
         adds.uname  = adds.name;
-        adds.units = "";
-        adds.uunits = adds.metric->units(context->athlete->useMetricUnits);
+        adds.units = adds.metric->units(context->athlete->useMetricUnits);
+        adds.uunits = adds.units;
 
         // default units to metric name if it is blank
         if (adds.uunits == "") adds.uunits = adds.name;


### PR DESCRIPTION
... fill "units" field with original "units" from Metrics if new Chart is created
... store original "unit" into LTMSettings for later reference in automatic translation
... use a new version of LTMSettings to be compatible with any written version