### PR TITLE
Changed BestTime metrics units to minutes

### DIFF
--- a/src/Charts/LTMPlot.cpp
+++ b/src/Charts/LTMPlot.cpp
@@ -981,9 +981,9 @@ LTMPlot::setData(LTMSettings *set)
                             labelString = (QString("%1").arg(value, 0, 'f', 1));
                         }
 
-                        // Pace units use mm:ss format for the label
-                        if (PaceZones::isPaceUnit(metricDetail.uunits))
-                            labelString = time_to_string(value*60);
+                        // Format minutes in sexagesimal format
+                        if (isMinutes(metricDetail.uunits))
+                            labelString = time_to_string(value*60, true);
 
                         // Qwt uses its own text objects
                         QwtText text(labelString);
@@ -1148,9 +1148,9 @@ LTMPlot::setData(LTMSettings *set)
                         labelString = (QString("%1").arg(value, 0, 'f', 1));
                     }
 
-                    // Pace units use mm:ss format for the label
-                    if (PaceZones::isPaceUnit(metricDetail.uunits))
-                        labelString = time_to_string(value*60);
+                    // Format minutes in sexagesimal format
+                    if (isMinutes(metricDetail.uunits))
+                        labelString = time_to_string(value*60, true);
 
 
                     // Qwt uses its own text objects
@@ -2093,9 +2093,9 @@ LTMPlot::setCompareData(LTMSettings *set)
                                 labelString = (QString("%1").arg(value, 0, 'f', 1));
                             }
 
-                            // Pace units use mm:ss format for the label
-                            if (PaceZones::isPaceUnit(metricDetail.uunits))
-                                labelString = time_to_string(value*60);
+                            // Format minutes in sexagesimal format
+                            if (isMinutes(metricDetail.uunits))
+                                labelString = time_to_string(value*60, true);
 
 
                             // Qwt uses its own text objects
@@ -2260,9 +2260,9 @@ LTMPlot::setCompareData(LTMSettings *set)
                             labelString = (QString("%1").arg(value, 0, 'f', 1));
                         }
 
-                        // Pace units use mm:ss format for the label
-                        if (PaceZones::isPaceUnit(metricDetail.uunits))
-                            labelString = time_to_string(value*60);
+                        // Format minutes in sexagesimal format
+                        if (isMinutes(metricDetail.uunits))
+                            labelString = time_to_string(value*60, true);
 
 
                         // Qwt uses its own text objects
@@ -3572,8 +3572,8 @@ LTMPlot::pointHover(QwtPlotCurve *curve, int index)
 
         // convert minutes to time string for pace, otherwise use precision
         QString txtValue;
-        if (PaceZones::isPaceUnit(units) || PaceZones::isPaceUnit(this->axisTitle(curve->yAxis()).text())) {
-            txtValue = QString("%1").arg(time_to_string(value*60.0));
+        if (isMinutes(units) || isMinutes(this->axisTitle(curve->yAxis()).text())) {
+            txtValue = QString("%1").arg(time_to_string(value*60.0, true));
         } else {
             txtValue = QString("%1").arg(value, 0, 'f', precision);
         }
@@ -3876,4 +3876,9 @@ void LTMPlot::refreshZoneLabels(QwtAxisId axisid)
     }
     bg = new LTMPlotBackground(this, axisid);
     bg->attach(this);
+}
+
+bool LTMPlot::isMinutes(QString units)
+{
+    return units == "minutes" || units == tr("minutes") || PaceZones::isPaceUnit(units);
 }

--- a/src/Charts/LTMPlot.h
+++ b/src/Charts/LTMPlot.h
@@ -56,6 +56,7 @@ class LTMPlot : public QwtPlot
         void setData(LTMSettings *);
         void setCompareData(LTMSettings *);
         void setAxisTitle(QwtAxisId axis, QString label);
+        static bool isMinutes(QString units);
 
     public slots:
         void pointHover(QwtPlotCurve*, int);

--- a/src/Core/TimeUtils.cpp
+++ b/src/Core/TimeUtils.cpp
@@ -23,13 +23,13 @@
 #include <QFormLayout>
 #include <QLabel>
 
