### PR TITLE
minor building warning fix

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -292,6 +292,8 @@ main(int argc, char *argv[])
         // now redirect stderr
 #ifndef WIN32
         if (!debug) nostderr(home.canonicalPath());
+#else
+        Q_UNUSED(debug)
 #endif
 
         // install QT Translator to enable QT Dialogs translation


### PR DESCRIPTION
Just add Q_UNUSED to avoid unused variable warning when building for windows
I've not changed variable declaration as may be useful later to use this variable also for windows build
(in this case Q_UNUSED will not have any impact)