### PR TITLE
Travis CI Deploys to GitHub Releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -108,7 +108,7 @@ after_success:
 - echo "Cleaning up installed QT libraries from $QT"
 - brew remove $QT
 - echo "Renaming dmg file to branch and build number ready for deploy"
-- export FINAL_NAME=master-build-${TRAVIS_BUILD_NUMBER}.dmg
+- export FINAL_NAME=dev-prerelease-branch-master-build-${TRAVIS_BUILD_NUMBER}.dmg
 - mv GoldenCheetah.dmg $FINAL_NAME
 - ls -l $FINAL_NAME
 - echo "Mounting dmg file and testing it can execute"

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,24 +100,28 @@ script:
 - CC=clang CXX=clang++ make -j4 sub-src
 after_success:
 - cd src
-- ls -laR GoldenCheetah.app
+- echo "Checking GoldenCheetah.app can execute"
 - GoldenCheetah.app/Contents/MacOS/GoldenCheetah --help
+- echo "About to create dmg file and fix up"
 - /usr/local/opt/$QT_PATH/bin/macdeployqt GoldenCheetah.app -verbose=2 -dmg
-## fix up the bundle with macdeployqtfix
 - python ../travis/macdeployqtfix.py GoldenCheetah.app /usr/local/opt/$QT_PATH
+- echo "Cleaning up installed QT libraries from $QT"
 - brew remove $QT
-- mv GoldenCheetah.dmg GoldenCheetah_$QT.dmg
-- hdiutil mount GoldenCheetah_$QT.dmg
+- echo "Renaming dmg file to branch and build number ready for deploy"
+- export FINAL_NAME=master-build-${TRAVIS_BUILD_NUMBER}.dmg
+- mv GoldenCheetah.dmg $FINAL_NAME
+- ls -l $FINAL_NAME
+- echo "Mounting dmg file and testing it can execute"
+- hdiutil mount $FINAL_NAME
 - cd /Volumes/GoldenCheetah
-- ls -laR GoldenCheetah.app
 - GoldenCheetah.app/Contents/MacOS/GoldenCheetah --help
-##deploy broken in travis, read-only filesystem error
-##before_deploy:
-##- gem install mime-types -v 2.6.2
-##deploy:
-##  provider: releases
-##  api_key: $GH_OAUTH_TOKEN
-##  file: GoldenCheetah_$QT.dmg
-##  skip_cleanup: true
-##  on:
-##    tags: true
+- echo "Make sure we are back in the Travis build directory"
+- cd $TRAVIS_BUILD_DIR
+deploy:
+  provider: releases
+  api_key:
+    secure: INSERT_HERE
+  file: src/$FINAL_NAME
+  skip_cleanup: true
+  on:
+    repo: GoldenCheetah/GoldenCheetah

--- a/.travis.yml
+++ b/.travis.yml
@@ -120,8 +120,8 @@ after_success:
 deploy:
   provider: releases
   api_key:
-    secure: INSERT_HERE
+    secure: XljNoPrDYmKmg/rdJ5+EpyauVFWvbeS8Dx6FmBLoBTrHWDZVtZzLEOKTpqGX5GnzWHv45Ao+J8SSummlqogFhO8O189escMQmr/kibVsQFEeXvViyjEIjPs1jrD16nOJoIw2XmJfN+2iXkg5JWMouKVWLmUdzoRHW6vO+1ZSzjtq+6C15rkMq5geHJbntcB1uDQBk878Cg42fNHuOnbG5f2tVVmnEeSKDwG/4SvrK7ZgTbPkF97Pz0Z9j8vIgSNlyswkOcS1do4ScmtL0ew4ZLhp7d4Zey5EHOSGl6KOJfHe/A6//bopfUgQSELsdwS1gQ2QoupmptvFw/qMISprG+cHRKLlzofvs387pCz4/iA9J13dYKf4w287b2YTqnquwNXFdJAGa+QBnTmV4WDif8sQ+XilnC+BGxTaszQ4p3srReZqRGvMPABwk/gu+03dnrWpquivllnrvpdBVKuihN/bKck97ul/3Z9uc7CgECsWg6TubJeQ1XO91mWzS34/zbf82VPhUEm2Q1EiRP6w/OfluR9e/2ZZyElriW4h7e4fVicBc0Qz9MMIZUIesGUtiwM1JZLpRSuwEttdqXcVYq2ufBw8+yfTD3zkcd21BVESEjzLqngBcBJmS0N1swtGf8hbNEaWUrti7aViKRvkme1X558pn3Pu/nuUzUM4TI8=
   file: src/$FINAL_NAME
   skip_cleanup: true
   on:
-    repo: GoldenCheetah/GoldenCheetah
+    repo: arunh/GoldenCheetah


### PR DESCRIPTION
Change to Travis configuration such that the final dmg artefact is uploaded to the GitHub releases page. The artefact is named of the form 'dev-prerelease-branch-master-build-#' to make it clear this is not an official release; unfortunately there is no way using the existing Travis/GitHub integration to tag these uploads as 'Prerelease' in GitHub.

This integration will need someone with appropriate credentials to set the api_key in the .travis.yml file, replacing the text 'INSERT_HERE'. The easiest way to create the necessary API key would be for someone with the GoldenCheetah username/password for GitHub to edit the .travis.yml file and remove the deploy section temporarily. Then, run:

    travis setup releases

More info on the Travis command line interface is [here](https://github.com/travis-ci/travis.rb#installation). Doing this will put the deploy section back, but we only want the encryted api_key. So capture that from the .travis.yml, checkout to the master version and insert the API key we just generated in the master version of .travis.yml and commit. Sounds complex, really isn't!

I've tested this all works on my own fork with my own Travis CI build, but as it's infrastructure and I don't have the credentials for the "real thing" there is some risk this will need tweaking.