### PR TITLE
Show pace as mm:ss in Metrics Trends chart tooltip

### DIFF
--- a/src/Charts/LTMPlot.cpp
+++ b/src/Charts/LTMPlot.cpp
@@ -3554,18 +3554,27 @@ LTMPlot::pointHover(QwtPlotCurve *curve, int index)
             precision = 1; // need more precision now
         }
 
+
+        // convert minutes to time string for pace, otherwise use precision
+        QString txtValue;
+        if (PaceZones::isPaceUnit(units) || PaceZones::isPaceUnit(this->axisTitle(curve->yAxis()).text())) {
+            txtValue = QString("%1").arg(time_to_string(value*60.0));
+        } else {
+            txtValue = QString("%1").arg(value, 0, 'f', precision);
+        }
+
         // output the tooltip
         QString text;
         if (!parent->isCompare()) {
             text = QString("%1\n%2\n%3 %4")
                         .arg(datestr)
                         .arg(curve->title().text())
-                        .arg(value, 0, 'f', precision)
+                        .arg(txtValue)
                         .arg(this->axisTitle(curve->yAxis()).text());
         } else {
             text = QString("%1\n%2 %3")
                         .arg(curve->title().text())
-                        .arg(value, 0, 'f', precision)
+                        .arg(txtValue)
                         .arg(this->axisTitle(curve->yAxis()).text());
         }
 

--- a/src/Metrics/PaceZones.cpp
+++ b/src/Metrics/PaceZones.cpp
@@ -1016,3 +1016,13 @@ PaceZones::paceSetting() const
 {
     return swim ? GC_SWIMPACE : GC_PACE;
 }
+
+bool
+PaceZones::isPaceUnit(QString unit)
+{
+    QString paceUnits = "min/km," + tr("min/km,") +
+                        "min/mile," + tr("min/mile,") +
+                        "min/100m," + tr("min/100m,") +
+                        "min/100yd," + tr("min/100yd");
+    return paceUnits.contains(unit);
+}

--- a/src/Metrics/PaceZones.h
+++ b/src/Metrics/PaceZones.h
@@ -214,6 +214,7 @@ class PaceZones : public QObject
         QString kphToPaceString(double kph, bool metric) const;
         QString paceUnits(bool metric) const;
         QString paceSetting() const;
+        static bool isPaceUnit(QString unit);
 };
 
 QColor paceZoneColor(int zone, int num_zones);


### PR DESCRIPTION
Reported in #2063, it doesn't solve the general issue but allows to see the details in proper format in the same way as in other charts.