### PR TITLE
ANT: Cope with event counter wraparound

### DIFF
--- a/src/ANTChannel.cpp
+++ b/src/ANTChannel.cpp
@@ -438,7 +438,7 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                 //
                 case ANT_WHEELTORQUE_POWER: // 0x11 - wheel torque (Powertap)
                 {
-                    uint8_t events = antMessage.eventCount - lastMessage.eventCount;
+                    uint8_t events = eventCount(antMessage, lastMessage);
                     uint16_t period = antMessage.period - lastMessage.period;
                     uint16_t torque = antMessage.torque - lastMessage.torque;
 
@@ -476,7 +476,7 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                 //
                 case ANT_STANDARD_POWER: // 0x10 - standard power
                 {
-                    uint8_t events = antMessage.eventCount - lastStdPwrMessage.eventCount;
+                    uint8_t events = eventCount(antMessage, lastStdPwrMessage);
                     if (lastStdPwrMessage.type && events) {
                         stdNullCount = 0;
                         is_alt ? parent->setAltWatts(antMessage.instantPower) : parent->setWatts(antMessage.instantPower);
@@ -502,7 +502,7 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                 case ANT_TE_AND_PS_POWER: // 0x13 - optional extension to standard power / event Count is defined to be in sync with 0x10 - so not separate calculation
                                           // and just take whatever is delivered - data may not be sent for every power reading - but minimum every 5th pwr message
                 {
-                    uint8_t events = antMessage.eventCount - lastStdPwrMessage.eventCount;
+                    uint8_t events = eventCount(antMessage, lastStdPwrMessage);
                     if (events) {
                         // provide valid values only
                         if (antMessage.leftTorqueEffectiveness != 0xFF && antMessage.rightTorqueEffectiveness != 0xFF) {
@@ -528,7 +528,7 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                 //
                 case ANT_CRANKTORQUE_POWER: // 0x12 - crank torque (Quarq)
                 {
-                    uint8_t events = antMessage.eventCount - lastMessage.eventCount;
+                    uint8_t events = eventCount(antMessage, lastMessage);
                     uint16_t period = antMessage.period - lastMessage.period;
                     uint16_t torque = antMessage.torque - lastMessage.torque;
 

--- a/src/ANTChannel.h
+++ b/src/ANTChannel.h
@@ -109,6 +109,16 @@ class ANTChannel : public QObject {
         int product_id;
         int product_version;
 
+        // Calculate number of events between the curr and last
+        // ANTMessages, accounting for overflow.
+        uint8_t eventCount(const ANTMessage &curr,
+                           const ANTMessage &last) const {
+            // The event count wraps around at 0xFF.
+            if (curr.eventCount < last.eventCount)
+                return ((curr.eventCount + 256) - last.eventCount) & 0xff;
+            return curr.eventCount - last.eventCount;
+        }
+
     public:
 
         // !!! THIS ENUM LIST MUST MATCH THE ORDER THAT ant_sensor_type_t


### PR DESCRIPTION
The event count wraps at 0xFF so we need a function eventCount()
to properly calculate the number of events when the overflow occurs
i.e.
0x00 (curr) - 0xFF (prev) = 0x01
0x01 (curr) - 0xFF (prev) = 0x02