### PR TITLE
Allow min value of 1 for binWidth in 3D plot

### DIFF
--- a/src/Charts/ModelWindow.cpp
+++ b/src/Charts/ModelWindow.cpp
@@ -123,7 +123,7 @@ ModelWindow::ModelWindow(Context *context) :
     binWidthSlider = new QSlider(Qt::Horizontal);
     binWidthSlider->setTickPosition(QSlider::TicksBelow);
     binWidthSlider->setTickInterval(1);
-    binWidthSlider->setMinimum(3);
+    binWidthSlider->setMinimum(1);
     binWidthSlider->setMaximum(100);
     binWidthSlider->setValue(5);
     cl->addRow(binWidthSlider);


### PR DESCRIPTION
This enables creating high resolution 3D profiles:

![profile3d](https://cloud.githubusercontent.com/assets/759436/15687088/3d1d88e0-2773-11e6-9d32-098f4bd801f6.png)
