### PR TITLE
WorkoutWidget: increase x-axis length during workouts if needed

### DIFF
--- a/src/Train/WorkoutWidget.cpp
+++ b/src/Train/WorkoutWidget.cpp
@@ -207,6 +207,9 @@ WorkoutWidget::telemetryUpdate(RealtimeData rt)
         if (s > speedMax) speedMax=s;
         if (h > hrMax) hrMax=h;
 
+        // Do we need to increase plot x-axis max? (add 15 min at a time)
+        if (cadence.size() > maxVX_) setMaxVX(maxVX_ + 900);
+
         // replot
         update();
     }


### PR DESCRIPTION
This should fix rescaling when running more than one hour in manual erg/slope mode.

I hope it's ok to use cadence.size() as a metric of how long the workout is, should always be increased even if cadence is not available, right?