### PR TITLE
A few more low-hanging performance tweaks.

### DIFF
--- a/src/Core/RideDB.l
+++ b/src/Core/RideDB.l
@@ -40,25 +40,31 @@
 static QString unprotect(char *string)
 {
     // sending UTF-8 to FLEX demands symetric conversion back to QString
-    QString string2 = QString::fromUtf8(string);
-
+#if QT_VERSION < 0x050000
+    QString s = QString::fromUtf8(string);
+#else
+    QString s(string);
+#endif
     // this is a lexer string so it will be enclosed
     // in quotes. Lets strip those first
-    QString s = string2.mid(1,string2.length()-2);
+    s.remove(0,1);
+    s.chop(1);
 
     // does it end with a space (to avoid token conflict) ?
-    if (s.endsWith(" ")) s = s.mid(0, s.length()-1);
+    if (s.endsWith(" ")) s.chop(1);
 
     // now un-escape the control characters
-    s.replace("\\t", "\t");  // tab
-    s.replace("\\n", "\n");  // newline
-    s.replace("\\r", "\r");  // carriage-return
-    s.replace("\\b", "\b");  // backspace
-    s.replace("\\f", "\f");  // formfeed
-    s.replace("\\/", "/");   // solidus
-    s.replace("\\\"", "\""); // quote
-    s.replace("\\\\", "\\"); // backslash
-
+    if (s.contains("\\"))
+    {
+        s.replace("\\t", "\t");  // tab
+        s.replace("\\n", "\n");  // newline
+        s.replace("\\r", "\r");  // carriage-return
+        s.replace("\\b", "\b");  // backspace
+        s.replace("\\f", "\f");  // formfeed
+        s.replace("\\/", "/");   // solidus
+        s.replace("\\\"", "\""); // quote
+        s.replace("\\\\", "\\"); // backslash
+    }
     return s;
 }
 

