### PR TITLE
CloudDB - gChart support - improvements

### DIFF
--- a/src/Charts/ChartBar.cpp
+++ b/src/Charts/ChartBar.cpp
@@ -123,6 +123,10 @@ ChartBar::ChartBar(Context *context) : QWidget(context->mainWindow), context(con
     barMenu = new QMenu("Add");
     chartMenu = barMenu->addMenu(tr("Add Chart"));
 
+#ifdef GC_HAS_CLOUD_DB
+    barMenu->addAction(tr("Add Chart from CloudDB"));
+    connect(barMenu, SIGNAL(triggered(QAction*)), context->mainWindow, SLOT(addChartFromCloudDB(QAction*)));
+#endif
     // menu
     connect(menuButton, SIGNAL(clicked()), this, SLOT(menuPopup()));
     connect(chartMenu, SIGNAL(aboutToShow()), this, SLOT(setChartMenu()));

--- a/src/Cloud/CloudDBChart.cpp
+++ b/src/Cloud/CloudDBChart.cpp
@@ -1014,8 +1014,6 @@ CloudDBChartListDialog::applyAllFilters() {
         if (g_role == CloudDBCommon::UserImport) {
             int winId = chart.ChartType.toInt();
             for (int i = 0; GcWindows[i].relevance; i++) {
-                int x = GcWindows[i].id;
-                int y = GcWindows[i].relevance;
                 if (GcWindows[i].id == winId && (GcWindows[i].relevance & mask)) {
                     chartOkForView = true;
                     break;

--- a/src/Cloud/CloudDBChart.h
+++ b/src/Cloud/CloudDBChart.h
@@ -37,6 +37,7 @@
 
 struct ChartAPIv1 {
     CommonAPIHeaderV1 Header;
+    QString ChartSport;
     QString ChartType;
     QString ChartView;
     QString ChartDef;
@@ -78,7 +79,7 @@ private:
     QString g_cacheDir;
 
     static const int chart_magic_string = 1029384756;
-    static const int chart_cache_version = 2;
+    static const int chart_cache_version = 3;
 
     QString  g_chart_url_base;
     QString  g_chart_url_header;
@@ -105,6 +106,7 @@ struct ChartWorkingStructure {
     QString gchartType;
     QString gchartView;
     QString gchartDef;
+    QString gchartSport;
     bool createdByMe;
 };
 
@@ -117,7 +119,7 @@ public:
     CloudDBChartListDialog();
     ~CloudDBChartListDialog();
 
-    bool prepareData(QString athlete, CloudDBCommon::UserRole role);
+    bool prepareData(QString athlete, CloudDBCommon::UserRole role, int chartView = 0);
     QList<QString> getSelectedSettings() {return g_selected; }
 
     // re-implemented
@@ -133,6 +135,7 @@ private slots:
     void ownChartsToggled(bool);
     void toggleTextFilterApply();
     void curationStateFilterChanged(int);
+    void sportComboFilterChanged(int);
     void languageFilterChanged(int);
     void textFilterEditingFinished();
     void cellDoubleClicked(int, int);
@@ -171,6 +174,7 @@ private:
     QCheckBox *ownChartsOnly;
     QComboBox *curationStateCombo;
     QComboBox *langCombo;
+    QComboBox *sportCombo;
     QLineEdit *textFilter;
     QPushButton *textFilterApply;
 
@@ -185,6 +189,7 @@ private:
 
     // UserRole - UserEdit
     QPushButton *deleteUserEditButton, *editUserEditButton, *closeUserEditButton;
+    int g_chartView;
 
     // UserRole - Curator Edit
     QPushButton *curateCuratorEditButton, *editCuratorEditButton, *deleteCuratorEditButton, *closeCuratorButton;
@@ -259,6 +264,7 @@ private:
     bool nameOk;
 
     QComboBox *langCombo;
+    QComboBox *sportCombo;
 
     QLabel *image;
 

--- a/src/Cloud/CloudDBCommon.cpp
+++ b/src/Cloud/CloudDBCommon.cpp
@@ -153,6 +153,10 @@ QList<QString> CloudDBCommon::cloudDBLangs = QList<QString>() << QObject::tr("En
                                              QObject::tr("Italian") << QObject::tr("German") << QObject::tr("Russian") << QObject::tr("Czech") <<
                                              QObject::tr("Spanish") << QObject::tr("Portugese") << QObject::tr("Chinese (Simplified)") << QObject::tr("Chinese (Traditional)") << QObject::tr("Other");
 
+QList<QString> CloudDBCommon::cloudDBSportIds = QList<QString>() << "bike" << "run" << "swim" << "other";
+
+QList<QString> CloudDBCommon::cloudDBSports = QList<QString>() << QObject::tr("Bike") << QObject::tr("Run") << QObject::tr("Swim") << QObject::tr("Other");
+
 QString CloudDBCommon::cloudDBTimeFormat = "yyyy-MM-ddTHH:mm:ssZ";
 
 bool CloudDBCommon::addCuratorFeatures = false;
@@ -250,6 +254,12 @@ CloudDBCommon::unmarshallAPIHeaderV1(QByteArray json, QList<CommonAPIHeaderV1> *
     if (document.isObject()) {
         CommonAPIHeaderV1 chartHeader;
         QJsonObject object = document.object();
+        // handle addtional Chart Header properties - if one exists, all are expected to exist
+        if (!object.value("chartView").isUndefined()) {
+            chartHeader.ChartType = object.value("chartType").toString();
+            chartHeader.ChartView = object.value("chartView").toString();
+            chartHeader.ChartSport = object.value("chartSport").toString();
+        }
         QJsonObject header = object["header"].toObject();
         unmarshallAPIHeaderV1Object(&header, &chartHeader);
         charts->append(chartHeader);
@@ -261,6 +271,12 @@ CloudDBCommon::unmarshallAPIHeaderV1(QByteArray json, QList<CommonAPIHeaderV1> *
             if (value.isObject()) {
                 CommonAPIHeaderV1 chartHeader;
                 QJsonObject object = value.toObject();
+                // handle addtional Chart Header properties - if one exists, all are expected to exist
+                if (!object.value("chartView").isUndefined()) {
+                    chartHeader.ChartType = object.value("chartType").toString();
+                    chartHeader.ChartView = object.value("chartView").toString();
+                    chartHeader.ChartSport = object.value("chartSport").toString();
+                }
                 QJsonObject header = object["header"].toObject();
                 unmarshallAPIHeaderV1Object(&header, &chartHeader);
                 charts->append(chartHeader);
@@ -357,6 +373,11 @@ CloudDBHeader::writeHeaderCache(QList<CommonAPIHeaderV1>* header, CloudDBHeaderT
        out << h.CreatorId;
        out << h.Deleted;
        out << h.Curated;
+       if (headerType == CloudDBHeaderType::CloudDB_Chart) {
+           out << h.ChartSport;
+           out << h.ChartType;
+           out << h.ChartView;
+       }
    }
    file.close();
    return true;
@@ -407,6 +428,11 @@ CloudDBHeader::readHeaderCache(QList<CommonAPIHeaderV1>* header, CloudDBHeaderTy
         in >> h.CreatorId;
         in >> h.Deleted;
         in >> h.Curated;
+        if (headerType == CloudDBHeaderType::CloudDB_Chart) {
+            in >> h.ChartSport;
+            in >> h.ChartType;
+            in >> h.ChartView;
+        }
         header->append(h);
     }
     file.close();

--- a/src/Cloud/CloudDBCommon.cpp
+++ b/src/Cloud/CloudDBCommon.cpp
@@ -373,7 +373,7 @@ CloudDBHeader::writeHeaderCache(QList<CommonAPIHeaderV1>* header, CloudDBHeaderT
        out << h.CreatorId;
        out << h.Deleted;
        out << h.Curated;
-       if (headerType == CloudDBHeaderType::CloudDB_Chart) {
+       if (headerType == CloudDB_Chart) {
            out << h.ChartSport;
            out << h.ChartType;
            out << h.ChartView;
@@ -428,7 +428,7 @@ CloudDBHeader::readHeaderCache(QList<CommonAPIHeaderV1>* header, CloudDBHeaderTy
         in >> h.CreatorId;
         in >> h.Deleted;
         in >> h.Curated;
-        if (headerType == CloudDBHeaderType::CloudDB_Chart) {
+        if (headerType == CloudDB_Chart) {
             in >> h.ChartSport;
             in >> h.ChartType;
             in >> h.ChartView;

--- a/src/Cloud/CloudDBCommon.h
+++ b/src/Cloud/CloudDBCommon.h
@@ -45,6 +45,10 @@ typedef struct {
     QString CreatorId;
     bool    Curated;
     bool    Deleted;
+    // gchart specific header cache fields
+    QString ChartType;
+    QString ChartView;
+    QString ChartSport;
 } CommonAPIHeaderV1;
 
 
@@ -73,6 +77,11 @@ public:
     // Languages explicitely supported to store artifacts == UI Languages
     static QList<QString> cloudDBLangsIds;
     static QList<QString> cloudDBLangs;
+
+    // Sport Types supported
+    static QList<QString> cloudDBSportIds;
+    static QList<QString> cloudDBSports;
+
     static QString cloudDBTimeFormat;
     static const int APIresponseOk = 200; // also used in case of 204 (No Content)
     static const int APIresponseCreated = 201;
@@ -139,7 +148,7 @@ public:
 private:
 
     static const int header_magic_string = 1253346430;
-    static const int header_cache_version = 2;  //increase version to clear existing cache
+    static const int header_cache_version = 3;  //increase version to clear existing cache
 
     static bool chartHeaderStatusStale;
     static bool userMetricHeaderStatusStale;

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -233,7 +233,7 @@ class MainWindow : public QMainWindow
         void cloudDBuserEditChart();
         void cloudDBcuratorEditChart();
         void cloudDBshowStatus();
-        void cloudDBimportGChart();
+        void addChartFromCloudDB(QAction *);
 #endif
         // save and restore state to context
         void saveGCState(Context *);


### PR DESCRIPTION
... add "Sport" metadata as filter option
... move "Import" from main menue to "Add chart" - "hamburger menu"
... make chart lists context sensitive on home, activities and diary
... import directly into current context - without extra dialog