### PR TITLE
dp: FixMoxy add config options (fix BSXInsight support)

### DIFF
--- a/src/Settings.cpp
+++ b/src/Settings.cpp
@@ -585,6 +585,8 @@ GSettings::upgradeGlobal() {
     migrateValue(GC_SWIMPACE);
     migrateValue(GC_ELEVATION_HYSTERESIS);
     migrateValue(GC_START_HTTP);
+    migrateValue(GC_CAD2SMO2);
+    migrateValue(GC_SPD2THB);
 
 
 

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -164,6 +164,9 @@
 #define GC_DPDP_BIKEWEIGHT              "<global-general>dataprocess/fixderivepower/bikewheight"
 #define GC_DPDP_CRR                     "<global-general>dataprocess/fixderivepower/crr"
 #define GC_DPFV_MA                     "<global-general>dataprocess/fixspeed/ma"
+#define GC_CAD2SMO2                     "<global-general>dataprocess/fixmoxy/cad2smo2"
+#define GC_SPD2THB			"<global-general>dataprocess/fixmoxy/spd2thb"
+
 
 // device Configurations NAME/SPEC/TYPE/DEFI/DEFR all get a number appended
 // to them to specify which configured device i.e. devices1 ... devicesn where


### PR DESCRIPTION
Number of data fields depends on sensor model
MoxySensor transmit SMO2 as cadance, tHB as speed,
BSX Insight 2 transmit only SMO2 as cadance, tHB is not supported.

So in case of BSXInsight we should not convert speed data. Let's allow
user to chose which datafields to transfer.

This patch add two new check buttons FixMoxy dialog
 - Cadence to SMO2
 - Speed to tHb