### PR TITLE
Fixed a german translation in AboutDialog to have a fixed length

### DIFF
--- a/src/translations/gc_de.ts
+++ b/src/translations/gc_de.ts
@@ -36,11 +36,7 @@
     <message>
         <location filename="../AboutDialog.cpp" line="25"/>
         <source>About GoldenCheetah</source>
-        <translatorcomment>Über GoldenCheetah</translatorcomment>
-        <translation variants="yes">
-            <lengthvariant>Über GoldenCheetah</lengthvariant>
-            <lengthvariant></lengthvariant>
-        </translation>
+        <translation>Über GoldenCheetah</translation>
     </message>
     <message>
         <location filename="../AboutDialog.cpp" line="36"/>


### PR DESCRIPTION
Before:
![2015-12-25-12 14 56-screenshot](https://cloud.githubusercontent.com/assets/905221/12002561/22ab5bf2-ab01-11e5-8e37-7cf54a6652f0.png)

After:
![2015-12-25-12 04 28-screenshot](https://cloud.githubusercontent.com/assets/905221/12002553/027a6882-ab01-11e5-9423-97058f519d9a.png)

Problem: Looky ugly and could crash the programm if protected memory is accessed.