### PR TITLE
fix_tacx_vortex

### DIFF
--- a/src/ANTChannel.cpp
+++ b/src/ANTChannel.cpp
@@ -622,7 +622,8 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                static float last_measured_rpm;
                uint16_t time = antMessage.crankMeasurementTime - lastMessage.crankMeasurementTime;
                uint16_t revs = antMessage.crankRevolutions - lastMessage.crankRevolutions;
-               if (time) {
+               if (time && revs) {
+                   // note: revs!=0 ensure that data are valid (some trainers simulates sensor event by computing fake timestamp)
                    rpm = 1024*60*revs / time;
                    last_measured_rpm = rpm;
                    lastMessageTimestamp = QTime::currentTime();
@@ -646,7 +647,8 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                // cadence first...
                uint16_t time = antMessage.crankMeasurementTime - lastMessage.crankMeasurementTime;
                uint16_t revs = antMessage.crankRevolutions - lastMessage.crankRevolutions;
-               if (time) {
+               if (time && revs) {
+                   // note: revs!=0 ensure that data are valid (some trainers simulates sensor event by computing fake timestamp)
                    rpm = 1024*60*revs / time;
                    last_measured_rpm = rpm;
 
@@ -666,7 +668,8 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                // now speed ...
                time = antMessage.wheelMeasurementTime - lastMessage.wheelMeasurementTime;
                revs = antMessage.wheelRevolutions - lastMessage.wheelRevolutions;
-               if (time) {
+               if (time && revs) {
+                   // note: revs!=0 ensure that data are valid (some trainers simulates sensor event by computing fake timestamp)
                    rpm = 1024*60*revs / time;
                    if (is_moxy) /* do nothing for now */ ; //XXX fixme when moxy arrives XXX
                    else parent->setWheelRpm(rpm);
@@ -689,7 +692,8 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                float rpm;
                uint16_t time = antMessage.wheelMeasurementTime - lastMessage.wheelMeasurementTime;
                uint16_t revs = antMessage.wheelRevolutions - lastMessage.wheelRevolutions;
-               if (time) {
+               if (time && revs) {
+                   // note: revs!=0 ensure that data are valid (some trainers simulates sensor event by computing fake timestamp)
                    rpm = 1024*60*revs / time;
                    lastMessageTimestamp = QTime::currentTime();
                } else {


### PR DESCRIPTION
Should fix the Tacx Vortex "fake" speed event timestamp (when simulating real speed sensor few messages have different timestamp related to same wheel revolution event).
Tested on linux with speed and cadence sensor actuated by hand without any issue (regression test).
Note: I'm unable to test it with Tacx Vortex during more than few seconds at present (broken toe & laptop hardware failure).
Thus any intensive test with vortex will be welcome!
