### PR TITLE
Monark: Add support for controlling power on LCx models

### DIFF
--- a/src/Monark.cpp
+++ b/src/Monark.cpp
@@ -26,10 +26,10 @@ Monark::Monark(QObject *parent,  QString devname) : QObject(parent),
     m_power(0),
     m_cadence(0)
 {
-    m_lt2.setSerialPort(devname);
-    connect(&m_lt2, SIGNAL(power(quint32)), this, SLOT(newPower(quint32)), Qt::QueuedConnection);
-    connect(&m_lt2, SIGNAL(cadence(quint32)), this, SLOT(newCadence(quint32)), Qt::QueuedConnection);
-    connect(&m_lt2, SIGNAL(pulse(quint32)), this, SLOT(newHeartRate(quint32)), Qt::QueuedConnection);
+    m_monarkConnection.setSerialPort(devname);
+    connect(&m_monarkConnection, SIGNAL(power(quint32)), this, SLOT(newPower(quint32)), Qt::QueuedConnection);
+    connect(&m_monarkConnection, SIGNAL(cadence(quint32)), this, SLOT(newCadence(quint32)), Qt::QueuedConnection);
+    connect(&m_monarkConnection, SIGNAL(pulse(quint32)), this, SLOT(newHeartRate(quint32)), Qt::QueuedConnection);
 }
 
 Monark::~Monark()
@@ -38,7 +38,7 @@ Monark::~Monark()
 
 int Monark::start()
 {
-    m_lt2.start();
+    m_monarkConnection.start();
     return 0;
 }
 
@@ -80,7 +80,7 @@ bool Monark::discover(QString portName)
 
     if (sp.open(QSerialPort::ReadWrite))
     {
-        m_lt2.configurePort(&sp);
+        m_monarkConnection.configurePort(&sp);
 
         // Discard any existing data
         QByteArray data = sp.readAll();
@@ -113,4 +113,10 @@ bool Monark::discover(QString portName)
     sp.close();
 
     return found;
+}
+
+
+void Monark::setLoad(double load)
+{
+    m_monarkConnection.setLoad((unsigned int)load);
 }

--- a/src/Monark.h
+++ b/src/Monark.h
@@ -45,13 +45,13 @@ public:
     quint32 cadence() {return m_cadence;}
     bool discover(QString portName);
 
+    void setLoad(double load);
 
 private:
-    MonarkConnection m_lt2;
+    MonarkConnection m_monarkConnection;
     quint32 m_heartRate;
     quint32 m_power;
     quint32 m_cadence;
-
 
 private slots:
     void newHeartRate(quint32);

--- a/src/MonarkConnection.h
+++ b/src/MonarkConnection.h
@@ -40,6 +40,7 @@ public slots:
     void requestPower();
     void requestPulse();
     void requestCadence();
+    void setLoad(unsigned int load);
 
 private:
     QString m_serialPortName;
@@ -51,6 +52,9 @@ private:
     QByteArray readAnswer(int timeoutMs = -1);
     QMutex m_mutex;
     bool m_canControlPower;
+    unsigned int m_load;
+    unsigned int m_loadToWrite;
+    bool m_shouldWriteLoad;
 
 signals:
     void pulse(quint32);

--- a/src/MonarkController.cpp
+++ b/src/MonarkController.cpp
@@ -71,7 +71,7 @@ MonarkController::discover(QString name)
 
 bool MonarkController::doesPush() { return false; }
 bool MonarkController::doesPull() { return true; }
-bool MonarkController::doesLoad() { return false; }
+bool MonarkController::doesLoad() { return true; }
 
 /*
  * gets called from the GUI to get updated telemetry.
@@ -89,4 +89,7 @@ MonarkController::getRealtimeData(RealtimeData &rtData)
 
 void MonarkController::pushRealtimeData(RealtimeData &) { } // update realtime data with current values
 
-
+void MonarkController::setLoad(double load)
+{
+    m_monark->setLoad(load);
+}

--- a/src/MonarkController.h
+++ b/src/MonarkController.h
@@ -45,6 +45,7 @@ public:
     void getRealtimeData(RealtimeData &rtData);
     void pushRealtimeData(RealtimeData &rtData);
     
+    void setLoad(double);
     void setMode(int) { return ; }
 };
 


### PR DESCRIPTION
Since there's no manual control lever for resistance on LC-models (there is on my LT2) the previous "read only" support wasn't really useful on those models since the load was stuck on ~15W. I've added load control for LC-models and have gotten help from LC owners to confirm it's actually working. Would be awesome to get this in a 3.3 RC and eventually 3.3 if possible.

