### PR TITLE
Prevent a crash when selecting an interval after PowerTap download

### DIFF
--- a/src/Charts/RideEditor.cpp
+++ b/src/Charts/RideEditor.cpp
@@ -3078,6 +3078,9 @@ void XDataEditor::setRideItem(RideItem *item)
 void
 XDataEditor::selectIntervals(QList<IntervalItem*> intervals)
 {
+    // no model or no series, nothing to select
+    if (_model == NULL || _model->series == NULL) return;
+
     // highlight selection and jump to last
     foreach(IntervalItem *interval, intervals) {
 


### PR DESCRIPTION
Reproducible downloading/importing a PowerTap .raw file and
selecting an interval for the first time, _model->series is NULL
in this case, no model case added for safety