### PR TITLE
Performance improvements

### DIFF
--- a/src/AllPlot.cpp
+++ b/src/AllPlot.cpp
@@ -33,6 +33,7 @@
 #include "Colors.h"
 #include "WPrime.h"
 #include "IndendPlotMarker.h"
+#include "Utils.h"
 
 #include <qwt_plot_curve.h>
 #include <qwt_plot_canvas.h>
@@ -2753,7 +2754,9 @@ AllPlot::setYMax()
         if (axisHeight) {
             QFontMetrics labelWidthMetric = QFontMetrics( QwtPlot::axisFont(yLeft) );
             int labelWidth = labelWidthMetric.width( (maxY > 1000) ? " 8,888 " : " 888 " );
-            while( ( qCeil(maxY / step) * labelWidth ) > axisHeight ) nextStep(step);
+
+            if (axisHeight > labelWidth*2) //Avoid insane iterations
+                while( ( qCeil(maxY / step) * labelWidth ) > axisHeight ) nextStep(step);
         }
 
         QwtValueList xytick[QwtScaleDiv::NTickTypes];
@@ -2823,7 +2826,9 @@ AllPlot::setYMax()
             QFontMetrics labelWidthMetric = QFontMetrics( QwtPlot::axisFont(yLeft) );
             int labelWidth = labelWidthMetric.width( "888 " );
             ymax *= 1.05;
-            while((qCeil(ymax / step) * labelWidth) > axisHeight) nextStep(step);
+
+            if (axisHeight>labelWidth*2) //Avoid insane iterations
+                while((qCeil(ymax / step) * labelWidth) > axisHeight) nextStep(step);
         }
 
         QwtValueList xytick[QwtScaleDiv::NTickTypes];
@@ -2940,7 +2945,9 @@ AllPlot::setYMax()
             QFontMetrics labelWidthMetric = QFontMetrics( QwtPlot::axisFont(yRight) );
             int labelWidth = labelWidthMetric.width( "888 " );
             ymax *= 1.05;
-            while((qCeil(ymax / step) * labelWidth) > axisHeight) nextStep(step);
+
+            if (axisHeight>labelWidth*2) //Avoid insane iterations
+                while((qCeil(ymax / step) * labelWidth) > axisHeight) nextStep(step);
         }
 
         QwtValueList xytick[QwtScaleDiv::NTickTypes];
@@ -2993,7 +3000,9 @@ AllPlot::setYMax()
         if (axisHeight) {
             QFontMetrics labelWidthMetric = QFontMetrics( QwtPlot::axisFont(yLeft) );
             int labelWidth = labelWidthMetric.width( (ymax > 1000) ? " 8888 " : " 888 " );
-            while( ( qCeil( (ymax - ymin ) / step) * labelWidth ) > axisHeight ) nextStep(step);
+
+            if (axisHeight>labelWidth*2) //Avoid insane iterations
+                while( ( qCeil( (ymax - ymin ) / step) * labelWidth ) > axisHeight ) nextStep(step);
         }
 
         QwtValueList xytick[QwtScaleDiv::NTickTypes];

--- a/src/ComparePane.cpp
+++ b/src/ComparePane.cpp
@@ -30,6 +30,7 @@
 #include "TimeUtils.h"
 #include "Units.h"
 #include "Zones.h"
+#include "Utils.h"
 
 #include <QCheckBox>
 #include <QFormLayout>
@@ -228,9 +229,10 @@ ComparePane::refreshTable()
                 // check for both original and translated
                 if (!(m->units(context->athlete->useMetricUnits) == "seconds" || m->units(context->athlete->useMetricUnits) == tr("seconds")))
                     units = m->units(context->athlete->useMetricUnits);
-                QTextEdit name(m->name()); // process html encoding of(TM)
-                if (units != "") list << QString("%1 (%2)").arg(name.toPlainText()).arg(units);
-                else list << QString("%1").arg(name.toPlainText());
+
+                QString name( Utils::unprotect(m->name()));
+                if (units != "") list << QString("%1 (%2)").arg(name).arg(units);
+                else list << QString("%1").arg(name);
             }
         }
 
@@ -396,9 +398,9 @@ ComparePane::refreshTable()
                 QString units;
                 if (!(m->units(context->athlete->useMetricUnits) == "seconds" || m->units(context->athlete->useMetricUnits) == tr("seconds")))
                     units = m->units(context->athlete->useMetricUnits);
