### PR TITLE
Use filename suffix to determine filetype if possible during export

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1409,21 +1409,43 @@ MainWindow::exportRide()
     RideFile *currentRide = currentTab->context->ride ? currentTab->context->ride->ride() : NULL;
     bool result=false;
 
-    int idx = allFormats.indexOf(getSuffix.cap(0));
-    if (idx>1) {
+    // Extract suffix from chosen file name and convert to lower case
+    QString fileNameSuffix;
+    int lastDot = fileName.lastIndexOf(".");
+    if (lastDot >=0) fileNameSuffix = fileName.mid(fileName.lastIndexOf(".")+1);
+    fileNameSuffix = fileNameSuffix.toLower();
 
-        result = RideFileFactory::instance().writeRideFile(currentTab->context, currentRide, file, getSuffix.cap(1));
+    // See if this suffix can be used to determine file type (not ok for csv since there are options)
+    bool useFileTypeSuffix = false;
+    if (!fileNameSuffix.isEmpty() && fileNameSuffix != "csv")
+    {
+        useFileTypeSuffix = rff.writeSuffixes().contains(fileNameSuffix);
+    }
 
-    } else if (idx==0){
+    if (useFileTypeSuffix)
+    {
+        result = RideFileFactory::instance().writeRideFile(currentTab->context, currentRide, file, fileNameSuffix);
+    }
+    else
+    {
+        // Use the value of drop down list to determine file type
+        int idx = allFormats.indexOf(getSuffix.cap(0));
 
-        CsvFileReader writer;
-        result = writer.writeRideFile(currentTab->context, currentRide, file, CsvFileReader::gc);
+        if (idx>1) {
 
-    } else if (idx==1){
+            result = RideFileFactory::instance().writeRideFile(currentTab->context, currentRide, file, getSuffix.cap(1));
 
-        CsvFileReader writer;
-        result = writer.writeRideFile(currentTab->context, currentRide, file, CsvFileReader::wprime);
+        } else if (idx==0){
 
+            CsvFileReader writer;
+            result = writer.writeRideFile(currentTab->context, currentRide, file, CsvFileReader::gc);
+
+        } else if (idx==1){
+
+            CsvFileReader writer;
+            result = writer.writeRideFile(currentTab->context, currentRide, file, CsvFileReader::wprime);
+
+        }
     }
 
     if (result == false) {


### PR DESCRIPTION
I'd like your thoughts on this, if you think it's a good idea or just confusing since it's not valid for all cases since there's multiple csv options. I do a lot of indoor rides and always export to tcx for Garmin Connect, and often I miss to select the right format since I kind of expect that it will "do the right this".

Basically it checks if the chosen filename has a suffix that matches a "file writer", if so it will write using that format. If not it defaults to the old behavior of using the format selected in the drop-down list.