### PR TITLE
Strava upload: set correct activity type

### DIFF
--- a/src/ShareDialog.cpp
+++ b/src/ShareDialog.cpp
@@ -482,7 +482,12 @@ StravaUploader::requestUploadStrava()
 
     QHttpPart activityTypePart;
     activityTypePart.setHeader(QNetworkRequest::ContentDispositionHeader, QVariant("form-data; name=\"activity_type\""));
-    activityTypePart.setBody("ride");
+    if (ride->isRun)
+      activityTypePart.setBody("run");
+    else if (ride->isSwim)
+      activityTypePart.setBody("swim");
+    else
+      activityTypePart.setBody("ride");
 
     QHttpPart activityNamePart;
     activityNamePart.setHeader(QNetworkRequest::ContentDispositionHeader, QVariant("form-data; name=\"activity_name\""));


### PR DESCRIPTION
Ensures that activities uploaded to strava are assigned the correct activity type and not just the ride default.