### PR TITLE
WIP FE-C calibration and configuration

### DIFF
--- a/src/ANT.cpp
+++ b/src/ANT.cpp
@@ -309,9 +309,60 @@ void ANT::refreshFecGradient()
         sendMessage(ANTMessage::fecSetTrackResistance(fecChannel, gradient, currentRollingResistance));
 }
 
+bool ANT::getFecPowerCalibInProgress() const
+{
+    if (fecChannel == -1)
+        return false;
+
+    return antChannel[fecChannel]->getFecPowerCalibInProgress();
+}
+
+bool ANT::getFecResisCalibInProgress() const
+{
+    if (fecChannel == -1)
+        return false;
+
+    return antChannel[fecChannel]->getFecResisCalibInProgress();
+}
+
+void ANT::setFecPowerCalibInProgress(const bool calibInProgress)
+{
+    if (fecChannel == -1)
+        return;
+
+    antChannel[fecChannel]->setFecPowerCalibInProgress(calibInProgress);
+}
+
+void ANT::setFecResisCalibInProgress(const bool calibInProgress)
+{
+    if (fecChannel == -1)
+        return;
+
+    antChannel[fecChannel]->setFecResisCalibInProgress(calibInProgress);
+}
+
 void ANT::requestFecCapabilities()
 {
+    if (fecChannel == -1)
+        return;
+
     sendMessage(ANTMessage::fecRequestCapabilities(fecChannel));
+}
+
+void ANT::requestFecCalib(const bool zeroOffset, const bool spinDownTime)
+{
+    if (fecChannel == -1)
+        return;
+
+    sendMessage(ANTMessage::fecRequestCalib(fecChannel, zeroOffset, spinDownTime));
+}
+
+void ANT::fecUserConfig(const float kgCyclistWeight, const float kgCycleWeight, const float mmDiameter, const float gearRatio)
+{
+    if (fecChannel == -1)
+        return;
+
+    sendMessage(ANTMessage::fecUserConfig(fecChannel, kgCyclistWeight, kgCycleWeight, mmDiameter, gearRatio));
 }
 
 void ANT::refreshVortexLoad()

--- a/src/ANT.h
+++ b/src/ANT.h
@@ -283,10 +283,14 @@ struct setChannelAtom {
 #define TACX_VORTEX_DATA_CALIBRATION   3
 
 // ant+ fitness equipment profile data pages
+#define FITNESS_EQUIPMENT_CALIBRATION_PAGE          0x01
+#define FITNESS_EQUIPMENT_CALIBRATION_PROGRESS_PAGE 0x02
 #define FITNESS_EQUIPMENT_GENERAL_PAGE              0x10
 #define FITNESS_EQUIPMENT_TRAINER_SPECIFIC_PAGE     0x19
 #define FITNESS_EQUIPMENT_TRAINER_TORQUE_PAGE       0x20
 #define FITNESS_EQUIPMENT_TRAINER_CAPABILITIES_PAGE 0x36
+#define FITNESS_EQUIPMENT_TRAINER_USER_CONFIG_PAGE  0x37
+#define FITNESS_EQUIPMENT_REQUEST_DATA_PAGE         0x46
 #define FITNESS_EQUIPMENT_COMMAND_STATUS_PAGE       0x47
 
 #define FITNESS_EQUIPMENT_TYPE_GENERAL              0x10
@@ -481,20 +485,28 @@ public:
         telemetry.setRPS(rps);
     }
 
+    QString getTrainCyclist() const { return trainCyclist; };
+
     void setFecChannel(int channel);
     void refreshFecLoad();
     void refreshFecGradient();
     void requestFecCapabilities();
-
+    void requestFecCalib(const bool zeroOffset, const bool spinDownTime);
+    void fecUserConfig(const float kgCyclistWeight, const float kgCycleWeight, const float mmDiameter, const float gearRatio);
+    bool getFecPowerCalibInProgress() const;
+    bool getFecResisCalibInProgress() const;
+    void setFecPowerCalibInProgress(const bool calibInProgress);
+    void setFecResisCalibInProgress(const bool calibInProgress);
     void setVortexData(int channel, int id);
     void refreshVortexLoad();
 
     void setTrainerStatusAvailable(bool status) { telemetry.setTrainerStatusAvailable(status); }
