### PR TITLE
Skip non relevant metrics for RideSummary in Trends view

### DIFF
--- a/src/Charts/RideSummaryWindow.cpp
+++ b/src/Charts/RideSummaryWindow.cpp
@@ -2158,11 +2158,20 @@ RideSummaryWindow::htmlCompareSummary() const
                                              // case we ever come back here or use it for other things.
             summary += "<td bgcolor='" + bgColor.name() + "'>&nbsp;</td>"; // spacing
 
+            QStringList relevantMetricsList;
             foreach (QString symbol, metricsList) {
                 const RideMetric *m = factory.rideMetric(symbol);
 
-                // skip not relevant metrics
-                if (!context->athlete->rideCache->isMetricRelevantForRides(specification, m)) continue;
+                // Skip metrics not relevant for all ranges in compare pane
+                bool isRelevant = false;
+                foreach(CompareDateRange x, context->compareDateRanges) {
+                    if (x.context->athlete->rideCache->isMetricRelevantForRides(x.specification, m)) {
+                        isRelevant = true;
+                        break;
+                    }
+                }
+                if (!isRelevant) continue;
+                relevantMetricsList << symbol;
 
                 QString name, units;
                 if (!(m->units(context->athlete->useMetricUnits) == "seconds" || m->units(context->athlete->useMetricUnits) == tr("seconds")))
@@ -2190,13 +2199,10 @@ RideSummaryWindow::htmlCompareSummary() const
                 summary += "<td>" + dr.name + "</td>";
                 summary += "<td bgcolor='" + bgColor.name() +"'>&nbsp;</td>"; // spacing
 
-                foreach (QString symbol, metricsList) {
+                foreach (QString symbol, relevantMetricsList) {
 
                     // the values ...
                     const RideMetric *m = factory.rideMetric(symbol);
-
-                    // skip not relevant metrics
-                    if (!context->athlete->rideCache->isMetricRelevantForRides(specification, m)) continue;
 
                     // get value and convert if needed (use local context for units)
                     double value = dr.context->athlete->rideCache->getAggregate(symbol, dr.specification,

--- a/src/Charts/RideSummaryWindow.cpp
+++ b/src/Charts/RideSummaryWindow.cpp
@@ -1207,6 +1207,17 @@ RideSummaryWindow::htmlSummary()
             activities++;
         }
 
+        // Select relevant metrics for activities of each sport
+        QStringList rideMetrics, runMetrics, swimMetrics;
+        for (j = 0; j< metricColumn.count(); ++j) {
+            QString symbol = metricColumn[j];
+            const RideMetric *m = factory.rideMetric(symbol);
+
+            if (context->athlete->rideCache->isMetricRelevantForRides(specification, m, RideCache::OnlyRides)) rideMetrics << symbol;
+            if (context->athlete->rideCache->isMetricRelevantForRides(specification, m, RideCache::OnlyRuns)) runMetrics << symbol;
+            if (context->athlete->rideCache->isMetricRelevantForRides(specification, m, RideCache::OnlySwims)) swimMetrics << symbol;
+        }
+
         // some people have a LOT of metrics, so we only show so many since
         // you quickly run out of screen space, but if they have > 4 we can
         // take out elevation and work from the totals/
@@ -1214,7 +1225,9 @@ RideSummaryWindow::htmlSummary()
         int totalCols;
         if (metricColumn.count() > 4) totalCols = 2;
         else totalCols = rtotalColumn.count();
-        int metricCols = metricColumn.count() > 7 ? 7 : metricColumn.count();
+        int rideCols = rideMetrics.count() > 7 ? 7 : rideMetrics.count();
+        int runCols = runMetrics.count() > 7 ? 7 : runMetrics.count();
+        int swimCols = swimMetrics.count() > 7 ? 7 : swimMetrics.count();
 
         //Rides first
         if (context->ishomefiltered || context->isfiltered || filtered) {
@@ -1244,8 +1257,8 @@ RideSummaryWindow::htmlSummary()
 
             summary += QString("<td align=\"center\">%1</td>").arg(m->name());
         }
-        for (j = 0; j< metricCols; ++j) {
-            QString symbol = metricColumn[j];
+        for (j = 0; j< rideCols; ++j) {
+            QString symbol = rideMetrics[j];
             const RideMetric *m = factory.rideMetric(symbol);
 
             summary += QString("<td align=\"center\">%1</td>").arg(m->name());
@@ -1263,8 +1276,8 @@ RideSummaryWindow::htmlSummary()
             if (units == "seconds" || units == tr("seconds")) units = "";
             summary += QString("<td align=\"center\">%1</td>").arg(units);
         }
-        for (j = 0; j< metricCols; ++j) {
-            QString symbol = metricColumn[j];
+        for (j = 0; j< rideCols; ++j) {
+            QString symbol = rideMetrics[j];
             const RideMetric *m = factory.rideMetric(symbol);
 
             QString units = m->units(useMetricUnits);
@@ -1305,8 +1318,8 @@ RideSummaryWindow::htmlSummary()
                 QString value = ride->getStringForSymbol(symbol,useMetricUnits);
                 summary += QString("<td align=\"center\">%1</td>").arg(value);
             }
-            for (j = 0; j< metricCols; ++j) {
-                QString symbol = metricColumn[j];
+            for (j = 0; j< rideCols; ++j) {
+                QString symbol = rideMetrics[j];
 
                 // get this value
                 QString value = ride->getStringForSymbol(symbol,useMetricUnits);
@@ -1344,8 +1357,8 @@ RideSummaryWindow::htmlSummary()
 
             summary += QString("<td align=\"center\">%1</td>").arg(m->name());
         }
-        for (j = 0; j< metricCols; ++j) {
-            QString symbol = metricColumn[j];
+        for (j = 0; j< runCols; ++j) {
+            QString symbol = runMetrics[j];
             const RideMetric *m = factory.rideMetric(symbol);
 
             summary += QString("<td align=\"center\">%1</td>").arg(m->name());
@@ -1363,8 +1376,8 @@ RideSummaryWindow::htmlSummary()
             if (units == "seconds" || units == tr("seconds")) units = "";
             summary += QString("<td align=\"center\">%1</td>").arg(units);
         }
-        for (j = 0; j< metricCols; ++j) {
-            QString symbol = metricColumn[j];
+        for (j = 0; j< runCols; ++j) {
+            QString symbol = runMetrics[j];
             const RideMetric *m = factory.rideMetric(symbol);
 
             QString units = m->units(useMetricUnits);
@@ -1404,8 +1417,8 @@ RideSummaryWindow::htmlSummary()
                 QString value = ride->getStringForSymbol(symbol,useMetricUnits);
                 summary += QString("<td align=\"center\">%1</td>").arg(value);
             }
-            for (j = 0; j< metricCols; ++j) {
-                QString symbol = metricColumn[j];
+            for (j = 0; j< runCols; ++j) {
+                QString symbol = runMetrics[j];
 
                 // get this value
                 QString value = ride->getStringForSymbol(symbol,useMetricUnits);
@@ -1443,8 +1456,8 @@ RideSummaryWindow::htmlSummary()
 
             summary += QString("<td align=\"center\">%1</td>").arg(m->name());
         }
-        for (j = 0; j< metricCols; ++j) {
-            QString symbol = metricColumn[j];
+        for (j = 0; j< swimCols; ++j) {
+            QString symbol = swimMetrics[j];
             const RideMetric *m = factory.rideMetric(symbol);
 
             summary += QString("<td align=\"center\">%1</td>").arg(m->name());
@@ -1462,8 +1475,8 @@ RideSummaryWindow::htmlSummary()
             if (units == "seconds" || units == tr("seconds")) units = "";
             summary += QString("<td align=\"center\">%1</td>").arg(units);
         }
-        for (j = 0; j< metricCols; ++j) {
-            QString symbol = metricColumn[j];
+        for (j = 0; j< swimCols; ++j) {
+            QString symbol = swimMetrics[j];
             const RideMetric *m = factory.rideMetric(symbol);
 
             QString units = m->units(useMetricUnits);
@@ -1503,8 +1516,8 @@ RideSummaryWindow::htmlSummary()
                 QString value = ride->getStringForSymbol(symbol,useMetricUnits);
                 summary += QString("<td align=\"center\">%1</td>").arg(value);
             }
-            for (j = 0; j< metricCols; ++j) {
-                QString symbol = metricColumn[j];
+            for (j = 0; j< swimCols; ++j) {
+                QString symbol = swimMetrics[j];
 
                 // get this value
                 QString value = ride->getStringForSymbol(symbol,useMetricUnits);

--- a/src/Core/RideCache.cpp
+++ b/src/Core/RideCache.cpp
@@ -902,3 +902,21 @@ RideCache::getRideTypeCounts(Specification specification, int& nActivities,
         else nRides++;
     }
 }
+
+bool
+RideCache::isMetricRelevantForRides(Specification specification,
+                                    const RideMetric* metric)
+{
+    bool isRelevant = false;
+
+    // loop through and aggregate
+    foreach (RideItem *ride, rides_) {
+
+        // skip filtered rides
+        if (!specification.pass(ride)) continue;
+
+        isRelevant = isRelevant || metric->isRelevantForRide(ride);
+    }
+
+    return isRelevant;
+}

--- a/src/Core/RideCache.cpp
+++ b/src/Core/RideCache.cpp
@@ -907,16 +907,14 @@ bool
 RideCache::isMetricRelevantForRides(Specification specification,
                                     const RideMetric* metric)
 {
-    bool isRelevant = false;
-
     // loop through and aggregate
     foreach (RideItem *ride, rides_) {
 
         // skip filtered rides
         if (!specification.pass(ride)) continue;
 
-        isRelevant = isRelevant || metric->isRelevantForRide(ride);
+        if (metric->isRelevantForRide(ride)) return true;
     }
 
-    return isRelevant;
+    return false;
 }

--- a/src/Core/RideCache.cpp
+++ b/src/Core/RideCache.cpp
@@ -905,13 +905,19 @@ RideCache::getRideTypeCounts(Specification specification, int& nActivities,
 
 bool
 RideCache::isMetricRelevantForRides(Specification specification,
-                                    const RideMetric* metric)
+                                    const RideMetric* metric,
+                                    SportRestriction sport)
 {
     // loop through and aggregate
     foreach (RideItem *ride, rides_) {
 
         // skip filtered rides
         if (!specification.pass(ride)) continue;
+
+        // skip non selected sports when restriction supplied
+        if ((sport == OnlyRides) && (ride->isSwim || ride->isRun)) continue;
+        if ((sport == OnlyRuns) && !ride->isRun) continue;
+        if ((sport == OnlySwims) && !ride->isSwim) continue;
 
         if (metric->isRelevantForRide(ride)) return true;
     }

--- a/src/Core/RideCache.h
+++ b/src/Core/RideCache.h
@@ -73,6 +73,9 @@ class RideCache : public QObject
         // Count of activities matching specification
         void getRideTypeCounts(Specification specification, int& nActivities,
                                int& nRides, int& nRuns, int& nSwims);
+        // Check if metric is relevant for some  activity matching specification
+        bool isMetricRelevantForRides(Specification specification,
+                                      const RideMetric* metric);
 
         // is running ?
         bool isRunning() { return future.isRunning(); }

--- a/src/Core/RideCache.h
+++ b/src/Core/RideCache.h
@@ -74,8 +74,10 @@ class RideCache : public QObject
         void getRideTypeCounts(Specification specification, int& nActivities,
                                int& nRides, int& nRuns, int& nSwims);
         // Check if metric is relevant for some  activity matching specification
+        enum SportRestriction { AnySport, OnlyRides, OnlyRuns, OnlySwims };
         bool isMetricRelevantForRides(Specification specification,
-                                      const RideMetric* metric);
+                                      const RideMetric* metric,
+                                      SportRestriction sport=AnySport);
 
         // is running ?
         bool isRunning() { return future.isRunning(); }

--- a/src/Gui/ComparePane.cpp
+++ b/src/Gui/ComparePane.cpp
@@ -401,6 +401,16 @@ ComparePane::refreshTable()
             // get the metric name
             const RideMetric *m = factory.rideMetric(metric);
             if (m) {
+                // Skip metrics not relevant for all ranges in compare pane
+                bool isRelevant = false;
+                foreach(CompareDateRange x, context->compareDateRanges) {
+                    if (x.context->athlete->rideCache->isMetricRelevantForRides(x.specification, m)) {
+                        isRelevant = true;
+                        break;
+                    }
+                }
+                if (!isRelevant) continue;
+
                 worklist << metric;
                 QString units;
                 if (!(m->units(context->athlete->useMetricUnits) == "seconds" || m->units(context->athlete->useMetricUnits) == tr("seconds")))


### PR DESCRIPTION
Adds isMetricRelevantForRides(specification, metric) to RideCache
to check if a metric isRelevant for some of the activities passing
the specification
Also reduces from 3 to 1 the calls to getRideTypeCounts

A similar criteria could be applied to the columns of rides/runs/swims lists to filter columns not relevant for any of the activities in the list.