### PR TITLE
Changes anomaly criteria for HR Speed and Cadence

### DIFF
--- a/src/TRIMPPoints.cpp
+++ b/src/TRIMPPoints.cpp
@@ -299,10 +299,9 @@ public:
             const RideMetric *durationMetric = deps.value("workout_time");
             assert(timeRidingMetric);
             assert(durationMetric);
-            assert(averageHrMetric);
             double secs = timeRidingMetric->value(true) ?
                             timeRidingMetric->value(true) :
-                            durationMetric->value(true);;
+                            durationMetric->value(true);
             int nZone = hrZones->whichZone(hrZoneRange, hr);
             if (nZone >= 0 && nZone < trimpk.size())
                 value += trimpk[nZone] * secs;


### PR DESCRIPTION
Tie HR warnings to Max-HR, if available, instead of hard-coded 200bpm
Speed warning changes to 9kph for swims, 36 for runs and 100 for rides
Cadence warning changes to 80 for swims, 120 for runs and 200 for rides
"Non-zero torque but zero cadence" is disabled for runs and swims
Fixes #1483 

When Vmax be introduced for swims and runs it could be made even more specific.
Raised Cadence threshold from 150 to 200 for rides, but not made it configurable yet.