### PR TITLE
Fix calculation of minimum values of SmO2 and tHb and average of tHB

### DIFF
--- a/src/FileIO/CsvRideFile.cpp
+++ b/src/FileIO/CsvRideFile.cpp
@@ -181,6 +181,7 @@ RideFile *CsvFileReader::openRideFile(QFile &file, QStringList &errors, QList<Ri
     int cadenceIndex=-1;
     int smo2Index=-1;
     int hrIndex=-1;
+    int kphIndex = -1;
     int gctIndex = -1, voIndex =-1;
 
     double precAvg=0.0;
@@ -438,6 +439,7 @@ RideFile *CsvFileReader::openRideFile(QFile &file, QStringList &errors, QList<Ri
                 QRegExp hrHeader("( )*(hr|heart_rate)( )*", Qt::CaseInsensitive);
                 QRegExp gctHeader("( )*(groundcontacttime)( )*", Qt::CaseInsensitive);
                 QRegExp voHeader("( )*(verticaloscillation)( )*", Qt::CaseInsensitive);
+                QRegExp kphHeader("( )*(speed)( )*", Qt::CaseInsensitive);
                 QStringList headers = line.split(",");
 
                 QStringListIterator i(headers);
@@ -487,6 +489,11 @@ RideFile *CsvFileReader::openRideFile(QFile &file, QStringList &errors, QList<Ri
                         voIndex = headers.indexOf(header);
                         if (csvType == bsx)
                             voIndex++;
+                    }
+                    if (kphHeader.indexIn(header) != -1)  {
+                        kphIndex = headers.indexOf(header);
+                        if (csvType == bsx)
+                            kphIndex++;
                     }
                 }
 
@@ -753,6 +760,12 @@ RideFile *CsvFileReader::openRideFile(QFile &file, QStringList &errors, QList<Ri
                     }
                     if (voIndex > -1) {
                         vo = line.section(',', voIndex, voIndex).toDouble();
+                    }
+                    if (kphIndex > -1) {
+                        kph = line.section(',', kphIndex, kphIndex).toDouble() * 3.6f; // running speed is given in m/s, convert to km/h
+                        if (!metric) {
+                           kph *= KM_PER_MILE;
+                        }
                     }
                 }
                else if(csvType == motoactv) {

--- a/src/FileIO/FitRideFile.cpp
+++ b/src/FileIO/FitRideFile.cpp
@@ -297,6 +297,7 @@ struct FitFileReaderState
                 case 1765: case 2130: case 2131: case 2132: return "Garmin FR920XT";
                 case 1836: case 2052: case 2053: case 2070: case 2100: return "Garmin Edge 1000";
                 case 1903: return "Garmin FR15";
+                case 1907: return "Garmin Vivoactive";
                 case 1967: return "Garmin Fenix2";
                 case 2050: case 2188: case 2189: return "Garmin Fenix3";
                 case 2067: case 2260: return "Garmin Edge 520";
@@ -355,6 +356,12 @@ struct FitFileReaderState
         } else if (manu == 95) {
             // Stryd
             return "Stryd";
+        } else if (manu == 98) {
+            // BSX
+            switch(prod) {
+                  case 2: return "BSX Insight 2";
+                  default: return QString("BSX %1").arg(prod);
+            }
         } else if (manu == 260) {
             // Zwift!
             return "Zwift";

--- a/src/Metrics/BasicRideMetrics.cpp
+++ b/src/Metrics/BasicRideMetrics.cpp
@@ -997,17 +997,17 @@ struct AvgtHb : public RideMetric {
             return;
         }
 
-        total = count = 0;
+        total = count = 0.0f;
 
         RideFileIterator it(item->ride(), spec);
         while (it.hasNext()) {
             struct RideFilePoint *point = it.next();
-            if (point->thb >= 0.0) {
+            if (point->thb > 0.0f) {
                 total += point->thb;
                 ++count;
             }
         }
-        setValue(count > 0 ? total / count : 0);
+        setValue(count > 0.0f ? total / count : 0.0f);
         setCount(count);
     }
 
@@ -1800,12 +1800,17 @@ class MinSmO2 : public RideMetric {
             return;
         }
 
+        bool notset = true;
+
         RideFileIterator it(item->ride(), spec);
         while (it.hasNext()) {
             struct RideFilePoint *point = it.next();
 
-            if (point->smo2 > 0 && point->smo2 >= min)
+            if (point->smo2 >= 0.0f && (notset || point->smo2 < min)) {
                 min = point->smo2;
+                if (point->smo2 > 0.0f && notset)
+                  notset = false;
+            }
         }
         setValue(min);
     }
@@ -1844,11 +1849,15 @@ class MintHb : public RideMetric {
             return;
         }
 
+        bool notset = true;
+
         RideFileIterator it(item->ride(), spec);
         while (it.hasNext()) {
             struct RideFilePoint *point = it.next();
-            if (point->thb > 0 && point->thb >= min)
+            if (point->thb > 0.0f && (notset || point->thb < min)) {
                 min = point->thb;
+                notset = false;
+            }
         }
         setValue(min);
     }

--- a/src/Metrics/BasicRideMetrics.cpp
+++ b/src/Metrics/BasicRideMetrics.cpp
@@ -949,7 +949,7 @@ struct AvgSmO2 : public RideMetric {
         while (it.hasNext()) {
             struct RideFilePoint *point = it.next();
 
-            if (point->smo2 >= 0.0) {
+            if (point->smo2 > 0.0f) {  // SmO2 should always be > 0.0f
                 total += point->smo2;
                 ++count;
             }


### PR DESCRIPTION
In file *src/Metrics/BasicRideMetrics.cpp*  the minimum values of **SmO2** and **tHb** and the average of **tHb** are calculated incorrectly. In functions *compute* of class *MinSmO2* resp. class *MintHb* actually the maximum values get computed. 
For *MinSmO2* the comparison in function *compute* should read:

```c++
    if (point->smo2 >= 0.0f && (notset || point->smo2 < min)) {
        min = point->smo2;
        if (point->smo2 > 0.0f && notset)
            notset = false; 
    }
```

with *min* being a double initialized to 0.0f and  *notset* a boolean initialized to *true*.
For *MinSmO2* we've got to handle that the first recorded values might be zero, e.g. when the athlete did not attach the Moxy sensor to the muscle prior to starting recording. If the comparison given above holds true we have to verify that we get a valid value > 0 first before allowing SmO2 to fall down to zero again.

For *MintHb* the comparison in function *compute*  should read:

```c++
    if (point->thb > 0.0f && (notset || point->thb < min)) {
        min = point->thb;
        notset = false;
     }
```

with *min* being a double initialized to 0.0f and  *notset* a boolean initialized to *true*.
Please note that for physiological reasons the minimum value of **tHb** must not be zero as this would imply that the muscle under observation were totally drained from blood.

At the end of functions *compute* in classes *MinSmO2* and *MintHb* we have to set the correct value:

```c++
    setValue(min); // was max before
```
In class *AvgtHb* we have to take into account that **tHb** must not be zero as well for the same reason as stated above. In function *compute* the comparison should read:

```c++
    if (point->thb > 0.0f) { 
        total += point->thb;
        ++count;
    }
```

References #2050 
please review
