### PR TITLE
Set linked defaults on import

### DIFF
--- a/src/Gui/RideImportWizard.cpp
+++ b/src/Gui/RideImportWizard.cpp
@@ -33,6 +33,7 @@
 #include "JsonRideFile.h"
 #include "TcxRideFile.h" // for opening multi-ride file
 #include "DataProcessor.h"
+#include "RideMetadata.h" // for linked defaults processing
 
 #include <QDebug>
 #include <QWaitCondition>
@@ -1013,6 +1014,9 @@ RideImportWizard::abortClicked()
             ride->setTag("Filename", activitiesTarget);
             if (errors.count() > 0)
                 ride->setTag("Import errors", errors.join("\n"));
+
+            // process linked defaults
+            context->athlete->rideMetadata()->setLinkedDefaults(ride);
 
             // run the processor first...
             DataProcessorFactory::instance().autoProcess(ride);

--- a/src/Metrics/RideMetadata.cpp
+++ b/src/Metrics/RideMetadata.cpp
@@ -945,6 +945,23 @@ FormField::setLinkedDefault(QString text)
 }
 
 void
+RideMetadata::setLinkedDefaults(RideFile* ride)
+{
+    bool changed;
+
+    do {
+        changed = false;
+
+        foreach (DefaultDefinition adefault, getDefaults())
+            if (ride->getTag(adefault.field, "") == adefault.value)
+                if (ride->getTag(adefault.linkedField, "") == "") {
+                    ride->setTag(adefault.linkedField, adefault.linkedValue);
+                    changed = true;
+                }
+    } while (changed);
+}
+
+void
 FormField::stateChanged(int state)
 {
     if (active || ourRideItem == NULL) return; // being updated programmatically

--- a/src/Metrics/RideMetadata.h
+++ b/src/Metrics/RideMetadata.h
@@ -177,6 +177,7 @@ class RideMetadata : public QWidget
 
         QPalette palette; // to be applied to all widgets
 
+        void setLinkedDefaults(RideFile* ride);
 
     public slots:
         void configChanged(qint32);


### PR DESCRIPTION
For defaults which depend, directly or indirectly, on fields automatically
set on import
Fixes #2023