### PR TITLE
ANT FE-C

### DIFF
--- a/src/ANT.cpp
+++ b/src/ANT.cpp
@@ -730,6 +730,13 @@ ANT::channelInfo(int channel, int device_number, int device_id)
         qDebug()<<"kickr found."<<kickrDeviceID<<"on channel"<<kickrChannel;
     }
 
+    // ANT FE-C DEVICE DETECTED - ACT ACCORDINGLY !
+    // if we just got an ANT FE-C trainer, request the capabilities
+    if (!configuring && antChannel[channel]->is_fec) {
+        antChannel[channel]->capabilities();
+        qDebug()<<"ANT FE-C device found."<<device_number<<"on channel"<<channel;
+    }
+
     //qDebug()<<"found device number"<<device_number<<"type"<<device_id<<"on channel"<<channel
     //<< "is a "<<deviceTypeDescription(device_id) << "with code"<<deviceTypeCode(device_id);
 }

--- a/src/ANT.cpp
+++ b/src/ANT.cpp
@@ -285,7 +285,7 @@ ANT::setLoad(double load)
     }
 
     // if we have a FE-C trainer connected, relay the change in target power to the brake
-    if (fecChannel != -1)
+    if ((fecChannel != -1) && (antChannel[fecChannel]->capabilities() & FITNESS_EQUIPMENT_POWER_MODE_CAPABILITY))
     {
         sendMessage(ANTMessage::fecSetTargetPower(fecChannel, (int)load));
     }
@@ -293,7 +293,11 @@ ANT::setLoad(double load)
 
 void ANT::refreshFecLoad()
 {
-    sendMessage(ANTMessage::fecSetTargetPower(fecChannel, (int)load));
+    if (fecChannel == -1)
+        return;
+
+    if ((fecChannel != -1) && (antChannel[fecChannel]->capabilities() & FITNESS_EQUIPMENT_POWER_MODE_CAPABILITY))
+        sendMessage(ANTMessage::fecSetTargetPower(fecChannel, (int)load));
 }
 
 void ANT::refreshFecGradient()

--- a/src/ANT.cpp
+++ b/src/ANT.cpp
@@ -296,7 +296,7 @@ void ANT::refreshFecLoad()
     if (fecChannel == -1)
         return;
 
-    if ((fecChannel != -1) && (antChannel[fecChannel]->capabilities() & FITNESS_EQUIPMENT_POWER_MODE_CAPABILITY))
+    if (antChannel[fecChannel]->capabilities() & FITNESS_EQUIPMENT_POWER_MODE_CAPABILITY)
         sendMessage(ANTMessage::fecSetTargetPower(fecChannel, (int)load));
 }
 

--- a/src/ANTChannel.cpp
+++ b/src/ANTChannel.cpp
@@ -679,7 +679,6 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
 
            case CHANNEL_TYPE_FITNESS_EQUIPMENT:
            {
-               is_fec = true;
                static int fecRefreshCounter = 1;
 
                parent->setFecChannel(number);
@@ -779,6 +778,12 @@ void ANTChannel::channelId(unsigned char *ant_message) {
 
     if (is_kickr) {
         qDebug()<<number<<"KICKR DETECTED VIA CHANNEL ID EVENT";
+    }
+
+    is_fec = (device_id == ANT_SPORT_FITNESS_EQUIPMENT_TYPE);
+
+    if (is_fec) {
+        qDebug()<<number<<"ANT FE-C DETECTED VIA CHANNEL ID EVENT";
     }
 
     // tell controller we got a new channel id
@@ -951,7 +956,6 @@ void ANTChannel::attemptTransition(int message_id)
 
 uint8_t ANTChannel::capabilities()
 {
-    // TODO: run this request once when just connected to device
     if (!is_fec)
         return 0;
 
@@ -961,7 +965,7 @@ uint8_t ANTChannel::capabilities()
     // if we do not know device capabilities, request it
     qDebug() << qPrintable("Ask for capabilities");
     parent->requestFecCapabilities();
-        return 0;
+    return 0;
 }
 
 // Calibrate... needs fixing in version 3.1


### PR DESCRIPTION
Detect FE-C trainer at channel connection (based on the kickr code), 
and make an initial request for device capabilities at this time.

Check erg mode is supported before requesting a target load.

Works well for me, but will ask both Mark and Vianney to review prior to merging..