--- a/src/Core/RideDB.l
+++ b/src/Core/RideDB.l
@@ -40,6 +40,7 @@
 static QString unprotect(char *string)
 {
     // sending UTF-8 to FLEX demands symetric conversion back to QString
+    // fromUtf8 is the default behaviour for the char* QString constructor on Qt5
 #if QT_VERSION < 0x050000
     QString s = QString::fromUtf8(string);
 #else

--- a/src/FileIO/JsonRideFile.l
+++ b/src/FileIO/JsonRideFile.l
@@ -36,11 +36,21 @@
 // interactions
 #define YYSTYPE QString
 
+#if QT_VERSION < 0x050000
+#define QSTRINGUTF8(x) QString::fromUtf8(x)
+#else
+#define QSTRINGUTF8(x) QString(x)
+#endif
+
 // Un-Escape special characters (JSON compliance)
 static QString unprotect(char *string)
 {
     // sending UTF-8 to FLEX demands symetric conversion back to QString
+#if QT_VERSION < 0x050000
     QString string2 = QString::fromUtf8(string);
+#else
+    QString string2(string);
+#endif
 
     // this is a lexer string so it will be enclosed
     // in quotes. Lets strip those first
@@ -152,10 +162,9 @@ void JsonRideFilefree (void * ptr , yyscan_t /*scanner*/)
 \"RCON\"            return RCON;
 \"RVERT\"           return RVERT;
 \"RCAD\"            return RCAD;
-[-+]?[0-9]+                     { *yylval = QString::fromUtf8(yytext); return JS_INTEGER; }
-[-+]?[0-9]+e-[0-9]+             { *yylval = QString::fromUtf8(yytext); return JS_FLOAT;   }
-[-+]?[0-9]+\.[-+e0-9]*          { *yylval = QString::fromUtf8(yytext); return JS_FLOAT;   }
-
+[-+]?[0-9]+                     { *yylval = QSTRINGUTF8(yytext); return JS_INTEGER; }
+[-+]?[0-9]+e-[0-9]+             { *yylval = QSTRINGUTF8(yytext); return JS_FLOAT;   }
+[-+]?[0-9]+\.[-+e0-9]*          { *yylval = QSTRINGUTF8(yytext); return JS_FLOAT;   }
 \"([^\"]|\\\")*\"               { *yylval = unprotect(yytext); return JS_STRING;  } /* contains non-quotes or escaped-quotes */
 [ \n\t\r]                       ;               /* we just ignore whitespace */
 .                               return yytext[0]; /* any other character, typically :, { or } */

--- a/src/FileIO/JsonRideFile.l
+++ b/src/FileIO/JsonRideFile.l
@@ -36,6 +36,7 @@
 // interactions
 #define YYSTYPE QString
 
+// fromUtf8 is the default behaviour for the char* QString constructor on Qt5
 #if QT_VERSION < 0x050000
 #define QSTRINGUTF8(x) QString::fromUtf8(x)
 #else

--- a/src/FileIO/RideFile.cpp
+++ b/src/FileIO/RideFile.cpp
@@ -151,15 +151,20 @@ RideFile::isRun() const
 {
     // for now we just look at Sport and if there are any
     // running specific data series in the data
-    return (getTag("Sport", "") == "Run" || getTag("Sport", "") == tr("Run")) ||
-           (areDataPresent()->rvert || areDataPresent()->rcad || areDataPresent()->rcontact);
+
+    // we call this *a lot* and it doesn't change once we have the file, so only lookup once.
+    static bool isrun = (getTag("Sport", "") == "Run" || getTag("Sport", "") == tr("Run")) ||
+            (areDataPresent()->rvert || areDataPresent()->rcad || areDataPresent()->rcontact);
+    return isrun;
 }
 
 bool
 RideFile::isSwim() const
 {
     // for now we just look at Sport
-    return (getTag("Sport", "") == "Swim" || getTag("Sport", "") == tr("Swim"));
+    // we call this *a lot* and it doesn't change once we have the file, so only lookup once.
+    static bool isswim = (getTag("Sport", "") == "Swim" || getTag("Sport", "") == tr("Swim"));
+    return isswim;
 }
 
 QString

--- a/src/FileIO/RideFile.h
+++ b/src/FileIO/RideFile.h
@@ -191,6 +191,8 @@ class RideFile : public QObject // QObject to emit signals
         // the max gap to interpolate also passed as a parameter
         RideFile *resample(double recIntSecs, int interpolate=30);
 
+        enum filetype { unknown=0, swim, run };
+
         // Working with DATASERIES
         enum seriestype { secs=0, cad, cadd, hr, hrd, km, kph, kphd, nm, nmd, watts, wattsd,
                           alt, lon, lat, headwind, slope, temp, interval, NP, xPower, 
@@ -392,6 +394,7 @@ class RideFile : public QObject // QObject to emit signals
         void updateAvg(RideFilePoint* point);
 
         bool dstale; // is derived data up to date?
+        mutable filetype filetype_; // swim or run?
 
         // data required to compute headwind based on weather broadcast
         double windSpeed_, windHeading_;

--- a/src/Gui/RideNavigator.cpp
+++ b/src/Gui/RideNavigator.cpp
@@ -265,8 +265,10 @@ RideNavigator::resetView()
 
     // add metrics to the map
     const RideMetricFactory &factory = RideMetricFactory::instance();
+    QTextEdit convertor;
     for (int i=0; i<factory.metricCount(); i++) {
-        QString converted = QTextEdit(factory.rideMetric(factory.metricName(i))->name()).toPlainText();
+        convertor.setText(factory.rideMetric(factory.metricName(i))->name());
+        QString converted = convertor.toPlainText();
 
         // from sql column name to friendly metric name
         nameMap.insert(QString("%1").arg(factory.metricName(i)), converted);


### PR DESCRIPTION
Some more minor performance tweaks, mostly related to reducing intermediate string operations.

- isSwim and isRun are called a *colossal* number of times during file import, and each time are performing multiple string constructions and destructions and QMap lookups so only calculate this once since it won't change when a RideFile exists.
- fromUtf8 is now the default on Qt5.
- QTextEdit is very expensive to create, make once and re-use.