### PR TITLE
Show field name in Calendar Text when field type is not text

### DIFF
--- a/src/RideCache.cpp
+++ b/src/RideCache.cpp
@@ -124,7 +124,7 @@ RideCache::configChanged(qint32 what)
 
             foreach (FieldDefinition field, context->athlete->rideMetadata()->getFields()) 
                 if (field.diary == true) 
-                    calendarText += QString("%1\n").arg(item->metadata_.value(field.name, ""));
+                    calendarText += field.calendarText(item->metadata_.value(field.name, ""));
 
             item->metadata_.insert("Calendar Text", calendarText);
         }

--- a/src/RideFile.cpp
+++ b/src/RideFile.cpp
@@ -618,8 +618,7 @@ RideFile *RideFileFactory::openRideFile(Context *context, QFile &file,
         QString calendarText;
         foreach (FieldDefinition field, context->athlete->rideMetadata()->getFields()) {
             if (field.diary == true && result->getTag(field.name, "") != "") {
-                calendarText += QString("%1\n")
-                        .arg(result->getTag(field.name, ""));
+                calendarText += field.calendarText(result->getTag(field.name, ""));
             }
         }
         result->setTag("Calendar Text", calendarText);

--- a/src/RideMetadata.cpp
+++ b/src/RideMetadata.cpp
@@ -725,8 +725,7 @@ FormField::metadataFlush()
     QString calendarText;
     foreach (FieldDefinition field, meta->getFields()) {
         if (field.diary == true) {
-            calendarText += QString("%1\n")
-                    .arg(ourRideItem->ride()->getTag(field.name, ""));
+            calendarText += field.calendarText(ourRideItem->ride()->getTag(field.name, ""));
         }
     }
     ourRideItem->ride()->setTag("Calendar Text", calendarText);
@@ -1150,6 +1149,24 @@ FieldDefinition::getCompleter(QObject *parent)
         }
     }
     return completer;
+}
+
+QString
+FieldDefinition::calendarText(QString value)
+{
+    switch (type) {
+    case FIELD_INTEGER:
+    case FIELD_DOUBLE:
+    case FIELD_DATE:
+    case FIELD_TIME:
+    case FIELD_CHECKBOX:
+        return QString("%1: %2\n").arg(name).arg(value);
+    case FIELD_TEXT:
+    case FIELD_TEXTBOX:
+    case FIELD_SHORTTEXT:
+    default:
+        return QString("%1\n").arg(value);
+    }
 }
 
 unsigned long

--- a/src/RideMetadata.h
+++ b/src/RideMetadata.h
@@ -66,6 +66,7 @@ class FieldDefinition
 
         static unsigned long fingerprint(QList<FieldDefinition>);
         QCompleter *getCompleter(QObject *parent);
+        QString calendarText(QString value);
 
         FieldDefinition() : tab(""), name(""), type(0), diary(false), values() {}
         FieldDefinition(QString tab, QString name, int type, bool diary, QStringList values)


### PR DESCRIPTION
Fixes #1524