### PR TITLE
Fixed LTMPlot so By Week grouping starts on monday

### DIFF
--- a/src/Charts/LTMPlot.cpp
+++ b/src/Charts/LTMPlot.cpp
@@ -1232,7 +1232,7 @@ LTMPlot::setData(LTMSettings *set)
         // make start date always fall on a Monday
         if (settings->groupBy == LTM_WEEK) {
             int dow = settings->start.date().dayOfWeek(); // 1-7, where 1=monday
-            settings->start = QDateTime(settings->start.date().addDays(dow-1*-1));
+            settings->start = QDateTime(settings->start.date().addDays((dow-1)*-1));
         }
 
         // setup the xaxis at the bottom


### PR DESCRIPTION
instead of Wednesday due to missing parentheses

This was reported in https://groups.google.com/d/msg/golden-cheetah-users/wO8YmBtA0IE/ayRG7vQ2BgAJ and I could reproduce it.