-    void setTrainerCalibRequired(bool status) { telemetry.setTrainerCalibRequired(status); }
+    void setTrainerCalibStatus(uint8_t status) { telemetry.setTrainerCalibStatus(status); }
     void setTrainerConfigRequired(bool status) { telemetry.setTrainerConfigRequired(status); }
-    void setTrainerBrakeFault(bool status) { telemetry.setTrainerBrakeFault(status); }
+    void setTrainerBrakeStatus(uint8_t status) { telemetry.setTrainerBrakeStatus(status); }
     void setTrainerReady(bool status) { telemetry.setTrainerReady(status); }
     void setTrainerRunning(bool status) { telemetry.setTrainerRunning(status); }
+    uint8_t getTrainerCalibStatus() const { return telemetry.getTrainerCalibStatus(); }
 
 private:
 

--- a/src/ANTChannel.cpp
+++ b/src/ANTChannel.cpp
@@ -758,7 +758,7 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                    if (antMessage.fecUserConfigRequired)
                    {
                         qDebug() << "Trainer configuration required. Applying current GC settings...";
-                        float wheelSize = appsettings->cvalue(parent->getTrainCyclist(), GC_WHEELSIZE, 2100).toFloat() / pi;
+                        float wheelSize = appsettings->cvalue(parent->getTrainCyclist(), GC_WHEELSIZE, 2100).toFloat() / MATHCONST_PI;
                         float kgCyclistWeight = appsettings->cvalue(parent->getTrainCyclist(), GC_WEIGHT, 75).toFloat();
                         float gearRatio = 0.5; // TODO : add a parameter? Not really needed if we have external cadence meter.
                         float kgCycleWeight = appsettings->value(NULL, GC_DPDP_BIKEWEIGHT, "9.5").toFloat();

--- a/src/ANTChannel.h
+++ b/src/ANTChannel.h
@@ -25,7 +25,9 @@
 #include <QObject>
 #include <QTime>
 
-#define pi 3.14159265358979323846
+#ifndef MATHCONST_PI
+#define MATHCONST_PI 		    3.141592653589793238462643383279502884L /* pi */
+#endif
 
 #define CHANNEL_TYPE_QUICK_SEARCH 0x10 // or'ed with current channel type
 /* after fast search, wait for slow search.  Otherwise, starting slow

--- a/src/ANTChannel.h
+++ b/src/ANTChannel.h
@@ -25,6 +25,8 @@
 #include <QObject>
 #include <QTime>
 
+#define pi 3.14159265358979323846
+
 #define CHANNEL_TYPE_QUICK_SEARCH 0x10 // or'ed with current channel type
 /* after fast search, wait for slow search.  Otherwise, starting slow
    search might postpone the fast search on another channel. */
@@ -94,7 +96,8 @@ class ANTChannel : public QObject {
         int dualNullCount, nullCount, stdNullCount;
         double last_message_timestamp;
         uint8_t fecPrevRawDistance;
-        uint8_t  fecCapabilities;
+        uint8_t fecCapabilities;
+        bool    fecPowerCalibInProgress, fecResisCalibInProgress;
 
         double blanking_timestamp;
         int blanked;
@@ -191,6 +194,10 @@ class ANTChannel : public QObject {
         double channelValue2() { return value2; }
         double value,value2; // used during config, rather than rtData
         uint8_t capabilities();
+        bool   getFecPowerCalibInProgress() const { return fecPowerCalibInProgress; }
+        bool   getFecResisCalibInProgress() const { return fecResisCalibInProgress; }
+        void   setFecPowerCalibInProgress( const bool calibInProgress ) { fecPowerCalibInProgress = calibInProgress; }
+        void   setFecResisCalibInProgress( const bool calibInProgress ) { fecResisCalibInProgress = calibInProgress; }
 
         // search
         int isSearching();

--- a/src/ANTMessage.h
+++ b/src/ANTMessage.h
@@ -82,6 +82,9 @@ class ANTMessage {
         static ANTMessage fecSetTrackResistance(const uint8_t channel, const double grade, const double rollingResistance);
         static ANTMessage fecRequestCapabilities(const uint8_t channel);
         static ANTMessage fecRequestCommandStatus(const uint8_t channel, const uint8_t page);
+        static ANTMessage fecUserConfig(const uint8_t channel, const float kgCyclistWeight, const float kgCycleWeight,
+                                        const float mmDiameter, const float gearRatio);
+        static ANTMessage fecRequestCalib(const uint8_t channel, const bool zeroOffset, const bool spinDownTime);
 
         // kickr command channel messages all sent as broadcast data
         // over the command channel as type 0x4E
@@ -159,6 +162,7 @@ class ANTMessage {
         uint8_t  fecEqtType, fecCapabilities;
         bool     fecResistModeCapability, fecPowerModeCapability, fecSimulModeCapability;
         uint16_t fecMaxResistance;
+        bool     fecResisCalibInProgress, fecPowerCalibInProgress,  fecResisCalibSpeedUp, fecResisCalibFreeWheel;
 
         // for details and equations see ANT+ Fitness Equipment Device Profile, Rev 4.1 p 66... "6.8  Control Data Pages"
         uint8_t  fecLastCommandReceived, fecLastCommandSeq, fecLastCommandStatus;

--- a/src/RealtimeData.cpp
+++ b/src/RealtimeData.cpp
@@ -32,9 +32,9 @@ RealtimeData::RealtimeData()
     trainerStatusAvailable = false;
     trainerReady = true;
     trainerRunning = true;
-    trainerCalibRequired = false;
+    trainerCalibStatus = CALIBRATED;
     trainerConfigRequired = false;
-    trainerBrakeFault = false;
+    trainerBrakeStatus = TRAINER_BRAKE_OK;
     memset(spinScan, 0, 24);
 }
 
@@ -235,9 +235,9 @@ void RealtimeData::setTrainerRunning(bool status)
     this->trainerRunning = status;
 }
 
-void RealtimeData::setTrainerCalibRequired(bool status)
+void RealtimeData::setTrainerCalibStatus(uint8_t status)
 {
-    this->trainerCalibRequired = status;
+    this->trainerCalibStatus = status;
 }
 
 void RealtimeData::setTrainerConfigRequired(bool status)
@@ -245,9 +245,9 @@ void RealtimeData::setTrainerConfigRequired(bool status)
     this->trainerConfigRequired = status;
 }
 
-void RealtimeData::setTrainerBrakeFault(bool status)
+void RealtimeData::setTrainerBrakeStatus(uint8_t status)
 {
-    this->trainerBrakeFault = status;
+    this->trainerBrakeStatus = status;
 }
 
 bool RealtimeData::getTrainerReady() const
@@ -260,9 +260,9 @@ bool RealtimeData::getTrainerRunning() const
     return trainerRunning;
 }
 
-bool RealtimeData::getTrainerCalibRequired() const
+uint8_t RealtimeData::getTrainerCalibStatus() const
 {
-    return trainerCalibRequired;
+    return trainerCalibStatus;
 }
 
 bool RealtimeData::getTrainerConfigRequired() const
@@ -270,9 +270,9 @@ bool RealtimeData::getTrainerConfigRequired() const
     return trainerConfigRequired;
 }
 
