### PR TITLE
CloudDB - Version & Telemetry

### DIFF
--- a/src/Cloud/CloudDBTelemetry.h
+++ b/src/Cloud/CloudDBTelemetry.h
@@ -34,9 +34,8 @@ public:
     CloudDBTelemetryClient();
     ~CloudDBTelemetryClient();
 
-    static void storeTelemetry();
+    void upsertTelemetry();
 
-private:
 
 
 };
@@ -55,8 +54,8 @@ private slots:
 
 private:
 
-    QPushButton *proceedButton;
-    QPushButton *abortButton;
+    QPushButton *yesButton;
+    QPushButton *noButton;
 
 };
 

--- a/src/Cloud/CloudDBVersion.h
+++ b/src/Cloud/CloudDBVersion.h
@@ -46,15 +46,19 @@ public:
     CloudDBVersionClient();
     ~CloudDBVersionClient();
 
-    static QList<VersionAPIGetV1> getLatestVersions();
+    void informUserAboutLatestVersions();
 
     static int CloudDBVersion_Release;
     static int CloudDBVersion_ReleaseCandidate;
     static int CloudDBVersion_DevelopmentBuild;
 
+private slots:
+
+    void showVersionPopup(QNetworkReply*);
+
 private:
 
-    static bool unmarshallAPIGetV1(QByteArray , QList<VersionAPIGetV1> *versionList );
+    bool unmarshallAPIGetV1(QByteArray , QList<VersionAPIGetV1> *versionList );
 
 };
 

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -151,8 +151,9 @@
 #define GC_SWIMPACE                     "<global-general>swimpace"
 #define GC_ELEVATION_HYSTERESIS         "<global-general>elevationHysteresis"
 #define GC_UNIT                         "<global-general>unit"
-#define GC_ALLOW_TELEMETRY              "<global-general>telemetry"
-#define GC_ALLOW_TELEMETRY_DATE         "<global-general>telemetryDate"
+#define GC_ALLOW_TELEMETRY              "<global-general>telemetryAllowed"
+#define GC_ALLOW_TELEMETRY_DATE         "<global-general>telemetryDecisionDate"
+#define GC_TELEMETRY_ID                 "<global-general>telemetryId"
 #define GC_LAST_VERSION_CHECKED         "<global-general>lastVersionChecked"
 
 

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -630,7 +630,7 @@ MainWindow::MainWindow(const QDir &home)
 
 #ifdef GC_HAS_CLOUD_DB
 
-#if 0  // temporarily de-activated
+    telemetryClient = new CloudDBTelemetryClient();
     if (appsettings->value(NULL, GC_ALLOW_TELEMETRY, "undefined").toString() == "undefined" ) {
         // ask user if storing is allowed
 
@@ -638,18 +638,16 @@ MainWindow::MainWindow(const QDir &home)
         CloudDBAcceptTelemetryDialog acceptDialog;
         acceptDialog.setModal(true);
         if (acceptDialog.exec() == QDialog::Accepted) {
-            CloudDBTelemetryClient::storeTelemetry();
+            telemetryClient->upsertTelemetry();
         };
+    } else if (appsettings->value(NULL, GC_ALLOW_TELEMETRY, false).toBool()) {
+        telemetryClient->upsertTelemetry();
     }
-#endif
 
-    QList<VersionAPIGetV1> versions = CloudDBVersionClient::getLatestVersions();
-    if (versions.count() > 0) {
-        CloudDBUpdateAvailableDialog updateAvailableDialog(versions);
-        updateAvailableDialog.setModal(true);
-        // we are not interested in the result - update check status is updated as part of the dialog box
-        updateAvailableDialog.exec();
-    }
+    versionClient = new CloudDBVersionClient();
+    versionClient->informUserAboutLatestVersions();
+
+
 
 #endif
 

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -31,6 +31,8 @@
 #include "DragBar.h"
 #ifdef GC_HAS_CLOUD_DB
 #include "CloudDBChart.h"
+#include "CloudDBVersion.h"
+#include "CloudDBTelemetry.h"
 #endif
 
 #ifdef Q_OS_MAC
@@ -293,6 +295,10 @@ class MainWindow : public QMainWindow
 
         // Miscellany
         QSignalMapper *toolMapper;
+
+
+        CloudDBVersionClient *versionClient;
+        CloudDBTelemetryClient *telemetryClient;
 
 };
 


### PR DESCRIPTION
... improve Telemetry Dialog
... add more data to Telemetry Storage / including user counter
... do not show any network errors / lack of connection
... call all CloudDB functions asynchronously without blocking UI
... use an installer specific UUID as identifier - not IP address (as this is to volatile)