### PR TITLE
TrainMode - Use Multimedia Keys

### DIFF
--- a/src/TrainSidebar.cpp
+++ b/src/TrainSidebar.cpp
@@ -233,6 +233,9 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
     rewind->setStyleSheet("background-color: rgba( 255, 255, 255, 0% ); border: 0px;");
     rewind->setAutoRepeat(true);
     rewind->setAutoRepeatDelay(200);
+#if QT_VERSION > 0x050400
+    rewind->setShortcut(Qt::Key_MediaPrevious);
+#endif
     toolbuttons->addWidget(rewind);
 
     QIcon stopIcon(":images/oxygen/stop.png");
@@ -243,6 +246,9 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
     stop->setAutoDefault(false);
     stop->setFlat(true);
     stop->setStyleSheet("background-color: rgba( 255, 255, 255, 0% ); border: 0px;");
+#if QT_VERSION > 0x050400
+    stop->setShortcut(Qt::Key_MediaStop);
+#endif
     toolbuttons->addWidget(stop);
 
     QIcon playIcon(":images/oxygen/play.png");
@@ -253,6 +259,7 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
     play->setAutoDefault(false);
     play->setFlat(true);
     play->setStyleSheet("background-color: rgba( 255, 255, 255, 0% ); border: 0px;");
+    play->setShortcut(Qt::Key_MediaTogglePlayPause);
     toolbuttons->addWidget(play);
 
     QIcon fwdIcon(":images/oxygen/ffwd.png");
@@ -265,6 +272,9 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
     forward->setStyleSheet("background-color: rgba( 255, 255, 255, 0% ); border: 0px;");
     forward->setAutoRepeat(true);
     forward->setAutoRepeatDelay(200);
+#if QT_VERSION > 0x050400
+    forward->setShortcut(Qt::Key_MediaNext);
+#endif
     toolbuttons->addWidget(forward);
 
     QIcon lapIcon(":images/oxygen/lap.png");
@@ -275,6 +285,9 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
     lap->setAutoDefault(false);
     lap->setFlat(true);
     lap->setStyleSheet("background-color: rgba( 255, 255, 255, 0% ); border: 0px;");
+#if QT_VERSION > 0x050400
+    lap->setShortcut(Qt::Key_0);
+#endif
     toolbuttons->addWidget(lap);
     toolbuttons->addStretch();
 


### PR DESCRIPTION
... add Multimedia Keys to control the train mode
... Start/Stop/Forward/Rewind/Pause working on MCE (Windows Media Center compatible remote controls) without any problems
    ... tested with 2 MCE remotes under Windows (Mac and Unix still need to be tested/verified)
... For "new Lap" none of the special media keys worked - so choose "0" since this is available even on pure remotes

Since in earlier versions of QT not all Keys are defined, just start with 5.4 as pre-requisite.