### PR TITLE
Add "Save all modified activities" feature

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -501,6 +501,8 @@ MainWindow::MainWindow(const QDir &home)
     connect(backupMapper, SIGNAL(mapped(const QString &)), this, SLOT(backupAthlete(const QString &)));
 
     fileMenu->addSeparator();
+    fileMenu->addAction(tr("Save all modified activities"), this, SLOT(saveAllUnsavedRides()));
+    fileMenu->addSeparator();
     fileMenu->addAction(tr("Close Window"), this, SLOT(closeWindow()));
     fileMenu->addAction(tr("&Close Tab"), this, SLOT(closeTab()));
     fileMenu->addAction(tr("&Quit All Windows"), this, SLOT(closeAll()), tr("Ctrl+Q"));
@@ -1571,6 +1573,19 @@ MainWindow::saveRide()
     // save
     if (currentTab->context->ride) {
         saveRideSingleDialog(currentTab->context, currentTab->context->ride); // will signal save to everyone
+    }
+}
+
+void
+MainWindow::saveAllUnsavedRides()
+{
+    // flush in-flight changes
+    currentTab->context->notifyMetadataFlush();
+    currentTab->context->ride->notifyRideMetadataChanged();
+
+    // save
+    if (currentTab->context->ride) {
+        saveAllFilesSilent(currentTab->context); // will signal save to everyone
     }
 }
 

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -193,6 +193,7 @@ class MainWindow : public QMainWindow
         void addIntervals(); // pass thru to tab
         bool saveRideSingleDialog(Context *, RideItem *);
         void saveSilent(Context *, RideItem *);
+        void saveAllFilesSilent(Context *);
         void downloadRide();
         void manualRide();
         void exportRide();
@@ -222,6 +223,7 @@ class MainWindow : public QMainWindow
         void mergeRide();
         void deleteRide();
         void saveRide();                        // save current ride menu item
+        void saveAllUnsavedRides();
         void revertRide();
         bool saveRideExitDialog(Context *);              // save dirty rides on exit dialog
 

--- a/src/Gui/SaveDialogs.cpp
+++ b/src/Gui/SaveDialogs.cpp
@@ -195,6 +195,26 @@ MainWindow::saveSilent(Context *context, RideItem *rideItem)
     rideItem->ride()->emitSaved();
 }
 
+
+void
+MainWindow::saveAllFilesSilent(Context *context)
+{
+    QList<RideItem*> dirtyList;
+
+    // get a list of rides to save
+    foreach (RideItem *rideItem, context->athlete->rideCache->rides())
+        if (rideItem->isDirty() == true)
+            dirtyList.append(rideItem);
+
+    // we have some files to save...
+    if (dirtyList.count() > 0) {
+        for (int i=0; i<dirtyList.count(); i++) {
+                this->saveRideSingleDialog(context, dirtyList.at(i));
+
+        }
+    }
+}
+
 //----------------------------------------------------------------------
 // Save Single File Dialog Widget
 //----------------------------------------------------------------------


### PR DESCRIPTION
... when changing the ride by clicking in the list - while change e.g. Detail data in the activities view 
   GC aborted because the proxyIndex.internalPointer() was not initialized - checking the initialization 
   like in the other cases in the code fixed the problem

relates to:  https://github.com/GoldenCheetah/GoldenCheetah/issues/2126