### PR TITLE
Save rim and tire size settings

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -224,6 +224,8 @@
 #define GC_LTS_DAYS                             "<athlete-preferences>LTSdays"
 #define GC_STS_DAYS                             "<athlete-preferences>STSdays"
 #define GC_CRANKLENGTH                  "<athlete-preferences>crankLength"
+#define GC_RIMSIZEIDX                   "<athlete-preferences>rimsizeidx"
+#define GC_TIRESIZEIDX                  "<athlete-preferences>tiresizeidx"
 #define GC_WHEELSIZE                    "<athlete-preferences>wheelsize"
 #define GC_USE_CP_FOR_FTP               "<athlete-preferences>cp/useforftp"                       // use CP for FTP
 #define GC_USE_CP_FOR_FTP_RUN           "<athlete-preferences>cp/useforftprun"                    // use CP for FTP

--- a/src/Gui/Pages.cpp
+++ b/src/Gui/Pages.cpp
@@ -1205,14 +1205,20 @@ AboutRiderPage::AboutRiderPage(QWidget *parent, Context *context) : QWidget(pare
     // Wheel size
     //
     QLabel *wheelSizeLabel = new QLabel(tr("Wheelsize"), this);
+
+    int rimSizeIdx = appsettings->cvalue(context->athlete->cyclist, GC_RIMSIZEIDX, 0).toInt();
+    int tireSizeIdx = appsettings->cvalue(context->athlete->cyclist, GC_TIRESIZEIDX, 0).toInt();
     int wheelSize = appsettings->cvalue(context->athlete->cyclist, GC_WHEELSIZE, 2100).toInt();
 
     rimSizeCombo = new QComboBox();
     rimSizeCombo->addItems(WheelSize::RIM_SIZES);
+    if(rimSizeIdx < 0 || rimSizeIdx >= WheelSize::RIM_SIZES.count()) rimSizeIdx = 0;
+    rimSizeCombo->setCurrentIndex(rimSizeIdx);
 
     tireSizeCombo = new QComboBox();
     tireSizeCombo->addItems(WheelSize::TIRE_SIZES);
-
+    if(tireSizeIdx < 0 || tireSizeIdx >= WheelSize::TIRE_SIZES.count()) tireSizeIdx = 0;
+    tireSizeCombo->setCurrentIndex(tireSizeIdx);
 
     wheelSizeEdit = new QLineEdit(QString("%1").arg(wheelSize),this);
     wheelSizeEdit->setInputMask("0000");
@@ -1362,6 +1368,8 @@ AboutRiderPage::saveClicked()
     avatar.save(context->athlete->home->config().canonicalPath() + "/" + "avatar.png", "PNG");
 
     appsettings->setCValue(context->athlete->cyclist, GC_CRANKLENGTH, crankLengthCombo->currentText());
+    appsettings->setCValue(context->athlete->cyclist, GC_RIMSIZEIDX, rimSizeCombo->currentIndex());
+    appsettings->setCValue(context->athlete->cyclist, GC_TIRESIZEIDX, tireSizeCombo->currentIndex());
     appsettings->setCValue(context->athlete->cyclist, GC_WHEELSIZE, wheelSizeEdit->text().toInt());
 
     // Auto Backup

--- a/src/Train/AddDeviceWizard.cpp
+++ b/src/Train/AddDeviceWizard.cpp
@@ -1164,14 +1164,19 @@ AddFinal::AddFinal(AddDeviceWizard *parent) : QWizardPage(parent), wizard(parent
     //
     // Wheel size
     //
+    int rimSizeIdx = appsettings->cvalue(parent->context->athlete->cyclist, GC_RIMSIZEIDX, 0).toInt();
+    int tireSizeIdx = appsettings->cvalue(parent->context->athlete->cyclist, GC_TIRESIZEIDX, 0).toInt();
     int wheelSize = appsettings->cvalue(parent->context->athlete->cyclist, GC_WHEELSIZE, 2100).toInt();
 
     rimSizeCombo = new QComboBox();
     rimSizeCombo->addItems(WheelSize::RIM_SIZES);
+    if(rimSizeIdx < 0 || rimSizeIdx >= WheelSize::RIM_SIZES.count()) rimSizeIdx = 0;
+    rimSizeCombo->setCurrentIndex(rimSizeIdx);
 
     tireSizeCombo = new QComboBox();
     tireSizeCombo->addItems(WheelSize::TIRE_SIZES);
-
+    if(tireSizeIdx < 0 || tireSizeIdx >= WheelSize::TIRE_SIZES.count()) tireSizeIdx = 0;
+    tireSizeCombo->setCurrentIndex(tireSizeIdx);
 
     wheelSizeEdit = new QLineEdit(QString("%1").arg(wheelSize),this);
     wheelSizeEdit->setInputMask("0000");


### PR DESCRIPTION
This PR adds rim and tire size to the athlete's settings values (in addition to wheel size). UI elements for those settings have already been present, but the values have not been persisted so far.