### PR TITLE
Fix build failure reported as #1829

### DIFF
--- a/qwt/src/src.pri
+++ b/qwt/src/src.pri
@@ -77,7 +77,6 @@ SOURCES += \
     qwt_scale_div.cpp \
     qwt_scale_draw.cpp \
     qwt_scale_map.cpp \
-    qwt_scale_map_table.h \
     qwt_spline.cpp \
     qwt_scale_engine.cpp \
     qwt_symbol.cpp \


### PR DESCRIPTION
This commit removes the (probably accidental) definition of qwt_scale_map_table.h as both a header and a source file, fixing the build failure that has been reported.