### PR TITLE
LTMWindow: Fix missing include when building NOWEBKIT without GC_HAS_…

### DIFF
--- a/src/Charts/LTMWindow.cpp
+++ b/src/Charts/LTMWindow.cpp
@@ -38,6 +38,10 @@
 #include "GcUpgrade.h"
 #endif
 
+#ifdef NOWEBKIT
+#include <QWebEngineSettings>
+#endif
+
 #include <QtGui>
 #include <QString>
 #include <QDebug>


### PR DESCRIPTION
…CLOUD_DB