### PR TITLE
Windows Crash Handler - small changes

### DIFF
--- a/src/Core/WindowsCrashHandler.cpp
+++ b/src/Core/WindowsCrashHandler.cpp
@@ -1,3 +1,22 @@
+/*
+ * Copyright (c) 2017 Stefan Schake
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+
 // Only for Windows 64 Bit and MSVC
 #if defined(_MSC_VER) && defined(_WIN64)
 
@@ -13,14 +32,24 @@
 #include <dbghelp.h>
 #pragma comment(lib, "dbghelp.lib")
 
+static std::string installation_crash_path = "";
+
 static std::string getCrashFileName()
 {
     using namespace std::chrono;
     auto now = system_clock::now();
     auto nowTimeT = system_clock::to_time_t(now);
     std::stringstream ret;
+    if (installation_crash_path.length() > 0 ) {
+      ret << installation_crash_path << "\\";
+    }
     ret << "crash_" << std::put_time(std::localtime(&nowTimeT), "%H%M_%d%m%y");
     return ret.str();
+}
+
+static void setCrashFilePath(std::string file_path)
+{
+   installation_crash_path = file_path;
 }
 
 static LONG WINAPI ExceptionHandler(LPEXCEPTION_POINTERS exception)

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -115,6 +115,10 @@
 #include "GcUpgrade.h"
 #endif
 
+#if defined(_MSC_VER) && defined(_WIN64)
+#include "WindowsCrashHandler.cpp"
+#endif
+
 
 // We keep track of all theopen mainwindows
 QList<MainWindow *> mainwindows;
@@ -133,6 +137,16 @@ MainWindow::MainWindow(const QDir &home)
     // create a splash to keep user informed on first load
     // first one in middle of display, not middle of window
     setSplash(true);
+
+#if defined(_MSC_VER) && defined(_WIN64)
+    // set dbg/stacktrace directory for Windows to the athlete directory
+    // don't use the GC_HOMEDIR .ini value, since we want to have a proper path
+    // even if default athlete dirs are used.
+    QDir varHome = home;
+    varHome.cdUp();
+    setCrashFilePath(varHome.canonicalPath().toStdString());
+
+#endif
 
     // bootstrap
     Context *context = new Context(this);

--- a/src/src.pro
+++ b/src/src.pro
@@ -54,8 +54,8 @@ lessThan(QT_MAJOR_VERSION, 5) {
     ## QT5 modules we use
     QT += widgets concurrent serialport multimedia multimediawidgets
 
-    ## Always add debug information
-    CONFIG += force_debug_info
+    ## Always add debug information for Windows, MSVC
+    win32-msvc* { CONFIG += force_debug_info }
 
     ## If building with QT5 there is experimental suport for building
     ## with WebEngine now that WebKit is deprecated in QT 5.6
@@ -124,7 +124,7 @@ LIBS += $${LIBZ_LIBS}
 ###===============================
 
 # Microsoft Visual Studion toolchain dependencies
-*msvc2015 {
+win32-msvc* {
 
     # we need windows kit 8.2 or higher with MSVC, offer default location
     isEmpty(WINKIT_INSTALL) WINKIT_INSTALL= "C:/Program Files (x86)/Windows Kits/8.1/Lib/winv6.3/um/x64"
@@ -406,7 +406,7 @@ contains(DEFINES, "GC_HAVE_KQOAUTH") {
 
     # on MS VS the linker wants /LTCG for libkmldom due to
     # "MSIL .netmodule or module compiled with /GL found"
-    *msvc2015 { QMAKE_LFLAGS +=  /LTCG }
+    win32-msvc* { QMAKE_LFLAGS +=  /LTCG }
 
     DEFINES     += GC_HAVE_KML
     INCLUDEPATH += $${KML_INCLUDE}  $${BOOST_INCLUDE}


### PR DESCRIPTION
... add copyright notice to file
... store .dbg and .log in Athlete Directory (if known) and in installation directory only as default
... unify handling of "win32-msvc*" specific qmake commands in src.pro