-                QTextEdit name(m->name()); // process html encoding of(TM)
-                if (units != "") list << QString("%1 (%2)").arg(name.toPlainText()).arg(units);
-                else list << QString("%1").arg(name.toPlainText());
+                QString name( Utils::unprotect(m->name()));
+                if (units != "") list << QString("%1 (%2)").arg(name).arg(units);
+                else list << QString("%1").arg(name);
             }
         }
 

--- a/src/ErgFile.cpp
+++ b/src/ErgFile.cpp
@@ -27,6 +27,7 @@
 
 #include <stdint.h>
 #include "Units.h"
+#include "Utils.h"
 
 // Supported file types
 static QStringList supported;
@@ -607,24 +608,6 @@ ErgFile::Sections()
     return returning;
 }
 
-// when writing xml...
-static QString xmlprotect(QString string)
-{
-    QTextEdit trademark("&#8482;"); // process html encoding of(TM)
-    QString tm = trademark.toPlainText();
-
-    QString s = string;
-    s.replace( tm, "&#8482;" );
-    s.replace( "&", "&amp;" );
-    s.replace( ">", "&gt;" );
-    s.replace( "<", "&lt;" );
-    s.replace( "\"", "&quot;" );
-    s.replace( "\'", "&apos;" );
-    s.replace( "\n", "\\n" );
-    s.replace( "\r", "\\r" );
-    return s;
-}
-
 bool
 ErgFile::save(QStringList &errors)
 {
@@ -822,13 +805,13 @@ ErgFile::save(QStringList &errors)
         out << "<workout_file>\n";
 
         // metadata at top
-        if (Name != "") out << "    <name>"<<xmlprotect(Name)<<"</name>\n";
-        if (Source != "") out << "    <author>"<<xmlprotect(Source)<<"</author>\n";
-        if (Description != "") out << "    <description>"<<xmlprotect(Description)<<"</description>\n";
+        if (Name != "") out << "    <name>"<<Utils::xmlprotect(Name)<<"</name>\n";
+        if (Source != "") out << "    <author>"<<Utils::xmlprotect(Source)<<"</author>\n";
+        if (Description != "") out << "    <description>"<<Utils::xmlprotect(Description)<<"</description>\n";
         if (Tags.count()) {
             out << "    <tags>\n";
             foreach(QString tag, Tags)
-                out << "        <tag>"<<xmlprotect(tag)<<"</tag>\n";
+                out << "        <tag>"<<Utils::xmlprotect(tag)<<"</tag>\n";
             out << "    </tags>\n";
         }
 

--- a/src/HistogramWindow.cpp
+++ b/src/HistogramWindow.cpp
@@ -20,6 +20,8 @@
 #include "HistogramWindow.h"
 #include "Specification.h"
 #include "HelpWhatsThis.h"
+#include "Utils.h"
+
 
 // predefined deltas for each series
 static const double wattsDelta = 1.0;
@@ -180,8 +182,7 @@ HistogramWindow::HistogramWindow(Context *context, bool rangemode) : GcChartWind
 
             const RideMetric *m = factory.rideMetric(factory.metricName(i));
 
-            QTextEdit processHTML(m->name()); // process html encoding of(TM)
-            QString processed = processHTML.toPlainText();
+            QString processed(Utils::unprotect(m->name()));
 
             QTreeWidgetItem *add;
             add = new QTreeWidgetItem(distMetricTree->invisibleRootItem());

--- a/src/LTMChartParser.cpp
+++ b/src/LTMChartParser.cpp
@@ -20,6 +20,7 @@
 #include "LTMSettings.h"
 #include "LTMTool.h"
 #include "Athlete.h"
+#include "Utils.h"
 
 #include <QDate>
 #include <QDebug>
@@ -73,25 +74,6 @@ bool LTMChartParser::endDocument()
     return true;
 }
 
-// static helper to protect special xml characters
-// ideally we would use XMLwriter to do this but
-// the file format is trivial and this implementation
-// is easier to follow and modify... for now.
-static QString xmlprotect(QString string)
-{
-    QTextEdit trademark("&#8482;"); // process html encoding of(TM)
-    QString tm = trademark.toPlainText();
-
-    QString s = string;
-    s.replace( tm, "&#8482;" );
-    s.replace( "&", "&amp;" );
-    s.replace( ">", "&gt;" );
-    s.replace( "<", "&lt;" );
-    s.replace( "\"", "&quot;" );
-    s.replace( "\'", "&apos;" );
-    return s;
-}
-
 //
 // Write out the charts.xml file
 //
