### PR TITLE
Added Reset to default to Analysis Sidebar Navigator

### DIFF
--- a/src/Gui/AnalysisSidebar.cpp
+++ b/src/Gui/AnalysisSidebar.cpp
@@ -453,6 +453,12 @@ AnalysisSidebar::showActivityMenu(const QPoint &pos)
         QAction *collapseAll = new QAction(tr("Collapse All"), rideNavigator);
         connect(collapseAll, SIGNAL(triggered(void)), rideNavigator->tableView, SLOT(collapseAll()));
         menu.addAction(collapseAll);
+
+        // reset to default
+        QAction *resetToDefault = new QAction(tr("Reset to default"), rideNavigator);
+        connect(resetToDefault, SIGNAL(triggered(void)), rideNavigator, SLOT(setWidths()));
+        menu.addAction(resetToDefault);
+
         menu.exec(pos);
     }
 }

--- a/src/Gui/RideNavigator.h
+++ b/src/Gui/RideNavigator.h
@@ -152,7 +152,7 @@ class RideNavigator : public GcChartWindow
         void noGroups() { currentColumn=-1; setGroupByColumn(); }
 
         QString widths() const { return _widths; }
-        void setWidths (QString x) { _widths = x; resetView(); } // only reset once widths are set
+        void setWidths (QString x="") { _widths = x; resetView(); } // only reset once widths are set, witdths="" resets to default columns
 
         void resetView(); // when columns/width changes
 


### PR DESCRIPTION
To fix issues when column widths go crazy or column
name colisions after language change (Ex. for Italian Date is translated to Data and if language is later changed to English a Data column is shown instead of Date, Reset to default allows to solve the situation)
Fixes #1960