-bool RealtimeData::getTrainerBrakeFault() const
+uint8_t RealtimeData::getTrainerBrakeStatus() const
 {
-    return trainerBrakeFault;
+    return trainerBrakeStatus;
 }
 
 double RealtimeData::value(DataSeries series) const

--- a/src/RealtimeData.h
+++ b/src/RealtimeData.h
@@ -25,6 +25,17 @@
 #include <QString>
 #include <QApplication>
 
+#define CALIBRATED                  0x00
+#define CALIBR_REQUIRED             0x01
+#define CALIBR_INPROGRESS           0x02
+#define CALIBR_INPROGRESS_SPEEDUP   0x03
+#define CALIBR_INPROGRESS_FREEWHEEL 0x04
+
+#define TRAINER_BRAKE_OK            0x00
+#define TRAINER_BRAKE_NOK_LOWSPEED  0x01
+#define TRAINER_BRAKE_NOK_HIGHSPEED 0x02
+#define TRAINER_BRAKE_NOK           0x03
+
 class RealtimeData
 {
     Q_DECLARE_TR_FUNCTIONS(RealtimeData)
@@ -117,14 +128,14 @@ public:
     bool getTrainerStatusAvailable() const;
     void setTrainerReady(bool status);
     void setTrainerRunning(bool status);
-    void setTrainerCalibRequired(bool status);
+    void setTrainerCalibStatus(uint8_t status);
     void setTrainerConfigRequired(bool status);
-    void setTrainerBrakeFault(bool status);
+    void setTrainerBrakeStatus(uint8_t status);
     bool getTrainerReady() const;
     bool getTrainerRunning() const;
-    bool getTrainerCalibRequired() const;
+    uint8_t getTrainerCalibStatus() const;
     bool getTrainerConfigRequired() const;
-    bool getTrainerBrakeFault() const;
+    uint8_t getTrainerBrakeStatus() const;
 
     uint8_t spinScan[24];
 
@@ -150,9 +161,9 @@ private:
     bool trainerStatusAvailable;
     bool trainerReady;
     bool trainerRunning;
-    bool trainerCalibRequired;
     bool trainerConfigRequired;
-    bool trainerBrakeFault;
+    uint8_t trainerBrakeStatus;
+    uint8_t trainerCalibStatus;
 };
 
 #endif

