### PR TITLE
Set toolbar height dynamically for optimal height / screen usage

### DIFF
--- a/src/Gui/GcToolBar.cpp
+++ b/src/Gui/GcToolBar.cpp
@@ -21,11 +21,7 @@
 
 GcToolBar::GcToolBar(QWidget *parent) : QWidget(parent)
 {
-#ifdef WIN32
-    setFixedHeight(40);
-#else
-    setFixedHeight(50);
-#endif
+    //Height will be set when widget is added in MainWindow
     setContentsMargins(0,0,0,0);
     layout = new QHBoxLayout(this);
     layout->setSpacing(10);

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -303,6 +303,7 @@ MainWindow::MainWindow(const QDir &home)
     head->addWidget(sidebar);
     head->addWidget(lowbar);
     head->addWidget(styleSelector);
+    head->setFixedHeight(scopebar->height() + 7);
 
     // add a search box on far right, but with a little space too
     searchBox = new SearchFilterBox(this,context,false);


### PR DESCRIPTION
Removes the OS specific code, replacing with a generic solution. Effect is that toolbar height is set to be tight on the widgets it contains - gives more screen estate for charts.