### PR TITLE
MSVC - Problems detected when compiling Debug Code

### DIFF
--- a/src/AllPlot.cpp
+++ b/src/AllPlot.cpp
@@ -991,9 +991,10 @@ AllPlot::~AllPlot()
     compares.clear();
 
     // wipe the standard stuff
-    delete standard;
     if (tooltip) delete tooltip;
     if (_canvasPicker) delete _canvasPicker;
+    delete standard;
+
 }
 
 void

--- a/src/RideNavigator.cpp
+++ b/src/RideNavigator.cpp
@@ -65,7 +65,7 @@ RideNavigator::RideNavigator(Context *context, bool mainwindow) : context(contex
     groupByModel = new GroupByModel(this);
     groupByModel->setSourceModel(searchFilter);
 
-    sortModel = new BUGFIXQSortFilterProxyModel(this);
+    sortModel = new QSortFilterProxyModel(this);
     sortModel->setSourceModel(groupByModel);
     sortModel->setDynamicSortFilter(true);
 

--- a/src/RideNavigator.h
+++ b/src/RideNavigator.h
@@ -40,7 +40,7 @@ class SearchFilter;
 class SearchFilterBox;
 class DiaryWindow;
 class DiarySidebar;
-class BUGFIXQSortFilterProxyModel;
+class QSortFilterProxyModel;
 class DataFilter;
 class GcMiniCalendar;
 class SearchBox;
@@ -161,7 +161,7 @@ class RideNavigator : public GcWindow
 
     protected:
         GroupByModel *groupByModel; // for group by
-        BUGFIXQSortFilterProxyModel *sortModel; // for sort/filter
+        QSortFilterProxyModel *sortModel; // for sort/filter
 
         // keep track of the headers
         QList<QString> logicalHeadings;

--- a/src/RideNavigatorProxy.h
+++ b/src/RideNavigatorProxy.h
@@ -606,24 +606,6 @@ public slots:
     }
 };
 
-// SEE QT-BUG #14831 - when it is fixed this can be removed
-class BUGFIXQSortFilterProxyModel : public QSortFilterProxyModel
-{
-
-    public:
-
-    BUGFIXQSortFilterProxyModel(QWidget *p) : QSortFilterProxyModel(p) {}
-
-    bool lessThan(const QModelIndex &left, const QModelIndex &right) const {
-        QVariant l = (left.model() ? left.model()->data(left, sortRole()) : QVariant());
-        QVariant r = (right.model() ? right.model()->data(right, sortRole()) : QVariant());
-        switch (l.userType()) {
-            case QVariant::Invalid: return (r.type() == QVariant::Invalid);
-            default: return QSortFilterProxyModel::lessThan(left, right);
-        }
-        return false;
-    }
-};
 
 class SearchFilter : public QSortFilterProxyModel
 {


### PR DESCRIPTION
... 2 Fixes which get visible in GC when running in Debug mode under MSVC

MSVC - Fix Assert error when compiled in Debug mode
... Assert error in MSVC-core library when running code compied with /MDd (debug mode)
... Solution - removed BUGFix code related to QTBUG-14831 (which worked fine until now)
... Tested under MSVC (Release && Debug) QT 5.6.0 and MinGW (Release) QT 5.4.2

Fix Deletion sequence in destructor of AllPlot
... error/exception only visible when running in Debug Mode
... the destructor fo tooltip fires (via multiple step) and mouse even to AllPlot standard,
    which at that point is already deleted - changing the sequence let's GC
    end gracefully also in Debug Mode

