### PR TITLE
Fix shadowbuild

### DIFF
--- a/kqoauth/kqoauth.pro
+++ b/kqoauth/kqoauth.pro
@@ -1,5 +1,5 @@
 TARGET = kqoauth
-DESTDIR = .
+DESTDIR = ./lib
 win32:DLLDESTDIR = $${DESTDIR}
 
 VERSION = 0.97

--- a/qwt/src/src.pro
+++ b/qwt/src/src.pro
@@ -19,7 +19,7 @@ QWT_OUT_ROOT = $${OUT_PWD}/..
 TEMPLATE          = lib
 TARGET            = $$qwtLibraryTarget(qwt)
 
-DESTDIR           = $${PWD}/../lib
+DESTDIR           = $${QWT_OUT_ROOT}/lib
 
 contains(QWT_CONFIG, QwtDll) {
 

--- a/src/Resources/application.qrc
+++ b/src/Resources/application.qrc
@@ -80,18 +80,6 @@
         <file>images/settings.png</file>
         <file>images/addchart.png</file>
         <file>images/library.png</file>
-        <file>translations/gc_fr.qm</file>
-        <file>translations/gc_ja.qm</file>
-        <file>translations/gc_it.qm</file>
-        <file>translations/gc_pt-br.qm</file>
-        <file>translations/gc_de.qm</file>
-        <file>translations/gc_ru.qm</file>
-        <file>translations/gc_cs.qm</file>
-        <file>translations/gc_es.qm</file>
-        <file>translations/gc_pt.qm</file>
-        <file>translations/gc_zh-cn.qm</file>        
-        <file>translations/gc_zh-tw.qm</file>
-        <file>translations/gc_nl.qm</file>
         <file>xml/charts.xml</file>
         <file>xml/metadata.xml</file>
         <file>xml/train-layout.xml</file>

--- a/src/Resources/translations.qrc
+++ b/src/Resources/translations.qrc
@@ -1,0 +1,16 @@
+<RCC>
+    <qresource prefix="/">
+        <file>translations/gc_cs.qm</file>
+        <file>translations/gc_de.qm</file>
+        <file>translations/gc_es.qm</file>
+        <file>translations/gc_fr.qm</file>
+        <file>translations/gc_it.qm</file>
+        <file>translations/gc_ja.qm</file>
+        <file>translations/gc_nl.qm</file>
+        <file>translations/gc_pt-br.qm</file>
+        <file>translations/gc_pt.qm</file>
+        <file>translations/gc_ru.qm</file>
+        <file>translations/gc_zh-cn.qm</file>
+        <file>translations/gc_zh-tw.qm</file>
+    </qresource>
+</RCC>

--- a/src/src.pro
+++ b/src/src.pro
@@ -101,15 +101,15 @@ win32 {
 
     #QWT is configured to build 2 libs (release/debug) on win32 (see qwtbuild.pri)
     CONFIG(release, debug|release){
-    LIBS += -L$${PWD}/../qwt/lib -lqwt
+    LIBS += -L../qwt/lib -lqwt
     }
     CONFIG(debug, debug|release) {
-    LIBS += -L$${PWD}/../qwt/lib -lqwtd
+    LIBS += -L../qwt/lib -lqwtd
     }
 
 } else {
     #QWT is configured to build 1 lib for all other OS (see qwtbuild.pri)
-    LIBS += -L$${PWD}/../qwt/lib -lqwt
+    LIBS += -L../qwt/lib -lqwt
 }
 
 # compress and math libs must be defined in gcconfig.pri
@@ -208,7 +208,7 @@ isEmpty(QMAKE_LRELEASE) {
 }
 
 # how to run lrelease
-isEmpty(TS_DIR):TS_DIR = $${PWD}/Resources/translations
+isEmpty(TS_DIR):TS_DIR = Resources/translations
 TSQM.name = lrelease ${QMAKE_FILE_IN}
 TSQM.input = TRANSLATIONS
 TSQM.output = $$TS_DIR/${QMAKE_FILE_BASE}.qm
@@ -220,7 +220,7 @@ QMAKE_EXTRA_COMPILERS += TSQM
 ### RESOURCES
 ###==========
 
-RESOURCES = $${PWD}/Resources/application.qrc $${PWD}/Resources/RideWindow.qrc
+RESOURCES = Resources/application.qrc Resources/RideWindow.qrc
 
 
 
@@ -273,8 +273,8 @@ unix:!macx {
     # build from version in repo for Linux builds since
     # kqoauth is not packaged for the Debian and this makes
     # life much easier for the package maintainer
-    INCLUDEPATH += $${PWD}/../kqoauth
-    LIBS        += $${PWD}/../kqoauth/libkqoauth.a
+    INCLUDEPATH += ../kqoauth
+    LIBS        += ../kqoauth/libkqoauth.a
     DEFINES     += GC_HAVE_KQOAUTH
 
 } else {

--- a/src/src.pro
+++ b/src/src.pro
@@ -274,7 +274,7 @@ unix:!macx {
     # kqoauth is not packaged for the Debian and this makes
     # life much easier for the package maintainer
     INCLUDEPATH += ../kqoauth
-    LIBS        += ../kqoauth/libkqoauth.a
+    LIBS        += ../kqoauth/lib/libkqoauth.a
     DEFINES     += GC_HAVE_KQOAUTH
 
 } else {

--- a/src/src.pro
+++ b/src/src.pro
@@ -207,6 +207,15 @@ isEmpty(QMAKE_LRELEASE) {
     else:QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease
 }
 
+# empty variable: used to prevent the path from translations.qrc from being "fixified" to src dir
+__EMPTY_TR_QRC_ROOT__ =
+
+# copy translations.qrc file
+trqrc.target = $(__EMPTY_TR_QRC_ROOT__)Resources/translations.qrc
+trqrc.depends = $${PWD}/Resources/translations.qrc
+trqrc.commands = $$QMAKE_COPY_FILE $$shell_path($$trqrc.depends) $$shell_path($$trqrc.target)
+QMAKE_EXTRA_TARGETS += trqrc
+
 # how to run lrelease
 isEmpty(TS_DIR):TS_DIR = Resources/translations
 TSQM.name = lrelease ${QMAKE_FILE_IN}
@@ -220,7 +229,7 @@ QMAKE_EXTRA_COMPILERS += TSQM
 ### RESOURCES
 ###==========
 
-RESOURCES = Resources/application.qrc Resources/RideWindow.qrc
+RESOURCES = Resources/application.qrc Resources/RideWindow.qrc $$trqrc.target
 
 
 


### PR DESCRIPTION
This PR makes it possible to have clean shadow builds that don't have shared build output, which before were: libqwt, libkqoauth and the translation file lrelease compilation outputs. Shared build output lead to linker errors, when switching from one shadow build (e.g. with Qt 5.4) to another shadow build (e.g. with Qt 5.7).