### PR TITLE
ANT: Fix STD, CRANKTORQUE and TE_PS power event interaction

### DIFF
--- a/src/ANTChannel.h
+++ b/src/ANTChannel.h
@@ -82,7 +82,15 @@ class ANTChannel : public QObject {
 
         ANT *parent;
 
-        ANTMessage lastMessage, lastStdPwrMessage;
+        // Stores the last message.
+        ANTMessage lastMessage;
+        // Stores last message for ANT_STANDARD_POWER.
+        ANTMessage lastStdPwrMessage;
+        // Stores last message for ANT_CRANKTORQUE_POWER.
+        ANTMessage lastCrankTorquePwrMessage;
+        // Stores latest ANT_STANDARD_POWER or ANT_CRANKTORQUE_POWER
+        // for use by ANT_TE_AND_PS_POWER.
+        ANTMessage lastPwrForTePsMessage;
         int dualNullCount, nullCount, stdNullCount;
         double last_message_timestamp;
         uint8_t fecPrevRawDistance;


### PR DESCRIPTION
The ANT_TE_AND_PS_POWER events are directly related to
either the ANT_STANDARD_POWER or ANT_CRANKTORQUE_POWER events
(whichever is sooner).  The eventCount of TE_AND_PS will match
the eventCount of either of those events to be considered valid.

This change is required for Garmin Vector pedals which deliver
a sequence of ANT_STANDARD_POWER events, interleaved with
ANT_CRANKTORQUE_POWER events and occasional ANT_TE_AND_PS_POWER
events.  Without the change, the user will experience very frequent
power drop-outs (0W readings).  With the change, the power readings
are smooth and consistent.