### PR TITLE
FIT Importer

### DIFF
--- a/src/FileIO/FitRideFile.cpp
+++ b/src/FileIO/FitRideFile.cpp
@@ -1088,6 +1088,10 @@ struct FitFileReaderState
                 DumpFitValue(value);
             }
 
+            // ignore any developer fields in laps
+            if ( field.deve_idx > -1)
+                continue;
+
             switch (field.num) {
                 case 253:
                     time = value.v + qbase_time.toTime_t();

--- a/src/FileIO/FitRideFile.cpp
+++ b/src/FileIO/FitRideFile.cpp
@@ -348,6 +348,9 @@ struct FitFileReaderState
                 case 2157: return "Garmin FR230";
                 case 2204: return "Garmin Edge 1000 Explore";
                 case 2238: return "Garmin Edge 20";
+                case 2337: return "Garmin Vivoactive HR";
+                case 2347: return "Garmin Vivosmart HR+";
+                case 2348: return "Garmin Vivosmart HR";
                 case 2413: return "Garmin Fenix 3 HR";
                 case 2431: return "Garmin FR235";
                 case 2530: return "Garmin Edge 820";


### PR DESCRIPTION
FIT - Fix Lap Starting time
... if lap data contains a developer field, lap starting time is corrupt, if field num of the developer field == 2
... since we don't store any lap specific developer fields, let's ignore them all

FIT - add new Garmin devices to list