### PR TITLE
UI Nit - Compare Pane Action not marked in View menu

### DIFF
--- a/src/Gui/TabView.cpp
+++ b/src/Gui/TabView.cpp
@@ -297,7 +297,7 @@ TabView::setBottom(QWidget *widget)
 void 
 TabView::dragEvent(bool x)
 {
-    setShowBottom(x);
+    setBottomRequested(x);
     context->mainWindow->setToolButtons(); // toolbuttons reflect show/hide status
 }
 


### PR DESCRIPTION
... when ComparePane is opened by drag&drop event, the menu item "Show Compare Pane" was not marked active