-QString time_to_string(double secs)
+QString time_to_string(double secs, bool forceMinutes)
 {
     // negs are bad
     if (secs<0) secs=0;
 
     QString result;
-    if (secs < 60) result = QString("%1").arg(secs); // special case for < 60s
+    if (!forceMinutes && secs < 60) result = QString("%1").arg(secs); // special case for < 60s
     else{
         unsigned rounded = static_cast<unsigned>(round(secs));
         bool needs_colon = false;

--- a/src/Core/TimeUtils.h
+++ b/src/Core/TimeUtils.h
@@ -30,7 +30,7 @@
 
 QString interval_to_str(double secs);  // output like 1h 2m 3s
 double str_to_interval(QString s);     // convert 1h 2m 3s -> 3123.0 , e.g.
-QString time_to_string(double secs);   // output like 1:02:03
+QString time_to_string(double secs, bool forceMinutes=false);   // output like 1:02:03
 
 /* takes a string containing an ISO 8601 timestamp and converts it to local time
 */

--- a/src/Metrics/PeakPace.cpp
+++ b/src/Metrics/PeakPace.cpp
@@ -51,7 +51,7 @@ class PeakPace : public RideMetric {
         return RideMetric::value(metricRunPace);
     }
     QString toString(bool metric) const {
-        return time_to_string(value(metric)*60);
+        return time_to_string(value(metric)*60, true);
     }
     void setSecs(double secs) { this->secs=secs; }
 
@@ -364,7 +364,7 @@ class PeakPaceSwim : public RideMetric {
         return RideMetric::value(metricSwimPace);
     }
     QString toString(bool metric) const {
-        return time_to_string(value(metric)*60);
+        return time_to_string(value(metric)*60, true);
     }
     void setSecs(double secs) { this->secs=secs; }
 
@@ -666,7 +666,9 @@ class BestTime : public RideMetric {
     }
     // BestTime ordering is reversed
     bool isLowerBetter() const { return true; }
-    bool isTime() const { return true; }
+    QString toString(bool metric) const {
+        return time_to_string(value(metric)*60, true);
+    }
     void setMeters(double meters) { this->meters=meters; }
 
     void compute(RideItem *item, Specification spec, const QHash<QString,RideMetric*> &) {
@@ -683,7 +685,7 @@ class BestTime : public RideMetric {
         if (results.count() > 0) secs = results.first().stop - results.first().start;
         else secs = 0.0;
 
-        setValue(secs);
+        setValue(secs / 60.0);
     }
     bool isRelevantForRide(const RideItem *ride) const { return ride->present.contains("S"); }
     RideMetric *clone() const { return new BestTime(*this); }
@@ -700,8 +702,8 @@ class BestTime50m : public BestTime {
         }
         void initialize () {
             setName(tr("Best 50m"));
-            setMetricUnits(tr("seconds"));
-            setImperialUnits(tr("seconds"));
+            setMetricUnits(tr("minutes"));
+            setImperialUnits(tr("minutes"));
         }
         RideMetric *clone() const { return new BestTime50m(*this); }
 };
@@ -717,8 +719,8 @@ class BestTime100m : public BestTime {
         }
         void initialize () {
             setName(tr("Best 100m"));
-            setMetricUnits(tr("seconds"));
-            setImperialUnits(tr("seconds"));
+            setMetricUnits(tr("minutes"));
+            setImperialUnits(tr("minutes"));
         }
         RideMetric *clone() const { return new BestTime100m(*this); }
 };
@@ -734,8 +736,8 @@ class BestTime200m : public BestTime {
         }
         void initialize () {
             setName(tr("Best 200m"));
-            setMetricUnits(tr("seconds"));
-            setImperialUnits(tr("seconds"));
+            setMetricUnits(tr("minutes"));
+            setImperialUnits(tr("minutes"));
         }
         RideMetric *clone() const { return new BestTime200m(*this); }
 };
@@ -751,8 +753,8 @@ class BestTime400m : public BestTime {
         }
         void initialize () {
             setName(tr("Best 400m"));
-            setMetricUnits(tr("seconds"));
-            setImperialUnits(tr("seconds"));
+            setMetricUnits(tr("minutes"));
+            setImperialUnits(tr("minutes"));
         }
         RideMetric *clone() const { return new BestTime400m(*this); }
 };
@@ -768,8 +770,8 @@ class BestTime500m : public BestTime {
         }
         void initialize () {
             setName(tr("Best 500m"));
-            setMetricUnits(tr("seconds"));
-            setImperialUnits(tr("seconds"));
+            setMetricUnits(tr("minutes"));
+            setImperialUnits(tr("minutes"));
         }
         RideMetric *clone() const { return new BestTime500m(*this); }
 };
