### PR TITLE
TrainDB / Add upgrade feature to fix wrong default entries

### DIFF
--- a/src/GcUpgrade.cpp
+++ b/src/GcUpgrade.cpp
@@ -28,6 +28,7 @@
 #include "Context.h"
 #include "DataProcessor.h"
 #include "MainWindow.h"
+#include "TrainDB.h"
 
 #include <QDebug>
 #include <QMessageBox>
@@ -345,6 +346,18 @@ GcUpgrade::upgrade(const QDir &home)
     if (last < VERSION311_BUILD) {
 
         // add here the standard upgrade tasks
+
+    }
+
+
+    //----------------------------------------------------------------------
+    // 3.3 upgrade processing
+    //----------------------------------------------------------------------
+
+    if (last < VERSION33_BUILD) {
+
+        // cleanup/restore default entries in the trainDB
+        trainDB->updateDefaultEntries();
 
     }
 

--- a/src/TrainDB.h
+++ b/src/TrainDB.h
@@ -64,6 +64,9 @@ class TrainDB : public QObject
     // drop and recreate tables
     void rebuildDB();
 
+    // update default entries in the tables
+    bool updateDefaultEntries();
+
     signals:
         void dataChanged();
 
@@ -81,6 +84,9 @@ class TrainDB : public QObject
         bool dropVideoTable();
         bool createVideoSyncTable();
         bool dropVideoSyncTable();
+
+        bool createDefaultEntriesWorkout();
+        bool createDefaultEntriesVideosync();
 };
 
 extern TrainDB *trainDB;


### PR DESCRIPTION
TrainDB / Add upgrade feature to fix wrong default entries
.. videosync table version stored in TrainDB (was missing before)

.. upgrade to 3.3 fixes default entries for Workouts (e.g. due to wrong translation with missing " " in text        - at least in German)