### PR TITLE
QtWebEngine Cache on Windows

### DIFF
--- a/src/Gui/ChooseCyclistDialog.cpp
+++ b/src/Gui/ChooseCyclistDialog.cpp
@@ -97,7 +97,14 @@ ChooseCyclistDialog::getList()
     QStringListIterator i(home.entryList(QDir::Dirs | QDir::NoDotAndDotDot));
     while (i.hasNext()) {
         QString name = i.next();
-
+#ifdef NOWEBKIT
+#ifdef WIN32
+        // QtWebEngine puts it's cache into the User directory (only on Windows) - so do not show in list
+        QStringList webEngineDirs;
+        webEngineDirs << "QtWebEngine" << "cache";
+        if (webEngineDirs.contains(name)) continue;
+#endif
+#endif
         QListWidgetItem *newone = new QListWidgetItem(name, listWidget);
 
         // get avatar image if it exists

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1766,7 +1766,14 @@ MainWindow::setOpenWindowMenu()
     while (i.hasNext()) {
 
         QString name = i.next();
-
+#ifdef NOWEBKIT
+#ifdef WIN32
+        // QtWebEngine puts it's cache into the User directory (only on Windows) - so do not show in list
+        QStringList webEngineDirs;
+        webEngineDirs << "QtWebEngine" << "cache";
+        if (webEngineDirs.contains(name)) continue;
+#endif
+#endif
         // new action
         QAction *action = new QAction(QString("%1").arg(name), this);
 
@@ -1808,7 +1815,14 @@ MainWindow::setOpenTabMenu()
     while (i.hasNext()) {
 
         QString name = i.next();
-
+#ifdef NOWEBKIT
+#ifdef WIN32
+        // QtWebEngine puts it's cache into the User directory (only on Windows) - so do not show in list
+        QStringList webEngineDirs;
+        webEngineDirs << "QtWebEngine" << "cache";
+        if (webEngineDirs.contains(name)) continue;
+#endif
+#endif
         // new action
         QAction *action = new QAction(QString("%1").arg(name), this);
 
@@ -1850,7 +1864,14 @@ MainWindow::setBackupAthleteMenu()
     while (i.hasNext()) {
 
         QString name = i.next();
-
+#ifdef NOWEBKIT
+#ifdef WIN32
+        // QtWebEngine puts it's cache into the User directory (only on Windows) - so do not show in list
+        QStringList webEngineDirs;
+        webEngineDirs << "QtWebEngine" << "cache";
+        if (webEngineDirs.contains(name)) continue;
+#endif
+#endif
         // new action
         QAction *action = new QAction(QString("%1").arg(name), this);
 


### PR DESCRIPTION
... Default directory for the WebEngine Profile and Cache is /AppData/Local/<AppName which is the same GC uses as Default for Athletes.  Changing the location for QtWebEngine needs to be done for EVERY QWebPage. Until the use of QtWebEngine is limited to a few locations the easier way is to filter out the Directories created by QtWebEngine (assuming that no-one will call their athletes either "cache" or "QtWebEngine".
... This is only done if build with QtWebEngine and for Windows (on other OS Qt uses a better location for cache data, not a user location).