### PR TITLE
ANT FE-C Add periodic refresh of gradient in slope mode

### DIFF
--- a/src/ANT.cpp
+++ b/src/ANT.cpp
@@ -179,6 +179,11 @@ bool ANT::modeERGO(void) const
     return mode==RT_MODE_ERGO; 
 }
 
+bool ANT::modeSLOPE(void) const
+{
+    return mode==RT_MODE_SLOPE;
+}
+
 double ANT::channelValue2(int channel)
 {
     return antChannel[channel]->channelValue2();
@@ -289,6 +294,15 @@ ANT::setLoad(double load)
 void ANT::refreshFecLoad()
 {
     sendMessage(ANTMessage::fecSetTargetPower(fecChannel, (int)load));
+}
+
+void ANT::refreshFecGradient()
+{
+    if (fecChannel == -1)
+        return;
+
+    if (antChannel[fecChannel]->capabilities() & FITNESS_EQUIPMENT_SIMUL_MODE_CAPABILITY)
+        sendMessage(ANTMessage::fecSetTrackResistance(fecChannel, gradient, currentRollingResistance));
 }
 
 void ANT::requestFecCapabilities()

--- a/src/ANT.h
+++ b/src/ANT.h
@@ -403,6 +403,7 @@ public:
     int rawWrite(uint8_t *bytes, int size);
 
     bool modeERGO(void) const;
+    bool modeSLOPE(void) const;
 
     // channels update our telemetry
     double channelValue(int channel);
@@ -458,6 +459,7 @@ public:
 
     void setFecChannel(int channel);
     void refreshFecLoad();
+    void refreshFecGradient();
     void requestFecCapabilities();
 
     void setVortexData(int channel, int id);

--- a/src/ANTChannel.cpp
+++ b/src/ANTChannel.cpp
@@ -684,10 +684,13 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
 
                parent->setFecChannel(number);
                // we don't seem to receive ACK messages, so use this workaround
-               // to ensure load is always set correctly
-               if ((fecRefreshCounter++ % 10) == 0 && parent->modeERGO())
+               // to ensure load/gradient is always set correctly
+               if ((fecRefreshCounter++ % 10) == 0)
                {
-                   parent->refreshFecLoad();
+                   if  (parent->modeERGO())
+                       parent->refreshFecLoad();
+                   else if (parent->modeSLOPE())
+                        parent->refreshFecGradient();
                }
 
                if (antMessage.data_page == FITNESS_EQUIPMENT_TRAINER_SPECIFIC_PAGE)


### PR DESCRIPTION
As per the existing refresh in ergo mode, this is a workaround for
not receiving acknowledgements.

My trainer (Vortex Smart) was often missing the gradient updates 
when only transmitted once at each change.
