### PR TITLE
Changed select latest activity to skip future activities

### DIFF
--- a/src/Gui/Tab.cpp
+++ b/src/Gui/Tab.cpp
@@ -92,7 +92,16 @@ Tab::Tab(Context *context) : QWidget(context->mainWindow), context(context)
     connect(context,SIGNAL(rideSelected(RideItem*)), this, SLOT(rideSelected(RideItem*)));
 
     // selects the latest ride in the list:
-    if (context->athlete->rideCache->rides().count() != 0) 
+    // first skipping those in the future
+    QDateTime now = QDateTime::currentDateTime();
+    for (int i=context->athlete->rideCache->rides().count(); i>0; --i) {
+        if (context->athlete->rideCache->rides()[i-1]->dateTime <= now) {
+            context->athlete->selectRideFile(context->athlete->rideCache->rides()[i-1]->fileName);
+            break;
+        }
+    }
+    // otherwise just the latest
+    if (context->currentRideItem() == NULL && context->athlete->rideCache->rides().count() != 0) 
         context->athlete->selectRideFile(context->athlete->rideCache->rides().last()->fileName);
 }
 


### PR DESCRIPTION
When there are (planned) activities with future days it is
annoying to start at the latest planned activity, this change
try to select the latest which is not in the future.