@@ -122,7 +104,7 @@ LTMChartParser::serialize(QString filename, QList<LTMSettings> charts)
     // write out to file
     foreach (LTMSettings chart, charts) {
 
-        out <<"\t<chart name=\"" << xmlprotect(chart.name) <<"\">\"";
+        out <<"\t<chart name=\"" << Utils::xmlprotect(chart.name) <<"\">\"";
         // chart name
         QByteArray marshall;
         QDataStream s(&marshall, QIODevice::WriteOnly);
@@ -152,7 +134,7 @@ LTMChartParser::serializeToQString(QString* string, QList<LTMSettings> charts)
     // write out to file
     foreach (LTMSettings chart, charts) {
 
-        out <<"\t<chart name=\"" << xmlprotect(chart.name) <<"\">\"";
+        out <<"\t<chart name=\"" << Utils::xmlprotect(chart.name) <<"\">\"";
         // chart name
         QByteArray marshall;
         QDataStream s(&marshall, QIODevice::WriteOnly);

--- a/src/LTMPlot.cpp
+++ b/src/LTMPlot.cpp
@@ -31,6 +31,7 @@
 #include "Colors.h"
 #include "IndendPlotMarker.h"
 #include "DataFilter.h" // formulas
+#include "Utils.h"
 
 #include "PMCData.h" // for LTS/STS calculation
 #include "Zones.h"
@@ -3521,8 +3522,7 @@ LTMPlot::pointHover(QwtPlotCurve *curve, int index)
 
                 // BikeScore, RI and Daniels Points have no units
                 if (units == "" && metric != NULL) {
-                    QTextEdit processHTML(factory.rideMetric(c.key())->name());
-                    units  = processHTML.toPlainText();
+                    units  = Utils::unprotect(factory.rideMetric(c.key())->name());
                 }
                 break;
             }

--- a/src/LTMPopup.cpp
+++ b/src/LTMPopup.cpp
@@ -22,6 +22,7 @@
 #include "Specification.h"
 #include "RideCache.h"
 #include "RideFileCache.h" // for RideBest
+#include "Utils.h"
 
 LTMPopup::LTMPopup(Context *context) : QWidget(context->mainWindow), context(context)
 {
@@ -126,8 +127,8 @@ LTMPopup::setData(Specification spec, const RideMetric *metric, QString title)
     rides->setHorizontalHeaderItem(0,h);
 
     // value & process html encoding of(TM)
-    QTextEdit name(metric->name());
-    h = new QTableWidgetItem(name.toPlainText(), QTableWidgetItem::Type);
+    QString name(Utils::unprotect(metric->name()));
+    h = new QTableWidgetItem(name, QTableWidgetItem::Type);
 
     rides->setHorizontalHeaderItem(1,h);
 

--- a/src/LTMSettings.cpp
+++ b/src/LTMSettings.cpp
@@ -21,6 +21,7 @@
 #include "LTMTool.h"
 #include "Context.h"
 #include "LTMChartParser.h"
+#include "Utils.h"
 
 #include <QtGui>
 #include <qwt_plot.h>
@@ -148,11 +149,11 @@ LTMSettings::translateMetrics(bool useMetricUnits)
         const RideMetric *m = factory.rideMetric(metrics[j].symbol);
         if (m) {
             // set name, units only if there was a description before
-            QTextEdit processHTMLname(m->name());
+            QString name(Utils::unprotect(m->name()));
             // uname is replaced only if it matches english name
             if (metrics[j].uname == m->internalName())
-                metrics[j].uname = processHTMLname.toPlainText();
-            metrics[j].name = processHTMLname.toPlainText();
+                metrics[j].uname = name;
+            metrics[j].name = name;
             // uunits is replaced only if it matches unit,
             // ir units are not saved it don't translate uunits
             if (metrics[j].uunits == metrics[j].units)

--- a/src/LTMTool.cpp
+++ b/src/LTMTool.cpp
@@ -25,6 +25,7 @@
 #include "Tab.h"
 #include "RideNavigator.h"
 #include "HelpWhatsThis.h"
+#include "Utils.h"
 
 #include <QApplication>
 #include <QtGui>
@@ -184,8 +185,8 @@ LTMTool::LTMTool(Context *context, LTMSettings *settings) : QWidget(context->mai
         adds.smooth = false;
         adds.trendtype = 0;
         adds.topN = 1; // show top 1 by default always
-        QTextEdit processHTML(adds.metric->name()); // process html encoding of(TM)
-        adds.name   = processHTML.toPlainText();
+
+        adds.name   = Utils::unprotect(adds.metric->name());
 
         // set default for the user overiddable fields
         adds.uname  = adds.name;

--- a/src/Pages.cpp
+++ b/src/Pages.cpp
@@ -43,6 +43,7 @@
 #endif
 #include "LocalFileStore.h"
 #include "Secrets.h"
+#include "Utils.h"
 
 //
 // Main Config Page - tabs for each sub-page
@@ -2325,8 +2326,7 @@ IntervalMetricsPage::IntervalMetricsPage(QWidget *parent) :
         if (selectedMetrics.contains(symbol))
             continue;
         QSharedPointer<RideMetric> m(factory.newMetric(symbol));
-        QTextEdit name(m->name()); // process html encoding of(TM)
-        QListWidgetItem *item = new QListWidgetItem(name.toPlainText());
+        QListWidgetItem *item = new QListWidgetItem(Utils::unprotect(m->name()));
         item->setData(Qt::UserRole, symbol);
         availList->addItem(item);
     }
@@ -2334,8 +2334,7 @@ IntervalMetricsPage::IntervalMetricsPage(QWidget *parent) :
         if (!factory.haveMetric(symbol))
             continue;
         QSharedPointer<RideMetric> m(factory.newMetric(symbol));
-        QTextEdit name(m->name());  // process html encoding of(TM)
-        QListWidgetItem *item = new QListWidgetItem(name.toPlainText());
+        QListWidgetItem *item = new QListWidgetItem(Utils::unprotect(m->name()));
         item->setData(Qt::UserRole, symbol);
         selectedList->addItem(item);
     }
@@ -2522,8 +2521,7 @@ BestsMetricsPage::BestsMetricsPage(QWidget *parent) :
         if (selectedMetrics.contains(symbol))
             continue;
         QSharedPointer<RideMetric> m(factory.newMetric(symbol));
-        QTextEdit name(m->name()); //  process html encoding of(TM)
-        QListWidgetItem *item = new QListWidgetItem(name.toPlainText());
+        QListWidgetItem *item = new QListWidgetItem(Utils::unprotect(m->name()));
         item->setData(Qt::UserRole, symbol);
         availList->addItem(item);
     }
@@ -2531,8 +2529,7 @@ BestsMetricsPage::BestsMetricsPage(QWidget *parent) :
         if (!factory.haveMetric(symbol))
             continue;
         QSharedPointer<RideMetric> m(factory.newMetric(symbol));
-        QTextEdit name(m->name()); //  process html encoding of(TM)
-        QListWidgetItem *item = new QListWidgetItem(name.toPlainText());
+        QListWidgetItem *item = new QListWidgetItem(Utils::unprotect(m->name()));
         item->setData(Qt::UserRole, symbol);
         selectedList->addItem(item);
     }
