### PR TITLE
Make sure we don't log any tokens in the gc crash dialog.

### DIFF
--- a/src/GcCrashDialog.cpp
+++ b/src/GcCrashDialog.cpp
@@ -457,7 +457,7 @@ GcCrashDialog::setHTML()
         // RESPECT PRIVACY
         // we do not disclose user names and passwords or key ids
         if (key.endsWith("/user") || key.endsWith("/pass") ||
-            key.endsWith("/key") || key.endsWith("_token") ||
+            key.endsWith("/key") || key.endsWith("token") ||
             key.endsWith("_secret") || key.endsWith("googlecalid")) continue;
 
         // we do not disclose personally identifiable information


### PR DESCRIPTION
I noticed we logged the dropbox token in a crash report, we really shouldn't.