### PR TITLE
Support Metrics in Calendar Text

### DIFF
--- a/src/RideCache.cpp
+++ b/src/RideCache.cpp
@@ -121,11 +121,11 @@ RideCache::configChanged(qint32 what)
 
             // Construct the summary text used on the calendar
             QString calendarText;
-
-            foreach (FieldDefinition field, context->athlete->rideMetadata()->getFields()) 
-                if (field.diary == true) 
-                    calendarText += field.calendarText(item->metadata_.value(field.name, ""));
-
+            foreach (FieldDefinition field, context->athlete->rideMetadata()->getFields()) {
+                if (field.diary == true) {
+                    calendarText += field.calendarText(item, context->athlete->rideMetadata());
+                }
+            }
             item->metadata_.insert("Calendar Text", calendarText);
         }
     }

--- a/src/RideFile.cpp
+++ b/src/RideFile.cpp
@@ -614,17 +614,6 @@ RideFile *RideFileFactory::openRideFile(Context *context, QFile &file,
             notesFile.close();
         }
 
-        // Construct the summary text used on the calendar
-        QString calendarText;
-        if (context) { // will be null in standalone open
-            foreach (FieldDefinition field, context->athlete->rideMetadata()->getFields()) {
-                if (field.diary == true && result->getTag(field.name, "") != "") {
-                    calendarText += field.calendarText(result->getTag(field.name, ""));
-                }
-            }
-        }
-        result->setTag("Calendar Text", calendarText);
-
         // set other "special" fields
         result->setTag("Filename", QFileInfo(file.fileName()).fileName());
         result->setTag("Device", result->deviceType());

--- a/src/RideItem.cpp
+++ b/src/RideItem.cpp
@@ -594,6 +594,15 @@ RideItem::refresh()
         // we now match
         metacrc = metaCRC();
 
+        // Construct the summary text used on the calendar
+        QString calendarText;
+        foreach (FieldDefinition field, context->athlete->rideMetadata()->getFields()) {
+            if (field.diary == true) {
+                calendarText += field.calendarText(this, context->athlete->rideMetadata());
+            }
+        }
+        metadata_.insert("Calendar Text", calendarText);
+
         // close if we opened it
         if (doclose) {
             close();

--- a/src/RideMetadata.cpp
+++ b/src/RideMetadata.cpp
@@ -724,14 +724,6 @@ FormField::metadataFlush()
         }
     }
 
-    // Construct the summary text used on the calendar
-    QString calendarText;
-    foreach (FieldDefinition field, meta->getFields()) {
-        if (field.diary == true) {
-            calendarText += field.calendarText(ourRideItem->ride()->getTag(field.name, ""));
-        }
-    }
-    ourRideItem->ride()->setTag("Calendar Text", calendarText);
 }
 
 void
@@ -897,16 +889,6 @@ FormField::editFinished()
 
         // we actually edited it !
         setLinkedDefault(text);
-
-        // Construct the summary text used on the calendar
-        QString calendarText;
-        foreach (FieldDefinition field, meta->getFields()) {
-            if (field.diary == true) {
-                calendarText += QString("%1\n")
-                        .arg(ourRideItem->ride()->getTag(field.name, ""));
-            }
-        }
-        ourRideItem->ride()->setTag("Calendar Text", calendarText);
 
         // and update !
         ourRideItem->notifyRideMetadataChanged();
@@ -1155,8 +1137,19 @@ FieldDefinition::getCompleter(QObject *parent)
 }
 
 QString
-FieldDefinition::calendarText(QString value)
+FieldDefinition::calendarText(RideItem *rideItem, RideMetadata *meta)
 {
+    // "Weight" field is replace by "Athlete Weight" metric
+    QString fieldName = (name == "Weight") ? "Athlete Weight" : name;
+    QString value;
+    if (meta->sp.isMetric(fieldName)) {
+        value = rideItem->getStringForSymbol(meta->sp.rideMetric(fieldName)->symbol(), meta->context->athlete->useMetricUnits);
+    } else {
+        value = rideItem->ride()->getTag(fieldName, "");
+    }
+
+    if (value.isEmpty()) return value;
+
     switch (type) {
     case FIELD_INTEGER:
     case FIELD_DOUBLE:

--- a/src/RideMetadata.h
+++ b/src/RideMetadata.h
@@ -66,7 +66,7 @@ class FieldDefinition
 
         static unsigned long fingerprint(QList<FieldDefinition>);
         QCompleter *getCompleter(QObject *parent);
-        QString calendarText(QString value);
+        QString calendarText(RideItem *rideItem, RideMetadata *meta);
 
         FieldDefinition() : tab(""), name(""), type(0), diary(false), values() {}
         FieldDefinition(QString tab, QString name, int type, bool diary, QStringList values)

--- a/src/RideMetric.cpp
+++ b/src/RideMetric.cpp
@@ -128,8 +128,8 @@
 // 122 7   Nov 2015 Mark Liversedge    Added HR Zones 9 and 10
 // 123 19  Nov 2015 Mark Liversedge    Force recompute of TSS/IF after logic fix
 // 124 03  Dec 2015 Mark Liversedge    Min Temp
-
-int DBSchemaVersion = 124;
+// 125 08  Dec 2015 Ale Martinez       Support metrics in Calendar Text
+int DBSchemaVersion = 125;
 
 RideMetricFactory *RideMetricFactory::_instance;
 QVector<QString> RideMetricFactory::noDeps;


### PR DESCRIPTION
When the Diary checkbox is set for a metric
"Name: value" is added to Calendar Text.
The "Weight" field is special cased to "Athlete Weight" metric.
Calendar Text is no longer stored in RideFile, only cached in RideItem,
since it depends on from Metadata Configuration besides Tags and Metrics values.
Fixes #1563