### PR TITLE
Elevation widget to be used as an overlay during video training

### DIFF
--- a/src/MeterWidget.cpp
+++ b/src/MeterWidget.cpp
@@ -134,6 +134,7 @@ void TextMeterWidget::paintEvent(QPaintEvent* paintevent)
     MeterWidget::paintEvent(paintevent);
 
     m_MainBrush = QBrush(m_MainColor);
+    m_BackgroundBrush = QBrush(m_BackgroundColor);
     m_OutlinePen = QPen(m_OutlineColor);
     m_OutlinePen.setWidth(1);
     m_OutlinePen.setStyle(Qt::SolidLine);
@@ -141,6 +142,12 @@ void TextMeterWidget::paintEvent(QPaintEvent* paintevent)
     //painter
     QPainter painter(this);
     painter.setRenderHint(QPainter::Antialiasing);
+
+    //draw background
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(m_BackgroundBrush);
+    if (Text!=QString(""))
+        painter.drawRect (0, 0, m_Width, m_Height);
 
     QPainterPath my_painterPath;
     my_painterPath.addText(QPointF(0,0),m_MainFont,Text);

--- a/src/MeterWidget.cpp
+++ b/src/MeterWidget.cpp
@@ -37,7 +37,7 @@ MeterWidget::MeterWidget(QString Name, QWidget *parent, QString Source) : QWidge
     m_OutlineColor = QColor(128,128,128,180);
     m_MainFont = QFont(this->font().family(), 64);
     m_AltFont = QFont(this->font().family(), 48);
-    m_BackgroundColor = QColor(96, 96, 96, 200);
+    m_BackgroundColor = QColor(96, 96, 96, 0);
     m_RangeMin = 0;
     m_RangeMax = 100;
     m_Angle = 180.0;

--- a/src/MeterWidget.cpp
+++ b/src/MeterWidget.cpp
@@ -19,6 +19,8 @@
 #include <QtGui>
 #include <QGraphicsPathItem>
 #include "MeterWidget.h"
