### PR TITLE
Add "Shared Network Folder" as new "File Store" implementation

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -80,6 +80,7 @@
 #if QT_VERSION > 0x050000
 #include "Dropbox.h"
 #endif
+#include "NetworkFileStore.h"
 #include "FileStore.h"
 
 // GUI Widgets
@@ -606,6 +607,9 @@ MainWindow::MainWindow(const QDir &home)
     rideMenu->addAction(tr("Upload to &Dropbox"), this, SLOT(uploadDropbox()), tr("Ctrl+R"));
     rideMenu->addAction(tr("Synchronise Dropbox..."), this, SLOT(syncDropbox()), tr("Ctrl+O"));
 #endif
+    rideMenu->addSeparator ();
+    rideMenu->addAction(tr("Upload to Shared Network Folder"), this, SLOT(uploadNetworkFileStore()));
+    rideMenu->addAction(tr("Synchronise Shared Network Folder..."), this, SLOT(syncNetworkFileStore()));
 #ifdef GC_HAVE_SOAP
     rideMenu->addSeparator ();
     rideMenu->addAction(tr("&Upload to TrainingPeaks"), this, SLOT(uploadTP()), tr("Ctrl+T"));
@@ -1981,6 +1985,30 @@ MainWindow::syncDropbox()
 }
 
 #endif
+
+/*----------------------------------------------------------------------
+ * Network File Share (e.g. a mounted WebDAV folder)
+ *--------------------------------------------------------------------*/
+void
+MainWindow::uploadNetworkFileStore()
+{
+    // upload current ride, if we have one
+    if (currentTab->context->ride) {
+        NetworkFileStore db(currentTab->context);
+        FileStore::upload(this, &db, currentTab->context->ride);
+    }
+}
+
+void
+MainWindow::syncNetworkFileStore()
+{
+    // upload current ride, if we have one
+    NetworkFileStore db(currentTab->context);
+    FileStoreSyncDialog upload(currentTab->context, &db);
+    upload.exec();
+}
+
+
 /*----------------------------------------------------------------------
  * TrainingPeaks.com
  *--------------------------------------------------------------------*/

--- a/src/MainWindow.h
+++ b/src/MainWindow.h
@@ -188,6 +188,8 @@ class MainWindow : public QMainWindow
         void uploadDropbox();
         void syncDropbox();
 #endif
+        void uploadNetworkFileStore();
+        void syncNetworkFileStore();
         void importFile();
         void splitRide();
         void mergeRide();

