### PR TITLE
Do not action ConfigChange mid-workout

### DIFF
--- a/src/TrainSidebar.cpp
+++ b/src/TrainSidebar.cpp
@@ -482,6 +482,7 @@ intensity->hide(); //XXX!!! temporary
     status = 0;
     setStatusFlags(RT_MODE_ERGO);         // ergo mode by default
     mode = ERG;
+    pendingConfigChange = false;
 
     displayWorkoutLap = displayLap = 0;
     pwrcount = 0;
@@ -706,6 +707,12 @@ TrainSidebar::videosyncPopup()
 void
 TrainSidebar::configChanged(qint32)
 {
+    // do not refresh if workout running, defer to end of workout
+    if (status&RT_RUNNING) {
+        pendingConfigChange = true;
+        return;
+    }
+
     // auto connect is off by default
     autoConnect = appsettings->value(this, TRAIN_AUTOCONNECT, false).toBool();
 
@@ -1382,6 +1389,12 @@ void TrainSidebar::Stop(int deviceStatus)        // when stop button is pressed
 
     // tell the world
     context->notifyStop();
+
+    // if a config change was requested while workout was running, action it now
+    if (pendingConfigChange) {
+        pendingConfigChange = false;
+        configChanged(CONFIG_APPEARANCE | CONFIG_DEVICES | CONFIG_ZONES);
+    }
 
     // Re-enable gui elements
     // reset counters etc

--- a/src/TrainSidebar.h
+++ b/src/TrainSidebar.h
@@ -272,6 +272,7 @@ class TrainSidebar : public GcWindow
                     *disk_timer;    // write to .CSV file
 
         bool autoConnect;
+        bool pendingConfigChange;
 
     public:
         int mode;


### PR DESCRIPTION
Is disruptive as it zaps and recreates the devices. Instead
flag the changes to apply when workout ends.