### PR TITLE
Fix zones set mismatch

### DIFF
--- a/src/Charts/OverviewWindow.cpp
+++ b/src/Charts/OverviewWindow.cpp
@@ -741,7 +741,7 @@ Card::setData(RideItem *item)
             if (parent->context->athlete->zones(item->isRun)) {
 
                 int numzones;
-                int range = parent->context->athlete->hrZones(item->isRun)->whichRange(item->dateTime.date());
+                int range = parent->context->athlete->zones(item->isRun)->whichRange(item->dateTime.date());
 
                 if (range > -1) {
 


### PR DESCRIPTION
This was referencing hrZones when all checks around it used and later accessed zones.

This change should fix a crash first reported by Manuel Oberti on the mailing list:
https://groups.google.com/d/msg/golden-cheetah-users/zRamtWe9-Is/KWpfbcogBAAJ

[Exception call stack](https://github.com/GoldenCheetah/GoldenCheetah/files/828932/call_stack.txt)
