### PR TITLE
Add detach and attach options to VideoWindow widget

### DIFF
--- a/src/VideoWindow.cpp
+++ b/src/VideoWindow.cpp
@@ -145,6 +145,12 @@ VideoWindow::VideoWindow(Context *context)  :
     layout->addWidget(wd);
 #endif
 
+    detachAction = menu->addAction(tr("Detach"), this, SLOT(detachPlayer()));
+    attachAction = menu->addAction(tr("Attach"), this, SLOT(attachPlayer()));
+
+    attachAction->setEnabled(false);
+    detachAction->setEnabled(true);
+
     if (init) {
         // get updates..
         connect(context, SIGNAL(telemetryUpdate(RealtimeData)), this, SLOT(telemetryUpdate(RealtimeData)));
@@ -186,6 +192,51 @@ VideoWindow::~VideoWindow()
     delete mp;
     delete wd;
 #endif
+}
+
+void VideoWindow::detachPlayer()
+{
+    attachAction->setEnabled(true);
+    detachAction->setEnabled(false);
+
+#ifdef GC_VIDEO_VLC
+    QWidget *wd=x11Container;
+#elif WIN32
+    QWidget *wd=container;
+#elif GC_VIDEO_QT5
+    QWidget *wd=wd;
+#endif
+
+    QPoint pos = wd->pos();
+    QLayout *l = layout();
+
+    curSize = wd->size();
+    l->removeWidget(wd);
+
+    wd->setWindowFlags(Qt::Tool|Qt::CustomizeWindowHint|Qt::WindowMinMaxButtonsHint);
+    wd->move(pos);
+    wd->resize(curSize);
+    wd->show();
+
+    setFixedSize(QSize(100,48));
+}
+void VideoWindow::attachPlayer()
+{
+    attachAction->setEnabled(false);
+    detachAction->setEnabled(true);
+
+#ifdef GC_VIDEO_VLC
+    QWidget *wd=x11Container;
+#elif WIN32
+    QWidget *wd=container;
+#elif GC_VIDEO_QT5
+    QWidget *wd=wd;
+#endif
+
+    QLayout *l = layout();
+    wd->setWindowFlags(Qt::Widget);
+    l->addWidget(wd);
+    setFixedSize(curSize);
 }
 
 void VideoWindow::resizeEvent(QResizeEvent * )

--- a/src/VideoWindow.h
+++ b/src/VideoWindow.h
@@ -174,6 +174,8 @@ class VideoWindow : public GcWindow
         void telemetryUpdate(RealtimeData rtd);
         void seekPlayback(long ms);
         void mediaSelected(QString filename);
+        void detachPlayer();
+        void attachPlayer();
 
     protected:
 
@@ -183,9 +185,11 @@ class VideoWindow : public GcWindow
         int curPosition;
         RideFilePoint rfp;
         float currentVideoRate;
-
+        QSize curSize;
         // passed from Context *
         Context *context;
+        QAction *detachAction;
+        QAction *attachAction;
 
         bool m_MediaChanged;
 


### PR DESCRIPTION
Minor hack, adds an option on the VideoWindow mini-menu allowing it to be detached and placed on a separate screen.
When detached the widget shrinks down, 