### PR TITLE
Config local

### DIFF
--- a/src/ANT.cpp
+++ b/src/ANT.cpp
@@ -80,12 +80,15 @@ const ant_sensor_type_t ANT::ant_sensor_types[] = {
 // thread and is part of the GC architecture NOT related to the
 // hardware controller.
 //
-ANT::ANT(QObject *parent, DeviceConfiguration *devConf) : QThread(parent), devConf(devConf)
+ANT::ANT(QObject *parent, DeviceConfiguration *devConf, QString cyclist) : QThread(parent), devConf(devConf)
 {
     qRegisterMetaType<ANTMessage>("ANTMessage");
     qRegisterMetaType<uint16_t>("uint16_t");
     qRegisterMetaType<uint8_t>("uint8_t");
     qRegisterMetaType<struct timeval>("struct timeval");
+
+    //remember the cylist for wheelsize Settings
+    trainCyclist = cyclist;
 
     // device status and settings
     Status=0;
@@ -146,6 +149,7 @@ ANT::ANT(QObject *parent, DeviceConfiguration *devConf) : QThread(parent), devCo
     usb2 = new LibUsb(TYPE_ANT);
 #endif
     channels = 0;
+
 }
 
 ANT::~ANT()
@@ -180,7 +184,7 @@ void ANT::setWheelRpm(float x) {
     // devConf will be NULL if we are are running the add device wizard
     // we can default to the global setting
     if (devConf) telemetry.setSpeed(x * devConf->wheelSize / 1000 * 60 / 1000);
-    else telemetry.setSpeed(x * appsettings->value(NULL, GC_WHEELSIZE, 2100).toInt() / 1000 * 60 / 1000);
+    else telemetry.setSpeed(x * appsettings->cvalue(trainCyclist, GC_WHEELSIZE, 2100).toInt() / 1000 * 60 / 1000);
 }
 
 void ANT::setHb(double smo2, double thb)

--- a/src/ANT.h
+++ b/src/ANT.h
@@ -291,7 +291,7 @@ class ANT : public QThread
 
 
 public:
-    ANT(QObject *parent = 0, DeviceConfiguration *dc=0);
+    ANT(QObject *parent = 0, DeviceConfiguration *dc=0, QString cyclist="");
     ~ANT();
 
 signals:
@@ -483,6 +483,9 @@ private:
     // tacx vortex (we'll probably want to abstract this out cf. kickr)
     int vortexID;
     int vortexChannel;
+
+    // cylist for wheelsize settings
+    QString trainCyclist;
 };
 
 #include "ANTMessage.h"

