### PR TITLE
Added Calendar Popup to QDateEdit fields with default format

### DIFF
--- a/src/Core/Season.cpp
+++ b/src/Core/Season.cpp
@@ -120,9 +120,11 @@ EditSeasonDialog::EditSeasonDialog(Context *context, Season *season) :
 
     fromEdit = new QDateEdit(this);
     fromEdit->setDate(season->getStart());
+    fromEdit->setCalendarPopup(true);
 
     toEdit = new QDateEdit(this);
     toEdit->setDate(season->getEnd());
+    toEdit->setCalendarPopup(true);
 
     seedEdit = new QDoubleSpinBox(this);
     seedEdit->setDecimals(0);
@@ -207,6 +209,7 @@ EditSeasonEventDialog::EditSeasonEventDialog(Context *context, SeasonEvent *even
 
     dateEdit = new QDateEdit(this);
     dateEdit->setDate(event->date);
+    dateEdit->setCalendarPopup(true);
 
     grid->addWidget(name, 0,0);
     grid->addWidget(nameEdit, 0,1);
@@ -591,9 +594,11 @@ EditPhaseDialog::EditPhaseDialog(Context *context, Phase *phase) :
 
     fromEdit = new QDateEdit(this);
     fromEdit->setDate(phase->getStart());
+    fromEdit->setCalendarPopup(true);
 
     toEdit = new QDateEdit(this);
     toEdit->setDate(phase->getEnd());
+    toEdit->setCalendarPopup(true);
 
     seedEdit = new QDoubleSpinBox(this);
     seedEdit->setDecimals(0);

--- a/src/Core/TimeUtils.cpp
+++ b/src/Core/TimeUtils.cpp
@@ -181,6 +181,7 @@ DateSettingsEdit::DateSettingsEdit(QWidget *parent) : parent(parent), active(fal
     radioFrom->setFont(sameFont);
     startDateEdit = new QDateEdit(this);
     startDateEdit->setDate(QDate::currentDate().addMonths(-3));
+    startDateEdit ->setCalendarPopup(true);
     QHBoxLayout *from = new QHBoxLayout;
     from->addWidget(radioFrom);
     from->addWidget(startDateEdit);
@@ -192,7 +193,9 @@ DateSettingsEdit::DateSettingsEdit(QWidget *parent) : parent(parent), active(fal
     radioCustom->setFont(sameFont);
     radioCustom->setChecked(false);
     fromDateEdit = new QDateEdit(this);
+    fromDateEdit ->setCalendarPopup(true);
     toDateEdit = new QDateEdit(this);
+    toDateEdit ->setCalendarPopup(true);
     QHBoxLayout *custom = new QHBoxLayout;
     custom->addWidget(radioCustom);
     custom->addWidget(fromDateEdit);

--- a/src/Gui/ManualRideDialog.cpp
+++ b/src/Gui/ManualRideDialog.cpp
@@ -142,6 +142,7 @@ ManualRideDialog::ManualRideDialog(Context *context) : context(context)
     QLabel *dateLabel = new QLabel(tr("Date:"), this);
     dateEdit = new QDateEdit(this);
     dateEdit->setDate(QDate::currentDate());
+    dateEdit->setCalendarPopup(true);
 
     QLabel *timeLabel = new QLabel(tr("Start time:"), this);
     timeEdit = new QTimeEdit(this);

--- a/src/Gui/NewCyclistDialog.cpp
+++ b/src/Gui/NewCyclistDialog.cpp
@@ -55,6 +55,7 @@ NewCyclistDialog::NewCyclistDialog(QDir home) : QDialog(NULL, Qt::Dialog), home(
     name = new QLineEdit(this);
 
     dob = new QDateEdit(this);
+    dob->setCalendarPopup(true);
 
     sex = new QComboBox(this);
     sex->addItem(tr("Male"));

--- a/src/Gui/Pages.cpp
+++ b/src/Gui/Pages.cpp
@@ -1147,6 +1147,7 @@ AboutRiderPage::AboutRiderPage(QWidget *parent, Context *context) : QWidget(pare
 
     dob = new QDateEdit(this);
     dob->setDate(appsettings->cvalue(context->athlete->cyclist, GC_DOB).toDate());
+    dob->setCalendarPopup(true);
 
     sex = new QComboBox(this);
     sex->addItem(tr("Male"));
@@ -4137,6 +4138,7 @@ CPPage::CPPage(Context *context, Zones *zones_, SchemePage *schemePage) :
     QLabel *pmaxLabel = new QLabel(tr("Pmax"));
     dateEdit = new QDateEdit;
     dateEdit->setDate(QDate::currentDate());
+    dateEdit->setCalendarPopup(true);
 
      // Use CP for FTP
     useCPForFTPCombo = new QComboBox(this);
@@ -4977,6 +4979,7 @@ LTPage::LTPage(Context *context, HrZones *hrZones, HrSchemePage *schemePage) :
     QLabel *ltLabel = new QLabel(tr("Lactate Threshold"));
     dateEdit = new QDateEdit;
     dateEdit->setDate(QDate::currentDate());
+    dateEdit->setCalendarPopup(true);
 
     ltEdit = new QDoubleSpinBox;
     ltEdit->setMinimum(0);
@@ -5688,6 +5691,7 @@ CVPage::CVPage(PaceZones* paceZones, PaceSchemePage *schemePage) :
     QLabel *cpLabel = new QLabel(tr("Critical Velocity"));
     dateEdit = new QDateEdit;
     dateEdit->setDate(QDate::currentDate());
+    dateEdit->setCalendarPopup(true);
 
     // CV default is 4min/km for Running a round number inline with
     // CP default and 1:36min/100 for swimming (4:1 relation)


### PR DESCRIPTION
To enhance usability, specially when the locale uses 2 digits years.
Fixes #2123
In some places s.t. TPDowloadDialog and FileStore it was already set.
Not added to RideMetadata and RideImportWizard where 4 digits year is fixed.

Also discussed at the forum: https://groups.google.com/forum/#!topic/golden-cheetah-users/sf9NmFFaKDg