--- a/src/NetworkFileStore.cpp
+++ b/src/NetworkFileStore.cpp
@@ -1,0 +1,176 @@
+/*
+ * Copyright (c) 2015 Joern Rischmueller (joern.rm@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "NetworkFileStore.h"
+#include "Athlete.h"
+#include "Settings.h"
+
+NetworkFileStore::NetworkFileStore(Context *context) : FileStore(context), context(context), root_(NULL) {
+
+}
+
+NetworkFileStore::~NetworkFileStore() {
+
+}
+
+// open by connecting and getting a basic list of folders available
+bool
+NetworkFileStore::open(QStringList &errors)
+{
+
+    QString folder = appsettings->cvalue(context->athlete->cyclist, GC_NETWORKFILESTORE_FOLDER, "").toString();
+    if (folder == "") {
+        errors << tr("You must define a network folder first");
+        return false;
+    }
+
+    QDir folder_dir = QDir(folder);
+    if (!folder_dir.exists()) {
+        errors << tr("Folder %1 does not exist/is not accessible").arg(folder);
+        return false;
+    }
+
+    // we have a root
+    root_ = newFileStoreEntry();
+
+    // path name
+    root_->name = folder_dir.canonicalPath();
+    root_->isDir = true;
+    root_->size = 1;
+
+    // ok so far ?
+    if (errors.count()) return false;
+    return true;
+}
+
+bool 
+NetworkFileStore::close()
+{
+    // nothing to do for now
+    return true;
+}
+
+// home dire
+QString
+NetworkFileStore::home()
+{
+    return appsettings->cvalue(context->athlete->cyclist, GC_NETWORKFILESTORE_FOLDER, "").toString();
+}
+
+bool
+NetworkFileStore::createFolder(QString path)
+{
+    // not used for this FileStore, since the standard QFileDialog is used to define the Directory
+    return false;
+}
+
+QList<FileStoreEntry*> 
+NetworkFileStore::readdir(QString path, QStringList &errors)
+{
+    QList<FileStoreEntry*> returning;
+
+    QDir current_path = QDir(path);
+    if (!current_path.exists()) {
+        errors << tr("Folder %1 does not exist").arg(path);
+        return returning;
+    }
+
+    QFileInfoList files = current_path.entryInfoList();
+    foreach (QFileInfo info, files) {
+
+        FileStoreEntry *add = newFileStoreEntry();
+
+        //QFileInfo has full path, we just want the file name
+        add->name = info.fileName();
+        add->isDir = info.isDir();
+        add->size = info.size();
+
+        // dates in format "Tue, 19 Jul 2011 21:55:38 +0000"
+        add->modified = info.lastModified();
+
+        returning << add;
+
+    }
+
+    // all good ?
+    return returning;
+}
+
+// read a file at location (relative to home) into passed array
+bool
+NetworkFileStore::readFile(QByteArray *data, QString remotename)
+{
+
+    // is the path set ?
+    QString path = appsettings->cvalue(context->athlete->cyclist, GC_NETWORKFILESTORE_FOLDER, "").toString();
+    if (path == "") return false;
+
+    // open the path
+    QDir current_path = QDir(path);
+    if (!current_path.exists()) return false;
+
+    QFile file(path+"/"+remotename);
+    if (!file.exists()) return false;
+
+    if (file.open(QIODevice::ReadOnly)) {
+        *data = file.readAll();
+        file.close();
+    } else {
+        file.close();
+        return false;
+    };
+
+    emit readComplete(data, "", tr("Completed"));
+
+    return true;
+}
+
+bool 
+NetworkFileStore::writeFile(QByteArray &data, QString remotename)
+{
+
+    // is the path set ?
+    QString path = appsettings->cvalue(context->athlete->cyclist, GC_NETWORKFILESTORE_FOLDER, "").toString();
+    if (path == "") {
+        emit writeComplete("", tr("You must define a network folder first"));  // required for single upload to get to an end
+        return false;
+    };
+
+    // open the path
+    QDir current_path = QDir(path);
+    if (!current_path.exists()) {
+        emit writeComplete("", tr("Write to folder %1 failed").arg(path));  // required for single upload to get to an end
+        return false;
+    };
+
+    QFile file(path+"/"+remotename);
+    if (file.open(QIODevice::WriteOnly) ) {
+        file.write(data);
+        file.close();
+    } else {
+        file.close();
+        emit writeComplete("", tr("Write to folder %1 failed").arg(path));  // required for single upload to get to an end
+        return false;
+    };
+
+    emit writeComplete("", tr("Completed"));
+
+    return true;
+}
+
+

--- a/src/NetworkFileStore.h
+++ b/src/NetworkFileStore.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2015 Joern Rischmueller (joern.rm@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef GC_NetworkFileStore_h
+#define GC_NetworkFileStore_h
+
+#include "FileStore.h"
+
+class NetworkFileStore : public FileStore {
+
+    Q_OBJECT
+
+    public:
+
+        NetworkFileStore(Context *context);
+        ~NetworkFileStore();
+
+        QString name() { return (tr("Shared Network Folder")); }
+
+        // open/connect and close/disconnect
+        bool open(QStringList &errors);
+        bool close();
+
+        // home directory
+        QString home();
+
+        // write a file 
+        bool writeFile(QByteArray &data, QString remotename);
+
+        // read a file
+        bool readFile(QByteArray *data, QString remotename); 
+
+        // create a folder
+        bool createFolder(QString path);
+
+        // dirent style api
+        FileStoreEntry *root() { return root_; }
+        QList<FileStoreEntry*> readdir(QString path, QStringList &errors);
+
+    private:
+        Context *context;
+        FileStoreEntry *root_;
+
+};
+#endif

--- a/src/Pages.cpp
+++ b/src/Pages.cpp
@@ -39,6 +39,7 @@
 #if QT_VERSION >= 0x050000
 #include "Dropbox.h"
 #endif
+#include "NetworkFileStore.h"
 
 //
 // Main Config Page - tabs for each sub-page
@@ -414,6 +415,27 @@ CredentialsPage::CredentialsPage(QWidget *parent, Context *context) : QScrollAre
 #endif
 
     //////////////////////////////////////////////////
+    // Network FileStore
+
+
+    QLabel *nfs = new QLabel(tr("Shared Network Folder"));
+    nfs->setFont(current);
+    grid->addWidget(nfs, ++row, 0);
+
+    // Selecting the storage folder folder of the Network File Store
+    QLabel *networkFileStoreFolderLabel = new QLabel(tr("Shared Network Athlete Folder"));
+    networkFileStoreFolder = new QLineEdit(this);
+    networkFileStoreFolder->setText(appsettings->cvalue(context->athlete->cyclist, GC_NETWORKFILESTORE_FOLDER, "").toString());
+    networkFileStoreFolderBrowse = new QPushButton(tr("Browse"));
+    connect(networkFileStoreFolderBrowse, SIGNAL(clicked()), this, SLOT(chooseNetworkFileStoreFolder()));
+    QHBoxLayout *nwfsfchoose = new QHBoxLayout;
+    nwfsfchoose->addWidget(networkFileStoreFolder);
+    nwfsfchoose->addWidget(networkFileStoreFolderBrowse);
+    grid->addWidget(networkFileStoreFolderLabel, ++row, 0);
+    grid->addLayout(nwfsfchoose, row, 1);
+
+
+    //////////////////////////////////////////////////
     // Strava
 
     QLabel *str = new QLabel(tr("Strava"));
@@ -707,6 +729,8 @@ CredentialsPage::CredentialsPage(QWidget *parent, Context *context) : QScrollAre
 
 }
 
+
+
 void CredentialsPage::chooseDropboxFolder()
 {
 #if QT_VERSION >= 0x050000 // only in QT5 or higher
@@ -734,6 +758,19 @@ void CredentialsPage::chooseDropboxFolder()
     if (ret == QDialog::Accepted) dropboxFolder->setText(dialog.pathnameSelected());
 #endif
 }
+
+
+void CredentialsPage::chooseNetworkFileStoreFolder()
+{
+    // did the user type something ? if not, get it from the Settings
+    QString path = networkFileStoreFolder->text();
+    if (path == "") path = appsettings->cvalue(context->athlete->cyclist, GC_NETWORKFILESTORE_FOLDER, "").toString();
+    QString dir = QFileDialog::getExistingDirectory(this, tr("Choose Shared Network Folder Athlete Directory"),
+                            path, QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
+    if (dir != "") networkFileStoreFolder->setText(dir);  //only overwrite current dir, if a new was selected
+
+}
+
 
 #ifdef GC_HAVE_KQOAUTH
 void CredentialsPage::authoriseTwitter()
@@ -839,6 +876,7 @@ CredentialsPage::saveClicked()
     appsettings->setCValue(context->athlete->cyclist, GC_WEBCAL_URL, webcalURL->text());
     appsettings->setCValue(context->athlete->cyclist, GC_WEBCAL_URL, webcalURL->text());
     appsettings->setCValue(context->athlete->cyclist, GC_DROPBOX_FOLDER, dropboxFolder->text());
+    appsettings->setCValue(context->athlete->cyclist, GC_NETWORKFILESTORE_FOLDER, networkFileStoreFolder->text());
 
     // escape the at character
     QString url = dvURL->text();

--- a/src/Pages.h
+++ b/src/Pages.h
@@ -196,6 +196,7 @@ class CredentialsPage : public QScrollArea
         void authoriseCyclingAnalytics();
         void authoriseGoogleCalendar();
         void dvCALDAVTypeChanged(int);
+        void chooseNetworkFileStoreFolder();
 
     private:
         Context *context;
@@ -212,7 +213,9 @@ class CredentialsPage : public QScrollArea
 
         QComboBox *dvCALDAVType;
         QPushButton *stravaAuthorise, *stravaAuthorised, *twitterAuthorised, *dropboxAuthorised, *dropboxBrowse;
+        QPushButton *networkFileStoreFolderBrowse;
         QLineEdit *dropboxFolder;
+        QLineEdit *networkFileStoreFolder;
         QPushButton *cyclingAnalyticsAuthorise, *cyclingAnalyticsAuthorised;
         QPushButton *googleCalendarAuthorise, *googleCalendarAuthorised;
 

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -208,7 +208,7 @@
 #define GC_CRANKLENGTH                  "<athlete-preferences>crankLength"
 #define GC_WHEELSIZE                    "<athlete-preferences>wheelsize"
 #define GC_USE_CP_FOR_FTP               "<athlete-preferences>cp/useforftp"                       // use CP for FTP
-
+#define GC_NETWORKFILESTORE_FOLDER      "<athlete-preferences>networkfilestore/folder"            // folder to sync with
 
 // ride navigator
 #define GC_NAVHEADINGS                  "<athlete-preferences>navigator/headings"
@@ -242,7 +242,7 @@
 #define GC_DVGOOGLE_CALID               "<athlete-private>dv/googlecalid"
 //Twitter oauth keys
 #define GC_DROPBOX_TOKEN                "<athlete-private>dropbox/token"
-#define GC_DROPBOX_FOLDER                "<athlete-private>dropbox/folder"
+#define GC_DROPBOX_FOLDER               "<athlete-private>dropbox/folder"
 #define GC_TWITTER_TOKEN                "<athlete-private>twitter_token"
 #define GC_TWITTER_SECRET               "<athlete-private>twitter_secret"
 //Google Calendar-CALDAV oauthkeys

--- a/src/src.pro
+++ b/src/src.pro
@@ -427,6 +427,7 @@ HEADERS += \
         MUPlot.h \
         MUPool.h \
         MUWidget.h \
+        NetworkFileStore.h \
         NewCyclistDialog.h \
         NullController.h \
         OAuthDialog.h \
@@ -665,6 +666,7 @@ SOURCES += \
         MoxyDevice.cpp \
         MUPlot.cpp \
         MUWidget.cpp \
+        NetworkFileStore.cpp \
         NewCyclistDialog.cpp \
         NullController.cpp \
         OAuthDialog.cpp \


### PR DESCRIPTION
... use a shared network drive (e.g. mounted via WebDAV) to synchronize activity data
   (similar to Dropbox,...)

Open/TBD:
... where to best put the Preferences for the different FileStores
   (currently add the Network folder configuration on Preferences->Passwords,
    even though no PW is needed - with growing number of FileStores a
    dedicated Preferences Page may be the solution)
... where to put the MainWindow Menu entries if the number of FileStores increases