@@ -2898,8 +2895,7 @@ SummaryMetricsPage::SummaryMetricsPage(QWidget *parent) :
         if (selectedMetrics.contains(symbol))
             continue;
         QSharedPointer<RideMetric> m(factory.newMetric(symbol));
-        QTextEdit name(m->name()); //  process html encoding of(TM)
-        QListWidgetItem *item = new QListWidgetItem(name.toPlainText());
+        QListWidgetItem *item = new QListWidgetItem(Utils::unprotect(m->name()));
         item->setData(Qt::UserRole, symbol);
         availList->addItem(item);
     }
@@ -2907,8 +2903,7 @@ SummaryMetricsPage::SummaryMetricsPage(QWidget *parent) :
         if (!factory.haveMetric(symbol))
             continue;
         QSharedPointer<RideMetric> m(factory.newMetric(symbol));
-        QTextEdit name(m->name()); //  process html encoding of(TM)
-        QListWidgetItem *item = new QListWidgetItem(name.toPlainText());
+        QListWidgetItem *item = new QListWidgetItem(Utils::unprotect(m->name()));
         item->setData(Qt::UserRole, symbol);
         selectedList->addItem(item);
     }

--- a/src/SearchBox.cpp
+++ b/src/SearchBox.cpp
@@ -90,7 +90,7 @@ SearchBox::SearchBox(Context *context, QWidget *parent, bool nochooser)
 
 static bool insensitiveLessThan(const QString &a, const QString &b)
 {
-    return a.toLower() < b.toLower();
+    return (QString::compare(a,b,Qt::CaseInsensitive)<0);
 }
 
 void

