### PR TITLE
ANT+ updates

### DIFF
--- a/src/ANT/ANT.cpp
+++ b/src/ANT/ANT.cpp
@@ -1307,3 +1307,24 @@ qint64 ANT::getElapsedTime()
 {
     return elapsedTimer.elapsed();
 }
+
+// blacklist a specific sensor
+void ANT::blacklistSensor(int device_number, int device_id)
+{
+    for (int i=0; i<channels; i++) {
+        if ((antChannel[i]->device_number == device_number) && (antChannel[i]->device_id == device_id)) {
+            if (!antChannel[i]->blacklisted) {
+                char *name = NULL;
+                for (int i=0; ant_sensor_types[i].suffix !=  '\0'; i++) {
+                    if (ant_sensor_types[i].device_id == device_id)
+                        name = (char*)ant_sensor_types[i].descriptive_name;
+                }
+
+                if (name)
+                    qDebug() << "*** Blacklisting" << name << "sensor id" << device_number;
+
+                antChannel[i]->blacklisted = 1;
+            }
+        }
+    }
+}

--- a/src/ANT/ANT.cpp
+++ b/src/ANT/ANT.cpp
@@ -120,6 +120,11 @@ ANT::ANT(QObject *parent, DeviceConfiguration *devConf, QString athlete) : QThre
     currentRollingResistance = rollingResistance = 0.004; // typical for road
     gradient = 0.1;
 
+    // elapsed time reference
+    elapsedTimer.start();
+    if (!elapsedTimer.isMonotonic())
+        qDebug() << "Caution: ANT timer is not monotonic";
+
     // state machine
     state = ST_WAIT_FOR_SYNC;
     length = bytes = 0;
@@ -1296,4 +1301,9 @@ void ANT::setFecChannel(int channel)
 void ANT::setControlChannel(int channel)
 {
     controlChannel = channel;
+}
+
+qint64 ANT::getElapsedTime()
+{
+    return elapsedTimer.elapsed();
 }

--- a/src/ANT/ANT.h
+++ b/src/ANT/ANT.h
@@ -477,6 +477,7 @@ public:
     int removeDevice(int device_number, int channel_type);
     ANTChannel *findDevice(int device_number, int channel_type);
     int startWaitingSearch();
+    void blacklistSensor(int device_number, int channel_type);
 
     // transmission
     void sendMessage(ANTMessage);

--- a/src/ANT/ANT.h
+++ b/src/ANT/ANT.h
@@ -37,6 +37,7 @@
 #include <QStringList>
 #include <QTime>
 #include <QTimer>
+#include <QElapsedTimer>
 #include <QProgressDialog>
 #include <QFile>
 
@@ -564,6 +565,8 @@ public:
     void setTrainerReady(bool status) { telemetry.setTrainerReady(status); }
     void setTrainerRunning(bool status) { telemetry.setTrainerRunning(status); }
 
+    qint64 getElapsedTime();
+
 private:
 
     void run();
@@ -608,6 +611,8 @@ private:
     int checksum;
     int powerchannels; // how many power channels do we have?
     QDateTime lastCadenceMessage;
+
+    QElapsedTimer elapsedTimer;
 
     QQueue<setChannelAtom> channelQueue; // messages for configuring channels from controller
 

--- a/src/ANT/ANTChannel.cpp
+++ b/src/ANT/ANTChannel.cpp
@@ -59,7 +59,7 @@ ANTChannel::init()
     status = Closed;
     fecPrevRawDistance=0;
     fecCapabilities=0;
-    lastMessageTimestamp = lastMessageTimestamp2 = QTime::currentTime();
+    lastMessageTimestamp = lastMessageTimestamp2 = parent->getElapsedTime();
 }
 
 //
