### PR TITLE
Align interval bars plot with main plot

### DIFF
--- a/src/Charts/AllPlot.cpp
+++ b/src/Charts/AllPlot.cpp
@@ -7069,6 +7069,9 @@ AllPlot::intervalHover(IntervalItem *chosen)
 bool
 AllPlot::eventFilter(QObject *obj, QEvent *event)
 {
+    if (event->type() == QEvent::Resize) {
+        emit resized();
+    }
 
     // REFERENCE LINE FOR POWER
     if ((showPowerState<2 && scope == RideFile::none) || scope == RideFile::watts || scope == RideFile::aTISS || 

--- a/src/Charts/AllPlot.h
+++ b/src/Charts/AllPlot.h
@@ -660,6 +660,9 @@ class AllPlot : public QwtPlot
         void pointHover(QwtPlotCurve*, int);
         void intervalHover(IntervalItem *h);
 
+    signals:
+        void resized();
+
     protected:
 
         friend class ::AllPlotBackground;

--- a/src/Charts/AllPlotWindow.cpp
+++ b/src/Charts/AllPlotWindow.cpp
@@ -677,6 +677,8 @@ AllPlotWindow::AllPlotWindow(Context *context) :
     static_cast<QwtPlotCanvas*>(intervalPlot->canvas())->setBorderRadius(0);
     intervalPlot->setContentsMargins(0,0,0,0);
 
+    connect(allPlot, SIGNAL(resized()), this, SLOT(allPlotResized()));
+
     // tooltip on hover over point
     /*intervalPlot->tooltip = new LTMToolTip(QwtPlot::xBottom, QwtAxis::yLeft,
                                QwtPicker::VLineRubberBand,
@@ -3934,4 +3936,15 @@ AllPlotWindow::addPickers(AllPlot *_allPlot)
     connect(_allPlot->_canvasPicker, SIGNAL(pointHover(QwtPlotCurve*, int)), _allPlot, SLOT(pointHover(QwtPlotCurve*, int)));
     connect(_allPlot->tooltip, SIGNAL(moved(const QPoint &)), this, SLOT(plotPickerMoved(const QPoint &)));
     connect(_allPlot->tooltip, SIGNAL(appended(const QPoint &)), this, SLOT(plotPickerSelected(const QPoint &)));
+}
+
+void
+AllPlotWindow::allPlotResized()
+{
+    QwtPlotCanvas *allPlotCanvas = static_cast<QwtPlotCanvas *>(allPlot->canvas());
+    QwtScaleWidget *xAxis = allPlot->axisWidget(QwtAxisId(QwtPlot::xBottom));
+    QwtScaleDraw *xAxisScaleDraw = xAxis->scaleDraw();
+    int left = xAxis->x() + xAxisScaleDraw->pos().x() - 3;
+    int right = allPlot->width() - allPlotCanvas->width() - allPlotCanvas->x() + 1;
+    intervalPlot->setContentsMargins(left, 0, right, 0);
 }

--- a/src/Charts/AllPlotWindow.h
+++ b/src/Charts/AllPlotWindow.h
@@ -418,6 +418,7 @@ class AllPlotWindow : public GcChartWindow
         void addPickers(AllPlot *allPlot2);
         void plotPickerMoved(const QPoint &);
         void plotPickerSelected(const QPoint &);
+        void allPlotResized();
 };
 
 #endif // _GC_AllPlotWindow_h


### PR DESCRIPTION
This commit fixes the issue that the interval bars (in AllPlotInterval) are not correctly aligned
with the interval sections in the main plot (AllPlot). This is done by calculating the margins from
the main plotting area to the border and setting left and right margin of the interval plot
accordingly.