### PR TITLE
Fix seg fault that occurs after closing app

### DIFF
--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -612,5 +612,7 @@ main(int argc, char *argv[])
 
     } while (restarting);
 
+    delete application;
+
     return ret;
 }


### PR DESCRIPTION
Freeing the application object before returning from main, fixes the seg fault I'm getting each time after closing the app.