@@ -631,9 +631,9 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                if (time) {
                    rpm = 1024*60*revs / time;
                    last_measured_rpm = rpm;
-                   lastMessageTimestamp = QTime::currentTime();
+                   lastMessageTimestamp = parent->getElapsedTime();
                } else {
-                   int ms = lastMessageTimestamp.msecsTo(QTime::currentTime());
+                   qint64 ms = parent->getElapsedTime() - lastMessageTimestamp;
                    rpm = qMin((float)(1000.0*60.0*1.0) / ms, parent->getCadence());
                    // If we received a message but timestamp remain unchanged then we know that sensor have not detected magnet thus we deduct that rpm cannot be higher than this
                    if (rpm < last_measured_rpm / 2.0)
@@ -658,9 +658,10 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
 
                    if (is_moxy) /* do nothing for now */ ; //XXX fixme when moxy arrives XXX
                    else parent->setCadence(rpm);
-                   lastMessageTimestamp = QTime::currentTime();
+                   lastMessageTimestamp = parent->getElapsedTime();
                } else {
-                   int ms = lastMessageTimestamp.msecsTo(QTime::currentTime());
+                   qint64 ms = parent->getElapsedTime() - lastMessageTimestamp;
+                   //qDebug() << "cadence ms:" << ms;
                    rpm = qMin((float)(1000.0*60.0*1.0) / ms, parent->getCadence());
                    // If we received a message but timestamp remain unchanged then we know that sensor have not detected magnet thus we deduct that rpm cannot be higher than this
                    if (rpm < last_measured_rpm / 2.0)
@@ -676,9 +677,10 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                    rpm = 1024*60*revs / time;
                    if (is_moxy) /* do nothing for now */ ; //XXX fixme when moxy arrives XXX
                    else parent->setWheelRpm(rpm);
-                   lastMessageTimestamp2 = QTime::currentTime();
+                   lastMessageTimestamp2 = parent->getElapsedTime();
                } else {
-                   int ms = lastMessageTimestamp2.msecsTo(QTime::currentTime());
+                   qint64 ms = parent->getElapsedTime() - lastMessageTimestamp2;
+                   //qDebug() << "speed ms:" << ms;
                    rpm = qMin((float)(1000.0*60.0*1.0) / ms, parent->getWheelRpm());
                    // If we received a message but timestamp remain unchanged then we know that sensor have not detected magnet thus we deduct that rpm cannot be higher than this
                    if (rpm < (float) 15.0)
@@ -697,9 +699,9 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                uint16_t revs = antMessage.wheelRevolutions - lastMessage.wheelRevolutions;
                if (time) {
                    rpm = 1024*60*revs / time;
-                   lastMessageTimestamp = QTime::currentTime();
+                   lastMessageTimestamp = parent->getElapsedTime();
                } else {
-                   int ms = lastMessageTimestamp.msecsTo(QTime::currentTime());
+                   qint64 ms = parent->getElapsedTime() - lastMessageTimestamp;
                    rpm = qMin((float)(1000.0*60.0*1.0) / ms, parent->getWheelRpm());
                    // If we received a message but timestamp remain unchanged then we know that sensor have not detected magnet thus we deduct that rpm cannot be higher than this
                    if (rpm < (float) 15.0)
@@ -823,8 +825,8 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                 // just process strides for now
                 if (antMessage.fpodInstant == false) {
 
-                    QTime now=QTime::currentTime();
-                    int ms = lastMessageTimestamp.msecsTo(now);
+                    qint64 now = parent->getElapsedTime();
+                    qint64 ms = now - lastMessageTimestamp;
                     lastMessageTimestamp = now;
 
                     // how many strides since last ?

--- a/src/ANT/ANTChannel.cpp
+++ b/src/ANT/ANTChannel.cpp
@@ -760,14 +760,14 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                    parent->setTrainerStatusAvailable(true);
                    // temporarily disabled until calibration included in the code / TODO : remove && false
                    parent->setTrainerCalibRequired((antMessage.fecPowerCalibRequired || antMessage.fecResisCalibRequired) && false);
-                   if (antMessage.fecPowerCalibRequired)
-                        qDebug() << "Trainer calibration required (power)";
-                   if (antMessage.fecResisCalibRequired)
-                        qDebug() << "Trainer calibration required (resistance)";
+                   //if (antMessage.fecPowerCalibRequired)
+                   //     qDebug() << "Trainer calibration required (power)";
+                   //if (antMessage.fecResisCalibRequired)
+                   //     qDebug() << "Trainer calibration required (resistance)";
                    // temporarily disabled until calibration included in the code / TODO : remove && false
                    parent->setTrainerConfigRequired(antMessage.fecUserConfigRequired && false);
-                   if (antMessage.fecUserConfigRequired)
-                        qDebug() << "Trainer configuration required";
+                   //if (antMessage.fecUserConfigRequired)
+                   //     qDebug() << "Trainer configuration required";
                    parent->setTrainerBrakeFault(antMessage.fecPowerOverLimits==FITNESS_EQUIPMENT_POWER_NOK_LOWSPEED
                                             ||  antMessage.fecPowerOverLimits==FITNESS_EQUIPMENT_POWER_NOK_HIGHSPEED
                                             ||  antMessage.fecPowerOverLimits==FITNESS_EQUIPMENT_POWER_NOK);

--- a/src/ANT/ANTChannel.h
+++ b/src/ANT/ANTChannel.h
@@ -102,10 +102,10 @@ class ANTChannel : public QObject {
         char id[10]; // short identifier
         ANTChannelInitialisation mi;
 
-        int   messages_received; // for signal strength metric
-        int   messages_dropped;
-        QTime lastMessageTimestamp;
-        QTime lastMessageTimestamp2;
+        int    messages_received; // for signal strength metric
+        int    messages_dropped;
+        qint64 lastMessageTimestamp; // for time comparisons
+        qint64 lastMessageTimestamp2;
 
         unsigned char rx_burst_data[RX_BURST_DATA_LEN];
         int           rx_burst_data_index;

--- a/src/ANT/ANTChannel.h
+++ b/src/ANT/ANTChannel.h
@@ -114,9 +114,9 @@ class ANTChannel : public QObject {
         void (*tx_ack_disposition)(struct ant_channel *);
 
         // what we got
-        int manufacturer_id;
         int product_id;
         int product_version;
+        int manufacturer_id;
 
     public:
 
@@ -153,6 +153,7 @@ class ANTChannel : public QObject {
         int device_number;
         int channel_type_flags;
         int device_id;
+        int blacklisted;
 
         // special cases
         bool is_kickr;

--- a/src/Train/AddDeviceWizard.cpp
+++ b/src/Train/AddDeviceWizard.cpp
@@ -673,7 +673,7 @@ AddPair::initializePage()
 
     // defaults
     static const int index4[4] = { 1,2,3,5 };
-    static const int index8[8] = { 1,2,3,4,5,6,9,0 };
+    static const int index8[8] = { 1,2,3,4,5,6,9,10 };
     const int *index = channels == 4 ? index4 : index8;
 
     // how many devices we got then?


### PR DESCRIPTION
- Use a Monotonic timer instead of wall time for ANT messages (S&C and footpod)
- Ignore S&C sensor if also Tacx FE-C device
- Silence some debug noise
- Ensure FE-C device is shown in pairing dialog