### PR TITLE
Autoimport / Dialog Mode enhancement + new Background Mode

### DIFF
--- a/src/Athlete.cpp
+++ b/src/Athlete.cpp
@@ -121,8 +121,9 @@ Athlete::Athlete(Context *context, const QDir &homeDir)
         }
     }
 
-    // read athlete's autoimport configuration
+    // read athlete's autoimport configuration and initialize the autoimport process
     autoImportConfig = new RideAutoImportConfig(home->config());
+    autoImport = NULL;
 
     // read athlete's charts.xml and translate etc
     loadCharts();
@@ -230,6 +231,9 @@ Athlete::~Athlete()
     delete zones_;
     delete hrzones_;
     for (int i=0; i<2; i++) delete pacezones_[i];
+    delete autoImportConfig;
+    delete autoImport;
+
 }
 
 void Athlete::selectRideFile(QString fileName)
@@ -343,16 +347,15 @@ Athlete::configChanged(qint32 state)
 void
 Athlete::importFilesWhenOpeningAthlete() {
 
+    autoImport = NULL;
     // just do it if something is configured
     if (autoImportConfig->hasRules()) {
 
-        RideImportWizard *import = new RideImportWizard(autoImportConfig, context);
+        autoImport = new RideImportWizard(autoImportConfig, context);
 
         // only process the popup if we have any files available at all
-        if ( import->getNumberOfFiles() > 0) {
-           import->process();
-        } else {
-           delete import;
+        if ( autoImport->getNumberOfFiles() > 0) {
+           autoImport->process();
         }
     }
 }

--- a/src/Athlete.h
+++ b/src/Athlete.h
@@ -51,6 +51,7 @@ class PMCData;
 class LTMSettings;
 class Routes;
 class AthleteDirectoryStructure;
+class RideImportWizard;
 class RideAutoImportConfig;
 class RideCache;
 class IntervalCache;
@@ -118,7 +119,8 @@ class Athlete : public QObject
         CalDAV *davCalendar;
 #endif
 
-        // Athlete's autoimport configuration
+        // Athlete's autoimport handling
+        RideImportWizard *autoImport;
         RideAutoImportConfig *autoImportConfig;
 
         // ride metadata definitions

--- a/src/RideAutoImportConfig.cpp
+++ b/src/RideAutoImportConfig.cpp
@@ -35,6 +35,10 @@ RideAutoImportRule::RideAutoImportRule() {
     _ruleDescriptions.append(tr("Autoimport with dialog - past  90 days"));
     _ruleDescriptions.append(tr("Autoimport with dialog - past 180 days"));
     _ruleDescriptions.append(tr("Autoimport with dialog - past 360 days"));
+    _ruleDescriptions.append(tr("Autoimport in background"));
+    _ruleDescriptions.append(tr("Autoimport in background - past  90 days"));
+    _ruleDescriptions.append(tr("Autoimport in background - past 180 days"));
+    _ruleDescriptions.append(tr("Autoimport in background - past 360 days"));
 
 
 }

--- a/src/RideAutoImportConfig.h
+++ b/src/RideAutoImportConfig.h
@@ -30,7 +30,8 @@ class RideAutoImportRule {
 
 public:
     static QList<QString> rules;
-    enum ImportRule { noImport=0, importAll=1, importLast90days=2, importLast180days=3, importLast360days=4 };
+    enum ImportRule { noImport=0, importAll=1, importLast90days=2, importLast180days=3, importLast360days=4,
+                      importBackgroundAll=5, importBackground90=6, importBackground180=7, importBackground360=8 };
 
     RideAutoImportRule();
 

--- a/src/RideImportWizard.cpp
+++ b/src/RideImportWizard.cpp
@@ -394,8 +394,6 @@ RideImportWizard::process()
     // So, therefore the progress bar runs from 0 to files*4. (since step 5 is not implemented yet)
     progressBar->setMinimum(0);
     progressBar->setMaximum(filenames.count()*4);
-    if (!isActiveWindow()) activateWindow();
-
 
     // Pass one - Is it valid?
     phaseLabel->setText(tr("Step 1 of 4: Check file permissions"));
@@ -430,7 +428,6 @@ RideImportWizard::process()
     }
 
     if (aborted) { done(0); }
-    if (!isActiveWindow()) activateWindow();
     repaint();
     QApplication::processEvents();
 
@@ -451,7 +448,6 @@ RideImportWizard::process()
               QApplication::processEvents();
 
               if (aborted) { done(0); }
-              if (!isActiveWindow()) activateWindow();
               this->repaint();
               QApplication::processEvents();
 
@@ -616,7 +612,6 @@ RideImportWizard::process()
         progressBar->setValue(progressBar->value()+1);
         QApplication::processEvents();
         if (aborted) { done(0); }
-        if (!isActiveWindow()) activateWindow();
         this->repaint();
 
         next:;
@@ -639,11 +634,10 @@ RideImportWizard::process()
 
         // does nothing for the moment
         progressBar->setValue(progressBar->value()+1);
-        if (!isActiveWindow()) activateWindow();
         progressBar->repaint();
    }
