### PR TITLE
Kettler serial connection fixes

### DIFF
--- a/src/FileIO/Serial.cpp
+++ b/src/FileIO/Serial.cpp
@@ -380,21 +380,22 @@ find_devices(char *result[], int capacity)
     // relevant for PT downloads. The original list was rather restrictive in this respect
     //
     // To help decode this regexp;
-    // /dev/cu.PL2303-[0-9A-F]+        - Prolific device driver for USB/serial device
-    // /dev/cu.usbserial               - typical for Sewell on Mac
-    // /dev/cu.ANTUSBStick.slabvcp     - Silicon Labs Virtual Com driver for Garmin USB1 stick on a Mac
-    // /dev/cu.SLAB_USBtoUART          - Silicon Labs Driver for USB/Serial
-    // /dev/cu.usbmodem[0-9A-F]+       - Usb modem module driver (generic)
-    // /dev/cu.usbserial-[0-9A-Z]+     - usbserial module driver (generic)
-    // /dev/cu.KeySerial[0-9]          - Keyspan USB/Serial driver
-    // /dev/ttyU[0-9]                  - Open BSD usb serial devices
-    // /dev/ttyUSB[0-9]                - Standard USB/Serial device on Linux/Mac
-    // /dev/ttyS[0-2]                  - Serial TTY, 0-2 is restrictive, but noone has complained yet!
-    // /dev/ttyACM*                    - ACM converter, admittedly used largely for Mobiles
-    // /dev/ttyMI*                     - MOXA PCI cards
-    // /dev/rfcomm*                    - Bluetooth devices
-    if (regcomp(&reg, 
-                "^(cu\\.(PL2303-[0-9A-F]+|ANTUSBStick.slabvcp|SLAB_USBtoUART|usbmodem[0-9A-F]+|usbserial-[0-9A-Z]+|KeySerial[0-9]|usbserial)|ttyU[0-9]|ttyUSB[0-9]|ttyS[0-2]|ttyACM*|ttyMI*|rfcomm*)$",
+    // /dev/cu.PL2303-[0-9A-F]+              - Prolific device driver for USB/serial device
+    // /dev/cu.usbserial                     - typical for Sewell on Mac
+    // /dev/cu.ANTUSBStick.slabvcp           - Silicon Labs Virtual Com driver for Garmin USB1 stick on a Mac
+    // /dev/cu.SLAB_USBtoUART                - Silicon Labs Driver for USB/Serial
+    // /dev/cu.usbmodem[0-9A-F]+             - Usb modem module driver (generic)
+    // /dev/cu.usbserial-[0-9A-Z]+           - usbserial module driver (generic)
+    // /dev/cu.KeySerial[0-9]                - Keyspan USB/Serial driver
+    // /dev/cu.KETTLER[0-9A-Z]+-SerialPort   - Kettler serial over bluetooth
+    // /dev/ttyU[0-9]                        - Open BSD usb serial devices
+    // /dev/ttyUSB[0-9]                      - Standard USB/Serial device on Linux/Mac
+    // /dev/ttyS[0-2]                        - Serial TTY, 0-2 is restrictive, but noone has complained yet!
+    // /dev/ttyACM*                          - ACM converter, admittedly used largely for Mobiles
+    // /dev/ttyMI*                           - MOXA PCI cards
+    // /dev/rfcomm*                          - Bluetooth devices
+    if (regcomp(&reg,
+                "^(cu\\.(PL2303-[0-9A-F]+|ANTUSBStick.slabvcp|SLAB_USBtoUART|usbmodem[0-9A-F]+|usbserial-[0-9A-Z]+|KeySerial[0-9]|usbserial|KETTLER[0-9A-Z]+-SerialPort)|ttyU[0-9]|ttyUSB[0-9]|ttyS[0-2]|ttyACM*|ttyMI*|rfcomm*)$",
                 REG_EXTENDED|REG_NOSUB)) {
         assert(0);
     }

--- a/src/FileIO/Serial.cpp
+++ b/src/FileIO/Serial.cpp
@@ -382,11 +382,11 @@ find_devices(char *result[], int capacity)
     // To help decode this regexp;
     // /dev/cu.PL2303-[0-9A-F]+        - Prolific device driver for USB/serial device
     // /dev/cu.usbserial               - typical for Sewell on Mac
-    // /dev/ANTUSBStick.slabvcp        - Silicon Labs Virtual Com driver for Garmin USB1 stick on a Mac
-    // /dev/SLAB_USBtoUART             - Silicon Labs Driver for USB/Serial
-    // /dev/usbmodem[0-9A-F]+          - Usb modem module driver (generic)
-    // /dev/usbserial-[0-9A-Z]+        - usbserial module driver (generic)
-    // /dev/KeySerial[0-9]             - Keyspan USB/Serial driver
+    // /dev/cu.ANTUSBStick.slabvcp     - Silicon Labs Virtual Com driver for Garmin USB1 stick on a Mac
+    // /dev/cu.SLAB_USBtoUART          - Silicon Labs Driver for USB/Serial
+    // /dev/cu.usbmodem[0-9A-F]+       - Usb modem module driver (generic)
+    // /dev/cu.usbserial-[0-9A-Z]+     - usbserial module driver (generic)
+    // /dev/cu.KeySerial[0-9]          - Keyspan USB/Serial driver
     // /dev/ttyU[0-9]                  - Open BSD usb serial devices
     // /dev/ttyUSB[0-9]                - Standard USB/Serial device on Linux/Mac
     // /dev/ttyS[0-2]                  - Serial TTY, 0-2 is restrictive, but noone has complained yet!

--- a/src/Train/Kettler.cpp
+++ b/src/Train/Kettler.cpp
@@ -94,7 +94,7 @@ bool Kettler::discover(QString portName)
         QByteArray data = sp.readAll();
 
         // Read id from bike
-        sp.write("cd\r\n");
+        sp.write("ID\r\n");
         sp.waitForBytesWritten(500);
 
         QByteArray reply = sp.readAll();

--- a/src/Train/KettlerConnection.cpp
+++ b/src/Train/KettlerConnection.cpp
@@ -109,7 +109,7 @@ void KettlerConnection::requestAll()
     // Discard any existing data
     QByteArray discarded = m_serial->readAll();
 
-    m_serial->write("st\r\n");
+    m_serial->write("ST\r\n");
     m_serial->waitForBytesWritten(1000);
 
     QByteArray data;


### PR DESCRIPTION
This provides some small fixes for using a Kettler serial device as discussed in [this mail thread](https://groups.google.com/forum/#!topic/golden-cheetah-users/Gg6TXXM2_c8). It's tested against a Kettler Racer 9.

The commands sent are now upper-cased, and are ST for status and ID to get the ID of the bike. CD returns ERROR from the bike, cd returns nothing.

---

This replaces #2191, whose commit history I messed up in my forked repo. I've now tested this with my Kettler Racer 9, it finds the device and reads from it successfully. The search dialog actually fails to find the device, though it does give the port `/dev/cu.KETTLER...` in the dropdown. Selecting that does work -- the device is usable and gets data to record.

This is a strict improvement over the previous version, though the search functionality doesn't appear to work yet. Would you be happy merging this now?

/cc @erikboto @liversedge 