### PR TITLE
CloudDB - add .gchart Support

### DIFF
--- a/src/Charts/GoldenCheetah.h
+++ b/src/Charts/GoldenCheetah.h
@@ -250,12 +250,17 @@ private:
     GcOverlayWidget *overlayWidget;
     bool wantOverlay;
 
+    // handle Chart Serialissation
+    void serializeChartToQTextStream(QTextStream& out);
+
+
 public:
     GcChartWindow(Context *context);
 
-    // parse a .gchart file and return a list of charts expressed
+    // parse a .gchart file / or string and return a list of charts expressed
     // as a property list in a QMap1
-    static QList<QMap<QString,QString> > chartProperties(QString filename);
+    static QList<QMap<QString,QString> > chartPropertiesFromFile(QString filename);
+    static QList<QMap<QString,QString> > chartPropertiesFromString(QString contents);
 
     QWidget *mainWidget() { return _mainWidget; }
     GcOverlayWidget *helperWidget() { return overlayWidget; }
@@ -271,6 +276,9 @@ public slots:
     void hideRevealControls();
     void saveImage();
     void saveChart();
+#ifdef GC_HAS_CLOUD_DB
+    void exportChartToCloudDB();
+#endif
     void colorChanged(QColor);
 };
 

--- a/src/Charts/LTMWindow.h
+++ b/src/Charts/LTMWindow.h
@@ -227,9 +227,7 @@ class LTMWindow : public GcChartWindow
 
         void exportData();
         void exportConfig();
-#ifdef GC_HAS_CLOUD_DB
-        void shareConfig();
-#endif
+
         QString dataTable(bool html=true); // true as html, false as csv
 
         void configChanged(qint32);

--- a/src/Cloud/CloudDBChart.h
+++ b/src/Cloud/CloudDBChart.h
@@ -37,7 +37,9 @@
 
 struct ChartAPIv1 {
     CommonAPIHeaderV1 Header;
-    QString ChartXML;
+    QString ChartType;
+    QString ChartView;
+    QString ChartDef;
     QByteArray Image;
     QString CreatorNick;
     QString CreatorEmail;
@@ -76,7 +78,7 @@ private:
     QString g_cacheDir;
 
     static const int chart_magic_string = 1029384756;
-    static const int chart_cache_version = 1;
+    static const int chart_cache_version = 2;
 
     QString  g_chart_url_base;
     QString  g_chart_url_header;
@@ -100,8 +102,9 @@ struct ChartWorkingStructure {
     QString language;
     QDateTime createdAt;
     QPixmap image;
-    bool validLTMSettings;
-    LTMSettings ltmSettings;
+    QString gchartType;
+    QString gchartView;
+    QString gchartDef;
     bool createdByMe;
 };
 
@@ -115,7 +118,7 @@ public:
     ~CloudDBChartListDialog();
 
     bool prepareData(QString athlete, CloudDBCommon::UserRole role);
-    LTMSettings getSelectedSettings() {return g_selected; }
+    QList<QString> getSelectedSettings() {return g_selected; }
 
     // re-implemented
     void closeEvent(QCloseEvent* event);
@@ -177,7 +180,7 @@ private:
     QVBoxLayout *mainLayout;
 
     // UserRole - UserGet
-    LTMSettings g_selected;
+    QList<QString> g_selected;
     QPushButton *addAndCloseUserGetButton, *closeUserGetButton;
 
     // UserRole - UserEdit

--- a/src/Cloud/CloudDBCommon.h
+++ b/src/Cloud/CloudDBCommon.h
@@ -139,7 +139,7 @@ public:
 private:
 
     static const int header_magic_string = 1253346430;
-    static const int header_cache_version = 1;
+    static const int header_cache_version = 2;  //increase version to clear existing cache
 
     static bool chartHeaderStatusStale;
     static bool userMetricHeaderStatusStale;

--- a/src/Gui/LTMSidebar.cpp
+++ b/src/Gui/LTMSidebar.cpp
@@ -32,12 +32,6 @@
 #include "LTMWindow.h" // for LTMWindow::settings()
 #include "LTMChartParser.h" // for LTMChartParser::serialize && ChartTreeView
 
-#ifdef GC_HAS_CLOUD_DB
-#include "CloudDBCommon.h"
-#include "CloudDBChart.h"
-#include "GcUpgrade.h"
-#endif
-
 #include <QApplication>
 #include <QScrollBar>
 #include <QtGui>
@@ -1573,11 +1567,6 @@ LTMSidebar::presetPopup()
     QAction *import = new QAction(tr("Import Charts"), chartTree);
     menu.addAction(import);
     connect(import, SIGNAL(triggered(void)), this, SLOT(importPreset(void)));
-#ifdef GC_HAS_CLOUD_DB
-    QAction *importCloudDB = new QAction(tr("Import Chart from CloudDB..."), chartTree);
-    menu.addAction(importCloudDB);
-    connect(importCloudDB, SIGNAL(triggered(void)), this, SLOT(importCloudDBPreset(void)));
-#endif
 
     // this one needs to be in a corner away from the crowd
     menu.addSeparator();
@@ -1731,33 +1720,6 @@ LTMSidebar::importPreset()
     }
 }
 
-#ifdef GC_HAS_CLOUD_DB
-
-void
-LTMSidebar::importCloudDBPreset()
-{
-    if (!(appsettings->cvalue(context->athlete->cyclist, GC_CLOUDDB_TC_ACCEPTANCE, false).toBool())) {
-       CloudDBAcceptConditionsDialog acceptDialog(context->athlete->cyclist);
-       acceptDialog.setModal(true);
-       if (acceptDialog.exec() == QDialog::Rejected) {
-          return;
-       };
-    }
-
-    if (context->cdbChartListDialog == NULL) {
-        context->cdbChartListDialog = new CloudDBChartListDialog();
-    }
-
-    if (context->cdbChartListDialog->prepareData(context->athlete->cyclist, CloudDBCommon::UserImport)) {
-        if (context->cdbChartListDialog->exec() == QDialog::Accepted) {
-            LTMSettings s = context->cdbChartListDialog->getSelectedSettings();
-            // now append to the QList and QTreeWidget
-            context->athlete->presets += s;
-            context->notifyPresetsChanged();
-        }
-    }
-}
-#endif
 
 void
 LTMSidebar::resetPreset()

--- a/src/Gui/LTMSidebar.h
+++ b/src/Gui/LTMSidebar.h
@@ -29,11 +29,6 @@
 
 #include "SearchFilterBox.h"
 
-#ifdef GC_HAS_CLOUD_DB
-#include "CloudDBCommon.h"
-#include "CloudDBChart.h"
-#endif
-
 #include <QDir>
 #include <QtGui>
 
@@ -97,10 +92,6 @@ class LTMSidebar : public QWidget
         void resetPreset();
         void exportPreset();
         void importPreset();
-
-#ifdef GC_HAS_CLOUD_DB
-        void importCloudDBPreset();
-#endif
 
         void filterTreeWidgetSelectionChanged();
         void resetFilters(); // rebuild the seasons list if it changes

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -233,6 +233,7 @@ class MainWindow : public QMainWindow
         void cloudDBuserEditChart();
         void cloudDBcuratorEditChart();
         void cloudDBshowStatus();
+        void cloudDBimportGChart();
 #endif
         // save and restore state to context
         void saveGCState(Context *);


### PR DESCRIPTION
... add export support for the new .gchart format (allowing to post all chart types to CloudDB)
... add import in main menu for the new .gchart format
... allow to import multiple charts at once

... remove specific LTM Chart support (menu, db,... -since this is covered by general .gchart format)