@@ -785,8 +787,8 @@ class BestTime800m : public BestTime {
         }
         void initialize () {
             setName(tr("Best 800m"));
-            setMetricUnits(tr("seconds"));
-            setImperialUnits(tr("seconds"));
+            setMetricUnits(tr("minutes"));
+            setImperialUnits(tr("minutes"));
         }
         RideMetric *clone() const { return new BestTime800m(*this); }
 };
@@ -802,8 +804,8 @@ class BestTime1000m : public BestTime {
         }
         void initialize () {
             setName(tr("Best 1000m"));
-            setMetricUnits(tr("seconds"));
-            setImperialUnits(tr("seconds"));
+            setMetricUnits(tr("minutes"));
+            setImperialUnits(tr("minutes"));
         }
         RideMetric *clone() const { return new BestTime1000m(*this); }
 };
@@ -819,8 +821,8 @@ class BestTime1500m : public BestTime {
         }
         void initialize () {
             setName(tr("Best 1500m"));
-            setMetricUnits(tr("seconds"));
-            setImperialUnits(tr("seconds"));
+            setMetricUnits(tr("minutes"));
+            setImperialUnits(tr("minutes"));
         }
         RideMetric *clone() const { return new BestTime1500m(*this); }
 };
@@ -836,8 +838,8 @@ class BestTime2000m : public BestTime {
         }
         void initialize () {
             setName(tr("Best 2000m"));
-            setMetricUnits(tr("seconds"));
-            setImperialUnits(tr("seconds"));
+            setMetricUnits(tr("minutes"));
+            setImperialUnits(tr("minutes"));
         }
         RideMetric *clone() const { return new BestTime2000m(*this); }
 };
@@ -853,8 +855,8 @@ class BestTime3000m : public BestTime {
         }
         void initialize () {
             setName(tr("Best 3000m"));
-            setMetricUnits(tr("seconds"));
-            setImperialUnits(tr("seconds"));
+            setMetricUnits(tr("minutes"));
+            setImperialUnits(tr("minutes"));
         }
         RideMetric *clone() const { return new BestTime3000m(*this); }
 };
@@ -870,8 +872,8 @@ class BestTime4000m : public BestTime {
         }
         void initialize () {
             setName(tr("Best 4000m"));
-            setMetricUnits(tr("seconds"));
-            setImperialUnits(tr("seconds"));
+            setMetricUnits(tr("minutes"));
+            setImperialUnits(tr("minutes"));
         }
         RideMetric *clone() const { return new BestTime4000m(*this); }
 };
@@ -887,8 +889,8 @@ class BestTime5000m : public BestTime {
         }
         void initialize () {
             setName(tr("Best 5000m"));
-            setMetricUnits(tr("seconds"));
-            setImperialUnits(tr("seconds"));
+            setMetricUnits(tr("minutes"));
+            setImperialUnits(tr("minutes"));
         }
         RideMetric *clone() const { return new BestTime5000m(*this); }
 };
@@ -904,8 +906,8 @@ class BestTime10km : public BestTime {
         }
         void initialize () {
             setName(tr("Best 10km"));
-            setMetricUnits(tr("seconds"));
-            setImperialUnits(tr("seconds"));
+            setMetricUnits(tr("minutes"));
+            setImperialUnits(tr("minutes"));
         }
         RideMetric *clone() const { return new BestTime10km(*this); }
 };
@@ -921,8 +923,8 @@ class BestTime15km : public BestTime {
         }
         void initialize () {
             setName(tr("Best 15km"));
-            setMetricUnits(tr("seconds"));
-            setImperialUnits(tr("seconds"));
+            setMetricUnits(tr("minutes"));
+            setImperialUnits(tr("minutes"));
         }
         RideMetric *clone() const { return new BestTime15km(*this); }
 };
@@ -938,8 +940,8 @@ class BestTime20km : public BestTime {
         }
         void initialize () {
             setName(tr("Best 20km"));
-            setMetricUnits(tr("seconds"));
-            setImperialUnits(tr("seconds"));
+            setMetricUnits(tr("minutes"));
+            setImperialUnits(tr("minutes"));
         }
         RideMetric *clone() const { return new BestTime20km(*this); }
 };