+#include "ErgFile.h"
+#include "Context.h"
 
 MeterWidget::MeterWidget(QString Name, QWidget *parent, QString Source) : QWidget(parent), m_Name(Name), m_container(parent), m_Source(Source)
 {
@@ -305,4 +307,88 @@ void NeedleMeterWidget::paintEvent(QPaintEvent* paintevent)
     my_painterPath.lineTo(-2, 0);
     painter.drawPath(my_painterPath);
     painter.restore();
+}
+
+ElevationMeterWidget::ElevationMeterWidget(QString Name, QWidget *parent, QString Source, Context *context) : MeterWidget(Name, parent, Source), context(context)
+{
+    forceSquareRatio = false;
+    gradientValue = 0.0;
+}
+
+void ElevationMeterWidget::paintEvent(QPaintEvent* paintevent)
+{
+    // TODO : show Power when not in slope simulation mode
+    if (!context || !context->currentErgFile() || context->currentErgFile()->Points.size()<=1)
+        return;
+
+    MeterWidget::paintEvent(paintevent);
+
+    m_MainBrush = QBrush(m_MainColor);
+    m_BackgroundBrush = QBrush(m_BackgroundColor);
+    m_OutlinePen = QPen(m_OutlineColor);
+    m_OutlinePen.setWidth(1);
+    m_OutlinePen.setStyle(Qt::SolidLine);
+
+    //painter
+    QPainter painter(this);
+    painter.setRenderHint(QPainter::Antialiasing);
+
+//    at present no more background, maybe it will be restored in a future developpment
+//    //draw background
+//    painter.setPen(Qt::NoPen);
+//    painter.setBrush(m_BackgroundBrush);
+//    painter.drawRect (0, 0, m_Width, m_Height);
+
+    // TODO : do this only once for the same ergfile, make Min/Max and Polygon part of class members
+    //find min/max
+    double minX, minY, maxX, maxY;
+    // (based on ErgFilePlot.cpp)
+    minX=maxX=context->currentErgFile()->Points[0].x; // meters
+    minY=maxY=context->currentErgFile()->Points[0].y; // meters
+    foreach(ErgFilePoint x, context->currentErgFile()->Points)
+    {
+        if (x.y > maxY) maxY = x.y;
+        if (x.x > maxX) maxX = x.x;
+        if (x.y < minY) minY = x.y;
+        if (x.x < minX) minX = x.x;
+    }
+    // check if slope shown will not be too inconsistent (based on widget's width/height ratio)
+    // we accept 20 times i.e. 5% gradient will be shown as 45°
+    if ( m_Width!=0 && (maxY-minY) / 0.05 < (double)m_Height * 0.80 * (maxX-minX) / (double)m_Width)
+        maxY = minY + (double)m_Height * 0.80 * (maxX-minX) / (double)m_Width * 0.05;
+    double bubbleSize = (double)m_Height*0.10f;
+    minY -= (maxY-minY) * 0.20f; // add 20% as bottom headroom (slope gradient will be shown there in a bubble)
+    double cyclistX = (this->Value * 1000.0 - minX) * (double)m_Width / (maxX-minX);
+
+    QPolygon polygon;
+    polygon << QPoint(0.0, (double)m_Height);
+    double x, y, pt=0;
+    double nextX = 1;
+    for( pt=0; pt < context->currentErgFile()->Points.size(); pt++)
+    {
+        for ( ; x < nextX && pt < context->currentErgFile()->Points.size(); pt++)
+        {
+            x = (context->currentErgFile()->Points[pt].x - minX) * (double)m_Width / (maxX-minX);
+            y = (context->currentErgFile()->Points[pt].y - minY) * (double)m_Height / (maxY-minY);
+        }
+        // FIXME : we should not have twice pt++
+        polygon << QPoint(x, (double)m_Height - y);
+        nextX = floor(x) + 1.0;
+    }
+    polygon << QPoint((double) m_Width, (double)m_Height);
+    polygon << QPoint(fmin((double) m_Width,cyclistX+bubbleSize), (double)m_Height);
+    polygon << QPoint(cyclistX, (double)m_Height-bubbleSize);
+    polygon << QPoint(fmax(0.0, cyclistX-bubbleSize), (double)m_Height);
+    // TODO : add text in the bubble for gradient
+    painter.setPen(m_OutlinePen);
+    painter.setBrush(m_BackgroundBrush);
+    painter.drawPolygon(polygon);
+
+    m_OutlinePen = QPen(m_MainColor);
+    m_OutlinePen.setWidth(1);
+    m_OutlinePen.setStyle(Qt::SolidLine);
+    painter.setPen(m_OutlinePen);
+    painter.drawLine(cyclistX, 0.0, cyclistX, (double)m_Height-bubbleSize);
+
+    // TODO : indicate slope in the bottom 10% of the widget, under position mark
 }

--- a/src/MeterWidget.cpp
+++ b/src/MeterWidget.cpp
@@ -43,6 +43,7 @@ MeterWidget::MeterWidget(QString Name, QWidget *parent, QString Source) : QWidge
     m_Angle = 180.0;
     m_SubRange = 10;
     boundingRectVisibility = false;
+    forceSquareRatio = true;
 }
 
 void MeterWidget::SetRelativeSize(float RelativeWidth, float RelativeHeight)
@@ -75,7 +76,13 @@ void MeterWidget::AdjustSizePos()
 
 void MeterWidget::ComputeSize()
 {
-    m_Width = m_Height = (m_container->width() * m_RelativeWidth + m_container->height() * m_RelativeHeight) / 2;
+    if (forceSquareRatio)
+        m_Width = m_Height = (m_container->width() * m_RelativeWidth + m_container->height() * m_RelativeHeight) / 2;
+    else
+    {
+        m_Width = m_container->width() * m_RelativeWidth;
+        m_Height =  m_container->height() * m_RelativeHeight;
+    }
 }
 
 QSize MeterWidget::sizeHint() const
