### PR TITLE
Fix "out-of-source" build

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -183,7 +183,7 @@ isEmpty(TS_DIR):TS_DIR = Resources/translations
 TSQM.name = lrelease ${QMAKE_FILE_IN}
 TSQM.input = TRANSLATIONS
 TSQM.output = $$TS_DIR/${QMAKE_FILE_BASE}.qm
-TSQM.commands = $$QMAKE_LRELEASE ${QMAKE_FILE_IN} -qm $$TS_DIR/${QMAKE_FILE_BASE}.qm
+TSQM.commands = $$QMAKE_LRELEASE ${QMAKE_FILE_IN}
 TSQM.CONFIG = no_link target_predeps
 QMAKE_EXTRA_COMPILERS += TSQM
 


### PR DESCRIPTION
... translation files are searched for in the "src" dir, but were created in the build dir

(I tested both out-of-source, in-source build - not sure if I missed a variant which required the previous approach),