### PR TITLE
Preserve timing values on qwkcode -> ERG -> qwkcode round trip translation.

### DIFF
--- a/src/Train/WorkoutWidget.cpp
+++ b/src/Train/WorkoutWidget.cpp
@@ -1775,7 +1775,7 @@ WorkoutWidget::qwkcode()
         double ap=0;
 
         // how long is this section ?
-        int duration = points_[i+1]->x - points_[i]->x;
+        int duration = round(points_[i+1]->x) - round(points_[i]->x);
 
         bool hasStartLapMarker, hasEndLapMarker;
         hasStartLapMarker = hasEndLapMarker = false;

--- a/src/Train/WorkoutWidget.cpp
+++ b/src/Train/WorkoutWidget.cpp
@@ -795,8 +795,8 @@ WorkoutWidget::setBlockCursor()
 
     bool returning=false;
     QPointF last(0,0);
-    int lastx=0;
-    int lasty=0;
+    double lastx=0;
+    double lasty=0;
     int hoveri=-1;
 
     foreach(WWPoint *p, points_) {
@@ -1917,7 +1917,7 @@ WorkoutWidget::hoverQwkcode()
     for (int i=from; i<=to; i++) {
 
         if (i>from) {
-            int time= points_[i]->x - points_[i-1]->x;
+            double time = points_[i]->x - points_[i-1]->x;
             sumTime += time;
             sumJoules += time * ((points_[i]->y + points_[i-1]->y)/2);
         }


### PR DESCRIPTION
The behavior described in #2175 is fixed by f3e377b5683cf7216daf33d82508cbca7d7e71ac.

We already round to the nearest hundredth of a minute when saving qwkcode -> ERG. By rounding to the nearest second when translating ERG -> qwkcode we can preserve the original qwkcode timing.

While investigating I noticed some cosmetic inconsistencies in how fractional seconds are displayed. These cases have been changed to consistently show a value that accurately represents the fractional minute value stored in ERG format.