@@ -955,8 +957,8 @@ class BestTimeHalfMarathon : public BestTime {
         }
         void initialize () {
             setName(tr("Best Half Marathon"));
-            setMetricUnits(tr("seconds"));
-            setImperialUnits(tr("seconds"));
+            setMetricUnits(tr("minutes"));
+            setImperialUnits(tr("minutes"));
         }
         RideMetric *clone() const { return new BestTimeHalfMarathon(*this); }
 };
@@ -972,8 +974,8 @@ class BestTime30km : public BestTime {
         }
         void initialize () {
             setName(tr("Best 30km"));
-            setMetricUnits(tr("seconds"));
-            setImperialUnits(tr("seconds"));
+            setMetricUnits(tr("minutes"));
+            setImperialUnits(tr("minutes"));
         }
         RideMetric *clone() const { return new BestTime30km(*this); }
 };
@@ -989,8 +991,8 @@ class BestTime40km : public BestTime {
         }
         void initialize () {
             setName(tr("Best 40km"));
-            setMetricUnits(tr("seconds"));
-            setImperialUnits(tr("seconds"));
+            setMetricUnits(tr("minutes"));
+            setImperialUnits(tr("minutes"));
         }
         RideMetric *clone() const { return new BestTime40km(*this); }
 };
@@ -1006,8 +1008,8 @@ class BestTimeMarathon : public BestTime {
         }
         void initialize () {
             setName(tr("Best Marathon"));
-            setMetricUnits(tr("seconds"));
-            setImperialUnits(tr("seconds"));
+            setMetricUnits(tr("minutes"));
+            setImperialUnits(tr("minutes"));
         }
         RideMetric *clone() const { return new BestTimeMarathon(*this); }
 };

--- a/src/Metrics/RideMetric.cpp
+++ b/src/Metrics/RideMetric.cpp
@@ -143,8 +143,9 @@
 // 133 22  Jul 2016 Damien Grauser     Added Efficiency Index
 // 134 22  Jul 2016 Damien Grauser     Add Stride length
 // 135 10  Aug 2016 Ale Martinez       Added Average Swim Pace for the 4 Strokes
+// 136 17  Oct 2016 Ale Martinez       Changed Best Times units to minutes
 
-int DBSchemaVersion = 135;
+int DBSchemaVersion = 136;
 
 RideMetricFactory *RideMetricFactory::_instance;
 QVector<QString> RideMetricFactory::noDeps;

--- a/src/Metrics/RideMetric.h
+++ b/src/Metrics/RideMetric.h
@@ -164,6 +164,9 @@ public:
         case Peak:
             setValue(value(true) > other.value(true) ? value(true) : other.value(true));
             break;
+        case Low:
+            setValue((value(true) > 0.0 && value(true) < other.value(true)) ? value(true) : other.value(true));
+            break;
         case Average:
             setValue(((value(true) * count()) + (other.value(true) * other.count()))
                                 / (count()+other.count()));

--- a/src/Metrics/RunMetrics.cpp
+++ b/src/Metrics/RunMetrics.cpp
@@ -276,7 +276,7 @@ class Pace : public RideMetric {
     }
 
     QString toString(bool metric) const {
-        return time_to_string(value(metric)*60);
+        return time_to_string(value(metric)*60, true);
     }
 
     void initialize() {

--- a/src/Metrics/SwimMetrics.cpp
+++ b/src/Metrics/SwimMetrics.cpp
@@ -111,7 +111,7 @@ class PaceSwim : public RideMetric {
     }
 
     QString toString(bool metric) const {
-        return time_to_string(value(metric)*60);
+        return time_to_string(value(metric)*60, true);
     }
 
     void initialize() {
@@ -179,7 +179,7 @@ class SwimPace : public RideMetric {
     }
 
     QString toString(bool metric) const {
-        return time_to_string(value(metric)*60);
+        return time_to_string(value(metric)*60, true);
     }
 
     void initialize() {
@@ -454,7 +454,7 @@ class SwimPaceStroke : public RideMetric {
     }
 
     QString toString(bool metric) const {
-        return time_to_string(value(metric)*60);
+        return time_to_string(value(metric)*60, true);
     }
 
     void initialize() {


### PR DESCRIPTION
It is a more natural unit is most cases and allows enhanced
plotting in LTM charts since seconds are converted to hours.
Labels and ToolTip are shown in sexagesimal format.
The metrics changed were added on https://github.com/GoldenCheetah/GoldenCheetah/pull/2009/commits/0bbc571ccc539991193f7060ab25c012eb315b7d