### PR TITLE
Fix Compile error if Secrets not declared for Withings / Twitter

### DIFF
--- a/src/Cloud/TwitterDialog.cpp
+++ b/src/Cloud/TwitterDialog.cpp
@@ -21,6 +21,7 @@
 #include "Context.h"
 #include "Settings.h"
 #include "TimeUtils.h"
+#include "Secrets.h"
 #include <QUrl>
 #include <kqoauthmanager.h>
 #include <kqoauthrequest.h>

--- a/src/Cloud/WithingsDownload.cpp
+++ b/src/Cloud/WithingsDownload.cpp
@@ -20,6 +20,7 @@
 #include "MainWindow.h"
 #include "Athlete.h"
 #include "RideCache.h"
+#include "Secrets.h"
 #include <QMessageBox>
 
 #ifdef GC_HAVE_KQOAUTH


### PR DESCRIPTION
... happens e.g. in appveyor CI since it has no secrets declared (yet)