-   // get it on top
-   activateWindow();
+   // get it on top to save / correct missing dates
+    if (!isActiveWindow()) activateWindow();
 
    // Wait for user to press save
    abortButton->setText(tr("Save"));
@@ -827,7 +821,6 @@ RideImportWizard::todayClicked(int index)
     }
     // phew! - repaint!
     QApplication::processEvents();
-    if (!isActiveWindow()) activateWindow();
     tableWidget->repaint();
 
 }
@@ -922,7 +915,6 @@ RideImportWizard::abortClicked()
         tableWidget->setCurrentCell(i,5);
         QApplication::processEvents();
         if (aborted) { done(0); }
-        if (!isActiveWindow()) activateWindow();
         this->repaint();
 
 
@@ -1031,7 +1023,6 @@ RideImportWizard::abortClicked()
         QApplication::processEvents();
         if (aborted) { done(0); }
         progressBar->setValue(progressBar->value()+1);
-        if (!isActiveWindow()) activateWindow();
         this->repaint();
     }
 
@@ -1049,6 +1040,7 @@ RideImportWizard::abortClicked()
     progressBar->setValue(progressBar->maximum());
     phaseLabel->setText(donemessage);
     abortButton->setText(tr("Finish"));
+    if (!isActiveWindow()) activateWindow();
     aborted = false;
 }
 

--- a/src/RideImportWizard.h
+++ b/src/RideImportWizard.h
@@ -48,10 +48,13 @@ public:
     RideImportWizard(RideAutoImportConfig *dirs, Context *context, QWidget *parent = 0);
 
     ~RideImportWizard();
+    void closeEvent(QCloseEvent*);
+    void done(int);
+
     int getNumberOfFiles();  // get the number of files selected for processing
     int process();
-
-signals:
+    bool importInProcess() { return _importInProcess; }
+    bool isAutoImport() { return autoImportMode;}
 
 private slots:
     void abortClicked();
@@ -72,6 +75,8 @@ private:
     QDir tmpActivities; // activitiy .JSON is stored here until rideCache() update was successfull
     bool aborted;
     bool autoImportMode;
+    bool autoImportStealth;
+    bool _importInProcess;
     QLabel *phaseLabel;
     QTableWidget *tableWidget;
     QTableWidget *directoryWidget;


### PR DESCRIPTION
Enhancements of Autoimport in Dialog

... don't force focus on the import dialog window
... bring dialog to front only if user interaction is required

Autoimport Stealth/Background Mode

... new Feature to Autoimport without Dialog (with same timeframe option like the Dialog version)
... in case "Dates/Time" is missing - the Dialog Window appears and waits for input -
    if entered and "Save" presses no further input action is required
... malformed activity files are silently ignored

... to avoid inconsistencies closing of the Athlete for which Background Import is running
   is blocked until the Import is finalized (Info on import complete is sent to UI)

.. UI is not blocked by Autoimport - but a bit less reactive as long as the import is executed