### PR TITLE
Fixes for Fortius USB timeout issue and new Fortius VR driver package…

### DIFF
--- a/src/Fortius.h
+++ b/src/Fortius.h
@@ -74,6 +74,8 @@
 #define DEFAULT_CALIBRATION  0.00
 #define DEFAULT_SCALING      1.00
 
+#define FT_USB_TIMEOUT      500
+
 class Fortius : public QThread
 {
 

--- a/src/LibUsb.cpp
+++ b/src/LibUsb.cpp
@@ -108,6 +108,11 @@ void LibUsb::close()
 
 int LibUsb::read(char *buf, int bytes)
 {
+	return this->read(buf, bytes, 125);
+}
+
+int LibUsb::read(char *buf, int bytes, int timeout)
+{
     // check it isn't closed already
     if (!device) return -1;
 
@@ -134,7 +139,7 @@ int LibUsb::read(char *buf, int bytes)
     readBufSize = 0;
     readBufIndex = 0;
 
-    int rc = usb_bulk_read(device, readEndpoint, readBuf, 64, 125);
+    int rc = usb_bulk_read(device, readEndpoint, readBuf, 64, timeout);
     if (rc < 0)
     {
         // don't report timeouts - lots of noise so commented out
@@ -163,6 +168,11 @@ int LibUsb::read(char *buf, int bytes)
 
 int LibUsb::write(char *buf, int bytes)
 {
+	return this->write(buf, bytes, 125);
+}
+
+int LibUsb::write(char *buf, int bytes, int timeout)
+{
 
     // check it isn't closed
     if (!device) return -1;
@@ -174,7 +184,7 @@ int LibUsb::write(char *buf, int bytes)
         // we use a non-interrupted write on Linux/Mac since the interrupt
         // write block size is incorrectly implemented in the version of
         // libusb we build with. It is no less efficient.
-        rc = usb_bulk_write(device, writeEndpoint, buf, bytes, 125);
+        rc = usb_bulk_write(device, writeEndpoint, buf, bytes, timeout);
     }
 
     if (rc < 0)

--- a/src/LibUsb.h
+++ b/src/LibUsb.h
@@ -58,7 +58,9 @@ public:
     int open();
     void close();
     int read(char *buf, int bytes);
+	int read(char *buf, int bytes, int timeout);
     int write(char *buf, int bytes);
+	int write(char *buf, int bytes, int timeout);
     bool find();
 private:
 


### PR DESCRIPTION
Fixes usb read timeout on some machines and adds driver inf for Fortius VR which is signed and installs properly on windows 10 x64

- Fortius.cpp was reading from device before writing to it. This can cause device to error
- LibUsb.cpp contains hard coded usb timeout

Added read / write override to LibUsb so can specify different timeout to the default ANT+ 125ms

Restructured run loop in Fortius.cpp

Also added Fortius VR inf package (libusb-0.1) to \contrib built with Zadig