### PR TITLE
Move "Unit" config from "Athlete" to "General" level

### DIFF
--- a/src/Athlete.cpp
+++ b/src/Athlete.cpp
@@ -79,11 +79,11 @@ Athlete::Athlete(Context *context, const QDir &homeDir)
     if (returnCode != 0) return;
 
     // metric / non-metric
-    QVariant unit = appsettings->cvalue(cyclist, GC_UNIT);
+    QVariant unit = appsettings->value(NULL, GC_UNIT, GC_UNIT_METRIC);
     if (unit == 0) {
         // Default to system locale
         unit = QLocale::system().measurementSystem() == QLocale::MetricSystem ? GC_UNIT_METRIC : GC_UNIT_IMPERIAL;
-        appsettings->setCValue(cyclist, GC_UNIT, unit);
+        appsettings->setValue(GC_UNIT, unit);
     }
     useMetricUnits = (unit.toString() == GC_UNIT_METRIC);
 
@@ -318,7 +318,7 @@ Athlete::configChanged(qint32 state)
 {
     // change units
     if (state & CONFIG_UNITS) {
-        QVariant unit = appsettings->cvalue(cyclist, GC_UNIT);
+        QVariant unit = appsettings->value(NULL, GC_UNIT, GC_UNIT_METRIC);
         useMetricUnits = (unit.toString() == GC_UNIT_METRIC);
     }
 

--- a/src/NewCyclistDialog.cpp
+++ b/src/NewCyclistDialog.cpp
@@ -301,9 +301,9 @@ NewCyclistDialog::saveClicked()
 
                 // lets setup!
                 if (unitCombo->currentIndex()==0)
-                    appsettings->setCValue(name->text(), GC_UNIT, GC_UNIT_METRIC);
+                    appsettings->setValue(GC_UNIT, GC_UNIT_METRIC);
                 else if (unitCombo->currentIndex()==1)
-                    appsettings->setCValue(name->text(), GC_UNIT, GC_UNIT_IMPERIAL);
+                    appsettings->setValue(GC_UNIT, GC_UNIT_IMPERIAL);
 
                 appsettings->setCValue(name->text(), GC_DOB, dob->date());
                 appsettings->setCValue(name->text(), GC_WEIGHT, weight->value() * (useMetricUnits ? 1.0 : KG_PER_LB));

--- a/src/Pages.h
+++ b/src/Pages.h
@@ -98,6 +98,8 @@ class GeneralPage : public QWidget
         QLineEdit *workoutDirectory;
         QPushButton *workoutBrowseButton;
         QPushButton *athleteBrowseButton;
+        QComboBox *unitCombo;
+
 
         QLabel *langLabel;
         QLabel *warningLabel;
@@ -105,6 +107,7 @@ class GeneralPage : public QWidget
         QLabel *athleteLabel;
 
         struct {
+            int unit;
             float hyst;
             int wbal;
             bool warn;
@@ -139,7 +142,6 @@ class RiderPage : public QWidget
         QLabel *weightlabel;
         QLabel *heightlabel;
         QLabel *wbaltaulabel;
-        QComboBox *unitCombo;
         QDoubleSpinBox *weight;
         QDoubleSpinBox *height;
         QSpinBox *wbaltau;
@@ -161,7 +163,6 @@ class RiderPage : public QWidget
 
 
     struct {
-        int unit;
         double weight;
         double height;
         int wheel;

--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -491,6 +491,20 @@ GSettings::migrateValueToCValue(QString athlete, QString key) {
     }
 }
 
+void
+GSettings::migrateCValueToValue(QString athlete, QString key) {
+
+    // only migrate if the value does not yet exist on the target INI file
+    if (!contains(key)) {
+        QString oldKey = key;
+        oldKey.remove(QRegExp("^<.*>"));
+        oldKey = athlete+"/"+oldKey;
+        if (oldsystemsettings->contains(oldKey)) {
+            setValue(key, oldsystemsettings->value(oldKey));
+        }
+    }
+}
+
 
 void
 GSettings::upgradeSystem() {
@@ -632,7 +646,6 @@ GSettings::upgradeAthlete(QString athlete) {
     migrateCValue(athlete, GC_BLANK_TRAIN);
     migrateCValue(athlete, GC_BLANK_HOME);
     migrateCValue(athlete, GC_BLANK_DIARY);
-    migrateCValue(athlete, GC_UNIT);
     migrateCValue(athlete, GC_NICKNAME);
     migrateCValue(athlete, GC_DOB);
     migrateCValue(athlete, GC_WEIGHT);
@@ -653,6 +666,7 @@ GSettings::upgradeAthlete(QString athlete) {
     migrateCValue(athlete, GC_USE_CP_FOR_FTP);
 
     migrateAndRenameCValue(athlete, "bavigator/headingwidths", GC_NAVHEADINGWIDTHS);
+    migrateCValueToValue(athlete, GC_UNIT);
 
     // Handle the splittersizes keys
     QStringList splitterKeys = oldsystemsettings->allKeys();

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -143,6 +143,8 @@
 #define GC_PACE                         "<global-general>pace"
 #define GC_SWIMPACE                     "<global-general>swimpace"
 #define GC_ELEVATION_HYSTERESIS         "<global-general>elevationHysteresis"
+#define GC_UNIT                         "<global-general>unit"
+
 
 
 // Fit/Tcx Smart recording
@@ -191,7 +193,6 @@
 #define GC_SETTINGS_SPLITTER_SIZES      "<athlete-layout>mainwindow/splitterSizes"
 
 
-#define GC_UNIT                         "<athlete-preferences>unit"
 #define GC_NICKNAME                     "<athlete-preferences>nickname"
 #define GC_DOB                          "<athlete-preferences>dob"
 #define GC_WEIGHT                       "<athlete-preferences>weight"
@@ -250,8 +251,6 @@
 #define GC_STRAVA_TOKEN                 "<athlete-private>strava_token"
 //Cycling Analytics
 #define GC_CYCLINGANALYTICS_TOKEN       "<athlete-private>cyclinganalytics_token"
-
-
 
 
 // --------------------------------------------------------------------------------
@@ -328,6 +327,7 @@ private:
     void migrateCValue(QString athleteName, QString key);
     void migrateAndRenameCValue(QString athleteName, QString wrongKey, QString key);
     void migrateValueToCValue(QString athleteName, QString key);
+    void migrateCValueToValue(QString athleteName, QString key);
 
     void upgradeSystem();
     void upgradeGlobal();


### PR DESCRIPTION
... Unit Field is moved from Athlete to General preferences
... first Athlete opened with new logic determines the general settings
... if configuration  is already migrated (based on one of the previous commits) -
    migration can be forced to happen again by removing the INI files or
    just the preferences pages has to be opened and Saved with the
    unit settings you want