### PR TITLE
ANT fixes

### DIFF
--- a/src/ANT.cpp
+++ b/src/ANT.cpp
@@ -842,6 +842,10 @@ ANT::slotStopBroadcastTimer(int channel) // timer
 
     //qDebug()<<"ANT::slotStopTimer req from channel "<<channel;
 
+    // disconnect the slot, else we duplicate signals on subsequent sessions
+    disconnect(antChannel[channel]->channelTimer, SIGNAL(timeout()), this, SLOT(slotControlTimerEvent()));
+
+
     // stop the broadcast timer..
     antChannel[channel]->channelTimer->stop();
 }

--- a/src/ANTChannel.cpp
+++ b/src/ANTChannel.cpp
@@ -177,7 +177,7 @@ void ANTChannel::channelEvent(unsigned char *ant_message) {
     // we should reimplement this via ANTMessage at some point
     unsigned char *message=ant_message+2;
 
-    //qDebug()<<number<<"channel event:"<< ANTMessage::channelEventMessage(*(message+1));
+    //qDebug()<<number<<"channel event:"<< ANTMessage::channelEventMessage(*(message+3));
     if (MESSAGE_IS_RESPONSE_NO_ERROR(message)) {
 
         //qDebug()<<number<<"channel event response no error";
@@ -187,7 +187,7 @@ void ANTChannel::channelEvent(unsigned char *ant_message) {
 
         //qDebug()<<number<<"channel event channel closed";
         if (status != Closing) {
-            //qDebug()<<"we got closed!! re-open !!";
+            //qDebug()<<number<<"we got closed!! re-open !!";
             status = Opening;
             attemptTransition(TRANSITION_START);
         } else {
@@ -236,7 +236,7 @@ void ANTChannel::channelEvent(unsigned char *ant_message) {
 
         //this cannot possibly be correct >> exit(-10);
 
-    } else if (MESSAGE_IS_EVENT_TRANSFER_TX_COMPLETED(message)) {
+    } else if (MESSAGE_IS_EVENT_TRANSFER_TX_COMPLETED(message) || MESSAGE_IS_EVENT_TX(message)) {
 
         // do nothing
 
@@ -244,7 +244,7 @@ void ANTChannel::channelEvent(unsigned char *ant_message) {
 
         // usually a response event, so lets get a debug going
         //qDebug()<<number<<"channel event other ....."<<QString("0x%1 0x%2 %3 %4")
-        //.arg(message[0], 1, 16).arg(message[1], 1, 16).arg(message[2]).arg(ANTMessage::channelEventMessage(message[2]));
+        //.arg(message[0], 1, 16).arg(message[1], 1, 16).arg(message[2]).arg(ANTMessage::channelEventMessage(message[3]));
     }
 }
 

--- a/src/ANTChannel.cpp
+++ b/src/ANTChannel.cpp
@@ -121,6 +121,11 @@ void ANTChannel::close()
     emit lostInfo(number);
     lastMessage = ANTMessage();
 
+    if (is_master) {
+        //qDebug()<<number<<"Stopping timer..";
+        emit broadcastTimerStop(number);
+    }
+
     // lets shutdown
     qDebug()<<"** CLOSING CHANNEL"<<number<<"**";
     status = Closing;
@@ -1059,10 +1064,6 @@ void ANTChannel::attemptTransition(int message_id)
         //qDebug()<<number<<"TRANSITION from closed";
         status = Closed;
         //qDebug()<<"** CHANNEL"<<number<<"NOW CLOSED **";
-        if (is_master) {
-            //qDebug()<<number<<"Stopping timer..";
-            emit broadcastTimerStop(number);
-        }
         break;
 
     default:

--- a/src/ANTChannel.cpp
+++ b/src/ANTChannel.cpp
@@ -1014,7 +1014,7 @@ void ANTChannel::attemptTransition(int message_id)
     case ANT_CHANNEL_ID:
         //qDebug()<<number<<"TRANSITION from channel id";
         //qDebug()<<number<<"**** adjust timeout";
-        if (channel_type & CHANNEL_TYPE_QUICK_SEARCH) {
+        if (channel_type_flags & CHANNEL_TYPE_QUICK_SEARCH) {
             parent->sendMessage(ANTMessage::setSearchTimeout(number, (int)(timeout_scan/2.5)));
         } else {
             parent->sendMessage(ANTMessage::setSearchTimeout(number, (int)(timeout_lost/2.5)));

--- a/src/ANTChannel.cpp
+++ b/src/ANTChannel.cpp
@@ -866,6 +866,7 @@ void ANTChannel::ackEvent(unsigned char *ant_message)
                     emit antRemoteControl(controlCmd);
 
                 lastControlSeq = controlSeq;
+                value = controlCmd;
                 break;
             }
         }

--- a/src/ANTChannel.cpp
+++ b/src/ANTChannel.cpp
@@ -905,7 +905,7 @@ void ANTChannel::channelId(unsigned char *ant_message) {
     // if we were searching,
     if (channel_type_flags&CHANNEL_TYPE_QUICK_SEARCH) {
         //qDebug()<<number<<"change timeout setting";
-        parent->sendMessage(ANTMessage::setSearchTimeout(number, (int)(timeout_lost/2.5)));
+        parent->sendMessage(ANTMessage::setHPSearchTimeout(number, (int)(timeout_lost/2.5)));
     }
     channel_type_flags &= ~CHANNEL_TYPE_QUICK_SEARCH;
 }
@@ -1015,9 +1015,9 @@ void ANTChannel::attemptTransition(int message_id)
         //qDebug()<<number<<"TRANSITION from channel id";
         //qDebug()<<number<<"**** adjust timeout";
         if (channel_type_flags & CHANNEL_TYPE_QUICK_SEARCH) {
-            parent->sendMessage(ANTMessage::setSearchTimeout(number, (int)(timeout_scan/2.5)));
+            parent->sendMessage(ANTMessage::setHPSearchTimeout(number, (int)(timeout_scan/2.5)));
         } else {
-            parent->sendMessage(ANTMessage::setSearchTimeout(number, (int)(timeout_lost/2.5)));
+            parent->sendMessage(ANTMessage::setHPSearchTimeout(number, (int)(timeout_lost/2.5)));
         }
         break;
 

--- a/src/ANTChannel.cpp
+++ b/src/ANTChannel.cpp
@@ -905,7 +905,7 @@ void ANTChannel::channelId(unsigned char *ant_message) {
     // if we were searching,
     if (channel_type_flags&CHANNEL_TYPE_QUICK_SEARCH) {
         //qDebug()<<number<<"change timeout setting";
-        parent->sendMessage(ANTMessage::setHPSearchTimeout(number, (int)(timeout_lost/2.5)));
+        parent->sendMessage(ANTMessage::setLPSearchTimeout(number, (int)(timeout_lost/2.5)));
     }
     channel_type_flags &= ~CHANNEL_TYPE_QUICK_SEARCH;
 }
@@ -1014,10 +1014,14 @@ void ANTChannel::attemptTransition(int message_id)
     case ANT_CHANNEL_ID:
         //qDebug()<<number<<"TRANSITION from channel id";
         //qDebug()<<number<<"**** adjust timeout";
+
+        // Disable high priority searching - for better coexistence with other channels
+        parent->sendMessage(ANTMessage::setHPSearchTimeout(number, 0));
+
         if (channel_type_flags & CHANNEL_TYPE_QUICK_SEARCH) {
-            parent->sendMessage(ANTMessage::setHPSearchTimeout(number, (int)(timeout_scan/2.5)));
+            parent->sendMessage(ANTMessage::setLPSearchTimeout(number, (int)(timeout_scan/2.5)));
         } else {
-            parent->sendMessage(ANTMessage::setHPSearchTimeout(number, (int)(timeout_lost/2.5)));
+            parent->sendMessage(ANTMessage::setLPSearchTimeout(number, (int)(timeout_lost/2.5)));
         }
         break;
 

--- a/src/ANTMessage.cpp
+++ b/src/ANTMessage.cpp
@@ -778,7 +778,13 @@ ANTMessage ANTMessage::unassignChannel(const unsigned char channel)
     return ANTMessage(1, ANT_UNASSIGN_CHANNEL, channel);
 }
 
-ANTMessage ANTMessage::setSearchTimeout(const unsigned char channel,
+ANTMessage ANTMessage::setLPSearchTimeout(const unsigned char channel,
+                                        const unsigned char timeout)
+{
+    return ANTMessage(2, ANT_LP_SEARCH_TIMEOUT, channel, timeout);
+}
+
+ANTMessage ANTMessage::setHPSearchTimeout(const unsigned char channel,
                                         const unsigned char timeout)
 {
     return ANTMessage(2, ANT_SEARCH_TIMEOUT, channel, timeout);

--- a/src/ANTMessage.h
+++ b/src/ANTMessage.h
@@ -48,8 +48,10 @@ class ANTMessage {
                                         const unsigned char network);
         static ANTMessage boostSignal(const unsigned char channel);
         static ANTMessage unassignChannel(const unsigned char channel);
-        static ANTMessage setSearchTimeout(const unsigned char channel,
-                                           const unsigned char timeout);
+        static ANTMessage setLPSearchTimeout(const unsigned char channel,
+                                             const unsigned char timeout);
+        static ANTMessage setHPSearchTimeout(const unsigned char channel,
+                                             const unsigned char timeout);
         static ANTMessage requestMessage(const unsigned char channel,
                                          const unsigned char request);
         static ANTMessage setChannelID(const unsigned char channel,

--- a/src/ANTlocalController.cpp
+++ b/src/ANTlocalController.cpp
@@ -148,9 +148,12 @@ void ANTlocalController::antRemoteControl(uint16_t command)
 {
     //qDebug() <<"AntlocalController::antRemoteControl()" << command;
 
-    // translate the ANT control code to a native command code
-    uint16_t nativeCmd = parent->remote->getNativeCmdId(command);
+    // When called from pairing dialog the parent is null, do nothing..
+    if (parent) {
+        // translate the ANT control code to a native command code
+        uint16_t nativeCmd = parent->remote->getNativeCmdId(command);
 
-    // pass native command code to train view
-    emit remoteControl(nativeCmd);
+        // pass native command code to train view
+        emit remoteControl(nativeCmd);
+    }
 }

--- a/src/AddDeviceWizard.cpp
+++ b/src/AddDeviceWizard.cpp
@@ -760,7 +760,9 @@ AddPair::sensorChanged(int channel)
         // for a remote control we are the master, so there is nothing for us to pair
         // just generate a random device number between 1 & 65535
         dynamic_cast<QLabel*>(channelWidget->itemWidget(item,3))->setText(tr("Master"));
-        dynamic_cast<QLineEdit *>(channelWidget->itemWidget(item,1))->setText(QString("%1").arg((qrand() % 65535) + 1));
+        uint16_t deviceNumber = (qrand() % 65535) + 1;
+        dynamic_cast<QLineEdit *>(channelWidget->itemWidget(item,1))->setText(QString("%1").arg(deviceNumber));
+        dynamic_cast<ANTlocalController*>(wizard->controller)->myANTlocal->setChannel(channel, deviceNumber, channel_type);
     } else {
         dynamic_cast<QLabel*>(channelWidget->itemWidget(item,3))->setText(tr("Searching..."));
         dynamic_cast<ANTlocalController*>(wizard->controller)->myANTlocal->setChannel(channel, 0, channel_type);


### PR DESCRIPTION
Don't think there is anything too controversial here, except perhaps 7b09d3a. Not sure whether it warrants further discussion on the dev list or whether you're happy as it stands?

The reason for the change is that I was seeing significant interference to remote control input from any searching channels. There's some background on the two scanning types at the following links;

https://www.thisisant.com/resources/an11-ant-channel-search-and-background-scanning-channel/
https://www.thisisant.com/resources/an15-multi-channel-design-considerations/

Haven't seen any downside to using low priority only. It resolves the channel interference issues, and I've tested searching for up to 8 active sensors/channels in the AddDevice dialog. 
