### PR TITLE
Collect all FE-C trainer data

### DIFF
--- a/src/ANT.h
+++ b/src/ANT.h
@@ -285,8 +285,18 @@ struct setChannelAtom {
 // ant+ fitness equipment profile data pages
 #define FITNESS_EQUIPMENT_GENERAL_PAGE              0x10
 #define FITNESS_EQUIPMENT_TRAINER_SPECIFIC_PAGE     0x19
+#define FITNESS_EQUIPMENT_TRAINER_TORQUE_PAGE       0x20
 #define FITNESS_EQUIPMENT_TRAINER_CAPABILITIES_PAGE 0x36
 #define FITNESS_EQUIPMENT_COMMAND_STATUS_PAGE       0x47
+
+#define FITNESS_EQUIPMENT_TYPE_GENERAL              0x10
+#define FITNESS_EQUIPMENT_TYPE_TREADMILL            0x13
+#define FITNESS_EQUIPMENT_TYPE_ELLIPTICAL           0x14
+#define FITNESS_EQUIPMENT_TYPE_STAT_BIKE            0x15
+#define FITNESS_EQUIPMENT_TYPE_ROWER                0x16
+#define FITNESS_EQUIPMENT_TYPE_CLIMBER              0x17
+#define FITNESS_EQUIPMENT_TYPE_NORDIC_SKI           0x18
+#define FITNESS_EQUIPMENT_TYPE_TRAINER              0x19
 
 #define FITNESS_EQUIPMENT_BASIC_RESISTANCE_ID       0x30
 #define FITNESS_EQUIPMENT_TARGET_POWER_ID           0x31
@@ -296,6 +306,20 @@ struct setChannelAtom {
 #define FITNESS_EQUIPMENT_RESIST_MODE_CAPABILITY    0x01
 #define FITNESS_EQUIPMENT_POWER_MODE_CAPABILITY     0x02
 #define FITNESS_EQUIPMENT_SIMUL_MODE_CAPABILITY     0x04
+
+#define FITNESS_EQUIPMENT_POWERCALIB_REQU           0x01
+#define FITNESS_EQUIPMENT_RESISCALIB_REQU           0x02
+#define FITNESS_EQUIPMENT_USERCONFIG_REQU           0x04
+
+#define FITNESS_EQUIPMENT_ASLEEP                    0x01
+#define FITNESS_EQUIPMENT_READY                     0x02
+#define FITNESS_EQUIPMENT_IN_USE                    0x03
+#define FITNESS_EQUIPMENT_FINISHED                  0x04
+
+#define FITNESS_EQUIPMENT_POWER_OK                  0x00
+#define FITNESS_EQUIPMENT_POWER_NOK_LOWSPEED        0x01 // trainer unable to brake as per request due to low speed
+#define FITNESS_EQUIPMENT_POWER_NOK_HIGHSPEED       0x02 // trainer unable to brake as per request due to high speed
+#define FITNESS_EQUIPMENT_POWER_NOK                 0x03 // trainer unable to brake as per request (no details available)
 
 #define ANT_MANUFACTURER_ID_PAGE                    0x50
 #define ANT_PRODUCT_INFO_PAGE                       0x51
@@ -464,6 +488,13 @@ public:
 
     void setVortexData(int channel, int id);
     void refreshVortexLoad();
+
+    void setTrainerStatusAvailable(bool status) { telemetry.setTrainerStatusAvailable(status); }
+    void setTrainerCalibRequired(bool status) { telemetry.setTrainerCalibRequired(status); }
+    void setTrainerConfigRequired(bool status) { telemetry.setTrainerConfigRequired(status); }
+    void setTrainerBrakeFault(bool status) { telemetry.setTrainerBrakeFault(status); }
+    void setTrainerReady(bool status) { telemetry.setTrainerReady(status); }
+    void setTrainerRunning(bool status) { telemetry.setTrainerRunning(status); }
 
 private:
 

--- a/src/ANTChannel.h
+++ b/src/ANTChannel.h
@@ -76,7 +76,6 @@ class ANTChannelInitialisation {
 
 
 class ANTChannel : public QObject {
-
     private:
 
         Q_OBJECT

--- a/src/ANTMessage.h
+++ b/src/ANTMessage.h
@@ -131,6 +131,9 @@ class ANTMessage {
         uint16_t slope, period, torque; // power
         uint16_t sumPower, instantPower; // power
         uint16_t wheelRevolutions, crankRevolutions; // speed and power and cadence
+        uint16_t wheelAccumulatedPeriod;
+        uint16_t accumulatedTorque;
+        uint8_t  elapsedTime;
         uint8_t instantCadence; // cadence
         uint8_t autoZeroStatus, autoZeroEnable;
         bool utcTimeRequired; // moxy
@@ -144,8 +147,14 @@ class ANTMessage {
         uint8_t vortexUsingVirtualSpeed;
 
         // fitness equipment data fields
-        uint16_t fecSpeed, fecInstantPower;
-        uint8_t  fecRawDistance, fecCadence;
+        uint16_t fecSpeed, fecInstantPower, fecAccumulatedPower;
+        uint8_t  fecRawDistance, fecCadence, fecPage0x19EventCount, fecPage0x20EventCount;
+        bool     fecPowerCalibRequired, fecResisCalibRequired, fecUserConfigRequired;
+        uint8_t  fecPowerOverLimits;
+        uint8_t  fecState;
+        uint8_t  fecHRSource;
+        bool     fecDistanceCapability;
+        bool     fecSpeedIsVirtual;
 
         uint8_t  fecEqtType, fecCapabilities;
         bool     fecResistModeCapability, fecPowerModeCapability, fecSimulModeCapability;

--- a/src/RealtimeData.cpp
+++ b/src/RealtimeData.cpp
@@ -29,7 +29,12 @@ RealtimeData::RealtimeData()
 	lap = msecs = lapMsecs = lapMsecsRemaining = 0;
     thb = smo2 = o2hb = hhb = 0.0;
     lrbalance = rte = lte = lps = rps = 0.0;
-
+    trainerStatusAvailable = false;
+    trainerReady = true;
+    trainerRunning = true;
+    trainerCalibRequired = false;
+    trainerConfigRequired = false;
+    trainerBrakeFault = false;
     memset(spinScan, 0, 24);
 }
 
@@ -210,6 +215,65 @@ double RealtimeData::getRPS() const
     return rps;
 }
 
+void RealtimeData::setTrainerStatusAvailable(bool status)
+{
+    this->trainerStatusAvailable = status;
+}
+
+bool RealtimeData::getTrainerStatusAvailable() const
+{
+    return trainerStatusAvailable;
+}
+
+void RealtimeData::setTrainerReady(bool status)
+{
+    this->trainerReady = status;
+}
+
+void RealtimeData::setTrainerRunning(bool status)
+{
+    this->trainerRunning = status;
+}
+
+void RealtimeData::setTrainerCalibRequired(bool status)
+{
+    this->trainerCalibRequired = status;
+}
+
+void RealtimeData::setTrainerConfigRequired(bool status)
+{
+    this->trainerConfigRequired = status;
+}
+
+void RealtimeData::setTrainerBrakeFault(bool status)
+{
+    this->trainerBrakeFault = status;
+}
+
+bool RealtimeData::getTrainerReady() const
+{
+    return trainerReady;
+}
+
+bool RealtimeData::getTrainerRunning() const
+{
+    return trainerRunning;
+}
+
+bool RealtimeData::getTrainerCalibRequired() const
+{
+    return trainerCalibRequired;
+}
+
+bool RealtimeData::getTrainerConfigRequired() const
+{
+    return trainerConfigRequired;
+}
+
+bool RealtimeData::getTrainerBrakeFault() const
+{
+    return trainerBrakeFault;
+}
 
 double RealtimeData::value(DataSeries series) const
 {

--- a/src/RealtimeData.h
+++ b/src/RealtimeData.h
@@ -46,6 +46,7 @@ public:
                       LeftPedalSmoothness, RightPedalSmoothness};
 
     typedef enum dataseries DataSeries;
+
     double value(DataSeries) const;
     static QString seriesName(DataSeries);
     static const QList<DataSeries> &listDataSeries();
@@ -112,6 +113,19 @@ public:
     double getRPS() const;
 
 
+    void setTrainerStatusAvailable(bool status);
+    bool getTrainerStatusAvailable() const;
+    void setTrainerReady(bool status);
+    void setTrainerRunning(bool status);
+    void setTrainerCalibRequired(bool status);
+    void setTrainerConfigRequired(bool status);
+    void setTrainerBrakeFault(bool status);
+    bool getTrainerReady() const;
+    bool getTrainerRunning() const;
+    bool getTrainerCalibRequired() const;
+    bool getTrainerConfigRequired() const;
+    bool getTrainerBrakeFault() const;
+
     uint8_t spinScan[24];
 
 private:
@@ -132,6 +146,13 @@ private:
     long msecs;
     long lapMsecs;
     long lapMsecsRemaining;
+
+    bool trainerStatusAvailable;
+    bool trainerReady;
+    bool trainerRunning;
+    bool trainerCalibRequired;
+    bool trainerConfigRequired;
+    bool trainerBrakeFault;
 };
 
 #endif

--- a/src/TrainSidebar.cpp
+++ b/src/TrainSidebar.cpp
@@ -1376,6 +1376,15 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
                     rtData.setLPS(local.getLPS());
                     rtData.setRPS(local.getRPS());
                 }
+                if (local.getTrainerStatusAvailable())
+                {
+                    rtData.setTrainerStatusAvailable(true);
+                    rtData.setTrainerReady(local.getTrainerReady());
+                    rtData.setTrainerRunning(local.getTrainerRunning());
+                    rtData.setTrainerCalibRequired(local.getTrainerCalibRequired());
+                    rtData.setTrainerConfigRequired(local.getTrainerConfigRequired());
+                    rtData.setTrainerBrakeFault(local.getTrainerBrakeFault());
+                }
             }
 
             // Distance assumes current speed for the last second. from km/h to km/sec

--- a/src/VideoWindow.cpp
+++ b/src/VideoWindow.cpp
@@ -311,6 +311,37 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
             p_meterWidget->Value =  rtd.getHr();
             p_meterWidget->Text = QString::number((int)p_meterWidget->Value) + tr(" bpm");
         }
