### PR TITLE
Set Sport to Bike and process defaults on Download

### DIFF
--- a/src/FileIO/Device.h
+++ b/src/FileIO/Device.h
@@ -105,6 +105,8 @@ struct Devices
 
     virtual QString downloadInstructions() const { return ""; };
 
+    virtual bool isBikeOnly() { return true; }; // Most supported devices are !
+
     static QList<QString> typeNames();
     static DevicesPtr getType(const QString &deviceTypeName );
     static bool addType(const QString &deviceTypeName, DevicesPtr p );

--- a/src/FileIO/MoxyDevice.h
+++ b/src/FileIO/MoxyDevice.h
@@ -36,6 +36,7 @@ struct MoxyDevices : public Devices
     virtual QString downloadInstructions() const;
     virtual bool canCleanup( void ) {return true; };
     virtual bool canPreview() { return false; }; // Moxy is dumb ass
+    virtual bool isBikeOnly() { return false; }; // Moxy is multisport
 };
 
 struct MoxyDevice : public Device,QThread

--- a/src/Gui/DownloadRideDialog.cpp
+++ b/src/Gui/DownloadRideDialog.cpp
@@ -26,6 +26,7 @@
 #include "JsonRideFile.h"
 #include "HelpWhatsThis.h"
 #include "RideItem.h"
+#include "RideMetadata.h"
 #include <assert.h>
 #include <errno.h>
 #include <QtGui>
@@ -440,6 +441,11 @@ DownloadRideDialog::downloadClicked()
             // add Source File Tag + New File Name
             ride->setTag("Source Filename", filename);
             ride->setTag("Filename", targetFileName);
+            // add Sport Tag when device is bike only
+            if (devtype->isBikeOnly()) ride->setTag("Sport", "Bike");
+            // process linked defaults
+            context->athlete->rideMetadata()->setLinkedDefaults(ride);
+
             JsonFileReader reader;
             // write to tempActivties first (until RideCache is updated without crash)
             targetFileTmpActivitiesName = context->athlete->home->tmpActivities().canonicalPath() + "/" + targetFileName;


### PR DESCRIPTION
When the device is isBikeOnly, default to true for all currently
supported devices, except Moxy.
Fixes #2156
