### PR TITLE
Changed toLatin1 for toStdString on gchart import

### DIFF
--- a/src/Charts/GoldenCheetah.cpp
+++ b/src/Charts/GoldenCheetah.cpp
@@ -1008,7 +1008,7 @@ GcChartWindow::chartPropertiesFromString(QString contents) {
     QList<QMap<QString,QString> > returning;
 
     // parse via MVJson to avoid QT5 dependency
-    MVJSONReader json(string(contents.toLatin1()));
+    MVJSONReader json(string(contents.toStdString()));
 
     if (json.root && json.root->hasField("CHART")) {
 


### PR DESCRIPTION
To allow the use of non-ascii characteres on chart title
Tested with accented spanish vowels
Fixes #2092