+        else if (p_meterWidget->Source() == QString("TrainerStatus"))
+        {
+            if (!rtd.getTrainerStatusAvailable())
+            {  // we don't have status from trainer thus we cannot indicate anything on screen
+                p_meterWidget->Text = tr("");
+            }
+            else if (rtd.getTrainerCalibRequired())
+            {
+                p_meterWidget->setColor(QColor(255,0,0,180));
+                p_meterWidget->Text = tr("Calibration required");
+            }
+            else if (rtd.getTrainerConfigRequired())
+            {
+                p_meterWidget->setColor(QColor(255,0,0,180));
+                p_meterWidget->Text = tr("Configuration required");
+            }
+            else if (rtd.getTrainerBrakeFault())
+            {
+                p_meterWidget->setColor(QColor(255,0,0,180));
+                p_meterWidget->Text = tr("brake fault");
+            }
+            else if (rtd.getTrainerReady())
+            {
+                p_meterWidget->setColor(QColor(0,255,0,180));
+                p_meterWidget->Text = tr("Ready");
+            }
+            else
+            {
+                p_meterWidget->Text = tr("");
+            }
+        }
     }
 
     foreach(MeterWidget* p_meterWidget , m_metersWidget)


### PR DESCRIPTION
I've included more data that were not read from ANT FE-C messages
such as calibration required, brake fault due to low speed (#1633)...
at present it just show a red "brake fault" message as overlay on video training screen and green "ready" when not running but ready
next steps:
 - user configuration (weight, wheel diameter, etc.) from GC to trainer
 - calibration process (how do you want it to be included in GUI?)

The data that I'll not use are just pointed out by a comment
The data that will be used in coming months are pointed out with TODO flags