--- a/src/TrainSidebar.cpp
+++ b/src/TrainSidebar.cpp
@@ -1381,9 +1381,9 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
                     rtData.setTrainerStatusAvailable(true);
                     rtData.setTrainerReady(local.getTrainerReady());
                     rtData.setTrainerRunning(local.getTrainerRunning());
-                    rtData.setTrainerCalibRequired(local.getTrainerCalibRequired());
+                    rtData.setTrainerCalibStatus(local.getTrainerCalibStatus());
                     rtData.setTrainerConfigRequired(local.getTrainerConfigRequired());
-                    rtData.setTrainerBrakeFault(local.getTrainerBrakeFault());
+                    rtData.setTrainerBrakeStatus(local.getTrainerBrakeStatus());
                 }
             }
 

--- a/src/VideoWindow.cpp
+++ b/src/VideoWindow.cpp
@@ -317,17 +317,37 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
             {  // we don't have status from trainer thus we cannot indicate anything on screen
                 p_meterWidget->Text = tr("");
             }
-            else if (rtd.getTrainerCalibRequired())
+            else if (rtd.getTrainerCalibStatus()==CALIBR_REQUIRED)
             {
                 p_meterWidget->setColor(QColor(255,0,0,180));
                 p_meterWidget->Text = tr("Calibration required");
+            }
+            else if (rtd.getTrainerCalibStatus()==CALIBR_INPROGRESS_SPEEDUP)
+            {
+                p_meterWidget->setColor(QColor(255,0,0,180));
+                p_meterWidget->Text = tr("Calibration in progress\nspeedup!");
+            }
+            else if (rtd.getTrainerCalibStatus()==CALIBR_INPROGRESS_FREEWHEEL)
+            {
+                p_meterWidget->setColor(QColor(255,0,0,180));
+                p_meterWidget->Text = tr("Calibration in progress\nfreewheel!");
             }
             else if (rtd.getTrainerConfigRequired())
             {
                 p_meterWidget->setColor(QColor(255,0,0,180));
                 p_meterWidget->Text = tr("Configuration required");
             }
-            else if (rtd.getTrainerBrakeFault())
+            else if (rtd.getTrainerBrakeStatus()==TRAINER_BRAKE_NOK_LOWSPEED)
+            {
+                p_meterWidget->setColor(QColor(255,0,0,180));
+                p_meterWidget->Text = tr("brake fault\nspeed too low");
+            }
+            else if (rtd.getTrainerBrakeStatus()==TRAINER_BRAKE_NOK_HIGHSPEED)
+            {
+                p_meterWidget->setColor(QColor(255,0,0,180));
+                p_meterWidget->Text = tr("brake fault\nspeed too high");
+            }
+            else if (rtd.getTrainerBrakeStatus()==TRAINER_BRAKE_NOK)
             {
                 p_meterWidget->setColor(QColor(255,0,0,180));
                 p_meterWidget->Text = tr("brake fault");


### PR DESCRIPTION
this add FE-C spindown time calibration and cyclist configuration messages (weight...)
- configuration is automatically done using cyclist profile in GC
- calibration is ready but not activated at present as GUI is needed ("&& false" placed in the code and pointed out with FIXME comment)
