### PR TITLE
Add missing 'text' entry to parser

### DIFF
--- a/src/MeterWidget.cpp
+++ b/src/MeterWidget.cpp
@@ -92,6 +92,11 @@ void MeterWidget::paintEvent(QPaintEvent* paintevent)
     Q_UNUSED(paintevent);
 }
 
+void  MeterWidget::setColor(QColor  mainColor)
+{
+    m_MainColor = mainColor;
+}
+
 TextMeterWidget::TextMeterWidget(QString Name, QWidget *parent, QString Source) : MeterWidget(Name, parent, Source)
 {
 }

--- a/src/MeterWidget.h
+++ b/src/MeterWidget.h
@@ -43,6 +43,7 @@ class MeterWidget : public QWidget
     virtual void paintEvent(QPaintEvent* paintevent);
     virtual QSize sizeHint() const;
     virtual QSize minimumSize() const;
+    void    setColor(QColor  mainColor);
 
     float Value, ValueMin, ValueMax;
     QString Text, AltText;

--- a/src/VideoLayoutParser.cpp
+++ b/src/VideoLayoutParser.cpp
@@ -208,6 +208,8 @@ bool VideoLayoutParser::endElement( const QString&, const QString&, const QStrin
             meterWidget->m_Angle = buffer.toFloat();
         else if (qName == "SubRange")
             meterWidget->m_SubRange = buffer.toInt();
+        else if (qName == "Text")
+            meterWidget->Text = QString(buffer);
 
         else if (qName == "meter")
         {

--- a/src/xml/video-layout.xml
+++ b/src/xml/video-layout.xml
@@ -32,8 +32,8 @@
        <Text>Watts</Text>
    </meter>
    <meter name="Cadencemeter" container="Video" source="Cadence" type="CircularBargraph">
-       <RelativeSize Width="20.0" Height="15.0" />
-       <RelativePosition X="50.0" Y="77.0" />
+       <RelativeSize Width="20.0" Height="13.0" />
+       <RelativePosition X="50.0" Y="73.0" />
        <Range Min="0.0" Max="200.0" />
        <MainColor R="5" G="0" B="255" A="180" />
        <Angle>280.0</Angle>
@@ -54,5 +54,9 @@
        <RelativeSize Width="15.0" Height="5.0" />
        <RelativePosition X="50.0" Y="90.0" />
        <MainColor R="255" G="0" B="0" A="180" />
+   </meter>
+   <meter name="status" container="Video" source="TrainerStatus" type="Text">
+       <RelativeSize Width="15.0" Height="5.0" />
+       <RelativePosition X="1.0" Y="10.0" />
    </meter>
 </layout>


### PR DESCRIPTION
Allows units to be displayed when overlay widgets are used on video training

This was part of initial video overlays development but unfortunately was not included in my commits.
It will be used later for messages such as trainer status (calibration required, trainer failure, trainer over its power limits...)