### PR TITLE
Fix speed & power spikes from Powertap G3

### DIFF
--- a/src/ANTChannel.cpp
+++ b/src/ANTChannel.cpp
@@ -343,6 +343,8 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
         product_id=MANUFACTURER_MODEL_NUMBER_ID(message);
         checkCinqo();
 
+    } else if (MESSAGE_IS_BATTERY_VOLTAGE(message)) {
+        // todo: push battery status up to train view when we have a means to display notifications
     }
     else {
         telemetry = true;


### PR DESCRIPTION
G3 hubs intermittently broadcast battery status messages, which
were being treated as telemetry and saved into lastMessage. This
was then corrupting the ANT_WHEELTORQUE_POWER calculations for
speed & power after each battery message.

Note: don't have a G3 to verify this against, but the fix makes
sense given the supplied log files!