@@ -119,12 +126,7 @@ void MeterWidget::setBoundingRectVisibility(bool show, QColor  boundingRectColor
 
 TextMeterWidget::TextMeterWidget(QString Name, QWidget *parent, QString Source) : MeterWidget(Name, parent, Source)
 {
-}
-
-void TextMeterWidget::ComputeSize()
-{
-    m_Width = m_container->width() * m_RelativeWidth;
-    m_Height =  m_container->height() * m_RelativeHeight;
+    forceSquareRatio = false;
 }
 
 void TextMeterWidget::paintEvent(QPaintEvent* paintevent)

--- a/src/MeterWidget.h
+++ b/src/MeterWidget.h
@@ -59,6 +59,7 @@ class MeterWidget : public QWidget
     float    m_RangeMin, m_RangeMax;
     float    m_Angle;
     int      m_SubRange;
+    bool     forceSquareRatio;
 
     QColor  m_MainColor;
     QColor  m_ScaleColor;
@@ -83,7 +84,6 @@ class TextMeterWidget : public MeterWidget
 {
   public:
     explicit TextMeterWidget(QString name, QWidget *parent = 0, QString Source = QString("None"));
-    virtual void ComputeSize();
     virtual void paintEvent(QPaintEvent* paintevent);
 };
 

--- a/src/MeterWidget.h
+++ b/src/MeterWidget.h
@@ -20,6 +20,7 @@
 #define _MeterWidget_h 1
 
 #include <QWidget>
+#include "Context.h"
 
 class MeterWidget : public QWidget
 {
@@ -107,6 +108,17 @@ class NeedleMeterWidget : public MeterWidget
   public:
     explicit NeedleMeterWidget(QString name, QWidget *parent = 0, QString Source = QString("None"));
     virtual void paintEvent(QPaintEvent* paintevent);
+};
+
+class ElevationMeterWidget : public MeterWidget
+{
+  public:
+    explicit ElevationMeterWidget(QString name, QWidget *parent = 0, QString Source = QString("None"), Context *context = NULL);
+    virtual void paintEvent(QPaintEvent* paintevent);
+    float gradientValue;
+    void setContext(Context *context) { this->context = context; }
+  private:
+    Context *context;
 };
 
 

--- a/src/VideoLayoutParser.cpp
+++ b/src/VideoLayoutParser.cpp
@@ -134,6 +134,10 @@ bool VideoLayoutParser::startElement( const QString&, const QString&,
         {
             meterWidget = new CircularBargraphMeterWidget(meterName, containerWidget, source);
         }
+        else if (meterType == QString("Elevation"))
+        {
+            meterWidget = new ElevationMeterWidget(meterName, containerWidget, source);
+        }
         else
         {
             qDebug() << QObject::tr("Error creating meter");

--- a/src/VideoLayoutParser.cpp
+++ b/src/VideoLayoutParser.cpp
@@ -47,7 +47,7 @@ void VideoLayoutParser::SetDefaultValues()
         meterWidget->m_MainColor = QColor(255,0,0,200);
         meterWidget->m_ScaleColor = QColor(255,255,255,200);
         meterWidget->m_OutlineColor = QColor(100,100,100,200);
-        meterWidget->m_BackgroundColor = QColor(100,100,100,200);
+        meterWidget->m_BackgroundColor = QColor(100,100,100,0);
         meterWidget->m_MainFont = QFont(meterWidget->font().family(), 64);
         meterWidget->m_AltFont = QFont(meterWidget->font().family(), 48);
     }

--- a/src/VideoWindow.cpp
+++ b/src/VideoWindow.cpp
@@ -296,6 +296,35 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
             p_meterWidget->Text = QString::number((int) rtd.getSpeed());
             p_meterWidget->AltText = QString(".") +QString::number((int)(p_meterWidget->Value * 10.0) - (((int) p_meterWidget->Value) * 10)) + tr(" kph");
         }
+        else if (p_meterWidget->Source() == QString("Distance"))
+        {
+            p_meterWidget->Value = rtd.getDistance();
+            p_meterWidget->Text = QString::number((int) p_meterWidget->Value);
+            p_meterWidget->AltText = QString(".") +QString::number((int)(p_meterWidget->Value * 10.0) - (((int) p_meterWidget->Value) * 10)) + tr(" km");
+        }
+        else if (p_meterWidget->Source() == QString("Duration"))
+        {
+            // TODO add fixed size property to TextWidget to avoid small movement of text
+            //     ... to be used when source is speed, duration & distance
+            p_meterWidget->Value = rtd.getMsecs();
+            int hours = p_meterWidget->Value / 3600000L;
+            int minutes = ((long)p_meterWidget->Value % 3600000L) / 60000L;
+            int seconds = ((long)p_meterWidget->Value % 60000L) / 1000L;
+            int dsecs = ((long)p_meterWidget->Value % 1000L) / 100L;
+            p_meterWidget->Text = QString("%1:%2").arg((int)hours,(int)1,(int)10,QLatin1Char('0')).arg((int)minutes,(int)2,(int)10,QLatin1Char('0'));
+            p_meterWidget->AltText = QString(":%1.%2").arg((int)seconds,(int)2,(int)10,QLatin1Char('0')).arg((int)dsecs,(int)1,(int)10,QLatin1Char('0'));
+        }
+        else if (p_meterWidget->Source() == QString("Gradient"))
+        {
+            // TODO : do not show when not in slope simulation mode
+            int curLap;
+            double slope = 0.0;
+            if (context && context->currentErgFile() && context->currentVideoSyncFile())
+                slope = context->currentErgFile()->gradientAt((context->currentVideoSyncFile()->km + context->currentVideoSyncFile()->manualOffset) * 1000.0, curLap);
+            p_meterWidget->Value = slope; // TODO to be tested
+            p_meterWidget->Text = ((-1.0 < slope && slope < 0.0)?QString("-"):QString("")) + QString::number((int) p_meterWidget->Value);
+            p_meterWidget->AltText = QString(".") + QString::number(abs((int)(p_meterWidget->Value * 10.0) % 10)) + QString("%");
+        }
         else if (p_meterWidget->Source() == QString("Cadence"))
         {
             p_meterWidget->Value = rtd.getCadence();

--- a/src/VideoWindow.cpp
+++ b/src/VideoWindow.cpp
@@ -413,8 +413,12 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
         if(curPosition > VideoSyncFiledataPoints.count()-1 || curPosition < 1)
             curPosition = 1; // minimum curPosition is 1 as we will use [curPosition-1]
 
-        double CurrentDistance = qBound(0.0,  rtd.getDistance() + context->currentVideoSyncFile()->manualOffset, context->currentVideoSyncFile()->Distance);
-        context->currentVideoSyncFile()->km = CurrentDistance;
+        double CurrentDistance = 0.0;
+        if (context && context->currentVideoSyncFile())
+        {
+            CurrentDistance = qBound(0.0,  rtd.getDistance() + context->currentVideoSyncFile()->manualOffset, context->currentVideoSyncFile()->Distance);
+            context->currentVideoSyncFile()->km = CurrentDistance;
+        }
 
         // make sure the current position is less than the new distance
         while ((VideoSyncFiledataPoints[curPosition].km > CurrentDistance) && (curPosition > 1))

--- a/src/VideoWindow.cpp
+++ b/src/VideoWindow.cpp
@@ -325,6 +325,24 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
             p_meterWidget->Text = ((-1.0 < slope && slope < 0.0)?QString("-"):QString("")) + QString::number((int) p_meterWidget->Value);
             p_meterWidget->AltText = QString(".") + QString::number(abs((int)(p_meterWidget->Value * 10.0) % 10)) + QString("%");
         }
+        else if (p_meterWidget->Source() == QString("Elevation"))
+        {
+            if (context && context->currentVideoSyncFile())
+                p_meterWidget->Value = context->currentVideoSyncFile()->km + context->currentVideoSyncFile()->manualOffset;
+            ElevationMeterWidget* elevationMeterWidget = dynamic_cast<ElevationMeterWidget*>(p_meterWidget);
+            if (!elevationMeterWidget)
+                qDebug() << "Error: Elevation keyword used but widget is not elevation type";
+            else
+            {
+                elevationMeterWidget->setContext(context);
+                // TODO : do not use gradient when not in slope simulation mode
+                int curLap;
+                double slope = 0.0;
+                if (context && context->currentErgFile() && context->currentVideoSyncFile())
+                    slope = context->currentErgFile()->gradientAt((context->currentVideoSyncFile()->km + context->currentVideoSyncFile()->manualOffset) * 1000.0, curLap);
+                elevationMeterWidget->gradientValue = slope; // TODO to be tested
+            }
+        }
         else if (p_meterWidget->Source() == QString("Cadence"))
         {
             p_meterWidget->Value = rtd.getCadence();

--- a/src/xml/video-layout.xml
+++ b/src/xml/video-layout.xml
@@ -65,6 +65,13 @@
         <RelativePosition X="10.0" Y="15.0" />
 		<BackgroundColor R="100" G="100" B="100" A="100" />
 	</meter>
+    <meter name="elevation" container="Video" source="Elevation" type="Elevation">
+        <RelativeSize Width="47.0" Height="20.0" />
+        <RelativePosition X="57.0" Y="85.0" />
+		<BackgroundColor R="100" G="100" B="100" A="100" />
+		<OutlineColor R="255" G="255" B="255" A="250" />
+		<MainColor R="255" G="0" B="0" A="250" />
+	</meter>
     <meter name="elapsed" container="Video" source="Duration" type="Text">
         <RelativeSize Width="10.0" Height="5.0" />
         <RelativePosition X="90.0" Y="3.0" />

--- a/src/xml/video-layout.xml
+++ b/src/xml/video-layout.xml
@@ -5,13 +5,13 @@
        <Range Min="0.0" Max="60.0" />
        <Angle>220.0</Angle>
        <SubRange>6</SubRange>
-       <MainColor R="0" G="255" B="0" A="180" />
+       <MainColor R="0" G="255" B="0" A="250" />
        <BackgroundColor R="100" G="100" B="100" A="100" />
    </meter>
    <meter name="Speedometer-text" container="Speedometer" source="Speed" type="Text">
        <RelativeSize Width="70.0" Height="40.0" />
        <RelativePosition X="50.0" Y="75.0" />
-       <MainColor R="0" G="255" B="0" A="180" />
+       <MainColor R="0" G="255" B="0" A="230" />
        <MainFont Name="Consolas" Size="64" />
    </meter>
    <meter name="Wattmeter" container="Video" source="Watt" type="CircularMeter">
@@ -23,12 +23,12 @@
    <meter name="Wattmeter-text" container="Wattmeter" source="Watt" type="Text">
        <RelativeSize Width="50.0" Height="40.0" />
        <RelativePosition X="50.0" Y="50.0" />
-       <MainColor R="255" G="100" B="100" A="180" />
+       <MainColor R="255" G="0" B="0" A="230" />
    </meter>
    <meter name="Wattmeter-unit" container="Wattmeter" source="None" type="Text">
        <RelativeSize Width="50.0" Height="20.0" />
        <RelativePosition X="50.0" Y="85.0" />
-       <MainColor R="255" G="100" B="100" A="180" />
+       <MainColor R="255" G="0" B="0" A="230" />
        <Text>Watts</Text>
    </meter>
    <meter name="Cadencemeter" container="Video" source="Cadence" type="CircularBargraph">
@@ -42,18 +42,18 @@
    <meter name="Cadencemeter-text" container="Cadencemeter" source="Cadence" type="Text">
        <RelativeSize Width="40.0" Height="30.0" />
        <RelativePosition X="50.0" Y="50.0" />
-       <MainColor R="255" G="100" B="100" A="180" />
+       <MainColor R="255" G="0" B="0" A="250" />
    </meter>
    <meter name="Cadencemeter-unit" container="Cadencemeter" source="None" type="Text">
        <RelativeSize Width="50.0" Height="20.0" />
        <RelativePosition X="50.0" Y="85.0" />
-       <MainColor R="255" G="100" B="100" A="180" />
+       <MainColor R="255" G="0" B="0" A="250" />
        <Text>rpm</Text>
    </meter>
    <meter name="HRM-text" container="Video" source="HRM" type="Text">
        <RelativeSize Width="15.0" Height="5.0" />
        <RelativePosition X="50.0" Y="90.0" />
-       <MainColor R="255" G="0" B="0" A="180" />
+       <MainColor R="255" G="0" B="0" A="250" />
    </meter>
    <meter name="status" container="Video" source="TrainerStatus" type="Text">
        <RelativeSize Width="15.0" Height="5.0" />

--- a/src/xml/video-layout.xml
+++ b/src/xml/video-layout.xml
@@ -58,5 +58,6 @@
    <meter name="status" container="Video" source="TrainerStatus" type="Text">
        <RelativeSize Width="15.0" Height="5.0" />
        <RelativePosition X="1.0" Y="10.0" />
+       <BackgroundColor R="100" G="100" B="100" A="100" />
    </meter>
 </layout>

--- a/src/xml/video-layout.xml
+++ b/src/xml/video-layout.xml
@@ -1,7 +1,7 @@
 <layout name="preset_1">
     <meter name="Speedometer" container="Video" source="Speed" type="NeedleMeter">
-        <RelativeSize Width="20.0" Height="15.0" />
-        <RelativePosition X="20.0" Y="77.0" />
+        <RelativeSize Width="15.0" Height="15.0" />
+        <RelativePosition X="12.0" Y="77.0" />
         <Range Min="0.0" Max="60.0" />
         <Angle>220.0</Angle>
         <SubRange>6</SubRange>
@@ -15,8 +15,8 @@
         <MainFont Name="Consolas" Size="64" />
     </meter>
     <meter name="Wattmeter" container="Video" source="Watt" type="CircularMeter">
-        <RelativeSize Width="20.0" Height="15.0" />
-        <RelativePosition X="80.0" Y="77.0" />
+        <RelativeSize Width="15.0" Height="13.0" />
+        <RelativePosition X="88.0" Y="73.0" />
         <Range Min="0.0" Max="350.0" />
         <Angle>280.0</Angle>
     </meter>
@@ -32,15 +32,15 @@
         <Text>Watts</Text>
     </meter>
     <meter name="Cadencemeter" container="Video" source="Cadence" type="CircularBargraph">
-        <RelativeSize Width="20.0" Height="13.0" />
-        <RelativePosition X="50.0" Y="73.0" />
+        <RelativeSize Width="15.0" Height="15.0" />
+        <RelativePosition X="27.0" Y="77.0" />
         <Range Min="0.0" Max="200.0" />
         <MainColor R="5" G="0" B="255" A="180" />
         <Angle>280.0</Angle>
         <SubRange>30</SubRange>
     </meter>
     <meter name="Cadencemeter-text" container="Cadencemeter" source="Cadence" type="Text">
-        <RelativeSize Width="40.0" Height="30.0" />
+        <RelativeSize Width="35.0" Height="27.0" />
         <RelativePosition X="50.0" Y="50.0" />
         <MainColor R="255" G="0" B="0" A="250" />
     </meter>
@@ -52,12 +52,12 @@
     </meter>
     <meter name="HRM-text" container="Video" source="HRM" type="Text">
         <RelativeSize Width="15.0" Height="5.0" />
-        <RelativePosition X="50.0" Y="90.0" />
+        <RelativePosition X="88.0" Y="90.0" />
         <MainColor R="255" G="0" B="0" A="250" />
     </meter>
     <meter name="status" container="Video" source="TrainerStatus" type="Text">
         <RelativeSize Width="15.0" Height="5.0" />
-        <RelativePosition X="1.0" Y="10.0" />
+        <RelativePosition X="10.0" Y="10.0" />
         <BackgroundColor R="100" G="100" B="100" A="100" />
     </meter>
     <meter name="status" container="Video" source="TrainerStatusDetails" type="Text">

--- a/src/xml/video-layout.xml
+++ b/src/xml/video-layout.xml
@@ -60,4 +60,21 @@
        <RelativePosition X="1.0" Y="10.0" />
        <BackgroundColor R="100" G="100" B="100" A="100" />
    </meter>
+    <meter name="status" container="Video" source="TrainerStatusDetails" type="Text">
+        <RelativeSize Width="15.0" Height="4.0" />
+        <RelativePosition X="10.0" Y="15.0" />
+		<BackgroundColor R="100" G="100" B="100" A="100" />
+	</meter>
+    <meter name="elapsed" container="Video" source="Duration" type="Text">
+        <RelativeSize Width="10.0" Height="5.0" />
+        <RelativePosition X="90.0" Y="3.0" />
+	</meter>
+    <meter name="distance" container="Video" source="Distance" type="Text">
+        <RelativeSize Width="10.0" Height="5.0" />
+        <RelativePosition X="90.0" Y="8.0" />
+	</meter>
+    <meter name="gradient" container="Video" source="Gradient" type="Text">
+        <RelativeSize Width="10.0" Height="5.0" />
+        <RelativePosition X="90.0" Y="13.0" />
+	</meter>
 </layout>

--- a/src/xml/video-layout.xml
+++ b/src/xml/video-layout.xml
@@ -1,65 +1,65 @@
 <layout name="preset_1">
-   <meter name="Speedometer" container="Video" source="Speed" type="NeedleMeter">
-       <RelativeSize Width="20.0" Height="15.0" />
-       <RelativePosition X="20.0" Y="77.0" />
-       <Range Min="0.0" Max="60.0" />
-       <Angle>220.0</Angle>
-       <SubRange>6</SubRange>
-       <MainColor R="0" G="255" B="0" A="250" />
-       <BackgroundColor R="100" G="100" B="100" A="100" />
-   </meter>
-   <meter name="Speedometer-text" container="Speedometer" source="Speed" type="Text">
-       <RelativeSize Width="70.0" Height="40.0" />
-       <RelativePosition X="50.0" Y="75.0" />
-       <MainColor R="0" G="255" B="0" A="230" />
-       <MainFont Name="Consolas" Size="64" />
-   </meter>
-   <meter name="Wattmeter" container="Video" source="Watt" type="CircularMeter">
-       <RelativeSize Width="20.0" Height="15.0" />
-       <RelativePosition X="80.0" Y="77.0" />
-       <Range Min="0.0" Max="350.0" />
-       <Angle>280.0</Angle>
-   </meter>
-   <meter name="Wattmeter-text" container="Wattmeter" source="Watt" type="Text">
-       <RelativeSize Width="50.0" Height="40.0" />
-       <RelativePosition X="50.0" Y="50.0" />
-       <MainColor R="255" G="0" B="0" A="230" />
-   </meter>
-   <meter name="Wattmeter-unit" container="Wattmeter" source="None" type="Text">
+    <meter name="Speedometer" container="Video" source="Speed" type="NeedleMeter">
+        <RelativeSize Width="20.0" Height="15.0" />
+        <RelativePosition X="20.0" Y="77.0" />
+        <Range Min="0.0" Max="60.0" />
+        <Angle>220.0</Angle>
+        <SubRange>6</SubRange>
+        <MainColor R="0" G="255" B="0" A="250" />
+        <BackgroundColor R="100" G="100" B="100" A="100" />
+    </meter>
+    <meter name="Speedometer-text" container="Speedometer" source="Speed" type="Text">
+        <RelativeSize Width="70.0" Height="40.0" />
+        <RelativePosition X="50.0" Y="75.0" />
+        <MainColor R="0" G="255" B="0" A="230" />
+        <MainFont Name="Consolas" Size="64" />
+    </meter>
+    <meter name="Wattmeter" container="Video" source="Watt" type="CircularMeter">
+        <RelativeSize Width="20.0" Height="15.0" />
+        <RelativePosition X="80.0" Y="77.0" />
+        <Range Min="0.0" Max="350.0" />
+        <Angle>280.0</Angle>
+    </meter>
+    <meter name="Wattmeter-text" container="Wattmeter" source="Watt" type="Text">
+        <RelativeSize Width="50.0" Height="40.0" />
+        <RelativePosition X="50.0" Y="50.0" />
+        <MainColor R="255" G="0" B="0" A="230" />
+    </meter>
+    <meter name="Wattmeter-unit" container="Wattmeter" source="None" type="Text">
+        <RelativeSize Width="50.0" Height="20.0" />
+        <RelativePosition X="50.0" Y="85.0" />
+        <MainColor R="255" G="0" B="0" A="230" />
+        <Text>Watts</Text>
+    </meter>
+    <meter name="Cadencemeter" container="Video" source="Cadence" type="CircularBargraph">
+        <RelativeSize Width="20.0" Height="13.0" />
+        <RelativePosition X="50.0" Y="73.0" />
+        <Range Min="0.0" Max="200.0" />
+        <MainColor R="5" G="0" B="255" A="180" />
+        <Angle>280.0</Angle>
+        <SubRange>30</SubRange>
+    </meter>
+    <meter name="Cadencemeter-text" container="Cadencemeter" source="Cadence" type="Text">
+        <RelativeSize Width="40.0" Height="30.0" />
+        <RelativePosition X="50.0" Y="50.0" />
+        <MainColor R="255" G="0" B="0" A="250" />
+    </meter>
+    <meter name="Cadencemeter-unit" container="Cadencemeter" source="None" type="Text">
        <RelativeSize Width="50.0" Height="20.0" />
-       <RelativePosition X="50.0" Y="85.0" />
-       <MainColor R="255" G="0" B="0" A="230" />
-       <Text>Watts</Text>
-   </meter>
-   <meter name="Cadencemeter" container="Video" source="Cadence" type="CircularBargraph">
-       <RelativeSize Width="20.0" Height="13.0" />
-       <RelativePosition X="50.0" Y="73.0" />
-       <Range Min="0.0" Max="200.0" />
-       <MainColor R="5" G="0" B="255" A="180" />
-       <Angle>280.0</Angle>
-       <SubRange>30</SubRange>
-   </meter>
-   <meter name="Cadencemeter-text" container="Cadencemeter" source="Cadence" type="Text">
-       <RelativeSize Width="40.0" Height="30.0" />
-       <RelativePosition X="50.0" Y="50.0" />
-       <MainColor R="255" G="0" B="0" A="250" />
-   </meter>
-   <meter name="Cadencemeter-unit" container="Cadencemeter" source="None" type="Text">
-       <RelativeSize Width="50.0" Height="20.0" />
-       <RelativePosition X="50.0" Y="85.0" />
-       <MainColor R="255" G="0" B="0" A="250" />
-       <Text>rpm</Text>
-   </meter>
-   <meter name="HRM-text" container="Video" source="HRM" type="Text">
-       <RelativeSize Width="15.0" Height="5.0" />
-       <RelativePosition X="50.0" Y="90.0" />
-       <MainColor R="255" G="0" B="0" A="250" />
-   </meter>
-   <meter name="status" container="Video" source="TrainerStatus" type="Text">
-       <RelativeSize Width="15.0" Height="5.0" />
-       <RelativePosition X="1.0" Y="10.0" />
-       <BackgroundColor R="100" G="100" B="100" A="100" />
-   </meter>
+        <RelativePosition X="50.0" Y="85.0" />
+        <MainColor R="255" G="0" B="0" A="250" />
+        <Text>rpm</Text>
+    </meter>
+    <meter name="HRM-text" container="Video" source="HRM" type="Text">
+        <RelativeSize Width="15.0" Height="5.0" />
+        <RelativePosition X="50.0" Y="90.0" />
+        <MainColor R="255" G="0" B="0" A="250" />
+    </meter>
+    <meter name="status" container="Video" source="TrainerStatus" type="Text">
+        <RelativeSize Width="15.0" Height="5.0" />
+        <RelativePosition X="1.0" Y="10.0" />
+        <BackgroundColor R="100" G="100" B="100" A="100" />
+    </meter>
     <meter name="status" container="Video" source="TrainerStatusDetails" type="Text">
         <RelativeSize Width="15.0" Height="4.0" />
         <RelativePosition X="10.0" Y="15.0" />


### PR DESCRIPTION
Next set of widgets that cover most of meters that may be expected by user.
Thus video can be scaled to full screen.
See screen capture below:
![gc capture](https://cloud.githubusercontent.com/assets/13483855/11381254/4de8d272-92fb-11e5-8709-4c09a7abc636.PNG)
Note: I forced "ready" for this screenshot. In fact "ready" is not shown when home trainer is running.
