### PR TITLE
Handle "Abort" and "Finish" correctly in RideImportWizard

### DIFF
--- a/src/Gui/RideImportWizard.cpp
+++ b/src/Gui/RideImportWizard.cpp
@@ -53,7 +53,7 @@ RideImportWizard::RideImportWizard(QList<QUrl> *urls, Context *context, QWidget 
     init(filenames, context);
     filenames.clear();
     _importInProcess = false;
-
+    _importState = READY;
 }
 
 RideImportWizard::RideImportWizard(QList<QString> files, Context *context, QWidget *parent) : QDialog(parent), context(context)
@@ -64,7 +64,7 @@ RideImportWizard::RideImportWizard(QList<QString> files, Context *context, QWidg
     autoImportStealth = false;
     init(files, context);
     _importInProcess = false;
-
+    _importState = READY;
 }
 
 
@@ -73,6 +73,7 @@ RideImportWizard::RideImportWizard(RideAutoImportConfig *dirs, Context *context,
     _importInProcess = true;
     autoImportMode = true;
     autoImportStealth = true;
+    _importState = READY;
 
     if (autoImportStealth) hide();
     QList<QString> files;
@@ -896,14 +897,14 @@ RideImportWizard::abortClicked()
     QString label = abortButton->text();
 
     // Process "ABORT"
-    if (label == tr("Abort")) {
+    if (_importState == RUNNING) {
         hide();
         aborted=true; // terminated. I'll be back.
         return;
     }
 
     // Process "FINISH"
-    if (label == tr("Finish")) {
+    if (_importState == DONE) {
        // phew. our work is done. -- lets force an update stats...
        hide();
        if (autoImportStealth) {
@@ -918,6 +919,7 @@ RideImportWizard::abortClicked()
 
     // SAVE STEP 2 - set the labels and make the text un-editable
     phaseLabel->setText(tr("Step 4 of 4: Save to Library"));
+    _importState = RUNNING;
 
     abortButton->setText(tr("Abort"));
     aborted = false;
@@ -1073,6 +1075,7 @@ RideImportWizard::abortClicked()
     progressBar->setValue(progressBar->maximum());
     phaseLabel->setText(donemessage);
     abortButton->setText(tr("Finish"));
+    _importState = DONE;
     aborted = false;
     if (autoImportStealth) {
         abortClicked();  // simulate pressing the "Finish" button - even if the window got visible

--- a/src/Gui/RideImportWizard.h
+++ b/src/Gui/RideImportWizard.h
@@ -91,6 +91,7 @@ private:
 
     QStringList deleteMe; // list of temp files created during import
 
+    enum { READY, RUNNING, DONE } _importState;
 
 };
 


### PR DESCRIPTION
I wonder if anybody else has this problem. The RideImportWizard 
dialog stays open forever. 

The current state was encoded in the text label of the abort button,
but the comparison operation did never match, so only the default state
was ever handled. This prevents aborts and causes the window to never
close.

Add a variable to store the current state, instead.