### PR TITLE
Indicate the path to the athlete directory during upgrade process.

### DIFF
--- a/src/GcUpgrade.cpp
+++ b/src/GcUpgrade.cpp
@@ -42,7 +42,7 @@ GcUpgrade::upgradeConfirmedByUser(const QDir &home)
 
     if (!folderUpgradeSuccess) {
 
-        GcUpgradeExecuteDialog msgBox(home.dirName());
+        GcUpgradeExecuteDialog msgBox(home);
         if (msgBox.exec() == QDialog::Accepted) return true;
 
         // if not accepted
@@ -692,8 +692,10 @@ GcUpgrade::removeIndex(QFile &index)
 }
 
 
-GcUpgradeExecuteDialog::GcUpgradeExecuteDialog(QString athlete) : QDialog(NULL, Qt::Dialog)
+GcUpgradeExecuteDialog::GcUpgradeExecuteDialog(QDir athleteHomeDir)
+    : QDialog(NULL, Qt::Dialog)
 {
+    const QString athlete = athleteHomeDir.dirName();
 
     setWindowTitle(QString(tr("Athlete %1").arg(athlete)));
     this->setMinimumWidth(550);
@@ -744,7 +746,10 @@ GcUpgradeExecuteDialog::GcUpgradeExecuteDialog(QString athlete) : QDialog(NULL, 
                      "<center><b>Please make sure that you have done a backup of your athlete data "
                      "before proceeding with the upgrade. We can't take responsibility for "
                      "any loss of data during the process. </b> </center> <br>"
-                     ));
+                     "Please backup the athlete directory: %1"
+                     ).arg(athleteHomeDir.absolutePath()));
+    
+    qDebug() << "Path to athlete home dir: " << athleteHomeDir.absolutePath();
     scrollText = new QScrollArea();
     scrollText->setWidget(text);
     vertical = scrollText->verticalScrollBar();

--- a/src/GcUpgrade.h
+++ b/src/GcUpgrade.h
@@ -115,8 +115,8 @@ class GcUpgradeExecuteDialog : public QDialog
     Q_OBJECT
 
     public:
-        GcUpgradeExecuteDialog(QString);
-
+        GcUpgradeExecuteDialog(QDir);
+    
     public slots:
         void checkVerticalScroll(int);
 


### PR DESCRIPTION
When upgrading the user may not know where the folder is in order to do a proper backup. This inserts the path into the upgrade dialog for the current athlete.