### PR TITLE
Fixed HRV to HR in SML files

### DIFF
--- a/src/FileIO/SmlParser.cpp
+++ b/src/FileIO/SmlParser.cpp
@@ -278,8 +278,8 @@ SmlParser::endElement(const QString&, const QString&, const QString& qName)
             double rr = strRR.toDouble() / 1000.0;
             if (ewmaRR < 0.0) ewmaRR = rr;
             else ewmaRR += (rr - ewmaRR)/ewmaTC;
-            if (secs + rr >= trunc(secs) + 1.0) {
-                rideFile->setPointValue(rideFile->timeIndex(secs), rideFile->hr, round(60.0/ ewmaRR));
+            for (int i = 0; secs + rr >= trunc(secs) + i + 1; i++) {
+                rideFile->dataPoints()[rideFile->timeIndex(secs + i)]->hr = round(60.0/ ewmaRR);
             }
             secs += rr;
         }


### PR DESCRIPTION
To avoid HR gaps when < 60 bpm
Added test file with HRV and no HR