### PR TITLE
Adjust Laps for Garmin Swim FIT files

### DIFF
--- a/src/FileIO/SmlParser.cpp
+++ b/src/FileIO/SmlParser.cpp
@@ -114,6 +114,10 @@ SmlParser::endElement(const QString&, const QString&, const QString& qName)
             else if (buffer.contains("Swimming", Qt::CaseInsensitive))
                 rideFile->setTag("Sport", "Swim");
         }
+        else if (qName == "PoolLength")
+        {
+            rideFile->setTag("Pool Length", buffer);
+        }
         return true;
     }
     else if (qName == "Lap")


### PR DESCRIPTION
Use total duration for both length and lap messages to synch them,
even when using drill mode. Tested with Garmin Swim and 920xt files.
Garmin 310xt is special cased since it doesn't generate rest length messages
Add Pool Length in meters as metadata