### PR TITLE
Fixed overridden metrics not initialized in Medatada

### DIFF
--- a/src/RideMetadata.cpp
+++ b/src/RideMetadata.cpp
@@ -1019,6 +1019,10 @@ FormField::metadataChanged()
                             value = QString("%1").arg(newvalue);
                         }
                     }
+
+                    // initialize widget to show overriden value
+                    if (isTime) ((QTimeEdit*)widget)->setTime(QTime(0,0,0,0).addSecs(value.toDouble()));
+                    else ((QDoubleSpinBox*)widget)->setValue(value.toDouble());
                 } else {
                     value = "0.0";
                     enabled->setChecked(false);


### PR DESCRIPTION
They appear with zero value after https://github.com/GoldenCheetah/GoldenCheetah/commit/cd3c8d3dd36a4326a9ecf582d64439a72c38e7e1