### PR TITLE
Fix "MiniCalendar" does not show colors on first open

### DIFF
--- a/src/DiarySidebar.cpp
+++ b/src/DiarySidebar.cpp
@@ -891,7 +891,7 @@ GcMultiCalendar::GcMultiCalendar(Context *context) : QScrollArea(context->mainWi
 
     GcMiniCalendar *mini = new GcMiniCalendar(context, true);
     calendars.append(mini);
-    mini->setDate(QDate::currentDate().month(), QDate::currentDate().year()); // default to this month
+    mini->setDate(1, 2000); // default to 01/2000 - which then moves to month of latest Ride
     layout->addWidget(mini);
 
     // only 1 months are visible right now


### PR DESCRIPTION
... ensures that Month is changed to month of current ride (which fixes the missing color)
... tested also for new Athlete creation (without any Ride data)

Note: Root cause may be a sequence issue of setting the calendar month, setting the ride, setting to current ride. So there might be a better way to fix the problem. But this one works.