### PR TITLE
add bounding box to meters widget overlays

### DIFF
--- a/src/MeterWidget.cpp
+++ b/src/MeterWidget.cpp
@@ -42,6 +42,7 @@ MeterWidget::MeterWidget(QString Name, QWidget *parent, QString Source) : QWidge
     m_RangeMax = 100;
     m_Angle = 180.0;
     m_SubRange = 10;
+    boundingRectVisibility = false;
 }
 
 void MeterWidget::SetRelativeSize(float RelativeWidth, float RelativeHeight)
@@ -90,11 +91,30 @@ QSize MeterWidget::minimumSize() const
 void MeterWidget::paintEvent(QPaintEvent* paintevent)
 {
     Q_UNUSED(paintevent);
+    if (boundingRectVisibility)
+    {
+        m_OutlinePen = QPen(boundingRectColor);
+        m_OutlinePen.setWidth(2);
+        m_OutlinePen.setStyle(Qt::SolidLine);
+
+        //painter
+        QPainter painter(this);
+        painter.setRenderHint(QPainter::Antialiasing);
+
+        painter.setPen(m_OutlinePen);
+        painter.drawRect (1, 1, m_Width-2, m_Height-2);
+    }
 }
 
 void  MeterWidget::setColor(QColor  mainColor)
 {
     m_MainColor = mainColor;
+}
+
+void MeterWidget::setBoundingRectVisibility(bool show, QColor  boundingRectColor)
+{
+    this->boundingRectVisibility=show;
+    this->boundingRectColor = boundingRectColor;
 }
 
 TextMeterWidget::TextMeterWidget(QString Name, QWidget *parent, QString Source) : MeterWidget(Name, parent, Source)

--- a/src/MeterWidget.h
+++ b/src/MeterWidget.h
@@ -44,6 +44,7 @@ class MeterWidget : public QWidget
     virtual QSize sizeHint() const;
     virtual QSize minimumSize() const;
     void    setColor(QColor  mainColor);
+    void    setBoundingRectVisibility(bool show, QColor  boundingRectColor = QColor(255,0,0,255));
 
     float Value, ValueMin, ValueMax;
     QString Text, AltText;
@@ -71,6 +72,9 @@ class MeterWidget : public QWidget
     QBrush m_AltBrush;
     QPen   m_OutlinePen;
     QPen   m_ScalePen;
+
+    bool    boundingRectVisibility;
+    QColor  boundingRectColor;
 
     friend class VideoLayoutParser;
 };


### PR DESCRIPTION
This bounding box feature will allow a future overlays developpment: drag'n drop
It will create a more convenient way to setup/adjust video layout by drag n drop of meters widgets