--- a/src/ANTlocalController.cpp
+++ b/src/ANTlocalController.cpp
@@ -25,7 +25,14 @@
 
 ANTlocalController::ANTlocalController(TrainSidebar *parent, DeviceConfiguration *dc) : RealtimeController(parent, dc)
 {
-    myANTlocal = new ANT (parent, dc, parent->context->athlete->cyclist);
+    // for Device Pairing the controller is called with parent = NULL
+    QString cyclist;
+    if (parent) {
+        cyclist = parent->context->athlete->cyclist;
+    } else {
+        cyclist = QString();
+    }
+    myANTlocal = new ANT (parent, dc, cyclist);
     connect(myANTlocal, SIGNAL(foundDevice(int,int,int)), this, SIGNAL(foundDevice(int,int,int)));
     connect(myANTlocal, SIGNAL(lostDevice(int)), this, SIGNAL(lostDevice(int)));
     connect(myANTlocal, SIGNAL(searchTimeout(int)), this, SIGNAL(searchTimeout(int)));

--- a/src/ANTlocalController.cpp
+++ b/src/ANTlocalController.cpp
@@ -25,7 +25,7 @@
 
 ANTlocalController::ANTlocalController(TrainSidebar *parent, DeviceConfiguration *dc) : RealtimeController(parent, dc)
 {
-    myANTlocal = new ANT (parent, dc);
+    myANTlocal = new ANT (parent, dc, parent->context->athlete->cyclist);
     connect(myANTlocal, SIGNAL(foundDevice(int,int,int)), this, SIGNAL(foundDevice(int,int,int)));
     connect(myANTlocal, SIGNAL(lostDevice(int)), this, SIGNAL(lostDevice(int)));
     connect(myANTlocal, SIGNAL(searchTimeout(int)), this, SIGNAL(searchTimeout(int)));

--- a/src/AddDeviceWizard.cpp
+++ b/src/AddDeviceWizard.cpp
@@ -588,6 +588,9 @@ AddPair::AddPair(AddDeviceWizard *parent) : QWizardPage(parent), wizard(parent)
 
     channelWidget = new QTreeWidget(this);
     layout->addWidget(channelWidget);
+
+    cyclist = parent->context->athlete->cyclist;
+
 }
 
 static void
@@ -791,7 +794,7 @@ AddPair::getChannelValues()
 
                 dynamic_cast<QLabel *>(channelWidget->itemWidget(item,2))->setText(QString("%1 %2")
                 .arg((int)dynamic_cast<ANTlocalController*>(wizard->controller)->myANTlocal->channelValue2(i) //speed
-                          * (appsettings->value(NULL, GC_WHEELSIZE, 2100).toInt()/1000) * 60 / 1000)
+                          * (appsettings->cvalue(cyclist, GC_WHEELSIZE, 2100).toInt()/1000) * 60 / 1000)
                 .arg((int)dynamic_cast<ANTlocalController*>(wizard->controller)->myANTlocal->channelValue(i))); // cad
 
             } else if (p->itemData(p->currentIndex()) == ANTChannel::CHANNEL_TYPE_MOXY) {
@@ -849,6 +852,9 @@ AddPairBTLE::AddPairBTLE(AddDeviceWizard *parent) : QWizardPage(parent), wizard(
 
     channelWidget = new QTreeWidget(this);
     layout->addWidget(channelWidget);
+
+    cyclist = parent->context->athlete->cyclist;
+
 }
 
 void
@@ -1026,7 +1032,7 @@ AddPairBTLE::getChannelValues()
             if (p->itemData(p->currentIndex()) == ANTChannel::CHANNEL_TYPE_SandC) {
             dynamic_cast<QLabel *>(channelWidget->itemWidget(item,2))->setText(QString("%1 %2")
                 .arg((int)dynamic_cast<ANTlocalController*>(wizard->controller)->myANTlocal->channelValue2(i) //speed
-                          * (appsettings->value(NULL, GC_WHEELSIZE, 2100).toInt()/1000) * 60 / 1000)
+                          * (appsettings->cvalue(cyclist, GC_WHEELSIZE, 2100).toInt()/1000) * 60 / 1000)
                 .arg((int)dynamic_cast<ANTlocalController*>(wizard->controller)->myANTlocal->channelValue(i))); // cad
             } else {
             dynamic_cast<QLabel *>(channelWidget->itemWidget(item,2))->setText(QString("%1")
@@ -1158,7 +1164,7 @@ AddFinal::AddFinal(AddDeviceWizard *parent) : QWizardPage(parent), wizard(parent
     //
     // Wheel size
     //
-    int wheelSize = appsettings->value(this, GC_WHEELSIZE, 2100).toInt();
+    int wheelSize = appsettings->cvalue(parent->context->athlete->cyclist, GC_WHEELSIZE, 2100).toInt();
 
     rimSizeCombo = new QComboBox();
     rimSizeCombo->addItems(WheelSize::RIM_SIZES);

--- a/src/AddDeviceWizard.h
+++ b/src/AddDeviceWizard.h
@@ -171,6 +171,7 @@ class AddPair : public QWizardPage
         QTreeWidget *channelWidget;
         QSignalMapper *signalMapper;
         QTimer updateValues;
+        QString cyclist;
 };
 
 class AddPairBTLE : public QWizardPage
@@ -199,6 +200,8 @@ class AddPairBTLE : public QWizardPage
         QTreeWidget *channelWidget;
         QSignalMapper *signalMapper;
         QTimer updateValues;
+        QString cyclist;
+
 };
 
 class AddFinal : public QWizardPage

--- a/src/Athlete.cpp
+++ b/src/Athlete.cpp
@@ -82,8 +82,7 @@ Athlete::Athlete(Context *context, const QDir &homeDir)
     QVariant unit = appsettings->cvalue(cyclist, GC_UNIT);
     if (unit == 0) {
         // Default to system locale
-        unit = appsettings->value(this, GC_UNIT,
-             QLocale::system().measurementSystem() == QLocale::MetricSystem ? GC_UNIT_METRIC : GC_UNIT_IMPERIAL);
+        unit = QLocale::system().measurementSystem() == QLocale::MetricSystem ? GC_UNIT_METRIC : GC_UNIT_IMPERIAL;
         appsettings->setCValue(cyclist, GC_UNIT, unit);
     }
     useMetricUnits = (unit.toString() == GC_UNIT_METRIC);
@@ -423,8 +422,7 @@ bool
 AthleteDirectoryStructure::upgradedDirectoriesHaveData() {
 
    if ( activities().exists() && config().exists()) {
-       QStringList activityFiles = activities().entryList(QDir::Files);
-       if (!activityFiles.isEmpty()) { return true; }
+       // just check for config files (activities are empty in case of a new athlete)
        QStringList configFiles = config().entryList(QDir::Files);
        if (!configFiles.isEmpty()) { return true; }
    }

--- a/src/Coggan.cpp
+++ b/src/Coggan.cpp
@@ -16,6 +16,7 @@
  * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
+#include "Context.h"
 #include "RideMetric.h"
 #include "RideItem.h"
 #include "Zones.h"
@@ -23,6 +24,7 @@
 #include "Units.h"
 #include <cmath>
 #include <QApplication>
+
 
 class NP : public RideMetric {
     Q_DECLARE_TR_FUNCTIONS(NP)
@@ -152,7 +154,7 @@ class IntensityFactor : public RideMetric {
     void compute(const RideFile *r, const Zones *zones, int zoneRange,
                  const HrZones *, int,
                  const QHash<QString,RideMetric*> &deps,
-                 const Context *) {
+                 const Context *context) {
         if (zones && zoneRange >= 0) {
             assert(deps.contains("coggan_np"));
             NP *np = dynamic_cast<NP*>(deps.value("coggan_np"));
@@ -160,7 +162,7 @@ class IntensityFactor : public RideMetric {
 
             int ftp = r->getTag("FTP","0").toInt();
 
-            bool useCPForFTP = (appsettings->value(NULL, GC_USE_CP_FOR_FTP, "1").toString() == "0");
+            bool useCPForFTP = (appsettings->cvalue(context->athlete->cyclist, GC_USE_CP_FOR_FTP, "1").toString() == "0");
 
             if (useCPForFTP) {
                 int cp = r->getTag("CP","0").toInt();
@@ -200,7 +202,7 @@ class TSS : public RideMetric {
     void compute(const RideFile *r, const Zones *zones, int zoneRange,
                  const HrZones *, int,
 	    const QHash<QString,RideMetric*> &deps,
-                 const Context *) {
+                 const Context *context) {
 	if (!zones || zoneRange < 0)
 	    return;
         assert(deps.contains("coggan_np"));
@@ -213,7 +215,7 @@ class TSS : public RideMetric {
 
         int ftp = r->getTag("FTP","0").toInt();
 
-        bool useCPForFTP = (appsettings->value(NULL, GC_USE_CP_FOR_FTP, "1").toString() == "0");
+        bool useCPForFTP = (appsettings->cvalue(context->athlete->cyclist, GC_USE_CP_FOR_FTP, "1").toString() == "0");
 
         if (useCPForFTP) {
             int cp = r->getTag("CP","0").toInt();

--- a/src/Colors.cpp
+++ b/src/Colors.cpp
@@ -522,6 +522,17 @@ GCColor::linearGradient(int size, bool active, bool alternate)
     return returning; 
 }
 
+QStringList
+GCColor::getConfigKeys() {
+
+    QStringList result;
+    for (unsigned int i=0; ColorList[i].name != ""; i++) {
+        result.append(ColorList[i].setting);
+    }
+    return result;
+}
+
+
 //
 // Themes
 //

--- a/src/Colors.h
+++ b/src/Colors.h
@@ -119,6 +119,9 @@ class GCColor : public QObject
         static void readConfig();
         static void setupColors();
 
+        // for upgrade/migration of Config
+        static QStringList getConfigKeys();
+
 };
 
 // return a color for a ride file

--- a/src/ConfigDialog.cpp
+++ b/src/ConfigDialog.cpp
@@ -251,6 +251,9 @@ void ConfigDialog::saveClicked()
             // lets restart
             restarting = true;
 
+            // save all setttings to disk
+            appsettings->syncQSettings();
+
             // close all the mainwindows
             foreach(MainWindow *m, mainwindows) m->byebye();
 

--- a/src/DataProcessor.cpp
+++ b/src/DataProcessor.cpp
@@ -54,7 +54,7 @@ DataProcessorFactory::autoProcess(RideFile *ride)
     while (i.hasNext()) {
         i.next();
         QString configsetting = QString("dp/%1/apply").arg(i.key());
-        if (appsettings->value(NULL, configsetting, "Manual").toString() == "Auto")
+        if (appsettings->value(NULL, GC_QSETTINGS_GLOBAL_GENERAL+configsetting, "Manual").toString() == "Auto")
             i.value()->postProcess(ride);
     }
 

--- a/src/GcCrashDialog.cpp
+++ b/src/GcCrashDialog.cpp
@@ -388,7 +388,7 @@ GcCrashDialog::setHTML()
     // files...
     text += "<center><h3>Athlete Directory - Activities</h3></center>";
     text += "<center><table border=0 cellspacing=10 width=\"90%\">";
-    foreach(QString file, home.activities().entryList(QDir::NoFilter, QDir::Time)) {
+    foreach(QString file, home.activities().entryList(QDir::NoDotAndDotDot, QDir::Time)) {
         text += QString("<tr><td align=\"right\"> %1</td><td align=\"left\">%2</td></tr>")
                 .arg(file)
                 .arg(QFileInfo(home.activities().canonicalPath() + "/" + file).lastModified().toString());
@@ -397,7 +397,7 @@ GcCrashDialog::setHTML()
 
     text += "<center><h3>Athlete Directory - Cache</h3></center>";
     text += "<center><table border=0 cellspacing=10 width=\"90%\">";
-    foreach(QString file, home.cache().entryList(QDir::NoFilter, QDir::Time)) {
+    foreach(QString file, home.cache().entryList(QDir::NoDotAndDotDot, QDir::Time)) {
         text += QString("<tr><td align=\"right\"> %1</td><td align=\"left\">%2</td></tr>")
                 .arg(file)
                 .arg(QFileInfo(home.cache().canonicalPath() + "/" + file).lastModified().toString());
@@ -406,7 +406,7 @@ GcCrashDialog::setHTML()
 
     text += "<center><h3>Athlete Directory - Config</h3></center>";
     text += "<center><table border=0 cellspacing=10 width=\"90%\">";
-    foreach(QString file, home.config().entryList(QDir::NoFilter, QDir::Time)) {
+    foreach(QString file, home.config().entryList(QDir::NoDotAndDotDot, QDir::Time)) {
         text += QString("<tr><td align=\"right\"> %1</td><td align=\"left\">%2</td></tr>")
                 .arg(file)
                 .arg(QFileInfo(home.config().canonicalPath() + "/" + file).lastModified().toString());
@@ -415,7 +415,7 @@ GcCrashDialog::setHTML()
 
     text += "<center><h3>Athlete Directory - Workouts</h3></center>";
     text += "<center><table border=0 cellspacing=10 width=\"90%\">";
-    foreach(QString file, home.workouts().entryList(QDir::NoFilter, QDir::Time)) {
+    foreach(QString file, home.workouts().entryList(QDir::NoDotAndDotDot, QDir::Time)) {
         text += QString("<tr><td align=\"right\"> %1</td><td align=\"left\">%2</td></tr>")
                 .arg(file)
                 .arg(QFileInfo(home.workouts().canonicalPath() + "/" + file).lastModified().toString());
@@ -424,7 +424,7 @@ GcCrashDialog::setHTML()
 
     text += "<center><h3>Athlete Directory - Imports</h3></center>";
     text += "<center><table border=0 cellspacing=10 width=\"90%\">";
-    foreach(QString file, home.imports().entryList(QDir::NoFilter, QDir::Time)) {
+    foreach(QString file, home.imports().entryList(QDir::NoDotAndDotDot, QDir::Time)) {
         text += QString("<tr><td align=\"right\"> %1</td><td align=\"left\">%2</td></tr>")
                 .arg(file)
                 .arg(QFileInfo(home.imports().canonicalPath() + "/" + file).lastModified().toString());
@@ -433,7 +433,7 @@ GcCrashDialog::setHTML()
 
     text += "<center><h3>Athlete Directory - Downloads</h3></center>";
     text += "<center><table border=0 cellspacing=10 width=\"90%\">";
-    foreach(QString file, home.downloads().entryList(QDir::NoFilter, QDir::Time)) {
+    foreach(QString file, home.downloads().entryList(QDir::NoDotAndDotDot, QDir::Time)) {
         text += QString("<tr><td align=\"right\"> %1</td><td align=\"left\">%2</td></tr>")
                 .arg(file)
                 .arg(QFileInfo(home.downloads().canonicalPath() + "/" + file).lastModified().toString());
@@ -447,17 +447,25 @@ GcCrashDialog::setHTML()
 
         // RESPECT PRIVACY
         // we do not disclose user names and passwords or key ids
-        if (key.endsWith("/user") || key.endsWith("/pass") || key.endsWith("/key")) continue;
+        if (key.endsWith("/user") || key.endsWith("/pass") || key.endsWith("/key") ||
+            key.endsWith("_token") || key.endsWith("_secret") || key.endsWith("googlecalid")) continue;
 
         // we do not disclose personally identifiable information
-        if (key.endsWith("/dob") || key.endsWith("/weight") ||
-            key.endsWith("/sex") || key.endsWith("/bio")) continue;
+        if (key.endsWith("dob") || key.endsWith("weight") ||
+            key.endsWith("sex") || key.endsWith("bio") ||
+            key.endsWith("height") || key.endsWith("nickname")) continue;
 
-
-        text += QString("<tr><td align=\"right\" width=\"50%\"> %1</td><td align=\"left\">"
-                        "<span style=\"max-width:50%;\">%2</span></td></tr>")
-                .arg(key)
-                .arg(appsettings->value(NULL, key).toString().leftJustified(60, ' ', true));
+        if (key.startsWith("<athlete-")) {
+            text += QString("<tr><td align=\"right\" width=\"50%\"> %1</td><td align=\"left\">"
+                            "<span style=\"max-width:50%;\">%2</span></td></tr>")
+                    .arg(key)
+                    .arg(appsettings->cvalue(home.root().dirName(), key).toString().leftJustified(60, ' ', true));
+        } else {
+            text += QString("<tr><td align=\"right\" width=\"50%\"> %1</td><td align=\"left\">"
+                            "<span style=\"max-width:50%;\">%2</span></td></tr>")
+                    .arg(key)
+                    .arg(appsettings->value(NULL, key).toString().leftJustified(60, ' ', true));
+        }
     }
     text += "</table></center>";
 

--- a/src/GcSideBarItem.cpp
+++ b/src/GcSideBarItem.cpp
@@ -90,7 +90,7 @@ GcSplitter::prepare(QString cyclist, QString name)
     control->addWidget(spacer);
 
     // get saved state
-    QString statesetting = QString("splitter/%1/sizes").arg(name);
+    QString statesetting = GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/%1/sizes").arg(name);
     QVariant sizes = appsettings->cvalue(cyclist, statesetting); 
     if (sizes != QVariant()) {
         splitter->restoreState(sizes.toByteArray());
@@ -99,7 +99,7 @@ GcSplitter::prepare(QString cyclist, QString name)
 
     // should we hide / show each widget?
     for(int i=0; i<splitter->count(); i++) {
-        QString hidesetting = QString("splitter/%1/hide/%2").arg(name).arg(i);
+        QString hidesetting = GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/%1/hide/%2").arg(name).arg(i);
         QVariant hidden = appsettings->cvalue(cyclist, hidesetting);
         if (i && hidden != QVariant()) {
             if (hidden.toBool() == true) {
@@ -113,12 +113,12 @@ void
 GcSplitter::saveSettings()
 {
     // get saved state
-    QString statesetting = QString("splitter/%1/sizes").arg(name);
+    QString statesetting = GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/%1/sizes").arg(name);
     appsettings->setCValue(cyclist, statesetting, splitter->saveState()); 
 
     // should we hide / show each widget?
     for(int i=0; i<splitter->count(); i++) {
-        QString hidesetting = QString("splitter/%1/hide/%2").arg(name).arg(i);
+        QString hidesetting = GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/%1/hide/%2").arg(name).arg(i);
         appsettings->setCValue(cyclist, hidesetting, QVariant(splitter->widget(i)->isHidden()));
     }
 }

--- a/src/GcUpgrade.cpp
+++ b/src/GcUpgrade.cpp
@@ -27,6 +27,7 @@
 #include "JsonRideFile.h"
 #include "Context.h"
 #include "DataProcessor.h"
+#include "MainWindow.h"
 
 #include <QDebug>
 #include <QMessageBox>
@@ -43,7 +44,7 @@ GcUpgrade::upgradeConfirmedByUser(const QDir &home)
     bool folderUpgradeSuccess =  appsettings->cvalue(home.dirName(), GC_UPGRADE_FOLDER_SUCCESS, false).toBool();
 
     //  reset upgrade flag - in case flag is set "true" and subfolder "/activities" and /config do NOT exist
-    //  or - if they exists - do not contain any files, then something is wrong with the upgrade flag -
+    //  or - if they exists, but config does not contain any files, then something is wrong with the upgrade flag -
     //  (potentially due to a not fitting data restore)
     //  so let's reset the flag to "false" and run the upgrade again - this can never go wrong (if their is
     //  nothing to be upgrade - upgrade a success anyway
@@ -114,32 +115,31 @@ GcUpgrade::upgrade(const QDir &home)
             if (weight_ <= 0.00) appsettings->setCValue(home.dirName(), GC_WEIGHT, "75.0");
 
             // 5. startup with common sidebars shown (less ugly)
-            appsettings->setCValue(home.dirName(), "splitter/LTM/hide", true);
-            appsettings->setCValue(home.dirName(), "splitter/LTM/hide/0", false);
-            appsettings->setCValue(home.dirName(), "splitter/LTM/hide/1", false);
-            appsettings->setCValue(home.dirName(), "splitter/LTM/hide/2", false);
-            appsettings->setCValue(home.dirName(), "splitter/LTM/hide/3", true);
-            appsettings->setCValue(home.dirName(), "splitter/analysis/hide", true);
-            appsettings->setCValue(home.dirName(), "splitter/analysis/hide/0", false);
-            appsettings->setCValue(home.dirName(), "splitter/analysis/hide/1", true);
-            appsettings->setCValue(home.dirName(), "splitter/analysis/hide/2", false);
-            appsettings->setCValue(home.dirName(), "splitter/analysis/hide/3", true);
-            appsettings->setCValue(home.dirName(), "splitter/diary/hide", true);
-            appsettings->setCValue(home.dirName(), "splitter/diary/hide/0", false);
-            appsettings->setCValue(home.dirName(), "splitter/diary/hide/1", false);
-            appsettings->setCValue(home.dirName(), "splitter/diary/hide/2", true);
-            appsettings->setCValue(home.dirName(), "splitter/train/hide", true);
-            appsettings->setCValue(home.dirName(), "splitter/train/hide/0", false);
-            appsettings->setCValue(home.dirName(), "splitter/train/hide/1", false);
-            appsettings->setCValue(home.dirName(), "splitter/train/hide/2", false);
-            appsettings->setCValue(home.dirName(), "splitter/train/hide/3", false);
+            appsettings->setCValue(home.dirName(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/LTM/hide"), true);
+            appsettings->setCValue(home.dirName(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/LTM/hide/0"), false);
+            appsettings->setCValue(home.dirName(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/LTM/hide/1"), false);
+            appsettings->setCValue(home.dirName(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/LTM/hide/2"), false);
+            appsettings->setCValue(home.dirName(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/LTM/hide/3"), true);
+            appsettings->setCValue(home.dirName(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/analysis/hide"), true);
+            appsettings->setCValue(home.dirName(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/analysis/hide/0"), false);
+            appsettings->setCValue(home.dirName(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/analysis/hide/1"), true);
+            appsettings->setCValue(home.dirName(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/analysis/hide/2"), false);
+            appsettings->setCValue(home.dirName(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/analysis/hide/3"), true);
+            appsettings->setCValue(home.dirName(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/diary/hide"), true);
+            appsettings->setCValue(home.dirName(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/diary/hide/0"), false);
+            appsettings->setCValue(home.dirName(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/diary/hide/1"), false);
+            appsettings->setCValue(home.dirName(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/diary/hide/2"), true);
+            appsettings->setCValue(home.dirName(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/train/hide"), true);
+            appsettings->setCValue(home.dirName(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/train/hide/0"), false);
+            appsettings->setCValue(home.dirName(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/train/hide/1"), false);
+            appsettings->setCValue(home.dirName(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/train/hide/2"), false);
+            appsettings->setCValue(home.dirName(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/train/hide/3"), false);
 
             // 6. Delete any old measures.xml -- its for withings only
             QFile msxml(QString("%1/measures.xml").arg(home.canonicalPath()));
             if (msxml.exists()) msxml.remove();
 
-            // FINALLY -- Set latest version - so only tries to upgrade once
-            appsettings->setCValue(home.dirName(), GC_VERSION_USED, VERSION_LATEST);
+
         }
     }
 
@@ -160,6 +160,7 @@ GcUpgrade::upgrade(const QDir &home)
         // 3. Remove metricDBv3 - force rebuild including the search index
         QFile db(QString("%1/metricDBv3").arg(home.canonicalPath()));
         if (db.exists()) db.remove();
+
     }
 
     //----------------------------------------------------------------------
@@ -347,6 +348,20 @@ GcUpgrade::upgrade(const QDir &home)
 
     }
 
+
+    //----------------------------------------------------------------------
+    // ... here any further Release Number dependent Upgrade Process is to be added ...
+    //----------------------------------------------------------------------
+
+
+
+    //----------------------------------------------------------------------
+    // All Version dependent Upgrade Steps are done ...
+    //----------------------------------------------------------------------
+
+    // FINALLY -- Set latest version - so only tries to upgrade once
+    appsettings->setCValue(home.dirName(), GC_VERSION_USED, VERSION_LATEST);
+
     //----------------------------------------------------------------------
     // 3.2 new subfolder introduction and upgrade processing
     //----------------------------------------------------------------------
@@ -369,6 +384,8 @@ GcUpgrade::upgrade(const QDir &home)
 
         AthleteDirectoryStructure newHome(home);
         newHome.createAllSubdirs();
+        //now we can created the QSettings for the Athlete and Migrate the oldseetings
+        appsettings->initializeQSettingsAthlete(gcroot, home.dirName());
 
         if (!newHome.subDirsExist()) {
            upgradeLog->append(QString(tr("Error: Creation of subdirectories failed")),2);

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -1532,9 +1532,11 @@ MainWindow::openWindow(QString name)
 {
     // open window...
     QDir home(gcroot);
+    appsettings->initializeQSettingsGlobal(gcroot);
     home.cd(name);
 
     if (!home.exists()) return;
+    appsettings->initializeQSettingsAthlete(gcroot, name);
 
     GcUpgrade v3;
     if (!v3.upgradeConfirmedByUser(home)) return;
@@ -1549,6 +1551,7 @@ void
 MainWindow::closeWindow()
 {
     // just call close, we might do more later
+    appsettings->syncQSettings();
     close();
 }
 
@@ -1556,9 +1559,11 @@ void
 MainWindow::openTab(QString name)
 {
     QDir home(gcroot);
+    appsettings->initializeQSettingsGlobal(gcroot);
     home.cd(name);
 
     if (!home.exists()) return;
+    appsettings->initializeQSettingsAthlete(gcroot, name);
 
     GcUpgrade v3;
     if (!v3.upgradeConfirmedByUser(home)) return;
@@ -1623,7 +1628,7 @@ MainWindow::closeTab()
     else {
         removeTab(currentTab);
     }
-
+    appsettings->syncQSettings();
     // we did it
     return true;
 }

--- a/src/ModelPlot.cpp
+++ b/src/ModelPlot.cpp
@@ -345,7 +345,7 @@ ModelDataProvider::describeType(int type, bool longer)
 ModelDataProvider::ModelDataProvider (ModelPlot &plot, ModelSettings *settings) : Function(plot), plot(plot)
 {
     // get application settings
-    cranklength = appsettings->value(NULL, GC_CRANKLENGTH, 0.0).toDouble() / 1000.0;
+    cranklength = appsettings->cvalue(plot.context->athlete->cyclist, GC_CRANKLENGTH, 0.0).toDouble() / 1000.0;
     useMetricUnits = plot.context->athlete->useMetricUnits;
 
     // if there are no settings or incomplete settings

--- a/src/NewCyclistDialog.cpp
+++ b/src/NewCyclistDialog.cpp
@@ -265,35 +265,39 @@ NewCyclistDialog::saveClicked()
         if (!home.exists(name->text())) {
             if (home.mkdir(name->text())) {
 
-                QDir athleteDir = QDir(home.absolutePath()+'/'+name->text());
+                QDir athleteDir = QDir(home.canonicalPath()+'/'+name->text());
                 AthleteDirectoryStructure *athleteHome = new AthleteDirectoryStructure(athleteDir);
 
                 // create the sub-Dirs here
                 athleteHome->createAllSubdirs();
 
                 // new Athlete/new Directories - no Upgrade required
+                appsettings->initializeQSettingsNewAthlete(home.canonicalPath(), name->text());
                 appsettings->setCValue(name->text(), GC_UPGRADE_FOLDER_SUCCESS, true);
 
+                // set the version under which the Athlete is created - to avoid unneccary upgrade execution
+                appsettings->setCValue(name->text(), GC_VERSION_USED, QVariant(VERSION_LATEST));           
+
                 // nice sidebars please!
-                appsettings->setCValue(name->text(), "splitter/LTM/hide", true);
-                appsettings->setCValue(name->text(), "splitter/LTM/hide/0", false);
-                appsettings->setCValue(name->text(), "splitter/LTM/hide/1", false);
-                appsettings->setCValue(name->text(), "splitter/LTM/hide/2", false);
-                appsettings->setCValue(name->text(), "splitter/LTM/hide/3", true);
-                appsettings->setCValue(name->text(), "splitter/analysis/hide", true);
-                appsettings->setCValue(name->text(), "splitter/analysis/hide/0", false);
-                appsettings->setCValue(name->text(), "splitter/analysis/hide/1", true);
-                appsettings->setCValue(name->text(), "splitter/analysis/hide/2", false);
-                appsettings->setCValue(name->text(), "splitter/analysis/hide/3", true);
-                appsettings->setCValue(name->text(), "splitter/diary/hide", true);
-                appsettings->setCValue(name->text(), "splitter/diary/hide/0", false);
-                appsettings->setCValue(name->text(), "splitter/diary/hide/1", false);
-                appsettings->setCValue(name->text(), "splitter/diary/hide/2", true);
-                appsettings->setCValue(name->text(), "splitter/train/hide", true);
-                appsettings->setCValue(name->text(), "splitter/train/hide/0", false);
-                appsettings->setCValue(name->text(), "splitter/train/hide/1", false);
-                appsettings->setCValue(name->text(), "splitter/train/hide/2", false);
-                appsettings->setCValue(name->text(), "splitter/train/hide/3", false);
+                appsettings->setCValue(name->text(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/LTM/hide"), true);
+                appsettings->setCValue(name->text(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/LTM/hide/0"), false);
+                appsettings->setCValue(name->text(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/LTM/hide/1"), false);
+                appsettings->setCValue(name->text(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/LTM/hide/2"), false);
+                appsettings->setCValue(name->text(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/LTM/hide/3"), true);
+                appsettings->setCValue(name->text(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/analysis/hide"), true);
+                appsettings->setCValue(name->text(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/analysis/hide/0"), false);
+                appsettings->setCValue(name->text(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/analysis/hide/1"), true);
+                appsettings->setCValue(name->text(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/analysis/hide/2"), false);
+                appsettings->setCValue(name->text(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/analysis/hide/3"), true);
+                appsettings->setCValue(name->text(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/diary/hide"), true);
+                appsettings->setCValue(name->text(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/diary/hide/0"), false);
+                appsettings->setCValue(name->text(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/diary/hide/1"), false);
+                appsettings->setCValue(name->text(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/diary/hide/2"), true);
+                appsettings->setCValue(name->text(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/train/hide"), true);
+                appsettings->setCValue(name->text(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/train/hide/0"), false);
+                appsettings->setCValue(name->text(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/train/hide/1"), false);
+                appsettings->setCValue(name->text(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/train/hide/2"), false);
+                appsettings->setCValue(name->text(), GC_QSETTINGS_ATHLETE_LAYOUT+QString("splitter/train/hide/3"), false);
 
                 // lets setup!
                 if (unitCombo->currentIndex()==0)
@@ -328,6 +332,8 @@ NewCyclistDialog::saveClicked()
                 PaceZones swPaceZones(true);
                 swPaceZones.addZoneRange(QDate(1900, 01, 01), swPaceZones.kphFromTime(cvSw, useMetricUnits));
                 swPaceZones.write(athleteHome->config().canonicalPath());
+
+                appsettings->syncQSettingsAllAthletes();
 
                 accept();
             } else {

--- a/src/Pages.h
+++ b/src/Pages.h
@@ -689,6 +689,8 @@ class ZonePage : public QWidget
     public:
 
         ZonePage(Context *);
+        Context *context;
+
         qint32 saveClicked();
 
         //ZoneScheme scheme;
@@ -704,7 +706,6 @@ class ZonePage : public QWidget
 
     protected:
 
-        Context *context;
         bool changed;
 
         QTabWidget *tabs;

--- a/src/PfPvPlot.cpp
+++ b/src/PfPvPlot.cpp
@@ -179,7 +179,7 @@ PfPvPlot::PfPvPlot(Context *context)
     curve = new QwtPlotCurve();
     curve->attach(this);
 
-    cl_ = appsettings->value(this, GC_CRANKLENGTH).toDouble() / 1000.0;
+    cl_ = appsettings->cvalue(context->athlete->cyclist, GC_CRANKLENGTH).toDouble() / 1000.0;
 
     // markup timeInQuadrant
     tiqMarker[0] = new QwtPlotMarker(); tiqMarker[0]->attach(this);
@@ -242,7 +242,7 @@ PfPvPlot::configChanged(qint32)
     mY->setLinePen(marker);
     cpCurve->setPen(cp);
 
-    setCL(appsettings->value(this, GC_CRANKLENGTH).toDouble() / 1000.0);
+    setCL(appsettings->cvalue(context->athlete->cyclist, GC_CRANKLENGTH).toDouble() / 1000.0);
 
     replot();
 }

--- a/src/RideEditor.cpp
+++ b/src/RideEditor.cpp
@@ -2166,7 +2166,7 @@ PasteSpecialDialog::setResultsTable()
         for (int i=0; hasHeader->isChecked() ? (i<sourceHeadings.count()) : (i<cells[0].count()); i++) {
             if (hasHeader->isChecked() == true) {
                 // have we mapped this before?
-                QString lookup = "colmap/" + sourceHeadings[i];
+                QString lookup = GC_QSETTINGS_GLOBAL_GENERAL+QString("colmap/") + sourceHeadings[i];
                 QString mapto = appsettings->value(this, lookup, "Ignore").toString();
                 // is this an available heading tho?
                 if (columnSelect->findText(mapto) != -1) {
@@ -2475,7 +2475,7 @@ PasteSpecialDialog::columnChanged()
 
     // lets remember this mapping if its to a source header
     if (hasHeader->isChecked() && headings[column] != "Ignore") {
-        QString lookup = "colmap/" + sourceHeadings[column];
+        QString lookup = GC_QSETTINGS_GLOBAL_GENERAL+QString("colmap/") + sourceHeadings[column];
         appsettings->setValue(lookup, headings[column]);
     }
 }

--- a/src/RideFile.cpp
+++ b/src/RideFile.cpp
@@ -1753,7 +1753,7 @@ RideFile::recalculateDerivedSeries(bool force)
 
     // wheelsize - use meta, then config then drop to 2100
     double wheelsize = getTag(tr("Wheelsize"), "0.0").toDouble();
-    if (wheelsize == 0) wheelsize = appsettings->value(this, GC_WHEELSIZE, 2100).toInt();
+    if (wheelsize == 0) wheelsize = appsettings->cvalue(context->athlete->cyclist, GC_WHEELSIZE, 2100).toInt();
     wheelsize /= 1000.00f; // need it in meters
 
     // last point looked at

--- a/src/ScatterPlot.cpp
+++ b/src/ScatterPlot.cpp
@@ -296,7 +296,7 @@ void ScatterPlot::setData (ScatterSettings *settings)
     minY = minX = 65535;
 
     // get application settings
-    cranklength = appsettings->value(this, GC_CRANKLENGTH, 175.00).toDouble() / 1000.0;
+    cranklength = appsettings->cvalue(context->athlete->cyclist, GC_CRANKLENGTH, 175.00).toDouble() / 1000.0;
 
     // how many curves do we need ?
     if (xseries == MODEL_LRBALANCE || xseries == MODEL_TE || xseries == MODEL_PS ||

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -173,6 +173,8 @@ GSettings::setValue(QString key, QVariant value)
 QVariant
 GSettings::cvalue(QString athleteName, QString key, QVariant def) {
 
+    if (athleteName.isNull() || athleteName.isEmpty()) return def;
+
     QString keyVar = QString(key);
     if (newFormat) {
         int store;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -467,6 +467,15 @@ GSettings::migrateCValue(QString athlete, QString key) {
 }
 
 void
+GSettings::migrateAndRenameCValue(QString athlete, QString wrongKey, QString key) {
+
+    wrongKey.remove(QRegExp("^<.*>"));
+    if (oldsystemsettings->contains(athlete+"/"+wrongKey)) {
+        setCValue(athlete, key, oldsystemsettings->value(athlete+"/"+wrongKey));
+    }
+}
+
+void
 GSettings::migrateValueToCValue(QString athlete, QString key) {
 
     QString oldKey = key;
@@ -631,13 +640,13 @@ GSettings::upgradeAthlete(QString athlete) {
     migrateCValue(athlete, GC_LTS_DAYS);
     migrateCValue(athlete, GC_STS_DAYS);
     migrateCValue(athlete, GC_NAVHEADINGS);
-    migrateCValue(athlete, GC_NAVHEADINGWIDTHS);
     migrateCValue(athlete, GC_NAVGROUPBY);
     migrateCValue(athlete, GC_SORTBY);
     migrateCValue(athlete, GC_WEBCAL_URL);
     migrateCValue(athlete, GC_DIARY_VIEW);
     migrateCValue(athlete, GC_USE_CP_FOR_FTP);
 
+    migrateAndRenameCValue(athlete, "bavigator/headingwidths", GC_NAVHEADINGWIDTHS);
 
     // Handle the splittersizes keys
     QStringList splitterKeys = oldsystemsettings->allKeys();

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -1,5 +1,26 @@
+/*
+ * Copyright (c) 2006 Sean C. Rhea (srhea@srhea.net)
+ * Copyright (c) 2015 Joern Rischmueller (joern.rm@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 #include <QDir>
 #include "Settings.h"
+#include "MainWindow.h"
+#include "Colors.h"
 #include <QSettings>
 #include <QDebug>
 
@@ -13,6 +34,8 @@ int OperatingSystem = LINUX;
 int OperatingSystem = OPENBSD;
 #endif
 
+// -------------- Initializer for the "extern" variable "appsettings" ----------------//
+
 static GSettings *GetApplicationSettings()
 {
   GSettings *settings;
@@ -25,20 +48,638 @@ static GSettings *GetApplicationSettings()
   return settings;
 }
 
-QVariant
-GSettings::value(const QObject * /*me*/, const QString key, const QVariant def) const
-{
+// local static helper routines
 
-    // debug output ?
-    //for (const QObject *p=me; p; p = p->parent()) {
-    //if (p->property("instanceName").toString() != "")
-    //qDebug()<<p->property("instanceName").toString();
-    //}
+// define the sections and the filenames
+enum SettingsType {SETTINGS_SYSTEM = 0,
+                   SETTINGS_GLOBAL = 1,
+                   SETTINGS_ATHLETE = 2 };
 
-        return QSettings::value(key, def);
+enum SettingsFilesIndexGlobal {GLOBAL_GENERAL = 0,
+                               GLOBAL_TRAINMODE = 1};
+
+enum SettingsFilesIndexAthlete { ATHLETE_GENERAL = 0,
+                                 ATHLETE_LAYOUT = 1,
+                                 ATHLETE_PREFERENCES = 2,
+                                 ATHLETE_PRIVATE = 3};
+
+static const QString settingFileNamesGlobal[2] = {"configglobal-general.ini","configglobal-trainmode.ini"};
+static const QString settingFileNamesAthlete[4] = {"athlete-general.ini","athlete-layout.ini","athlete-preferences.ini","athlete-private.ini"};
+
+
+
+static QString DetermineKey(QString & key, int& store, int& fileIndex) {
+
+    store = SETTINGS_SYSTEM; // default to systemsettings
+    fileIndex = 0;
+    if (key.startsWith(GC_QSETTINGS_GLOBAL_GENERAL)) {
+        store = SETTINGS_GLOBAL;
+        fileIndex = GLOBAL_GENERAL;
+    } else if (key.startsWith(GC_QSETTINGS_GLOBAL_TRAIN)) {
+        store = SETTINGS_GLOBAL;
+        fileIndex = GLOBAL_TRAINMODE;
+    } else if (key.startsWith(GC_QSETTINGS_ATHLETE_GENERAL)) {
+        store = SETTINGS_ATHLETE;
+        fileIndex = ATHLETE_GENERAL;
+    } else if (key.startsWith(GC_QSETTINGS_ATHLETE_LAYOUT)) {
+        store = SETTINGS_ATHLETE;
+        fileIndex = ATHLETE_LAYOUT;
+    } else if (key.startsWith(GC_QSETTINGS_ATHLETE_PREFERENCES)) {
+        store = SETTINGS_ATHLETE;
+        fileIndex = ATHLETE_PREFERENCES;
+    } else if (key.startsWith(GC_QSETTINGS_ATHLETE_PRIVATE)) {
+        store = SETTINGS_ATHLETE;
+        fileIndex = ATHLETE_PRIVATE;
+    }
+
+    // and make sure <> text is removed
+    return key.remove(QRegExp("^<.*>"));
+
 }
 
 
-// initialise with no cyclist
-// as soon as a cyclist is opened it will be initialised via mainwindow
+// -----------------------------constructor and public instance methods ------------------------//
+
+GSettings::GSettings(QString org, QString app) : newFormat(true){
+    oldsystemsettings = new QSettings(org,app);
+    systemsettings = new QSettings(QSettings::IniFormat, QSettings::UserScope, org, app);
+    global = new QVector<QSettings*>();
+}
+
+GSettings::GSettings(QString file, QSettings::Format format) : newFormat(false){
+    systemsettings = new QSettings(file,format);
+}
+
+GSettings::~GSettings() {
+    syncQSettings();
+}
+
+
+QVariant
+GSettings::value(const QObject * /*me*/, const QString key, const QVariant def) {
+
+    QString keyVar = QString(key);
+    if (newFormat) {
+        int store;
+        int file;
+        keyVar = DetermineKey(keyVar, store, file);
+        switch (store) {
+        case SETTINGS_SYSTEM:
+            return systemsettings->value(keyVar, def);
+            break;
+        case SETTINGS_GLOBAL:
+            return global->at(file)->value(keyVar, def);
+            break;
+        case SETTINGS_ATHLETE:
+            qDebug() << "GetValue key, keyVar, store:" << key << ":" << keyVar  << ": " << store; // error cases on code configuration
+            break;
+        }
+
+    } else {
+        keyVar.remove(QRegExp("^<.*>"));
+        return systemsettings->value(keyVar, def);
+    }
+    return QVariant();
+}
+
+void
+GSettings::setValue(QString key, QVariant value)
+{
+    QString keyVar = QString(key);
+    if (newFormat) {
+        int store;
+        int file;
+        keyVar = DetermineKey(keyVar, store, file);
+        switch (store) {
+        case SETTINGS_SYSTEM:
+            systemsettings->setValue(keyVar,value);
+            break;
+        case SETTINGS_GLOBAL:
+            global->at(file)->setValue(keyVar,value);
+            break;
+        case SETTINGS_ATHLETE:
+            qDebug() << "SetValue key, keyVar, store:" << key << ":" << keyVar  << ": " << store; // error cases on code configuration
+            break;
+
+        }
+    } else {
+        keyVar.remove(QRegExp("^<.*>"));
+        systemsettings->setValue(keyVar, value);
+    }
+
+}
+
+// access to athlete specific config
+QVariant
+GSettings::cvalue(QString athleteName, QString key, QVariant def) {
+
+    QString keyVar = QString(key);
+    if (newFormat) {
+        int store;
+        int file;
+        keyVar = DetermineKey(keyVar, store, file);
+
+        QHash<QString, AthleteQSettings*>::const_iterator i = athlete.find(athleteName);
+        if (i != athlete.end()) {
+            switch (store) {
+            case SETTINGS_SYSTEM:
+            case SETTINGS_GLOBAL:
+                qDebug() << "GetCValue key, keyVar, store:" << key << ":" << keyVar  << ": " << store; // error cases on code configuration
+                break;
+            case SETTINGS_ATHLETE:
+                return i.value()->getQSettings(file)->value(keyVar, def);
+                break;
+            }
+        } else {
+            // fall back to old settings - assuming that this can only happen during the upgrade of an athlete
+            // and before the new /config folder exists
+            return oldsystemsettings->value(athleteName+"/"+keyVar, def);
+        }
+
+    } else {
+        keyVar.remove(QRegExp("^<.*>"));
+        return systemsettings->value(athleteName+"/"+keyVar, def);
+    }
+    return QVariant();
+
+}
+
+void
+GSettings::setCValue(QString athleteName, QString key, QVariant value) {
+
+    QString keyVar = QString(key);
+    if (newFormat) {
+        int store;
+        int file;
+        keyVar = DetermineKey(keyVar, store, file);
+        QHash<QString, AthleteQSettings*>::const_iterator i = athlete.find(athleteName);
+        if (i != athlete.end()) {
+            switch (store) {
+            case SETTINGS_SYSTEM:
+            case SETTINGS_GLOBAL:
+                qDebug() << "SetCValue keyVar, store:" << key << ":" << keyVar  << ": " << store; // error cases on code configuration
+                break;
+            case SETTINGS_ATHLETE:
+                i.value()->getQSettings(file)->setValue(keyVar, value);
+                break;
+            }
+        } // if we do have have the athlete - then we do not store anything
+    } else {
+        keyVar.remove(QRegExp("^<.*>"));
+        systemsettings->setValue(athleteName + "/" + keyVar,value);
+
+    }
+}
+
+// other functions unsed from QSettings which GSettings needs to implement
+QStringList
+GSettings::allKeys() const {
+
+    if (newFormat) {
+        QStringList allKeys, tempKeys;
+        tempKeys = systemsettings->allKeys();
+        foreach (QString key, tempKeys) {
+           allKeys.append(GC_QSETTINGS_SYSTEM+key);
+        }
+        tempKeys = global->at(GLOBAL_GENERAL)->allKeys();
+        foreach (QString key, tempKeys) {
+           allKeys.append(GC_QSETTINGS_GLOBAL_GENERAL+key);
+        }
+        tempKeys = global->at(GLOBAL_TRAINMODE)->allKeys();
+        foreach (QString key, tempKeys) {
+           allKeys.append(GC_QSETTINGS_GLOBAL_TRAIN+key);
+        }
+        QHashIterator<QString, AthleteQSettings*> i(athlete);
+        i.toFront();
+        while (i.hasNext())
+        { i.next();
+            tempKeys = i.value()->getQSettings(ATHLETE_GENERAL)->allKeys();
+            foreach (QString key, tempKeys) {
+               allKeys.append(GC_QSETTINGS_ATHLETE_GENERAL+key);
+            }
+            tempKeys = i.value()->getQSettings(ATHLETE_LAYOUT)->allKeys();
+            foreach (QString key, tempKeys) {
+               allKeys.append(GC_QSETTINGS_ATHLETE_LAYOUT+key);
+            }
+            tempKeys = i.value()->getQSettings(ATHLETE_PREFERENCES)->allKeys();
+            foreach (QString key, tempKeys) {
+               allKeys.append(GC_QSETTINGS_ATHLETE_PREFERENCES+key);
+            }
+            tempKeys = i.value()->getQSettings(ATHLETE_PRIVATE)->allKeys();
+            foreach (QString key, tempKeys) {
+               allKeys.append(GC_QSETTINGS_ATHLETE_PRIVATE+key);
+            }
+        }
+        allKeys.removeDuplicates();  // remove duplicate keys from the Athlete Settings
+        return allKeys;
+    } else {
+        return systemsettings->allKeys();
+    }
+    return QStringList();
+}
+
+bool
+GSettings::contains(const QString & key) const {
+
+    QString keyVar = QString(key);
+    if (newFormat) {
+        int store;
+        int file;
+        keyVar = DetermineKey(keyVar, store, file);
+        switch (store) {
+        case SETTINGS_SYSTEM:
+            return systemsettings->contains(keyVar);
+            break;
+        case SETTINGS_GLOBAL:
+            return global->at(file)->contains(keyVar);
+            break;
+        case SETTINGS_ATHLETE:
+            qDebug() << "Contains Value key:" << key << "keyVar:" << keyVar; // error cases on code configuration
+            return false;
+            break;
+        }
+    } else {
+        keyVar.remove(QRegExp("^<.*>"));
+        return systemsettings->contains(keyVar);
+    }
+    return false;
+}
+
+void
+GSettings::migrateQSettingsSystem() {
+
+    // do the migration for the System Settings - if not yet done
+    // - System is only migrated once per PC (since it only exists once
+
+    if (systemsettings->allKeys().isEmpty()) {
+        upgradeSystem();
+        systemsettings->sync();
+    }
+}
+
+
+void
+GSettings::initializeQSettingsGlobal(QString athletesRootDir) {
+
+    if (!newFormat) return;
+
+    if (global->isEmpty()) {
+
+        global->append(new QSettings(athletesRootDir+"/"+settingFileNamesGlobal[GLOBAL_GENERAL],QSettings::IniFormat));
+        global->append(new QSettings(athletesRootDir+"/"+settingFileNamesGlobal[GLOBAL_TRAINMODE],QSettings::IniFormat));
+
+    }
+
+    // do the migration for the AthleteDir / Global Settings  if not yet done
+    // - Global is migrated to the root of ANY AthleteDirectory if it does not yet exist
+    //   this is too support migration if a user has multiple AthleteDirectories in place
+    //   but also creates a default like his previous old-style directory when new AthleteDirectory is created
+
+    if (global->at(GLOBAL_GENERAL)->allKeys().isEmpty() && global->at(GLOBAL_TRAINMODE)->allKeys().isEmpty()) {
+        upgradeGlobal();
+    }
+    syncQSettingsGlobal();
+
+}
+
+void
+GSettings::initializeQSettingsAthlete(QString athletesRootDir, QString athleteName) {
+
+    // assumption is that the directory "<athletesRootDir>/athleteName" exists //
+
+    if (!newFormat) return;
+
+    // handle not yet upgraded athlete folders without causing problems
+    // initializing of the QSettings would work anyway - but upgrade would fail,
+    // since the /config folder does not exist - so leave the upgrade for the next
+    // initialization after successfull upgrade (the case should be rare anyway)
+    QDir configDir(athletesRootDir+"/"+athleteName+"/config");
+    if (!configDir.exists()) {
+        return; // athlete has not yet been migrated and /config does not exist - so wait until next time
+    }
+
+    // create the New Athlete QSettings (if they do not yet exists and migrate the old data if required)
+
+    QHash<QString, AthleteQSettings*>::const_iterator i = athlete.find(athleteName);
+    if (i == athlete.end()) {
+
+        initializeQSettingsNewAthlete(athletesRootDir, athleteName);
+
+        QHash<QString, AthleteQSettings*>::const_iterator i2 = athlete.find(athleteName);
+        // do the upgrade for the Athlete Properties - but only if the Settings are currently empty - don't overwrite anything
+        if (i2 != athlete.end()) {
+            if (i2.value()->getQSettings(ATHLETE_GENERAL)->allKeys().isEmpty() &&
+                    i2.value()->getQSettings(ATHLETE_LAYOUT)->allKeys().isEmpty() &&
+                    i2.value()->getQSettings(ATHLETE_PREFERENCES)->allKeys().isEmpty() &&
+                    i2.value()->getQSettings(ATHLETE_PRIVATE)->allKeys().isEmpty() ) {
+                upgradeAthlete(athleteName);
+
+            }
+        }
+        syncQSettingsAllAthletes();
+    }
+}
+
+void
+GSettings::initializeQSettingsNewAthlete(QString athletesRootDir, QString athleteName) {
+
+    if (!newFormat) return;
+
+    // create the Athlete QSettings - they MUST not exist yet
+    AthleteQSettings* athleteSettings = new AthleteQSettings();
+    QString baseName = athletesRootDir + "/" + athleteName + "/config/";
+    athleteSettings->setQSettings(new QSettings(baseName+settingFileNamesAthlete[ATHLETE_GENERAL], QSettings::IniFormat), ATHLETE_GENERAL );
+    athleteSettings->setQSettings(new QSettings(baseName+settingFileNamesAthlete[ATHLETE_LAYOUT], QSettings::IniFormat), ATHLETE_LAYOUT );
+    athleteSettings->setQSettings(new QSettings(baseName+settingFileNamesAthlete[ATHLETE_PREFERENCES], QSettings::IniFormat), ATHLETE_PREFERENCES );
+    athleteSettings->setQSettings(new QSettings(baseName+settingFileNamesAthlete[ATHLETE_PRIVATE], QSettings::IniFormat), ATHLETE_PRIVATE );
+    athlete.insert(athleteName, athleteSettings);
+
+}
+
+
+void
+GSettings::syncQSettingsAllAthletes() {
+
+    if (!newFormat) return;
+
+    QHashIterator<QString, AthleteQSettings*> i(athlete);
+    i.toFront();
+    while (i.hasNext())
+    { i.next();
+        i.value()->getQSettings(ATHLETE_GENERAL)->sync();
+        i.value()->getQSettings(ATHLETE_LAYOUT)->sync();
+        i.value()->getQSettings(ATHLETE_PREFERENCES)->sync();
+        i.value()->getQSettings(ATHLETE_PRIVATE)->sync();
+    }
+}
+
+void
+GSettings::syncQSettingsGlobal() {
+
+    if (!newFormat) return;
+
+    if (global->size() == 2) {
+        global->at(GLOBAL_GENERAL)->sync();
+        global->at(GLOBAL_TRAINMODE)->sync();
+    };
+}
+
+void
+GSettings::syncQSettings() {
+
+    systemsettings->sync();
+    syncQSettingsGlobal();
+    syncQSettingsAllAthletes();
+
+}
+
+void
+GSettings::clearGlobalAndAthletes() {
+
+    if (!newFormat) return;
+    syncQSettings();
+    global->clear();
+    athlete.clear();
+}
+
+
+//------------------ special methods for Upgrade/Migration -------------------------------------//
+void
+GSettings::migrateValue(QString key) {
+
+    QString oldKey = key;
+    oldKey.remove(QRegExp("^<.*>"));
+    if (oldsystemsettings->contains(oldKey)) {
+        setValue(key, oldsystemsettings->value(oldKey));
+    }
+}
+
+void
+GSettings::migrateCValue(QString athlete, QString key) {
+
+    QString oldKey = key;
+    oldKey.remove(QRegExp("^<.*>"));
+    if (oldsystemsettings->contains(athlete+"/"+oldKey)) {
+        setCValue(athlete, key, oldsystemsettings->value(athlete+"/"+oldKey));
+    }
+}
+
+void
+GSettings::migrateValueToCValue(QString athlete, QString key) {
+
+    QString oldKey = key;
+    oldKey.remove(QRegExp("^<.*>"));
+    if (oldsystemsettings->contains(oldKey)) {
+        setCValue(athlete, key, oldsystemsettings->value(oldKey));
+    }
+}
+
+
+void
+GSettings::upgradeSystem() {
+
+    // by explicitely naming all the properties, and not choosing the "allKeys()" function,
+    // only the properties still in use are migrated - and not any orphans for previous releases
+
+    migrateValue(GC_HOMEDIR);
+    migrateValue(GC_SETTINGS_LAST);
+    migrateValue(GC_SETTINGS_MAIN_GEOM);
+    migrateValue(GC_SETTINGS_MAIN_STATE);
+    migrateValue(GC_SETTINGS_LAST_IMPORT_PATH);
+    migrateValue(GC_SETTINGS_LAST_WORKOUT_PATH);
+    migrateValue(GC_LAST_DOWNLOAD_DEVICE);
+    migrateValue(GC_LAST_DOWNLOAD_PORT);
+    migrateValue(GC_BE_LASTDIR);
+    migrateValue(GC_BE_LASTFMT);
+    migrateValue(GC_FONT_DEFAULT);
+    migrateValue(GC_FONT_TITLES);
+    migrateValue(GC_FONT_CHARTMARKERS);
+    migrateValue(GC_FONT_CHARTLABELS);
+    migrateValue(GC_FONT_CALENDAR);
+    migrateValue(GC_FONT_DEFAULT_SIZE);
+    migrateValue(GC_FONT_TITLES_SIZE);
+    migrateValue(GC_FONT_CHARTMARKERS_SIZE);
+    migrateValue(GC_FONT_CHARTLABELS_SIZE);
+    migrateValue(GC_FONT_CALENDAR_SIZE);
+
+    QStringList colorProperties = GCColor::getConfigKeys();
+    QStringListIterator colorIterator(colorProperties);
+    while (colorIterator.hasNext()) {
+        QString key = QString(colorIterator.next().data());
+        migrateValue(key);
+    }
+    migrateValue(GC_CHROME);
+
+
+}
+
+void
+GSettings::upgradeGlobal() {
+
+    // by explicitely naming all the properties, and not choosing the "allKeys()" function,
+    // only the properties still in use are migrated - and not any orphans for previous releases
+
+    migrateValue(GC_SETTINGS_SUMMARY_METRICS);
+    migrateValue(GC_SETTINGS_BESTS_METRICS);
+    migrateValue(GC_SETTINGS_INTERVAL_METRICS);
+    migrateValue(GC_TABBAR);
+    migrateValue(GC_WBALFORM);
+    migrateValue(GC_BIKESCOREDAYS);
+    migrateValue(GC_BIKESCOREMODE);
+    migrateValue(GC_WARNCONVERT);
+    migrateValue(GC_WARNEXIT);
+    migrateValue(GC_HIST_BIN_WIDTH);
+    migrateValue(GC_WORKOUTDIR);
+    migrateValue(GC_LINEWIDTH);
+    migrateValue(GC_ANTIALIAS);
+    migrateValue(GC_RIDEBG);
+    migrateValue(GC_RIDESCROLL);
+    migrateValue(GC_RIDEHEAD);
+    migrateValue(GC_SHADEZONES);
+    migrateValue(GC_GARMIN_SMARTRECORD);
+    migrateValue(GC_GARMIN_HWMARK);
+    migrateValue(GC_DPFG_TOLERANCE);
+    migrateValue(GC_DPFG_STOP);
+    migrateValue(GC_DPFS_MAX);
+    migrateValue(GC_DPFS_VARIANCE);
+    migrateValue(GC_DPTA);
+    migrateValue(GC_DPPA);
+    migrateValue(GC_DPFHRS_MAX);
+    migrateValue(GC_DPDP_BIKEWEIGHT);
+    migrateValue(GC_DPDP_CRR);
+    migrateValue(GC_LANG);
+    migrateValue(GC_PACE);
+    migrateValue(GC_SWIMPACE);
+    migrateValue(GC_ELEVATION_HYSTERESIS);
+    migrateValue(GC_START_HTTP);
+
+
+
+    // Handle the Dataprocessor dp/%1/apply keys
+    // Handle the RideEditor colmap/%1 keys
+    QStringList dpKeys = oldsystemsettings->allKeys();
+    QStringListIterator dpKeysIterator(dpKeys);
+    while (dpKeysIterator.hasNext()) {
+        QString key = QString(dpKeysIterator.next().data());
+        if (key.startsWith("dp/") || key.startsWith("colmap/")) {
+            migrateValue(GC_QSETTINGS_GLOBAL_GENERAL+key);
+        }
+    }
+
+    // handle the Device configuration
+    migrateValue(GC_DEV_COUNT);
+    QString devCountKey = GC_DEV_COUNT;
+    devCountKey.remove(QRegExp("^<.*>"));
+    QVariant configVal = oldsystemsettings->value(devCountKey);
+    int devicecount;
+    if (configVal.isNull()) {
+        devicecount=0;
+    } else {
+        devicecount = configVal.toInt();
+    }
+    for (int i = 0; i < devicecount; i++ ) {
+        QString configStr = QString("%1%2").arg(GC_DEV_NAME).arg(i+1);
+        migrateValue(configStr);
+        configStr = QString("%1%2").arg(GC_DEV_TYPE).arg(i+1);
+        migrateValue(configStr);
+        configStr = QString("%1%2").arg(GC_DEV_WHEEL).arg(i+1);
+        migrateValue(configStr);
+        configStr = QString("%1%2").arg(GC_DEV_SPEC).arg(i+1);
+        migrateValue(configStr);
+        configStr = QString("%1%2").arg(GC_DEV_PROF).arg(i+1);
+        migrateValue(configStr);
+        configStr = QString("%1%2").arg(GC_DEV_DEF).arg(i+1);
+        migrateValue(configStr);
+        configStr = QString("%1%2").arg(GC_DEV_VIRTUAL).arg(i+1);
+        migrateValue(configStr);
+    }
+
+    migrateValue(FORTIUS_FIRMWARE);
+    migrateValue(TRAIN_MULTI);
+
+}
+
+
+void
+GSettings::upgradeAthlete(QString athlete) {
+
+    // by explicitely naming all the properties, and not choosing the "allKeys()" function,
+    // only the properties still in use are migrated - and not any orphans for previous releases
+
+    migrateCValue(athlete, GC_VERSION_USED);
+    migrateCValue(athlete, GC_SAFEEXIT);
+    migrateCValue(athlete, GC_UPGRADE_FOLDER_SUCCESS);
+    migrateCValue(athlete, GC_LTM_LAST_DATE_RANGE);
+    migrateCValue(athlete, GC_LTM_AUTOFILTERS);
+    migrateCValue(athlete, GC_BLANK_ANALYSIS);
+    migrateCValue(athlete, GC_BLANK_TRAIN);
+    migrateCValue(athlete, GC_BLANK_HOME);
+    migrateCValue(athlete, GC_BLANK_DIARY);
+    migrateCValue(athlete, GC_UNIT);
+    migrateCValue(athlete, GC_NICKNAME);
+    migrateCValue(athlete, GC_DOB);
+    migrateCValue(athlete, GC_WEIGHT);
+    migrateCValue(athlete, GC_HEIGHT);
+    migrateCValue(athlete, GC_WBALTAU);
+    migrateCValue(athlete, GC_SEX);
+    migrateCValue(athlete, GC_BIO);
+    migrateCValue(athlete, GC_AVATAR);
+    migrateCValue(athlete, GC_DISCOVERY);
+    migrateCValue(athlete, GC_SB_TODAY);
+    migrateCValue(athlete, GC_LTS_DAYS);
+    migrateCValue(athlete, GC_STS_DAYS);
+    migrateCValue(athlete, GC_NAVHEADINGS);
+    migrateCValue(athlete, GC_NAVHEADINGWIDTHS);
+    migrateCValue(athlete, GC_NAVGROUPBY);
+    migrateCValue(athlete, GC_SORTBY);
+    migrateCValue(athlete, GC_WEBCAL_URL);
+    migrateCValue(athlete, GC_DIARY_VIEW);
+    migrateCValue(athlete, GC_USE_CP_FOR_FTP);
+
+
+    // Handle the splittersizes keys
+    QStringList splitterKeys = oldsystemsettings->allKeys();
+    QStringListIterator splitterKeysIterator(splitterKeys);
+    while (splitterKeysIterator.hasNext()) {
+        QString key = QString(splitterKeysIterator.next().data());
+        if (key.startsWith(athlete + "/mainwindow/splitterSizes") || key.startsWith(athlete+"/splitter")) {
+            key.remove(0, athlete.size()+1); // remove the Athlete name and / from the old setting !
+            migrateCValue(athlete, GC_QSETTINGS_ATHLETE_LAYOUT+key);
+        }
+    }
+
+    // --- private --- //
+    migrateCValue(athlete, GC_TWURL);
+    migrateCValue(athlete, GC_TPURL);
+    migrateCValue(athlete, GC_TPUSER);
+    migrateCValue(athlete, GC_TPPASS);
+    migrateCValue(athlete, GC_TPTYPE);
+    migrateCValue(athlete, GC_RWGPSUSER);
+    migrateCValue(athlete, GC_RWGPSPASS);
+    migrateCValue(athlete, GC_VELOHEROUSER);
+    migrateCValue(athlete, GC_VELOHEROPASS);
+    migrateCValue(athlete, GC_WIURL);
+    migrateCValue(athlete, GC_WIUSER);
+    migrateCValue(athlete, GC_WIKEY);
+    migrateCValue(athlete, GC_DVURL);
+    migrateCValue(athlete, GC_DVUSER);
+    migrateCValue(athlete, GC_DVPASS);
+    migrateCValue(athlete, GC_DVCALDAVTYPE);
+    migrateCValue(athlete, GC_DVGOOGLE_CALID);
+    migrateCValue(athlete, GC_TWITTER_TOKEN);
+    migrateCValue(athlete, GC_TWITTER_SECRET);
+    migrateCValue(athlete, GC_GOOGLE_CALENDAR_REFRESH_TOKEN);
+    migrateCValue(athlete, GC_STRAVA_TOKEN);
+    migrateCValue(athlete, GC_CYCLINGANALYTICS_TOKEN);
+
+    // migrate from system/global to athlete specific settings
+    migrateValueToCValue(athlete, GC_CRANKLENGTH);
+    migrateValueToCValue(athlete, GC_WHEELSIZE);
+
+}
+
+
+//----------------------------------------------------------------------------------------------//
+
+// initialise with no athlete
 GSettings *appsettings = GetApplicationSettings();

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -211,7 +211,7 @@
 
 // ride navigator
 #define GC_NAVHEADINGS                  "<athlete-preferences>navigator/headings"
-#define GC_NAVHEADINGWIDTHS             "<athlete-preferences>bavigator/headingwidths"
+#define GC_NAVHEADINGWIDTHS             "<athlete-preferences>navigator/headingwidths"
 #define GC_NAVGROUPBY                   "<athlete-preferences>navigator/groupby"
 #define GC_SORTBY                       "<athlete-preferences>navigator/sortby"
 #define GC_SORTBYORDER                  "<athlete-preferences>navigator/sortbyorder"
@@ -326,6 +326,7 @@ private:
     // special methods for Migration/Upgrade
     void migrateValue(QString key);
     void migrateCValue(QString athleteName, QString key);
+    void migrateAndRenameCValue(QString athleteName, QString wrongKey, QString key);
     void migrateValueToCValue(QString athleteName, QString key);
 
     void upgradeSystem();

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -190,6 +190,7 @@
 #define GC_BLANK_DIARY                  "<athlete-layout>blank/diary"
 #define GC_SETTINGS_SPLITTER_SIZES      "<athlete-layout>mainwindow/splitterSizes"
 
+
 #define GC_UNIT                         "<athlete-preferences>unit"
 #define GC_NICKNAME                     "<athlete-preferences>nickname"
 #define GC_DOB                          "<athlete-preferences>dob"
@@ -221,9 +222,9 @@
 
 #define GC_TPURL                        "<athlete-private>tp/url"
 #define GC_TWURL                        "<athlete-private>tw/url"
-#define GC_TPUSER                       "<athlete-private>tp/urltp/user"
-#define GC_TPPASS                       "<athlete-private>tp/urltp/pass"
-#define GC_TPTYPE                       "<athlete-private>tp/urltp/type"
+#define GC_TPUSER                       "<athlete-private>tp/user"
+#define GC_TPPASS                       "<athlete-private>tp/pass"
+#define GC_TPTYPE                       "<athlete-private>tp/type"
 #define GC_RWGPSUSER                    "<athlete-private>rwgps/user"
 #define GC_RWGPSPASS                    "<athlete-private>rwgps/pass"
 #define GC_TTBUSER                      "<athlete-private>ttb/user"

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2006 Sean C. Rhea (srhea@srhea.net)
+ * Copyright (c) 2015 Joern Rischmueller (joern.rm@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -21,260 +22,317 @@
 #include "GoldenCheetah.h"
 #include <QDebug>
 
-#define GC_HOMEDIR                  "homedirectory"
-#define GC_VERSION_USED             "versionused"
-#define GC_START_HTTP               "starthttp"
-#define GC_SAFEEXIT                 "safeexit"
-#define GC_SETTINGS_CO              "goldencheetah.org"
-#define GC_SETTINGS_APP             "GoldenCheetah"
-#define GC_SETTINGS_LAST            "mainwindow/lastOpened"
-#define GC_SETTINGS_MAIN_WIDTH      "mainwindow/width"
-#define GC_SETTINGS_MAIN_HEIGHT     "mainwindow/height"
-#define GC_SETTINGS_MAIN_X          "mainwindow/x"
-#define GC_SETTINGS_MAIN_Y          "mainwindow/y"
-#define GC_SETTINGS_MAIN_GEOM       "mainwindow/geometry"
-#define GC_SETTINGS_MAIN_STATE      "mainwindow/state"
-#define GC_SETTINGS_SPLITTER_SIZES  "mainwindow/splitterSizes"
-#define GC_SETTINGS_CALENDAR_SIZES  "mainwindow/calendarSizes"
-#define GC_TABS_TO_HIDE             "mainwindow/tabsToHide"
-#define GC_ELEVATION_HYSTERESIS     "elevationHysteresis"
-#define GC_SETTINGS_SUMMARY_METRICS "rideSummaryWindow/summaryMetrics"
-#define GC_SETTINGS_BESTS_METRICS    "rideSummaryWindow/bestsMetrics"
-#define GC_SETTINGS_INTERVAL_METRICS "rideSummaryWindow/intervalMetrics"
-#define GC_RIDE_PLOT_SMOOTHING       "ridePlot/Smoothing"
-#define GC_RIDE_PLOT_STACK           "ridePlot/Stack"
-#define GC_PERF_MAN_METRIC           "performanceManager/metric"
-#define GC_HIST_BIN_WIDTH            "histogamWindow/binWidth"
+
+
+/*
+ *  Global GC Properties which are not stored as GSettings are defined here
+ */
+
+#define GC_SETTINGS_CO                        "goldencheetah.org"
+#define GC_SETTINGS_APP                       "GoldenCheetah"
 #define GC_SETTINGS_BESTS_METRICS_DEFAULT "5s_critical_power,1m_critical_power,5m_critical_power,20m_critical_power,60m_critical_power,3m_critical_pace,20m_critical_pace,3m_critical_pace_swim,20m_critical_pace_swim"
 #define GC_SETTINGS_SUMMARY_METRICS_DEFAULT "triscore,skiba_xpower,skiba_relative_intensity,xPace,swimscore_xpace,trimp_points,aerobic_decoupling"
 #define GC_SETTINGS_INTERVAL_METRICS_DEFAULT "workout_time,total_distance,total_work,average_power,average_hr,average_cad,average_speed,pace,pace_swim,distance_swim"
-#define GC_DATETIME_FORMAT          "ddd MMM dd, yyyy, hh:mm"
-#define GC_UNIT                     "unit"
-#define GC_PACE                     "pace"
-#define GC_SWIMPACE                 "swimpace"
-#define GC_LANG                     "lang"
-#define GC_NICKNAME                 "nickname"
-#define GC_DOB                      "dob"
-#define GC_WEIGHT                   "weight"
-#define GC_HEIGHT                   "height"
-#define GC_WBALTAU                  "wbaltau"
-#define GC_SEX                      "sex"
-#define GC_BIO                      "bio"
-#define GC_AVATAR                   "avatar"
-#define GC_SETTINGS_LAST_IMPORT_PATH "mainwindow/lastImportPath"
-#define GC_SETTINGS_LAST_WORKOUT_PATH "mainwindow/lastWorkoutPath"
-#define GC_LAST_DOWNLOAD_DEVICE      "mainwindow/lastDownloadDevice"
-#define GC_LAST_DOWNLOAD_PORT        "mainwindow/lastDownloadPort"
-#define GC_CRANKLENGTH              "crankLength"
-#define GC_WHEELSIZE                "wheelsize"
-#define GC_BIKESCOREDAYS	    "bikeScoreDays"
-#define GC_BIKESCOREMODE	    "bikeScoreMode"
-#define GC_SB_TODAY             "PMshowSBtoday"
-#define GC_LTS_DAYS		    "LTSdays"
-#define GC_STS_DAYS		    "STSdays"
-#define GC_STS_NAME			"STSname"
-#define GC_STS_ACRONYM			"STS"
-#define GC_LTS_NAME			"LTSname"
-#define GC_LTS_ACRONYM			"LTS"
-#define GC_SB_NAME			"SBname"
-#define GC_SB_ACRONYM			"SB"
-#define GC_WARNCONVERT      "warnconvert"
-#define GC_WARNEXIT      "warnexit"
-#define GC_WORKOUTDIR      "workoutDir"
-#define GC_TRAIN_SPLITTER_SIZES  "trainwindow/splitterSizes"
-#define GC_LTM_SPLITTER_SIZES  "ltmwindow/splitterSizes"
-#define GC_LTM_LAST_DATE_RANGE "ltmwindow/lastDateRange"
-#define GC_LTM_AUTOFILTERS "ltmwindow/autofilters"
-#define GC_BLANK_ANALYSIS "blank/analysis"
-#define GC_BLANK_TRAIN    "blank/train"
-#define GC_BLANK_HOME     "blank/home"
-#define GC_BLANK_DIARY    "blank/diary"
-#define GC_LINEWIDTH      "linewidth"
-#define GC_ANTIALIAS      "antialias"
-#define GC_CHROME         "chrome" // mac or flat only so far
-#define GC_RIDEBG         "rideBG"
-#define GC_RIDESCROLL     "rideScroll"
-#define GC_RIDEHEAD       "rideHead"
-#define GC_DROPSHADOW     "dropshadow"
-#define GC_SHADEZONES     "shadezones"
-#define GC_PROXYTYPE      "proxy/type"
-#define GC_PROXYHOST      "proxy/host"
-#define GC_PROXYPORT      "proxy/port"
-#define GC_PROXYUSER      "proxy/user"
-#define GC_PROXYPASS      "proxy/pass"
-#define GC_GCURL          "gc/url"
-#define GC_GCUSER         "gc/user"
-#define GC_GCPASS         "gc/pass"
-#define GC_TPURL          "tp/url"
-#define GC_TPUSER         "tp/user"
-#define GC_TPPASS         "tp/pass"
-#define GC_TPTYPE         "tp/type"
-#define GC_TWURL          "tw/url"
-#define GC_TWUSER         "tw/user"
-#define GC_TWPASS         "tw/pass"
-#define GC_STRUSER        "str/user"
-#define GC_STRPASS        "str/pass"
-#define GC_RWGPSUSER      "rwgps/user"
-#define GC_RWGPSPASS      "rwgps/pass"
-#define GC_TTBUSER        "ttb/user"
-#define GC_TTBPASS        "ttb/pass"
-#define GC_VELOHEROUSER   "velohero/user"
-#define GC_VELOHEROPASS   "velohero/pass"
-#define GC_SELUSER        "sel/user"
-#define GC_SELPASS        "sel/pass"
-#define GC_WIURL          "wi/url"
-#define GC_WIUSER         "wi/user"
-#define GC_WIKEY          "wi/key"
-#define GC_DVURL          "dv/url"
-#define GC_DVUSER         "dv/user"
-#define GC_DVPASS         "dv/pass"
-#define GC_DVCALDAVTYPE   "dv/type"
-#define GC_DVGOOGLE_CALID "dv/googlecalid"
-#define GC_ZEOURL         "zeo/url"
-#define GC_ZEOUSER        "zeo/user"
-#define GC_ZEOPASS        "zeo/pass"
+#define GC_UNIT_METRIC                       "Metric"
+#define GC_UNIT_IMPERIAL                     "Imperial"
 
-#define GC_UNIT_METRIC    "Metric"
-#define GC_UNIT_IMPERIAL  "Imperial"
+//Twitter oauth keys / see also Athlete parameter
+#define GC_TWITTER_CONSUMER_KEY    "qbbmhDt8bG8ZBcT3r9nYw" //< consumer key
+#define GC_TWITTER_CONSUMER_SECRET "IWXu2G6mQC5xvhM8V0ohA0mPTUOqAFutiuKIva3LQg"
+
+//Google Calendar-CALDAV oauthkeys / see also Athlete parameter
+#define GC_GOOGLE_CALENDAR_CLIENT_ID      "426009671216-c588t1u6hafep30tfs7g0g1nuo72s8ko.apps.googleusercontent.com"
+
+//Strava / see also Athlete parameter
+#define GC_STRAVA_CLIENT_ID    "83" // client id
+
+//Cycling Analytics / see also Athlete parameter
+#define GC_CYCLINGANALYTICS_CLIENT_ID    "1504958" // app id
+
+
+/*
+ *  GoldenCheetah Properties are stored in different locations, depending on the prefix defined in the property name. The following different prefixes are supported
+ *  <system>
+ *  - Storage: the property value is stored in the system specific QSettings - e.g. Registry on Windows, PList on Mac,...
+ *  - Use: such properties relate to GC instance running / e.g. dependent on the hardware/screen-size,...
+ *
+ *  <global-$filename>
+ *  - Storage: the property value is stored in the .INI file with name "global_$filename.gc", which means that any change of the athlete directory means the settings are lost / have to be copied
+ *  - Use: such properties are shared between all Athletes in the same athlete Directory and are the same for all GC instance which point to this Athlete Directory
+ *    The supported filenames (substitute for $filename) are defined as GC_SETTINGS_... below - ANYTHING ELSE WILL CAUSE ERRORS - OR JUST NOT STORE ANYTHING WORK
+ *
+ *  <athlete-$filename>
+ *  - Storage: the property is stored in .INI file which is store in the athlete/config directory - the name of the file is "athlete-$filename.gc"
+ *  - Use: such properties are Athlete specific - the separation in different config files is aimed to help sharing such properties with others and easier backup/restore
+ *    The supported filenames (substitute for $filename) are defined as GC_SETTINGS_... below - - ANYTHING ELSE WILL CAUSE ERRORS - OR JUST NOT STORE ANYTHING WORK
+
+ *
+ *  Settings which get special coded treatment:
+ *  - Colors.h/Color.cpp -> stored in <system> since every PC/Mac may look different / similar to Fonts
+ *
+ */
+
+// - Prefixes to be used for the QSettings in any code - to identify which QSettings are to be used
+
+#define GC_QSETTINGS_SYSTEM              "<system>"
+#define GC_QSETTINGS_GLOBAL_GENERAL      "<global-general>"
+#define GC_QSETTINGS_GLOBAL_TRAIN        "<global-trainmode>"
+#define GC_QSETTINGS_ATHLETE_GENERAL     "<athlete-general>"
+#define GC_QSETTINGS_ATHLETE_LAYOUT      "<athlete-layout>"
+#define GC_QSETTINGS_ATHLETE_PREFERENCES "<athlete-preferences>"
+#define GC_QSETTINGS_ATHLETE_PRIVATE     "<athlete-private>"
+
+// -----------------------------------------------------------------------------------------------------------------------
+//    System specific properties - OS/PC dependent - stored in .ini file in the OS specific directory defined by QSettings
+// -----------------------------------------------------------------------------------------------------------------------
+
+#define GC_HOMEDIR                      "<system>homedirectory"
+#define GC_START_HTTP                   "<system>starthttp"
+
+#define GC_SETTINGS_LAST                "<system>mainwindow/lastOpened"
+#define GC_SETTINGS_MAIN_GEOM           "<system>mainwindow/geometry"
+#define GC_SETTINGS_MAIN_STATE          "<system>mainwindow/state"
+#define GC_SETTINGS_LAST_IMPORT_PATH    "<system>mainwindow/lastImportPath"
+#define GC_SETTINGS_LAST_WORKOUT_PATH   "<system>mainwindow/lastWorkoutPath"
+#define GC_LAST_DOWNLOAD_DEVICE         "<system>mainwindow/lastDownloadDevice"
+#define GC_LAST_DOWNLOAD_PORT           "<system>mainwindow/lastDownloadPort"
+
+// batch export last options
+#define GC_BE_LASTDIR                   "<system>batchexport/lastdir"
+#define GC_BE_LASTFMT                   "<system>batchexport/lastfmt"
+// Fonts
+#define GC_FONT_DEFAULT                 "<system>font/default"
+#define GC_FONT_TITLES                  "<system>font/titles"
+#define GC_FONT_CHARTMARKERS            "<system>font/chartmarkers"
+#define GC_FONT_CHARTLABELS             "<system>font/chartlabels"
+#define GC_FONT_CALENDAR                "<system>font/calendar"
+#define GC_FONT_DEFAULT_SIZE            "<system>font/defaultsize"
+#define GC_FONT_TITLES_SIZE             "<system>font/titlessize"
+#define GC_FONT_CHARTMARKERS_SIZE       "<system>font/chartmarkerssize"
+#define GC_FONT_CHARTLABELS_SIZE        "<system>font/chartlabelssize"
+#define GC_FONT_CALENDAR_SIZE           "<system>font/calendarsize"
+
+// Colors/Chrome - see special treatment sections (also stored in <system>)
+#define GC_CHROME                       "<system>chrome" // mac or flat only so far
+
+
+
+// --------------------------------------------------------------------
+// Global Properties - Stored in "root" of the active Athlete Directory
+// --------------------------------------------------------------------
+
+
+#define GC_SETTINGS_SUMMARY_METRICS     "<global-general>rideSummaryWindow/summaryMetrics"
+#define GC_SETTINGS_BESTS_METRICS       "<global-general>rideSummaryWindow/bestsMetrics"
+#define GC_SETTINGS_INTERVAL_METRICS    "<global-general>rideSummaryWindow/intervalMetrics"
+#define GC_TABBAR                       "<global-general>show/tabbar"                        // show tabbar
+#define GC_WBALFORM                     "<global-general>wbal/formula"                       // wbal formula to use
+#define GC_BIKESCOREDAYS	            "<global-general>bikeScoreDays"
+#define GC_BIKESCOREMODE	            "<global-general>bikeScoreMode"
+#define GC_WARNCONVERT                  "<global-general>warnconvert"
+#define GC_WARNEXIT                     "<global-general>warnexit"
+#define GC_HIST_BIN_WIDTH               "<global-general>histogamWindow/binWidth"
+#define GC_WORKOUTDIR                   "<global-general>workoutDir"
+#define GC_LINEWIDTH                    "<global-general>linewidth"
+#define GC_ANTIALIAS                    "<global-general>antialias"
+#define GC_RIDEBG                       "<global-general>rideBG"
+#define GC_RIDESCROLL                   "<global-general>rideScroll"
+#define GC_RIDEHEAD                     "<global-general>rideHead"
+#define GC_SHADEZONES                   "<global-general>shadezones"
+#define GC_LANG                         "<global-general>lang"
+#define GC_PACE                         "<global-general>pace"
+#define GC_SWIMPACE                     "<global-general>swimpace"
+#define GC_ELEVATION_HYSTERESIS         "<global-general>elevationHysteresis"
+
+
+// Fit/Tcx Smart recording
+#define GC_GARMIN_SMARTRECORD           "<global-general>garminSmartRecord"
+#define GC_GARMIN_HWMARK                "<global-general>garminHWMark"
+
+// data processor config
+#define GC_DPFG_TOLERANCE               "<global-general>dataprocess/fixgaps/tolerance"
+#define GC_DPFG_STOP                    "<global-general>dataprocess/fixgaps/stop"
+#define GC_DPFS_MAX                     "<global-general>dataprocess/fixspikes/max"
+#define GC_DPFS_VARIANCE                "<global-general>dataprocess/fixspikes/variance"
+#define GC_DPTA                         "<global-general>dataprocess/torqueadjust/adjustment"
+#define GC_DPPA                         "<global-general>dataprocess/poweradjust/adjustment"
+#define GC_DPFHRS_MAX                   "<global-general>dataprocess/fixhrspikes/max"
+#define GC_DPDP_BIKEWEIGHT              "<global-general>dataprocess/fixderivepower/bikewheight"
+#define GC_DPDP_CRR                     "<global-general>dataprocess/fixderivepower/crr"
 
 // device Configurations NAME/SPEC/TYPE/DEFI/DEFR all get a number appended
 // to them to specify which configured device i.e. devices1 ... devicesn where
 // n is defined in GC_DEV_COUNT
-#define GC_DEV_COUNT "devices"
-#define GC_DEV_NAME  "devicename"
-#define GC_DEV_SPEC  "devicespec"
-#define GC_DEV_PROF  "deviceprof"
-#define GC_DEV_TYPE  "devicetype"
-#define GC_DEV_DEF   "devicedef"
-#define GC_DEV_WHEEL "devicewheel"
-#define GC_DEV_VIRTUAL  "devicepostProcess"
+#define GC_DEV_COUNT                    "<global-trainmode>devices"
+#define GC_DEV_NAME                     "<global-trainmode>devicename"
+#define GC_DEV_SPEC                     "<global-trainmode>devicespec"
+#define GC_DEV_PROF                     "<global-trainmode>deviceprof"
+#define GC_DEV_TYPE                     "<global-trainmode>devicetype"
+#define GC_DEV_DEF                      "<global-trainmode>devicedef"
+#define GC_DEV_WHEEL                    "<global-trainmode>devicewheel"
+#define GC_DEV_VIRTUAL                  "<global-trainmode>devicepostProcess"
+#define FORTIUS_FIRMWARE                "<global-trainmode>fortius/firmware"
+#define TRAIN_MULTI                     "<global-trainmode>train/multi"
 
-// data processor config
-#define GC_DPFG_TOLERANCE "dataprocess/fixgaps/tolerance"
-#define GC_DPFG_STOP      "dataprocess/fixgaps/stop"
-#define GC_DPFS_MAX       "dataprocess/fixspikes/max"
-#define GC_DPFS_VARIANCE  "dataprocess/fixspikes/variance"
-#define GC_DPTA           "dataprocess/torqueadjust/adjustment"
-#define GC_DPPA           "dataprocess/poweradjust/adjustment"
-#define GC_DPFHRS_MAX     "dataprocess/fixhrspikes/max"
-#define GC_DPDP_BIKEWEIGHT "dataprocess/fixderivepower/bikewheight"
-#define GC_DPDP_CRR       "dataprocess/fixderivepower/crr"
+// --------------------------------------------------------------------------------
+// Athlete Specific Properties - Stored in /config subfolder of the related athlete
+// --------------------------------------------------------------------------------
+
+#define GC_VERSION_USED                 "<athlete-general>versionused"
+#define GC_SAFEEXIT                     "<athlete-general>safeexit"
+#define GC_UPGRADE_FOLDER_SUCCESS       "<athlete-general>upgradesuccess/folder"     // success tracking of folder upgrade stored on athlete level
+
+#define GC_LTM_LAST_DATE_RANGE          "<athlete-layout>ltmwindow/lastDateRange"
+#define GC_LTM_AUTOFILTERS              "<athlete-layout>ltmwindow/autofilters"
+#define GC_BLANK_ANALYSIS               "<athlete-layout>blank/analysis"
+#define GC_BLANK_TRAIN                  "<athlete-layout>blank/train"
+#define GC_BLANK_HOME                   "<athlete-layout>blank/home"
+#define GC_BLANK_DIARY                  "<athlete-layout>blank/diary"
+#define GC_SETTINGS_SPLITTER_SIZES      "<athlete-layout>mainwindow/splitterSizes"
+
+#define GC_UNIT                         "<athlete-preferences>unit"
+#define GC_NICKNAME                     "<athlete-preferences>nickname"
+#define GC_DOB                          "<athlete-preferences>dob"
+#define GC_WEIGHT                       "<athlete-preferences>weight"
+#define GC_HEIGHT                       "<athlete-preferences>height"
+#define GC_WBALTAU                      "<athlete-preferences>wbaltau"
+#define GC_SEX                          "<athlete-preferences>sex"
+#define GC_BIO                          "<athlete-preferences>bio"
+#define GC_AVATAR                       "<athlete-preferences>avatar"
+#define GC_DISCOVERY                    "<athlete-preferences>intervals/discovery"   // intervals to discover
+#define GC_SB_TODAY                     "<athlete-preferences>PMshowSBtoday"
+#define GC_LTS_DAYS		                "<athlete-preferences>LTSdays"
+#define GC_STS_DAYS		                "<athlete-preferences>STSdays"
+#define GC_CRANKLENGTH                  "<athlete-preferences>crankLength"
+#define GC_WHEELSIZE                    "<athlete-preferences>wheelsize"
+#define GC_USE_CP_FOR_FTP               "<athlete-preferences>cp/useforftp"                       // use CP for FTP
+
 
 // ride navigator
-#define GC_NAVHEADINGS      "navigator/headings"
-#define GC_NAVHEADINGWIDTHS "bavigator/headingwidths"
-#define GC_NAVGROUPBY       "navigator/groupby"
-#define GC_SORTBY           "navigator/sortby"
-#define GC_SORTBYORDER      "navigator/sortbyorder"
-
-// route interval navigator
-#define GC_ROUTEHEADINGS      "routenavigator/headings"
-#define GC_ROUTEHEADINGWIDTHS "routenavigator/headingwidths"
-#define GC_ROUTESORTBY        "routenavigator/sortby"
-#define GC_ROUTESORTBYORDER   "routenavigator/sortbyorder"
-
-// best interval navigator
-#define GC_BESTHEADINGS      "bestnavigator/headings"
-#define GC_BESTHEADINGWIDTHS "bestnavigator/headingwidths"
-#define GC_BESTSORTBY        "bestnavigator/sortby"
-#define GC_BESTSORTBYORDER   "bestnavigator/sortbyorder"
-
-//Twitter oauth keys
-#define GC_TWITTER_CONSUMER_KEY    "qbbmhDt8bG8ZBcT3r9nYw" //< consumer key
-#define GC_TWITTER_CONSUMER_SECRET "IWXu2G6mQC5xvhM8V0ohA0mPTUOqAFutiuKIva3LQg"
-#define GC_TWITTER_TOKEN "twitter_token"
-#define GC_TWITTER_SECRET "twitter_secret"
-
-//Google Calendar-CALDAV oauthkeys
-//Google Calendar-CALDAV oauthkeys
-#define GC_GOOGLE_CALENDAR_CLIENT_ID      "426009671216-c588t1u6hafep30tfs7g0g1nuo72s8ko.apps.googleusercontent.com"
-#define GC_GOOGLE_CALENDAR_REFRESH_TOKEN  "google_cal_refresh_token"
-
-//Strava
-#define GC_STRAVA_CLIENT_ID    "83" // client id
-#define GC_STRAVA_TOKEN "strava_token"
-
-//Cycling Analytics
-#define GC_CYCLINGANALYTICS_CLIENT_ID    "1504958" // app id
-#define GC_CYCLINGANALYTICS_TOKEN "cyclinganalytics_token"
-
-// Tcx Smart recording
-#define GC_GARMIN_SMARTRECORD "garminSmartRecord"
-#define GC_GARMIN_HWMARK "garminHWMark"
-
+#define GC_NAVHEADINGS                  "<athlete-preferences>navigator/headings"
+#define GC_NAVHEADINGWIDTHS             "<athlete-preferences>bavigator/headingwidths"
+#define GC_NAVGROUPBY                   "<athlete-preferences>navigator/groupby"
+#define GC_SORTBY                       "<athlete-preferences>navigator/sortby"
+#define GC_SORTBYORDER                  "<athlete-preferences>navigator/sortbyorder"
 // Calendar sync
-#define GC_WEBCAL_URL "webcal_url"
-
+#define GC_WEBCAL_URL                   "<athlete-preferences>webcal_url"
 // Default view on Diary
-#define GC_DIARY_VIEW "diaryview"
+#define GC_DIARY_VIEW                   "<athlete-preferences>diaryview"
 
-// Fonts
-#define GC_FONT_DEFAULT           "font/default"
-#define GC_FONT_TITLES            "font/titles"
-#define GC_FONT_CHARTMARKERS      "font/chartmarkers"
-#define GC_FONT_CHARTLABELS       "font/chartlabels"
-#define GC_FONT_CALENDAR          "font/calendar"
-#define GC_FONT_DEFAULT_SIZE      "font/defaultsize"
-#define GC_FONT_TITLES_SIZE       "font/titlessize"
-#define GC_FONT_CHARTMARKERS_SIZE "font/chartmarkerssize"
-#define GC_FONT_CHARTLABELS_SIZE  "font/chartlabelssize"
-#define GC_FONT_CALENDAR_SIZE     "font/calendarsize"
+#define GC_TPURL                        "<athlete-private>tp/url"
+#define GC_TWURL                        "<athlete-private>tw/url"
+#define GC_TPUSER                       "<athlete-private>tp/urltp/user"
+#define GC_TPPASS                       "<athlete-private>tp/urltp/pass"
+#define GC_TPTYPE                       "<athlete-private>tp/urltp/type"
+#define GC_RWGPSUSER                    "<athlete-private>rwgps/user"
+#define GC_RWGPSPASS                    "<athlete-private>rwgps/pass"
+#define GC_TTBUSER                      "<athlete-private>ttb/user"
+#define GC_TTBPASS                      "<athlete-private>ttb/pass"
+#define GC_VELOHEROUSER                 "<athlete-private>velohero/user"
+#define GC_VELOHEROPASS                 "<athlete-private>velohero/pass"
+#define GC_SELUSER                      "<athlete-private>sel/user"
+#define GC_SELPASS                      "<athlete-private>sel/pass"
+#define GC_WIURL                        "<athlete-private>wi/url"
+#define GC_WIUSER                       "<athlete-private>wi/user"
+#define GC_WIKEY                        "<athlete-private>wi/key"
+#define GC_DVURL                        "<athlete-private>dv/url"
+#define GC_DVUSER                       "<athlete-private>dv/user"
+#define GC_DVPASS                       "<athlete-private>dv/pass"
+#define GC_DVCALDAVTYPE                 "<athlete-private>dv/type"
+#define GC_DVGOOGLE_CALID               "<athlete-private>dv/googlecalid"
+//Twitter oauth keys
+#define GC_TWITTER_TOKEN                "<athlete-private>twitter_token"
+#define GC_TWITTER_SECRET               "<athlete-private>twitter_secret"
+//Google Calendar-CALDAV oauthkeys
+#define GC_GOOGLE_CALENDAR_REFRESH_TOKEN  "<athlete-private>google_cal_refresh_token"
+//Strava
+#define GC_STRAVA_TOKEN                 "<athlete-private>strava_token"
+//Cycling Analytics
+#define GC_CYCLINGANALYTICS_TOKEN       "<athlete-private>cyclinganalytics_token"
 
-// TreeMap selection
-#define GC_TM_FIRST               "tm/first"
-#define GC_TM_SECOND              "tm/second"
-#define GC_TM_METRIC              "tm/metric"
 
-#define FORTIUS_FIRMWARE          "fortius/firmware"
-#define TRAIN_MULTI               "train/multi"
 
-// batch export last options
-#define GC_BE_LASTDIR             "batchexport/lastdir"
-#define GC_BE_LASTFMT             "batchexport/lastfmt"
 
-// show tabbar
-#define GC_TABBAR                 "show/tabbar"
-
-// use CP for FTP
-#define GC_USE_CP_FOR_FTP         "cp/useforftp"
-
-// wbal formula to use
-#define GC_WBALFORM               "wbal/formula"
-
-// intervals to discover
-#define GC_DISCOVERY              "intervals/discovery"
-
-// success tracking of more complex upgrades stored on athlete level
-#define GC_UPGRADE_FOLDER_SUCCESS  "upgradesuccess/folder"
-
+// --------------------------------------------------------------------------------
 #include <QSettings>
 #include <QFileInfo>
 
-// wrap the standard QSettings so we can offer members
-// to get global or cyclist specific settings
-// via value() and cvalue()
-class GSettings : public QSettings
-{
+// Helper Class for the Athlete QSettings
+
+class AthleteQSettings {
     public:
-    GSettings(QString org, QString scope) : QSettings(org,scope) { }
-    GSettings(QString file, Format format) : QSettings(file,format) { }
-    ~GSettings() { QSettings::sync(); }
 
-    // standard access to global config
-    QVariant value(const QObject *me, const QString key, const QVariant def = 0) const ;
-    void setValue(QString key, QVariant value) {
-        QSettings::setValue(key,value);
-    }
+      AthleteQSettings() {}
+      ~AthleteQSettings() {}
 
-    // access to cyclist specific config
-    QVariant cvalue(QString cyclist, QString key, QVariant def = 0) {
-        return QSettings::value(cyclist+"/"+key, def);
-    }
-    void setCValue(QString cyclist, QString key, QVariant value) {
-        QSettings::setValue(cyclist + "/" + key,value);
-    }
+      void setQSettings(QSettings* settings, int index) {athlete[index] = settings; }
+      QSettings* getQSettings(int index) const { return athlete[index]; }
+
+    private:
+      QSettings* athlete[4];  // we support exactly 4 Athlete specific QSettings right now
 
 };
+
+
+// wrap the standard QSettings so we can offer members
+// to get global or atheleteName specific settings
+// via value() and cvalue()
+
+class GSettings
+{
+
+public:
+    // 2 Variants are supported - still the "old" one where ALL properties are in ONE .INI file and the
+    // new one were the properties are distributed as explained above (this is to keep compatibility)
+    GSettings(QString org, QString app);
+    GSettings(QString file, QSettings::Format format);
+    ~GSettings();
+
+    // standard access to global config
+    QVariant value(const QObject *me, const QString key, const QVariant def = 0) ;
+    void setValue(QString key, QVariant value);
+
+    // access to athleteName specific config
+    QVariant cvalue(QString athleteName, QString key, QVariant def = 0);
+
+    void setCValue(QString athleteName, QString key, QVariant value);
+
+    // add QSettings methods - which cannot be inherited since not a single, but multiple QSettings make GSettings
+    QStringList allKeys() const;
+    bool contains(const QString & key) const;
+
+    // initialization of global and athlete QSettings can only happen after they path and the athlete is known
+    void migrateQSettingsSystem();
+    void initializeQSettingsGlobal(QString athletesRootDir);
+    void initializeQSettingsAthlete(QString athletesRootDir, QString athleteName);
+    void initializeQSettingsNewAthlete(QString athletesRootDir, QString athleteName);
+
+    // QSettings need to be synched for all QSetting objects
+    void syncQSettings();
+    void syncQSettingsGlobal();
+    void syncQSettingsAllAthletes();
+
+    // Cleanup if AthleteDir is changed
+    void clearGlobalAndAthletes();
+
+private:
+    bool newFormat;
+    QSettings *systemsettings;
+    QSettings *oldsystemsettings;
+    QVector<QSettings*> *global;
+    QHash<QString, AthleteQSettings*> athlete;
+
+    // special methods for Migration/Upgrade
+    void migrateValue(QString key);
+    void migrateCValue(QString athleteName, QString key);
+    void migrateValueToCValue(QString athleteName, QString key);
+
+    void upgradeSystem();
+    void upgradeGlobal();
+    void upgradeAthlete(QString athleteName);
+
+};
+
 
 extern GSettings *appsettings;
 extern int OperatingSystem;

--- a/src/TrainSidebar.h
+++ b/src/TrainSidebar.h
@@ -83,6 +83,8 @@ class TrainSidebar : public GcWindow
     public:
 
         TrainSidebar(Context *context);
+        Context *context;
+
         QStringList listWorkoutFiles(const QDir &) const;
 
         QList<int> devices(); // convenience function for iterating over active devices
@@ -171,7 +173,6 @@ class TrainSidebar : public GcWindow
 
         friend class ::MultiDeviceDialog;
 
-        Context *context;
         GcSplitter   *trainSplitter;
         GcSplitterItem *deviceItem,
                        *workoutItem,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -205,15 +205,17 @@ main(int argc, char *argv[])
     static CocoaInitializer cocoaInitializer;
 #endif
 
+    // set default colors
+    GCColor::setupColors();
+    appsettings->migrateQSettingsSystem(); // colors must be setup before migration can take place, but reading has to be from the migrated ones
+    GCColor::readConfig();
+
     // set defaultfont
     QFont font;
     font.fromString(appsettings->value(NULL, GC_FONT_DEFAULT, QFont().toString()).toString());
     font.setPointSize(appsettings->value(NULL, GC_FONT_DEFAULT_SIZE, 10).toInt());
     application->setFont(font); // set default font
 
-    // set default colors
-    GCColor::setupColors();
-    GCColor::readConfig();
 
     //
     // OPEN FIRST MAINWINDOW
@@ -279,6 +281,8 @@ main(int argc, char *argv[])
 
         // set global root directory
         gcroot = home.canonicalPath();
+        appsettings->initializeQSettingsGlobal(gcroot);
+
 
         // now redirect stderr
 #ifndef WIN32
@@ -331,9 +335,16 @@ main(int argc, char *argv[])
             // no parameters passed lets open the last athlete we worked with
             lastOpened = appsettings->value(NULL, GC_SETTINGS_LAST);
 
-            // but hang on, did they crash? if so we need to open with a menu
-            if(appsettings->cvalue(lastOpened.toString(), GC_SAFEEXIT, true).toBool() != true)
+            // does lastopened Directory exists at all
+            QDir lastOpenedDir(gcroot+"/"+lastOpened.toString());
+            if (lastOpenedDir.exists()) {
+                // but hang on, did they crash? if so we need to open with a menu
+                appsettings->initializeQSettingsAthlete(gcroot, lastOpened.toString());
+                if(appsettings->cvalue(lastOpened.toString(), GC_SAFEEXIT, true).toBool() != true)
+                    lastOpened = QVariant();
+            } else {
                 lastOpened = QVariant();
+            }
             
         }
 
@@ -412,7 +423,9 @@ main(int argc, char *argv[])
             QStringListIterator i(list);
             while (i.hasNext()) {
                 QString cyclist = i.next();
+                QString homeDir = home.canonicalPath();
                 if (home.cd(cyclist)) {
+                    appsettings->initializeQSettingsAthlete(homeDir, cyclist);
                     GcUpgrade v3;
                     if (v3.upgradeConfirmedByUser(home)) {
                         MainWindow *mainWindow = new MainWindow(home);
@@ -442,12 +455,14 @@ main(int argc, char *argv[])
             }
 
             // chosen, so lets get the choice..
+            QString homeDir = home.canonicalPath();
             home.cd(d.choice());
             if (!home.exists()) {
                 delete trainDB;
                 exit(0);
             }
 
+            appsettings->initializeQSettingsAthlete(homeDir, d.choice());
             // .. and open a mainwindow
             GcUpgrade v3;
             if (v3.upgradeConfirmedByUser(home)) {
@@ -464,6 +479,9 @@ main(int argc, char *argv[])
 
         // close trainDB
         delete trainDB;
+
+        // reset QSettings (global & Athlete)
+        appsettings->clearGlobalAndAthletes();
 
         // clear web caches (stop warning of WebKit leaks)
         QWebSettings::clearMemoryCaches();


### PR DESCRIPTION
Settings (currently in PLIST/Registry/..) are now split and put into different .INI files. The migration of current setting properties happens "on-the-fly" and does not need any user interaction.

There are actually 3 locations now for Settings - all Settings are stored in ".INI" files like they are provided by QSettings. From QT documentation: The INI file format is a Windows file format that Qt supports on all platforms.

a) <system> settings like Colors, Screenpositions,... are moved to a System .INI file (which QT stores in OS specific locations - you can look up the location in QSettings documentation see here: http://doc.qt.io/qt-5/qsettings.html#platform-specific-notes

b) Global Configuration - stored in the root of each AthleteDirectory - 2 Files - one for the General Settings, one for the Trainmode specific settings 

c) Athlete specific Configuration - stored in /config of the new athlete directory structure - 4 files - one for General Settings, one for Preferences, one for Layout settings and one for "Private" settings (keeping all the PW/User info). 

Some extra info:

1. GC_CRANKLENGTH and GC_WHEELSIZE are now Athlete dependent preferences - the current values are migrated to any athlete when first opened
2. The new GC_USE_CP_FOR_FTP is also Athlete dependent
3. The dataprocessor settings (Manual/Auto) which were sometimes stored in the language the user has configured are now only stored once and with the technical name of the Data Processor
4. The existing QSettings are not deleted/overwritten by the migration