### PR TITLE
Added bestime(distance) to formulas

### DIFF
--- a/doc/user/formula-syntax.txt
+++ b/doc/user/formula-syntax.txt
@@ -37,6 +37,7 @@ vdottime(VDOT, distance)
 MEAN MAX and ZONE FUNCTIONS
 best(...)
 tiz(...)
+besttime(distance)
 
 PMC FUNCTIONS
 lts(p1)

--- a/src/Core/DataFilter.cpp
+++ b/src/Core/DataFilter.cpp
@@ -24,6 +24,7 @@
 #include "RideFileCache.h"
 #include "PMCData.h"
 #include "VDOTCalculator.h"
+#include "AddIntervalDialog.h"
 #include <QDebug>
 
 #include "Zones.h"
@@ -96,8 +97,9 @@ static struct {
     { "unset", 2 }, // unset(symbol, filter)
     { "isset", 1 }, // isset(symbol) - is the metric or metadata overridden/defined
 
-    // VDOT functions
+    // VDOT and time/distance functions
     { "vdottime", 2 }, // vdottime(VDOT, distance[km]) - result is seconds
+    { "besttime", 1 }, // besttime(distance[km]) - result is seconds
 
     // add new ones above this line
     { "", -1 }
@@ -2195,6 +2197,18 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
                     if (leaf->fparms.count() != 2) return Result(0);
 
                     return Result (60*VDOTCalculator::eqvTime(eval(df, leaf->fparms[0], x, m, p, c).number, 1000*eval(df, leaf->fparms[1], x, m, p, c).number));
+                }
+                break;
+
+        case 36 :
+                {   // BESTTIME (distance[km])
+
+                    if (leaf->fparms.count() != 1) return Result(0);
+
+                    QList<AddIntervalDialog::AddedInterval> results;
+                    AddIntervalDialog::findPeaks(m->context, false, m->ride(), RideFile::kph, RideFile::original, 1000*eval(df, leaf->fparms[0], x, m, p, c).number, 1, results, "","");
+
+                    return Result (results.count()>0 ? results.first().stop-results.first().start : 0);
                 }
                 break;
 


### PR DESCRIPTION
To have an easy way to track best times by distances
in Metrics Trends charts and User Defined Metrics
s.t. 40k TTs, 10k runs, 1500m swims, etc.