--- a/src/SpecialFields.cpp
+++ b/src/SpecialFields.cpp
@@ -18,6 +18,7 @@
 
 #include "SpecialFields.h"
 #include "RideMetric.h"
+#include "Utils.h"
 
 #include <QTextEdit>
 
@@ -64,16 +65,14 @@ SpecialFields::SpecialFields()
     // now add all the metric fields (for metric overrides)
     const RideMetricFactory &factory = RideMetricFactory::instance();
 
-    QTextEdit processHTML;
-    QTextEdit processHTMLinternal;
-
     for (int i=0; i<factory.metricCount(); i++) {
         const RideMetric *add = factory.rideMetric(factory.metricName(i));
-        processHTML.setText(add->name());
-        processHTMLinternal.setText(add->internalName());
+
+        QString name(Utils::unprotect(add->name()));
+        QString internal(Utils::unprotect(add->internalName()));
         // add->internalName() used for compatibility win metadata.xml, could be replaced by factory.metricName(i) or add->symbol()
-        namesmap.insert(processHTMLinternal.toPlainText(), processHTML.toPlainText());
-        metricmap.insert(processHTMLinternal.toPlainText(), add);
+        namesmap.insert(internal, name);
+        metricmap.insert(internal, add);
     }
 
     model_ = new QStringListModel;

--- a/src/TreeMapWindow.cpp
+++ b/src/TreeMapWindow.cpp
@@ -107,6 +107,7 @@ TreeMapWindow::TreeMapWindow(Context *context) :
 
     // initialise the metrics catalogue and user selector
     const RideMetricFactory &factory = RideMetricFactory::instance();
+    QTextEdit title;
     for (int i = 0; i < factory.metricCount(); ++i) {
 
         QTreeWidgetItem *add;
@@ -116,7 +117,7 @@ TreeMapWindow::TreeMapWindow(Context *context) :
         // I know it is confusing, but changing it will mean changing it absolutely
         // everywhere. Just remember - in the factory "name" refers to symbol and
         // if you want the user friendly metric description you get it via the metric
-        QTextEdit title(factory.rideMetric(factory.metricName(i))->name()); // to handle HTML
+        title.setText(factory.rideMetric(factory.metricName(i))->name()); // to handle HTML
         add->setText(0, title.toPlainText()); // long name
         add->setText(1, factory.metricName(i)); // symbol (hidden)
 

--- a/src/UserData.cpp
+++ b/src/UserData.cpp
@@ -21,6 +21,7 @@
 #include "RideNavigator.h"
 #include "Tab.h"
 #include "HelpWhatsThis.h"
+#include "Utils.h"
 
 #include <QTextEdit> // for parsing trademark symbols (!)
 
@@ -255,65 +256,23 @@ EditUserDataDialog::setButtonIcon(QColor color)
     seriesColor->setFixedWidth(34);
 }
 
-//
-// XML settings; read, write, parse, protect
-//
-static QString xmlprotect(QString string)
-{
-    QTextEdit trademark("&#8482;"); // process html encoding of(TM)
-    QString tm = trademark.toPlainText();
-
-    QString s = string;
-    s.replace( tm, "&#8482;" );
-    s.replace( "&", "&amp;" );
-    s.replace( ">", "&gt;" );
-    s.replace( "<", "&lt;" );
-    s.replace( "\"", "&quot;" );
-    s.replace( "\'", "&apos;" );
-    s.replace( "\n", "\\n" );
-    s.replace( "\r", "\\r" );
-    return s;
-}
-
-static QString unprotect(QString buffer)
-{
-    // get local TM character code
-    QTextEdit trademark("&#8482;"); // process html encoding of(TM)
-    QString tm = trademark.toPlainText();
-
-    // remove quotes
-    QString s = buffer.trimmed();
-
-    // replace html (TM) with local TM character
-    s.replace( "&#8482;", tm );
-
-    s.replace( "\\n", "\n" );
-    s.replace( "\\r", "\r" );
-    // html special chars are automatically handled
-    // NOTE: other special characters will not work
-    // cross-platform but will work locally, so not a biggie
-    // i.e. if the default charts.xml has a special character
-    // in it it should be added here
-    return s;
-}
-
 // output a snippet
