### PR TITLE
Implement support for multiple scopes in GoogleDrive

### DIFF
--- a/src/FileStore.cpp
+++ b/src/FileStore.cpp
@@ -426,9 +426,7 @@ FileStoreDialog::createFolderClicked()
 {
     FolderNameDialog dialog(this);
     int ret = dialog.exec();
-    printf("CREATE\n");
     if (ret == QDialog::Accepted && dialog.name() != "") {
-        printf("CREATE22\n");
         // go and create it !
         store->createFolder(pathname + "/" + dialog.name());
 

--- a/src/GoogleDrive.h
+++ b/src/GoogleDrive.h
@@ -56,6 +56,12 @@ class GoogleDrive : public FileStore {
         virtual QList<FileStoreEntry*> readdir(
             QString path, QStringList &errors);
 
+        static QString GetScope(Context* context);
+
+        // Returns the fild id or "" if no file was found, uses the local
+        // cache to determine file id.
+        QString GetFileId(const QString& path);
+        
     public slots:
 
         // getting data
@@ -74,15 +80,18 @@ class GoogleDrive : public FileStore {
         QJsonDocument FetchNextLink(const QString& url, const QString& token);
 
         FileInfo* WalkFileInfo(const QString& path, bool foo);
-        
+
+        FileInfo* BuildDirectoriesForAthleteDirectory(const QString& path);
+            
         static QNetworkRequest MakeRequestWithURL(
             const QString& url, const QString& token, const QString& args);
         static QNetworkRequest MakeRequest(
             const QString& token, const QString& args);
         // Make QString returns a "q" string usable for searches in Google
         // Drive.
-        static QString MakeQString();
-
+        static QString MakeQString(const QString& parent);
+        QString GetRootDirId();
+        
         Context *context_;
         QNetworkAccessManager *nam_;
         FileStoreEntry *root_;

--- a/src/OAuthDialog.cpp
+++ b/src/OAuthDialog.cpp
@@ -133,10 +133,14 @@ OAuthDialog::OAuthDialog(Context *context, OAuthSite site) :
         urlstr.append("response_type=code&");
         urlstr.append("client_id=").append(GC_GOOGLE_CALENDAR_CLIENT_ID);
     } else if (site == GOOGLE_DRIVE) {
+        const QString scope =
+            appsettings->cvalue(
+                context->athlete->cyclist,
+                GC_GOOGLE_DRIVE_AUTH_SCOPE, "drive.appdata").toString();
         // OAUTH 2.0 - Google flow for installed applications
         urlstr = QString("https://accounts.google.com/o/oauth2/auth?");
         // We only request access to the application data folder, not all files.
-        urlstr.append("scope=https://www.googleapis.com/auth/drive.appdata&");
+        urlstr.append("scope=https://www.googleapis.com/auth/" + scope + "&");
         urlstr.append("redirect_uri=urn:ietf:wg:oauth:2.0:oob&");
         urlstr.append("response_type=code&");
         urlstr.append("client_id=").append(GC_GOOGLE_DRIVE_CLIENT_ID);

--- a/src/OAuthDialog.cpp
+++ b/src/OAuthDialog.cpp
@@ -24,6 +24,8 @@
 #include "TimeUtils.h"
 
 #if QT_VERSION > 0x050000
+#include "GoogleDrive.h"
+
 #include <QJsonParseError>
 #endif
 
@@ -132,11 +134,9 @@ OAuthDialog::OAuthDialog(Context *context, OAuthSite site) :
         urlstr.append("redirect_uri=urn:ietf:wg:oauth:2.0:oob&");
         urlstr.append("response_type=code&");
         urlstr.append("client_id=").append(GC_GOOGLE_CALENDAR_CLIENT_ID);
+#if QT_VERSION >= 0x050000
     } else if (site == GOOGLE_DRIVE) {
-        const QString scope =
-            appsettings->cvalue(
-                context->athlete->cyclist,
-                GC_GOOGLE_DRIVE_AUTH_SCOPE, "drive.appdata").toString();
+        const QString scope = GoogleDrive::GetScope(context);
         // OAUTH 2.0 - Google flow for installed applications
         urlstr = QString("https://accounts.google.com/o/oauth2/auth?");
         // We only request access to the application data folder, not all files.
@@ -144,6 +144,7 @@ OAuthDialog::OAuthDialog(Context *context, OAuthSite site) :
         urlstr.append("redirect_uri=urn:ietf:wg:oauth:2.0:oob&");
         urlstr.append("response_type=code&");
         urlstr.append("client_id=").append(GC_GOOGLE_DRIVE_CLIENT_ID);
+#endif
     }
 
     // different process to get the token for STRAVA, CYCLINGANALYTICS vs.

--- a/src/Pages.h
+++ b/src/Pages.h
@@ -218,13 +218,14 @@ class CredentialsPage : public QScrollArea
 #if QT_VERSION >= 0x050000
         void authoriseDropbox();
         void chooseDropboxFolder();
-        void authoriseGoogleDrive();        
-        void chooseGoogleDriveFolder();        
+        void authoriseGoogleDrive();
+        void chooseGoogleDriveFolder();
+        void chooseGoogleDriveAuthScope(const QString& scope);
 #endif
         void authoriseStrava();
         void authoriseCyclingAnalytics();
         void authoriseGoogleCalendar();
-        void dvCALDAVTypeChanged(int);        
+        void dvCALDAVTypeChanged(int);
         void chooseLocalFileStoreFolder();
 
     private:
@@ -233,7 +234,7 @@ class CredentialsPage : public QScrollArea
             DRIVE,
         };
         void authoriseGoogle(GoogleType type);
-        
+
         Context *context;
 
         QLineEdit *tpUser;

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -271,6 +271,7 @@
 #define GC_GOOGLE_DRIVE_LAST_ACCESS_TOKEN_REFRESH "<athlete-private>google-drive/last_access_token_refresh"
 
 #define GC_GOOGLE_DRIVE_FOLDER          "<athlete-private>google-drive/folder"
+#define GC_GOOGLE_DRIVE_FOLDER_ID       "<athlete-private>google-drive/folder_id"
 #define GC_TWITTER_TOKEN                "<athlete-private>twitter_token"
 #define GC_TWITTER_SECRET               "<athlete-private>twitter_secret"
 //Google Calendar-CALDAV oauthkeys

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -265,6 +265,7 @@
 //Twitter oauth keys
 #define GC_DROPBOX_TOKEN                "<athlete-private>dropbox/token"
 #define GC_DROPBOX_FOLDER               "<athlete-private>dropbox/folder"
+#define GC_GOOGLE_DRIVE_AUTH_SCOPE      "<athlete-private>google-drive/auth_scope"
 #define GC_GOOGLE_DRIVE_ACCESS_TOKEN   "<athlete-private>google-drive/access_token"
 #define GC_GOOGLE_DRIVE_REFRESH_TOKEN   "<athlete-private>google-drive/refresh_token"
 #define GC_GOOGLE_DRIVE_LAST_ACCESS_TOKEN_REFRESH "<athlete-private>google-drive/last_access_token_refresh"


### PR DESCRIPTION
This allows a user to configure if the GC files are accessible or not and should also make it possible to share between different google accounts.