### PR TITLE
Fix QT < 5.4 build and QT < 5.0

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -456,6 +456,8 @@ MainWindow::MainWindow(const QDir &home)
                          SLOT(uploadGoogleDrive()), tr(""));
     shareMenu->addAction(tr("Synchronise GoogleDrive..."), this,
                          SLOT(syncGoogleDrive()), tr("Ctrl+P"));
+#endif
+#if QT_VERSION >= 0x050400
     shareMenu->addSeparator ();
     shareMenu->addAction(tr("Upload to Today's Plan"), this,
                          SLOT(uploadTodaysPlan()), tr(""));
@@ -485,7 +487,9 @@ MainWindow::MainWindow(const QDir &home)
     optionsMenu->addSeparator();
     optionsMenu->addAction(tr("Create a new workout..."), this, SLOT(showWorkoutWizard()));
     optionsMenu->addAction(tr("Download workouts from ErgDB..."), this, SLOT(downloadErgDB()));
+#if QT_VERSION > 0x050000
     optionsMenu->addAction(tr("Download workouts from Today's Plan..."), this, SLOT(downloadTodaysPlanWorkouts()));
+#endif
     optionsMenu->addAction(tr("Import workouts, videos, videoSyncs..."), this, SLOT(importWorkout()));
     optionsMenu->addAction(tr("Scan disk for workouts, videos, videoSyncs..."), this, SLOT(manageLibrary()));
 
@@ -2046,6 +2050,7 @@ MainWindow::downloadErgDB()
  * TodaysPlan Workouts
  *--------------------------------------------------------------------*/
 
+#if QT_VERSION > 0x050000
 void
 MainWindow::downloadTodaysPlanWorkouts()
 {
@@ -2062,7 +2067,7 @@ MainWindow::downloadTodaysPlanWorkouts()
         "Please check your preference settings."));
     }
 }
-
+#endif
 
 /*----------------------------------------------------------------------
  * Workout/Media Library
@@ -2122,6 +2127,8 @@ MainWindow::syncGoogleDrive()
     upload.exec();
 }
 
+#endif
+#if QT_VERSION >= 0x050400
 void
 MainWindow::uploadSixCycle()
 {

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -189,7 +189,9 @@ class MainWindow : public QMainWindow
         // Training View
         void addDevice();
         void downloadErgDB();
+#if QT_VERSION > 0x050000
         void downloadTodaysPlanWorkouts();
+#endif
         void manageLibrary();
         void showWorkoutWizard();
         void importWorkout();
@@ -226,6 +228,8 @@ class MainWindow : public QMainWindow
         void uploadGoogleDrive();
         void syncGoogleDrive();
 
+#endif
+#if QT_VERSION >= 0x050400
         void uploadSixCycle();
         void syncSixCycle();
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -618,10 +618,12 @@ greaterThan(QT_MAJOR_VERSION, 4) {
     HEADERS += Cloud/Dropbox.h
     SOURCES += Cloud/GoogleDrive.cpp
     HEADERS += Cloud/GoogleDrive.h
+    greaterThan(QT_MINOR_VERSION, 3) {
     SOURCES += Cloud/SixCycle.cpp
     HEADERS += Cloud/SixCycle.h
     SOURCES += Cloud/TodaysPlan.cpp
     HEADERS += Cloud/TodaysPlan.h
+    }
     SOURCES += Train/MonarkController.cpp Train/MonarkConnection.cpp
     HEADERS += Train/MonarkController.h Train/MonarkConnection.h
     SOURCES += Train/Kettler.cpp Train/KettlerController.cpp Train/KettlerConnection.cpp
@@ -738,8 +740,13 @@ HEADERS += Train/AddDeviceWizard.h Train/CalibrationData.h Train/ComputrainerCon
            Train/DeviceTypes.h Train/DialWindow.h Train/ErgDBDownloadDialog.h Train/ErgDB.h Train/ErgFile.h Train/ErgFilePlot.h \
            Train/Library.h Train/LibraryParser.h Train/MeterWidget.h Train/NullController.h Train/RealtimeController.h \
            Train/RealtimeData.h Train/RealtimePlot.h Train/RealtimePlotWindow.h Train/RemoteControl.h Train/SpinScanPlot.h \
-           Train/SpinScanPlotWindow.h Train/SpinScanPolarPlot.h Train/TodaysPlanWorkoutDownload.h \
-           Train/TrainBottom.h Train/TrainDB.h Train/TrainSidebar.h \
+           Train/SpinScanPlotWindow.h Train/SpinScanPolarPlot.h
+
+greaterThan(QT_MAJOR_VERSION, 4) {
+    HEADERS += Train/TodaysPlanWorkoutDownload.h
+}
+
+HEADERS += Train/TrainBottom.h Train/TrainDB.h Train/TrainSidebar.h \
            Train/VideoLayoutParser.h Train/VideoSyncFile.h Train/WorkoutPlotWindow.h Train/WebPageWindow.h \
            Train/WorkoutWidget.h Train/WorkoutWidgetItems.h Train/WorkoutWindow.h Train/WorkoutWizard.h Train/ZwoParser.h
 
@@ -827,8 +834,13 @@ SOURCES += Train/AddDeviceWizard.cpp Train/CalibrationData.cpp Train/Computraine
            Train/DeviceTypes.cpp Train/DialWindow.cpp Train/ErgDB.cpp Train/ErgDBDownloadDialog.cpp Train/ErgFile.cpp Train/ErgFilePlot.cpp \
            Train/Library.cpp Train/LibraryParser.cpp Train/MeterWidget.cpp Train/NullController.cpp Train/RealtimeController.cpp \
            Train/RealtimeData.cpp Train/RealtimePlot.cpp Train/RealtimePlotWindow.cpp Train/RemoteControl.cpp Train/SpinScanPlot.cpp \
-           Train/SpinScanPlotWindow.cpp Train/SpinScanPolarPlot.cpp Train/TodaysPlanWorkoutDownload.cpp \
-           Train/TrainBottom.cpp Train/TrainDB.cpp Train/TrainSidebar.cpp \
+           Train/SpinScanPlotWindow.cpp Train/SpinScanPolarPlot.cpp
+
+greaterThan(QT_MAJOR_VERSION, 4) {
+    SOURCES  += Train/TodaysPlanWorkoutDownload.cpp
+}
+
+SOURCES += Train/TrainBottom.cpp Train/TrainDB.cpp Train/TrainSidebar.cpp \
            Train/VideoLayoutParser.cpp Train/VideoSyncFile.cpp Train/WorkoutPlotWindow.cpp Train/WebPageWindow.cpp \
            Train/WorkoutWidget.cpp Train/WorkoutWidgetItems.cpp Train/WorkoutWindow.cpp Train/WorkoutWizard.cpp Train/ZwoParser.cpp
 


### PR DESCRIPTION
Both SixCycle and TodaysPlan uses QByteArray::toStdString
(introduced in Qt 5.4), while in QJsonParseError (introduced in Qt
5.0) is used in TodaysPlanWorkoutDownload.