-QString 
+QString
 UserData::settings() const
 {
     QString returning;
-    returning = "<userdata name=\"" + xmlprotect(name) + "\" units=\"" +  xmlprotect(units)+ "\"";
+    returning = "<userdata name=\"" + Utils::xmlprotect(name) + "\" units=\"" +  Utils::xmlprotect(units)+ "\"";
     returning += " color=\""+ color.name() + "\">";
-    returning += xmlprotect(formula);
+    returning += Utils::xmlprotect(formula);
     returning += "</userdata>";
 
-    // xml snippet 
+    // xml snippet
     return returning;
 
 }
 
 // read in a snippet
-void 
+void
 UserData::setSettings(QString settings)
 {
     // need to parse the user data xml snipper
@@ -344,8 +303,8 @@ bool UserDataParser::startElement( const QString&, const QString&, const QString
     for(int i=0; i<attrs.count(); i++) {
         // only 3 attributes for now
         if (attrs.qName(i) == "color") here->color = QColor(attrs.value(i));
-        if (attrs.qName(i) == "name")  here->name  = unprotect(attrs.value(i));
-        if (attrs.qName(i) == "units") here->units = unprotect(attrs.value(i));
+        if (attrs.qName(i) == "name")  here->name  = Utils::unprotect(attrs.value(i));
+        if (attrs.qName(i) == "units") here->units = Utils::unprotect(attrs.value(i));
     }
     return true;
 }
@@ -353,17 +312,17 @@ bool UserDataParser::startElement( const QString&, const QString&, const QString
 bool UserDataParser::endElement( const QString&, const QString&, const QString &) { return true; }
 bool UserDataParser::characters( const QString&chrs) { here->formula += chrs; return true; }
 bool UserDataParser::startDocument() { here->formula.clear(); return true; }
-bool UserDataParser::endDocument() { here->formula = unprotect(here->formula); return true; }
+bool UserDataParser::endDocument() { here->formula = Utils::unprotect(here->formula); return true; }
 
 // set / get the current ride item
-RideItem* 
+RideItem*
 UserData::getRideItem() const
 {
     return rideItem;
 }
 
 // set ride item and therefore set the data
-void 
+void
 UserData::setRideItem(RideItem*m)
 {
     rideItem = m;

--- a/src/UserMetricParser.cpp
+++ b/src/UserMetricParser.cpp
@@ -19,6 +19,7 @@
 #include "UserMetricParser.h"
 #include "UserMetricSettings.h"
 #include "Context.h"
+#include "Utils.h"
 
 #include <QDate>
 #include <QDebug>
@@ -88,25 +89,6 @@ bool UserMetricParser::endDocument()
     return true;
 }
 
-// static helper to protect special xml characters
-// ideally we would use XMLwriter to do this but
-// the file format is trivial and this implementation
-// is easier to follow and modify... for now.
-static QString xmlprotect(QString string)
-{
-    QTextEdit trademark("&#8482;"); // process html encoding of(TM)
-    QString tm = trademark.toPlainText();
-
-    QString s = string;
-    s.replace( tm, "&#8482;" );
-    s.replace( "&", "&amp;" );
-    s.replace( ">", "&gt;" );
-    s.replace( "<", "&lt;" );
-    s.replace( "\"", "&quot;" );
-    s.replace( "\'", "&apos;" );
-    return s;
-}
-
 //
 // Write out the charts.xml file
 //
@@ -138,22 +120,22 @@ UserMetricParser::serialize(QString filename, QList<UserMetricSettings> metrics)
     foreach (UserMetricSettings metric, metrics) {
 
         // symbol
-        out <<"\t<usermetric symbol=\"" << xmlprotect(metric.symbol) <<"\" ";
+        out <<"\t<usermetric symbol=\"" << Utils::xmlprotect(metric.symbol) <<"\" ";
 
-        out <<"name=\"" << xmlprotect(metric.name) << "\" ";
-        out <<"description=\"" << xmlprotect(metric.description) << "\" ";
-        out <<"unitsMetric=\"" << xmlprotect(metric.unitsMetric) << "\" ";
-        out <<"unitsImperial=\"" << xmlprotect(metric.unitsImperial) << "\" ";
+        out <<"name=\"" << Utils::xmlprotect(metric.name) << "\" ";
+        out <<"description=\"" << Utils::xmlprotect(metric.description) << "\" ";
+        out <<"unitsMetric=\"" << Utils::xmlprotect(metric.unitsMetric) << "\" ";
+        out <<"unitsImperial=\"" << Utils::xmlprotect(metric.unitsImperial) << "\" ";
         out <<"aggzero=\"" << (metric.aggzero ? 1 : 0) << "\" ";
         out <<"istime=\"" << (metric.istime ? 1 : 0) << "\" ";
         out <<"precision=\"" << metric.precision << "\" ";
         out <<"type=\"" << metric.type << "\" ";
         out <<"conversion=\"" << metric.conversion << "\" ";
         out <<"conversionSum=\"" << metric.conversionSum << "\" ";
-        out <<"fingerprint=\"" << xmlprotect(metric.fingerprint) << "\" ";
+        out <<"fingerprint=\"" << Utils::xmlprotect(metric.fingerprint) << "\" ";
 
         out << ">\n";
-        out << xmlprotect(metric.program);
+        out << Utils::xmlprotect(metric.program);
         out << "\n</usermetric>\n";
     }
 

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) Mark Liversedge (liversedge@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <QTextEdit>
+
+namespace Utils
+{
+// when writing xml...
+QString xmlprotect(const QString &string)
+{
+    static QString tm = QTextEdit("&#8482;").toPlainText();
+    std::string stm(tm.toStdString());
+
+    QString s = string;
+    s.replace( tm, "&#8482;" );
+    s.replace( "&", "&amp;" );
+    s.replace( ">", "&gt;" );
+    s.replace( "<", "&lt;" );
+    s.replace( "\"", "&quot;" );
+    s.replace( "\'", "&apos;" );
+    s.replace( "\n", "\\n" );
+    s.replace( "\r", "\\r" );
+    return s;
+}
+
+QString unprotect(const QString &buffer)
+{
+    // get local TM character code
+    // process html encoding of(TM)
+    static QString tm = QTextEdit("&#8482;").toPlainText();
+
+    // remove leading/trailing whitespace
+    QString s = buffer.trimmed();
+    // remove enclosing quotes
+    if (s.startsWith(QChar('\"')) && s.endsWith(QChar('\"')))
+    {
+        s.remove(0,1);
+        s.chop(1);
+    }
+
+    // replace html (TM) with local TM character
+    s.replace( "&#8482;", tm );
+
+    s.replace( "\\n", "\n" );
+    s.replace( "\\r", "\r" );
+    // html special chars are automatically handled
+    // NOTE: other special characters will not work
+    // cross-platform but will work locally, so not a biggie
+    // i.e. if the default charts.xml has a special character
+    // in it it should be added here
+    return s;
+}
+
+};
+

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Mark Liversedge (liversedge@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef _GC_Utils_h
+#define _GC_Utils_h
+
+// Common shared utility functions
+
+namespace Utils
+{
+    QString xmlprotect(const QString &string);
+    QString unprotect(const QString &buffer);
+};
+
+
+#endif

--- a/src/src.pro
+++ b/src/src.pro
@@ -769,6 +769,7 @@ HEADERS  += \
         UserData.h \
         UserMetricParser.h \
         UserMetricSettings.h \
+        Utils.h \
         VDOTCalculator.h \
         VeloHeroUploader.h \
         VideoLayoutParser.h \
@@ -1055,7 +1056,8 @@ SOURCES += \
         WPrime.cpp \
         Zones.cpp \
         ZwoParser.cpp \
-    TrainBottom.cpp
+        TrainBottom.cpp \
+        Utils.cpp
 
 
 ###======================================


### PR DESCRIPTION
Some more simple performance improvements that make the startup a bit snappier.
1. Helps startup time a bit more, mainly by removing all of the QTextEdit controls used for html esacping and moving them into a utils namespace.
2. Stopped excessive looping in setYMax where axis height was small.
