### PR TITLE
Added bestime(km) to formulas

### DIFF
--- a/doc/user/formula-syntax.txt
+++ b/doc/user/formula-syntax.txt
@@ -37,6 +37,7 @@ vdottime(VDOT, distance)
 MEAN MAX and ZONE FUNCTIONS
 best(...)
 tiz(...)
+besttime(km)
 
 PMC FUNCTIONS
 lts(p1)

--- a/src/Core/DataFilter.cpp
+++ b/src/Core/DataFilter.cpp
@@ -96,8 +96,9 @@ static struct {
     { "unset", 2 }, // unset(symbol, filter)
     { "isset", 1 }, // isset(symbol) - is the metric or metadata overridden/defined
 
-    // VDOT functions
+    // VDOT and time/distance functions
     { "vdottime", 2 }, // vdottime(VDOT, distance[km]) - result is seconds
+    { "besttime", 1 }, // besttime(distance[km]) - result is seconds
 
     // add new ones above this line
     { "", -1 }
@@ -2197,6 +2198,14 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
                     return Result (60*VDOTCalculator::eqvTime(eval(df, leaf->fparms[0], x, m, p, c).number, 1000*eval(df, leaf->fparms[1], x, m, p, c).number));
                 }
                 break;
+
+        case 36 :
+                {   // BESTTIME (distance[km])
+
+                    if (leaf->fparms.count() != 1 || m->fileCache() == NULL) return Result(0);
+
+                    return Result (m->fileCache()->bestTime(eval(df, leaf->fparms[0], x, m, p, c).number));
+                 }
 
         default:
             return Result(0);

--- a/src/FileIO/RideFileCache.cpp
+++ b/src/FileIO/RideFileCache.cpp
@@ -2296,3 +2296,16 @@ RideBest::getForSymbol(QString symbol, bool metric) const
         return metricValue;
     }
 }
+
+int
+RideFileCache::bestTime(double km)
+{
+    // divisor for series and conversion from secs to hours
+    double divisor = pow(10, decimalsFor(RideFile::kph)) * 3600.0;
+    // linear search over kph mean max array
+    int secs = 0;
+    while (secs < kphMeanMax.count() &&
+           double(kphMeanMax[secs] * secs) / divisor < km) secs++;
+    if (secs < kphMeanMax.count()) return secs;
+    return RideFile::NIL;
+}

--- a/src/FileIO/RideFileCache.h
+++ b/src/FileIO/RideFileCache.h
@@ -224,6 +224,9 @@ class RideFileCache
         static void doubleArray(QVector<double> &into, QVector<float> &from, RideFile::SeriesType series);
         static void doubleArrayForDistribution(QVector<double> &into, QVector<float> &from);
 
+        // Best time for distance, used by metrics and Data Filter
+        int bestTime(double km);
+
     protected:
 
         void refreshCache();              // compute arrays and update cache


### PR DESCRIPTION
To have a general way to track best times for non stardard
distances in Metrics Trends charts and User Defined Metrics.
Now it does a linear search on cached MeanMax speed array.