### PR TITLE
fix ANT speed and cadence: value was still at last computed value

### DIFF
--- a/src/ANT.h
+++ b/src/ANT.h
@@ -414,6 +414,7 @@ public:
         lastCadenceMessage = QDateTime(QDateTime::currentDateTime());
         telemetry.setCadence(x);
     }
+    float getCadence(void) { return telemetry.getCadence(); }
     void setSecondaryCadence(float x) {
         if (lastCadenceMessage.toTime_t() == 0 || (QDateTime::currentDateTime().toTime_t() - lastCadenceMessage.toTime_t())>10)  {
             telemetry.setCadence(x);
@@ -431,6 +432,8 @@ public:
     }
 
     void setWheelRpm(float x);
+    float getWheelRpm(void) { return telemetry.getWheelRpm(); }
+
     void setWatts(float x) {
         telemetry.setWatts(x);
     }

--- a/src/ANTChannel.cpp
+++ b/src/ANTChannel.cpp
@@ -58,7 +58,7 @@ ANTChannel::init()
     status = Closed;
     fecPrevRawDistance=0;
     fecCapabilities=0;
-    lastMessageTimestamp = QTime::currentTime();
+    lastMessageTimestamp = lastMessageTimestamp2 = QTime::currentTime();
 }
 
 //
@@ -629,9 +629,9 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                    rpm = 1024*60*revs / time;
                    if (is_moxy) /* do nothing for now */ ; //XXX fixme when moxy arrives XXX
                    else parent->setWheelRpm(rpm);
-                   lastMessageTimestamp = QTime::currentTime();
+                   lastMessageTimestamp2 = QTime::currentTime();
                } else {
-                   int ms = lastMessageTimestamp.msecsTo(QTime::currentTime());
+                   int ms = lastMessageTimestamp2.msecsTo(QTime::currentTime());
                    rpm = qMin((float)(1000.0*60.0*1.0) / ms, parent->getWheelRpm());
                    // If we received a message but timestamp remain unchanged then we know that sensor have not detected magnet thus we deduct that rpm cannot be higher than this
                    parent->setWheelRpm(rpm);

--- a/src/ANTChannel.cpp
+++ b/src/ANTChannel.cpp
@@ -595,6 +595,8 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                    int ms = lastMessageTimestamp.msecsTo(QTime::currentTime());
                    rpm = qMin((float)(1000.0*60.0*1.0) / ms, parent->getCadence());
                    // If we received a message but timestamp remain unchanged then we know that sensor have not detected magnet thus we deduct that rpm cannot be higher than this
+                   if (rpm < (float) 4.0)
+                       rpm = 0.0; // if rpm is less than 4 then we consider that we are stopped
                }
                parent->setCadence(rpm);
                value2 = value = rpm;
@@ -618,6 +620,8 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                    int ms = lastMessageTimestamp.msecsTo(QTime::currentTime());
                    rpm = qMin((float)(1000.0*60.0*1.0) / ms, parent->getCadence());
                    // If we received a message but timestamp remain unchanged then we know that sensor have not detected magnet thus we deduct that rpm cannot be higher than this
+                   if (rpm < (float) 4.0)
+                       rpm = 0.0; // if rpm is less than 4 then we consider that we are stopped
                    parent->setCadence(rpm);
                }
                value = rpm;
@@ -634,6 +638,8 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                    int ms = lastMessageTimestamp2.msecsTo(QTime::currentTime());
                    rpm = qMin((float)(1000.0*60.0*1.0) / ms, parent->getWheelRpm());
                    // If we received a message but timestamp remain unchanged then we know that sensor have not detected magnet thus we deduct that rpm cannot be higher than this
+                   if (rpm < (float) 4.0)
+                       rpm = 0.0; // if rpm is less than 4 then we consider that we are stopped
                    parent->setWheelRpm(rpm);
                }
                value2 = rpm;
@@ -653,6 +659,8 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                    int ms = lastMessageTimestamp.msecsTo(QTime::currentTime());
                    rpm = qMin((float)(1000.0*60.0*1.0) / ms, parent->getWheelRpm());
                    // If we received a message but timestamp remain unchanged then we know that sensor have not detected magnet thus we deduct that rpm cannot be higher than this
+                   if (rpm < (float) 4.0)
+                       rpm = 0.0; // if rpm is less than 4 then we consider that we are stopped
                }
                parent->setWheelRpm(rpm);
                value2=value=rpm;

--- a/src/ANTChannel.h
+++ b/src/ANTChannel.h
@@ -23,6 +23,7 @@
 #include "ANT.h"
 #include "ANTMessage.h"
 #include <QObject>
+#include <QTime>
 
 #define CHANNEL_TYPE_QUICK_SEARCH 0x10 // or'ed with current channel type
 /* after fast search, wait for slow search.  Otherwise, starting slow
@@ -93,8 +94,9 @@ class ANTChannel : public QObject {
         char id[10]; // short identifier
         ANTChannelInitialisation mi;
 
-        int messages_received; // for signal strength metric
-        int messages_dropped;
+        int   messages_received; // for signal strength metric
+        int   messages_dropped;
+        QTime lastMessageTimestamp;
 
         unsigned char rx_burst_data[RX_BURST_DATA_LEN];
         int           rx_burst_data_index;

--- a/src/ANTChannel.h
+++ b/src/ANTChannel.h
@@ -97,6 +97,7 @@ class ANTChannel : public QObject {
         int   messages_received; // for signal strength metric
         int   messages_dropped;
         QTime lastMessageTimestamp;
+        QTime lastMessageTimestamp2;
 
         unsigned char rx_burst_data[RX_BURST_DATA_LEN];
         int           rx_burst_data_index;


### PR DESCRIPTION
When using training mode with speed or cadence sensor or speed/cadence sensor the speed remain at previous value when we stop the wheel.
This is due to speed telemetry update done only when we receive a signal from ANT device indicating a magnet detection.
My patch decreases the speed step by step when we receive ANT message from sensor without magnet detection. Formula is : rpm cannot be more than duration from previous magnet detection.
Tested with ANT Speed sensor and Cadence sensor on Windows