### PR TITLE
Fixed tab order in New Athlete and Manual Workout

### DIFF
--- a/src/LTMPlot.cpp
+++ b/src/LTMPlot.cpp
@@ -2964,8 +2964,8 @@ LTMPlot::createPMCData(Context *context, LTMSettings *settings, MetricDetail met
             scoreType = "skiba_wprime_exp";
         } else if (metricDetail.symbol.startsWith("distance")) {
             scoreType = "total_distance";
-        } else if (metricDetail.symbol.startsWith("govss")) {
-            scoreType = "govss";
+        } else if (metricDetail.symbol.startsWith("triscore")) {
+            scoreType = "triscore";
         }
 
         stressType = STRESS_LTS; // if in doubt

--- a/src/LTMTool.cpp
+++ b/src/LTMTool.cpp
@@ -1079,81 +1079,81 @@ QList<MetricDetail> LTMTool::providePMmetrics() {
     trimpLTR.uunits = tr("Ramp");
     metrics.append(trimpLTR);
 
-    // GOVSS LTS
-    MetricDetail govssLTS;
-    govssLTS.type = METRIC_PM;
-    govssLTS.symbol = "govss_lts";
-    govssLTS.metric = NULL; // not a factory metric
-    govssLTS.penColor = QColor(Qt::blue);
-    govssLTS.curveStyle = QwtPlotCurve::Lines;
-    govssLTS.symbolStyle = QwtSymbol::NoSymbol;
-    govssLTS.smooth = false;
-    govssLTS.trendtype = 0;
-    govssLTS.topN = 1;
-    govssLTS.uname = govssLTS.name = tr("GOVSS Long Term Stress");
-    govssLTS.units = "Stress";
-    govssLTS.uunits = tr("Stress");
-    metrics.append(govssLTS);
+    // TriScore LTS
+    MetricDetail triscoreLTS;
+    triscoreLTS.type = METRIC_PM;
+    triscoreLTS.symbol = "triscore_lts";
+    triscoreLTS.metric = NULL; // not a factory metric
+    triscoreLTS.penColor = QColor(Qt::blue);
+    triscoreLTS.curveStyle = QwtPlotCurve::Lines;
+    triscoreLTS.symbolStyle = QwtSymbol::NoSymbol;
+    triscoreLTS.smooth = false;
+    triscoreLTS.trendtype = 0;
+    triscoreLTS.topN = 1;
+    triscoreLTS.uname = triscoreLTS.name = tr("TriScore Long Term Stress");
+    triscoreLTS.units = "Stress";
+    triscoreLTS.uunits = tr("Stress");
+    metrics.append(triscoreLTS);
 
-    MetricDetail govssSTS;
-    govssSTS.type = METRIC_PM;
-    govssSTS.symbol = "govss_sts";
-    govssSTS.metric = NULL; // not a factory metric
-    govssSTS.penColor = QColor(Qt::magenta);
-    govssSTS.curveStyle = QwtPlotCurve::Lines;
-    govssSTS.symbolStyle = QwtSymbol::NoSymbol;
-    govssSTS.smooth = false;
-    govssSTS.trendtype = 0;
-    govssSTS.topN = 1;
-    govssSTS.uname = govssSTS.name = tr("GOVSS Short Term Stress");
-    govssSTS.units = "Stress";
-    govssSTS.uunits = tr("Stress");
-    metrics.append(govssSTS);
+    MetricDetail triscoreSTS;
+    triscoreSTS.type = METRIC_PM;
+    triscoreSTS.symbol = "triscore_sts";
+    triscoreSTS.metric = NULL; // not a factory metric
+    triscoreSTS.penColor = QColor(Qt::magenta);
+    triscoreSTS.curveStyle = QwtPlotCurve::Lines;
+    triscoreSTS.symbolStyle = QwtSymbol::NoSymbol;
+    triscoreSTS.smooth = false;
+    triscoreSTS.trendtype = 0;
+    triscoreSTS.topN = 1;
+    triscoreSTS.uname = triscoreSTS.name = tr("TriScore Short Term Stress");
+    triscoreSTS.units = "Stress";
+    triscoreSTS.uunits = tr("Stress");
+    metrics.append(triscoreSTS);
 
-    MetricDetail govssSB;
-    govssSB.type = METRIC_PM;
-    govssSB.symbol = "govss_sb";
-    govssSB.metric = NULL; // not a factory metric
-    govssSB.penColor = QColor(Qt::yellow);
-    govssSB.curveStyle = QwtPlotCurve::Steps;
-    govssSB.symbolStyle = QwtSymbol::NoSymbol;
-    govssSB.smooth = false;
-    govssSB.trendtype = 0;
-    govssSB.topN = 1;
-    govssSB.uname = govssSB.name = tr("GOVSS Stress Balance");
-    govssSB.units = "Stress Balance";
-    govssSB.uunits = tr("Stress Balance");
-    metrics.append(govssSB);
+    MetricDetail triscoreSB;
+    triscoreSB.type = METRIC_PM;
+    triscoreSB.symbol = "triscore_sb";
+    triscoreSB.metric = NULL; // not a factory metric
+    triscoreSB.penColor = QColor(Qt::yellow);
+    triscoreSB.curveStyle = QwtPlotCurve::Steps;
+    triscoreSB.symbolStyle = QwtSymbol::NoSymbol;
+    triscoreSB.smooth = false;
+    triscoreSB.trendtype = 0;
+    triscoreSB.topN = 1;
+    triscoreSB.uname = triscoreSB.name = tr("TriScore Stress Balance");
+    triscoreSB.units = "Stress Balance";
+    triscoreSB.uunits = tr("Stress Balance");
+    metrics.append(triscoreSB);
 
-    MetricDetail govssSTR;
-    govssSTR.type = METRIC_PM;
-    govssSTR.symbol = "govss_sr";
-    govssSTR.metric = NULL; // not a factory metric
-    govssSTR.penColor = QColor(Qt::darkGreen);
-    govssSTR.curveStyle = QwtPlotCurve::Steps;
-    govssSTR.symbolStyle = QwtSymbol::NoSymbol;
-    govssSTR.smooth = false;
-    govssSTR.trendtype = 0;
-    govssSTR.topN = 1;
-    govssSTR.uname = govssSTR.name = tr("GOVSS STS Ramp");
-    govssSTR.units = "Ramp";
-    govssSTR.uunits = tr("Ramp");
-    metrics.append(govssSTR);
+    MetricDetail triscoreSTR;
+    triscoreSTR.type = METRIC_PM;
+    triscoreSTR.symbol = "triscore_sr";
+    triscoreSTR.metric = NULL; // not a factory metric
+    triscoreSTR.penColor = QColor(Qt::darkGreen);
+    triscoreSTR.curveStyle = QwtPlotCurve::Steps;
+    triscoreSTR.symbolStyle = QwtSymbol::NoSymbol;
+    triscoreSTR.smooth = false;
+    triscoreSTR.trendtype = 0;
+    triscoreSTR.topN = 1;
+    triscoreSTR.uname = triscoreSTR.name = tr("TriScore STS Ramp");
+    triscoreSTR.units = "Ramp";
+    triscoreSTR.uunits = tr("Ramp");
+    metrics.append(triscoreSTR);
 
-    MetricDetail govssLTR;
-    govssLTR.type = METRIC_PM;
-    govssLTR.symbol = "govss_lr";
-    govssLTR.metric = NULL; // not a factory metric
-    govssLTR.penColor = QColor(Qt::darkBlue);
-    govssLTR.curveStyle = QwtPlotCurve::Steps;
-    govssLTR.symbolStyle = QwtSymbol::NoSymbol;
-    govssLTR.smooth = false;
-    govssLTR.trendtype = 0;
-    govssLTR.topN = 1;
-    govssLTR.uname = govssLTR.name = tr("GOVSS LTS Ramp");
-    govssLTR.units = "Ramp";
-    govssLTR.uunits = tr("Ramp");
-    metrics.append(govssLTR);
+    MetricDetail triscoreLTR;
+    triscoreLTR.type = METRIC_PM;
+    triscoreLTR.symbol = "triscore_lr";
+    triscoreLTR.metric = NULL; // not a factory metric
+    triscoreLTR.penColor = QColor(Qt::darkBlue);
+    triscoreLTR.curveStyle = QwtPlotCurve::Steps;
+    triscoreLTR.symbolStyle = QwtSymbol::NoSymbol;
+    triscoreLTR.smooth = false;
+    triscoreLTR.trendtype = 0;
+    triscoreLTR.topN = 1;
+    triscoreLTR.uname = triscoreLTR.name = tr("TriScore LTS Ramp");
+    triscoreLTR.units = "Ramp";
+    triscoreLTR.uunits = tr("Ramp");
+    metrics.append(triscoreLTR);
 
     // done
 

--- a/src/ManualRideDialog.cpp
+++ b/src/ManualRideDialog.cpp
@@ -167,10 +167,10 @@ ManualRideDialog::ManualRideDialog(Context *context) : context(context)
     distance->setMinimum(0);
     distance->setMaximum(999);
 
-    QLabel *sportLabel = new QLabel(tr("Sport:"), this);
-    sport = new QLineEdit(this);
     QLabel *wcodeLabel = new QLabel(tr("Workout Code:"), this);
     wcode = new QLineEdit(this);
+    QLabel *sportLabel = new QLabel(tr("Sport:"), this);
+    sport = new QLineEdit(this);
     QLabel *notesLabel = new QLabel(tr("Notes:"), this);
     notes = new QTextEdit(this);
 

--- a/src/NewCyclistDialog.cpp
+++ b/src/NewCyclistDialog.cpp
@@ -120,13 +120,13 @@ NewCyclistDialog::NewCyclistDialog(QDir home) : QDialog(NULL, Qt::Dialog), home(
     maxhr->setValue(190);
 
     // cvRn default is a nice round number comparable to CP default
-    cvRn = new QTimeEdit(QTime::fromString("04:00", "mm:ss"));
+    cvRn = new QTimeEdit(QTime::fromString("04:00", "mm:ss"), this);
     cvRn->setMinimumTime(QTime::fromString("01:00", "mm:ss"));
     cvRn->setMaximumTime(QTime::fromString("20:00", "mm:ss"));
     cvRn->setDisplayFormat("mm:ss");
 
     // cvSw default is in 4-1 relation to cvRun
-    cvSw = new QTimeEdit(QTime::fromString("01:36", "mm:ss"));
+    cvSw = new QTimeEdit(QTime::fromString("01:36", "mm:ss"), this);
     cvSw->setMinimumTime(QTime::fromString("01:00", "mm:ss"));
     cvSw->setMaximumTime(QTime::fromString("20:00", "mm:ss"));
     cvSw->setDisplayFormat("mm:ss");

--- a/src/translations/gc_es.ts
+++ b/src/translations/gc_es.ts
@@ -13253,29 +13253,24 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
         <translation>TRIMP: Rampa ELP</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="1093"/>
         <source>GOVSS Long Term Stress</source>
-        <translation>GOVSS: Estrés a Largo Plazo</translation>
+        <translation type="vanished">GOVSS: Estrés a Largo Plazo</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="1108"/>
         <source>GOVSS Short Term Stress</source>
-        <translation>GOVSS: Estrés a Corto Plazo</translation>
+        <translation type="vanished">GOVSS: Estrés a Corto Plazo</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="1123"/>
         <source>GOVSS Stress Balance</source>
-        <translation>GOVSS: Balance de Estrés</translation>
+        <translation type="vanished">GOVSS: Balance de Estrés</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="1138"/>
         <source>GOVSS STS Ramp</source>
-        <translation>GOVSS: Rampa ECP</translation>
+        <translation type="vanished">GOVSS: Rampa ECP</translation>
     </message>
     <message>
-        <location filename="../LTMTool.cpp" line="1153"/>
         <source>GOVSS LTS Ramp</source>
-        <translation>GOVSS: Rampa ELP</translation>
+        <translation type="vanished">GOVSS: Rampa ELP</translation>
     </message>
     <message>
         <source>Entry Error</source>
@@ -13609,6 +13604,31 @@ Ajuste de Par - define un valor fijo en libras por pulgada o newton por metro pa
         <location filename="../LTMTool.cpp" line="299"/>
         <source>Curves</source>
         <translation>Curvas</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="1093"/>
+        <source>TriScore Long Term Stress</source>
+        <translation>TriScore: Estrés a Largo Plazo</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="1108"/>
+        <source>TriScore Short Term Stress</source>
+        <translation>TriScore: Estrés a Corto Plazo</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="1123"/>
+        <source>TriScore Stress Balance</source>
+        <translation>TriScore: Balance de Estrés</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="1138"/>
+        <source>TriScore STS Ramp</source>
+        <translation>TriScore: Rampa ECP</translation>
+    </message>
+    <message>
+        <location filename="../LTMTool.cpp" line="1153"/>
+        <source>TriScore LTS Ramp</source>
+        <translation>TriScore: Rampa ELP</translation>
     </message>
     <message>
         <location filename="../LTMTool.cpp" line="1229"/>
@@ -15475,12 +15495,12 @@ PC del ciclista %3 vatios</translation>
         <translation>Distancia (%1):</translation>
     </message>
     <message>
-        <location filename="../ManualRideDialog.cpp" line="170"/>
+        <location filename="../ManualRideDialog.cpp" line="172"/>
         <source>Sport:</source>
         <translation>Deporte:</translation>
     </message>
     <message>
-        <location filename="../ManualRideDialog.cpp" line="172"/>
+        <location filename="../ManualRideDialog.cpp" line="170"/>
         <source>Workout Code:</source>
         <translation>Código:</translation>
     </message>


### PR DESCRIPTION
Fixed tab order in New Athlete and Manual Workout - Fixes #1476
GOVSS stress metrics are new to v3.2 so it can be replaced for TriScore, which is more general.
Probably they could be deprecated anyway.