### PR TITLE
Add notice that the WIN32-INSTALL Instructions are deprecated

### DIFF
--- a/INSTALL-WIN32
+++ b/INSTALL-WIN32
@@ -1,3 +1,13 @@
+
+THESE INSTRUCTIONS ARE OUT OF DATE. 
+PLEASE REVIEW THE INFORMATION ON THE WIKI AND IN THE FORUMS.
+
+
+https://groups.google.com/forum/#!forum/golden-cheetah-developers
+
+
+
+
 Please note: This is an old build instruction set for Version 2.x.
 
 Most of it is still fairly valid for version 3.x.


### PR DESCRIPTION
I've wasted a bit of time trying to follow these old instructions, and, from the look of the issues log and developers forum, I think other people have too.
I've tried to update the Wiki with information as I find it, and this change just adds an instruction to future developers to look elsewhere.