### PR TITLE
XML Ridefile Formats exports - error on Windows

### DIFF
--- a/src/FitlogRideFile.cpp
+++ b/src/FitlogRideFile.cpp
@@ -233,7 +233,12 @@ FitlogFileReader::writeRideFile(Context *context, const RideFile *ride, QFile &f
 
     QByteArray xml = doc.toByteArray(4);
     if (!file.open(QIODevice::WriteOnly)) return(false);
-    if (file.write(xml) != xml.size()) return(false);
+    file.resize(0);
+    QTextStream out(&file);
+    out.setCodec("UTF-8");
+    out.setGenerateByteOrderMark(true);
+    out << xml;
+    out.flush();
     file.close();
     return(true);
 }

--- a/src/GcRideFile.cpp
+++ b/src/GcRideFile.cpp
@@ -270,8 +270,12 @@ GcFileReader::writeRideFile(Context *,const RideFile *ride, QFile &file) const
     QByteArray xml = doc.toByteArray(4);
     if (!file.open(QIODevice::WriteOnly))
         return false;
-    if (file.write(xml) != xml.size())
-        return false;
+    file.resize(0);
+    QTextStream out(&file);
+    out.setCodec("UTF-8");
+    out.setGenerateByteOrderMark(true);
+    out << xml;
+    out.flush();
     file.close();
     return true;
 }

--- a/src/PwxRideFile.cpp
+++ b/src/PwxRideFile.cpp
@@ -888,7 +888,12 @@ PwxFileReader::writeRideFile(Context *context, const RideFile *ride, QFile &file
 
     QByteArray xml = doc.toByteArray(4);
     if (!file.open(QIODevice::WriteOnly)) return(false);
-    if (file.write(xml) != xml.size()) return(false);
+    file.resize(0);
+    QTextStream out(&file);
+    out.setCodec("UTF-8");
+    out.setGenerateByteOrderMark(true);
+    out << xml;
+    out.flush();
     file.close();
     return(true);
 }

--- a/src/TcxRideFile.cpp
+++ b/src/TcxRideFile.cpp
@@ -415,7 +415,12 @@ TcxFileReader::writeRideFile(Context *context, const RideFile *ride, QFile &file
     QByteArray xml = toByteArray(context, ride, true, true, true, true);
 
     if (!file.open(QIODevice::WriteOnly)) return(false);
-    if (file.write(xml) != xml.size()) return(false);
+    file.resize(0);
+    QTextStream out(&file);
+    out.setCodec("UTF-8");
+    out.setGenerateByteOrderMark(true);
+    out << xml;
+    out.flush();
     file.close();
     return(true);
 }


### PR DESCRIPTION
... UTF-8 ByteOrderMarks was missing in the exported XML,... files 
    causing problems on Windows e.g. in cyrillic
... BOM header added for PWX, Fitlog, GC and TCX format
... Fixes https://github.com/GoldenCheetah/GoldenCheetah/issues/1547
