### PR TITLE
TrainMode - Don't allow to close GC Window if active/updating data

### DIFF
--- a/src/TrainSidebar.cpp
+++ b/src/TrainSidebar.cpp
@@ -393,7 +393,7 @@ intensity->hide(); //XXX!!! temporary
     // not used but kept in case re-instated in the future
     recordSelector = new QCheckBox(this);
     recordSelector->setText(tr("Save workout data"));
-    recordSelector->setChecked(Qt::Checked);
+    recordSelector->setChecked(true);
     recordSelector->hide(); // we don't let users change this for now
 
     trainSplitter = new GcSplitter(Qt::Vertical);
@@ -616,6 +616,15 @@ TrainSidebar::workoutPopup()
 bool
 TrainSidebar::eventFilter(QObject *, QEvent *event)
 {
+    // do not allow to close the Window when active
+    if (event->type() == QEvent::Close) {
+        if (gui_timer->isActive()) {
+            QMessageBox::warning(this, tr("Train mode active"), tr("Please stop the train mode before closing the window or application."));
+            event->ignore();
+            return true;
+        }
+    }
+
     // only when we are recording !
     if (status & RT_RECORDING) {
 
@@ -1734,7 +1743,7 @@ void TrainSidebar::nextDisplayMode()
 
 void TrainSidebar::warnnoConfig()
 {
-    QMessageBox::warning(this, tr("No Devices Configured"), "Please configure a device in Preferences.");
+    QMessageBox::warning(this, tr("No Devices Configured"), tr("Please configure a device in Preferences."));
 }
 
 //----------------------------------------------------------------------

--- a/src/TrainSidebar.cpp
+++ b/src/TrainSidebar.cpp
@@ -618,10 +618,14 @@ TrainSidebar::eventFilter(QObject *, QEvent *event)
 {
     // do not allow to close the Window when active
     if (event->type() == QEvent::Close) {
-        if (gui_timer->isActive()) {
+        if (status & RT_RUNNING) {
             QMessageBox::warning(this, tr("Train mode active"), tr("Please stop the train mode before closing the window or application."));
             event->ignore();
             return true;
+        } else if (gui_timer->isActive()) {
+            // we just disconnecting before allowing the window to close
+            Disconnect();
+            return false;
         }
     }
 


### PR DESCRIPTION
... while TrainMode is active and realtime data is updated/displayed
... (and avoid SEGV when closing)