### PR TITLE
Fixed POW precedence and dangling else ambiguity

### DIFF
--- a/src/DataFilter.y
+++ b/src/DataFilter.y
@@ -72,8 +72,10 @@ extern Leaf *root; // root node for parsed statement
 
 %type <leaf> symbol value lexpr expr parms;
 
-%left ADD SUBTRACT POW
+%right '?' ':'
+%left ADD SUBTRACT
 %left MULTIPLY DIVIDE
+%right POW
 %right EQ NEQ LT LTE GT GTE MATCHES ENDSWITH CONTAINS
 %right AND OR
 


### PR DESCRIPTION
Now 2*2^3+1 gives 17 instead of 65
expr1 ? expr2 ? expr3 : expr 4 : expr 5 is disambiguated to expr1 ? (expr2 ? expr3 : expr 4) : expr 5
Lowers shift/reduce conflitcs to 21