### PR TITLE
Introduce BodyMeasures as generalization of current Withings Data

### DIFF
--- a/src/Cloud/BodyMeasures.cpp
+++ b/src/Cloud/BodyMeasures.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright (c) 2015 Joern Rischmueller (joern.rm@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "BodyMeasures.h"
+
+#include <QList>
+#include <QMessageBox>
+#include <QTextStream>
+
+#include <QJsonDocument>
+#include <QJsonArray>
+#include <QJsonObject>
+
+bool
+BodyMeasureParser::serialize(QString filename, QList<BodyMeasure> &data) {
+
+    // open file - truncate contents
+    QFile file(filename);
+    if (!file.open(QFile::WriteOnly)) {
+        QMessageBox msgBox;
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.setText(QObject::tr("Problem Saving Body Measures"));
+        msgBox.setInformativeText(QObject::tr("File: %1 cannot be opened for 'Writing'. Please check file properties.").arg(filename));
+        msgBox.exec();
+        return false;
+    };
+    file.resize(0);
+    QTextStream out(&file);
+    out.setCodec("UTF-8");
+
+    QJsonArray measures;
+    for (int i = 0; i < data.count(); i++) {
+        BodyMeasure m = data.at(i);
+        QJsonObject measure;
+        measure.insert("when", m.when.toSecsSinceEpoch());
+        measure.insert("comment", m.comment);
+        measure.insert("weightkg", m.weightkg);
+        measure.insert("fatkg", m.fatkg);
+        measure.insert("boneskg", m.boneskg);
+        measure.insert("musclekg", m.musclekg);
+        measure.insert("leankg", m.leankg);
+        measure.insert("fatpercent", m.fatpercent);
+        measures.append(measure);
+    }
+
+    QJsonObject jsonObject;
+    // add a version in case of format changes
+    jsonObject.insert("version", 1);
+    jsonObject.insert("measures",  QJsonValue(measures));
+
+    QJsonDocument json;
+    json.setObject(jsonObject);
+
+    out << json.toJson();
+    out.flush();
+    file.close();
+    return true;
+
+}
+
+
+bool
+BodyMeasureParser::unserialize(QFile &file, QList<BodyMeasure> &data) {
+
+    // open file - truncate contents
+    if (!file.open(QFile::ReadOnly)) {
+        QMessageBox msgBox;
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.setText(QObject::tr("Problem Reading Body Measures"));
+        msgBox.setInformativeText(QObject::tr("File: %1 cannot be opened for 'Reading'. Please check file properties.").arg(file.fileName()));
+        msgBox.exec();
+        return false;
+    };
+    QByteArray jsonFileContent = file.readAll();
+    file.close();
+
+    QJsonParseError parseError;
+    QJsonDocument document = QJsonDocument::fromJson(jsonFileContent, &parseError);
+
+    if (parseError.error != QJsonParseError::NoError || document.isEmpty() || document.isNull()) {
+        QMessageBox msgBox;
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.setText(QObject::tr("Problem Parsing Body Measures"));
+        msgBox.setInformativeText(QObject::tr("File: %1 is not a proper JSON file. Parsing error: %2").arg(file.fileName()).arg(parseError.errorString()));
+        msgBox.exec();
+        return false;
+    }
+
+    data.clear();
+    QJsonObject object = document.object();
+    QJsonArray measures = object["measures"].toArray();
+    for (int i = 0; i < measures.count(); i++) {
+        QJsonObject measure = measures.at(i).toObject();
+        BodyMeasure m;
+        m.when = QDateTime::fromSecsSinceEpoch(measure["when"].toDouble());
+        m.comment = measure["comment"].toString();
+        m.weightkg = measure["weightkg"].toDouble();
+        m.fatkg = measure["fatkg"].toDouble();
+        m.boneskg = measure["boneskg"].toDouble();
+        m.musclekg = measure["musclekg"].toDouble();
+        m.leankg = measure["leankg"].toDouble();
+        m.fatpercent = measure["fatpercent"].toDouble();
+        data.append(m);
+    }
+
+    return true;
+}
+

--- a/src/Cloud/BodyMeasures.cpp
+++ b/src/Cloud/BodyMeasures.cpp
@@ -47,7 +47,7 @@ BodyMeasureParser::serialize(QString filename, QList<BodyMeasure> &data) {
     for (int i = 0; i < data.count(); i++) {
         BodyMeasure m = data.at(i);
         QJsonObject measure;
-        measure.insert("when", m.when.toSecsSinceEpoch());
+        measure.insert("when", m.when.toMSecsSinceEpoch()/1000);
         measure.insert("comment", m.comment);
         measure.insert("weightkg", m.weightkg);
         measure.insert("fatkg", m.fatkg);
@@ -107,7 +107,7 @@ BodyMeasureParser::unserialize(QFile &file, QList<BodyMeasure> &data) {
     for (int i = 0; i < measures.count(); i++) {
         QJsonObject measure = measures.at(i).toObject();
         BodyMeasure m;
-        m.when = QDateTime::fromSecsSinceEpoch(measure["when"].toDouble());
+        m.when = QDateTime::fromMSecsSinceEpoch(measure["when"].toDouble()*1000);
         m.comment = measure["comment"].toString();
         m.weightkg = measure["weightkg"].toDouble();
         m.fatkg = measure["fatkg"].toDouble();

--- a/src/Cloud/BodyMeasures.h
+++ b/src/Cloud/BodyMeasures.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2015 Joern Rischmueller (joern.rm@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef _Gc_BodyMeasures_h
+#define _Gc_BodyMeasures_h
+
+#include "Context.h"
+
+#include <QString>
+#include <QStringList>
+#include <QDateTime>
+
+#define BODY_WEIGHT_KG           0
+#define BODY_WEIGHT_FAT_KG       1
+#define BODY_WEIGHT_MUSCLE_KG    2
+#define BODY_WEIGHT_BONES_KG     3
+#define BODY_WEIGHT_LEAN_KG      4
+#define BODY_WEIGHT_FAT_PERCENT  5
+
+class BodyMeasure {
+
+public:
+    BodyMeasure() : when(QDateTime()), comment(""), weightkg(0), fatkg(0), musclekg(0), boneskg(0), leankg(0), fatpercent(0) {}
+
+    // depending on datasource not all fields may be filled with actual values
+
+    QDateTime when;         // when was this reading taken
+    QString comment;        // user commentary regarding this measurement
+
+    double  weightkg,       // weight in Kilograms
+            fatkg,          // fat in Kilograms
+			musclekg,       // muscles in Kilograms
+			boneskg,        // bones in Kilograms
+            leankg,         // lean mass in Kilograms
+            fatpercent;     // body fat as a percentage of weight
+
+    // used by qSort()
+    bool operator< (BodyMeasure right) const {
+        return (when < right.when);
+    }
+};
+
+class BodyMeasureParser  {
+
+public:
+    static bool serialize(QString, QList<BodyMeasure> &);
+    static bool unserialize(QFile &, QList<BodyMeasure> &);
+};
+
+
+#endif

--- a/src/Cloud/BodyMeasuresDownload.cpp
+++ b/src/Cloud/BodyMeasuresDownload.cpp
@@ -20,11 +20,12 @@
 #include "BodyMeasures.h"
 #include "Athlete.h"
 #include "RideCache.h"
+#include "HelpWhatsThis.h"
 
 #include <QList>
 #include <QMutableListIterator>
 #include <QGroupBox>
-#include <HelpWhatsThis.h>
+#include <QMessageBox>
 
 
 BodyMeasuresDownload::BodyMeasuresDownload(Context *context) : context(context) {

--- a/src/Cloud/BodyMeasuresDownload.cpp
+++ b/src/Cloud/BodyMeasuresDownload.cpp
@@ -1,0 +1,307 @@
+/*
+ * Copyright (c) 2017 Joern Rischmueller (joern.rm@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "BodyMeasuresDownload.h"
+#include "BodyMeasures.h"
+#include "Athlete.h"
+#include "RideCache.h"
+
+#include <QList>
+#include <QMutableListIterator>
+#include <QGroupBox>
+#include <HelpWhatsThis.h>
+
+
+BodyMeasuresDownload::BodyMeasuresDownload(Context *context) : context(context) {
+
+    setWindowTitle(tr("Body Measures download"));
+    HelpWhatsThis *help = new HelpWhatsThis(this);
+    this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Tools_Download_BodyMeasures));
+
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+
+    QGroupBox *groupBox1 = new QGroupBox(tr("Choose the download or import source"));
+    downloadWithings = new QRadioButton(tr("Withings"));
+    downloadTP = new QRadioButton(tr("Today's Plan"));
+    downloadCSV = new QRadioButton(tr("Import CSV file"));
+    QVBoxLayout *vbox1 = new QVBoxLayout;
+    vbox1->addWidget(downloadWithings);
+    vbox1->addWidget(downloadTP);
+    vbox1->addWidget(downloadCSV);
+    groupBox1->setLayout(vbox1);
+    mainLayout->addWidget(groupBox1);
+
+    QGroupBox *groupBox2 = new QGroupBox(tr("Choose date range for download"));
+    dateRangeAll = new QRadioButton(tr("From date of first recorded activity to today"));
+    dateRangeLastMeasure = new QRadioButton(tr("From date of last downloaded measure to today"));
+    dateRangeManual = new QRadioButton(tr("Enter manually:"));
+    dateRangeAll->setChecked(true);
+    QVBoxLayout *vbox2 = new QVBoxLayout;
+    vbox2->addWidget(dateRangeAll);
+    vbox2->addWidget(dateRangeLastMeasure);
+    vbox2->addWidget(dateRangeManual);
+    vbox2->addStretch();
+    QLabel *fromLabel = new QLabel("From");
+    QLabel *toLabel = new QLabel("To");
+    manualFromDate = new QDateEdit(this);
+    manualFromDate->setDate(QDate::currentDate().addMonths(-1));
+    manualToDate = new QDateEdit(this);
+    manualToDate->setDate(QDate::currentDate());
+    manualFromDate->setCalendarPopup(true);
+    manualToDate->setCalendarPopup(true);
+    manualFromDate->setEnabled(false);
+    manualToDate->setEnabled(false);
+    QHBoxLayout *dateRangeLayout = new QHBoxLayout;
+    dateRangeLayout->addStretch();
+    dateRangeLayout->addWidget(fromLabel);
+    dateRangeLayout->addWidget(manualFromDate);
+    dateRangeLayout->addWidget(toLabel);
+    dateRangeLayout->addWidget(manualToDate);
+    vbox2->addLayout(dateRangeLayout);
+    groupBox2->setLayout(vbox2);
+    mainLayout->addWidget(groupBox2);
+
+    discardExistingMeasures = new QCheckBox(tr("Discard all existing measures"), this);
+    discardExistingMeasures->setChecked(false);
+    mainLayout->addWidget(discardExistingMeasures);
+
+    progressBar = new QProgressBar(this);
+    progressBar->setMinimum(0);
+    progressBar->setMaximum(1);
+    progressBar->setValue(0);
+    QHBoxLayout *progressLayout = new QHBoxLayout;
+    progressLayout->addWidget(progressBar);
+    mainLayout->addLayout(progressLayout);
+
+    downloadButton = new QPushButton(tr("Download"));
+    closeButton = new QPushButton(tr("Close"));
+    QHBoxLayout *buttonLayout = new QHBoxLayout;
+    buttonLayout->addWidget(downloadButton);
+    buttonLayout->addStretch();
+    buttonLayout->addWidget(closeButton);
+    mainLayout->addLayout(buttonLayout);
+
+
+    connect(downloadButton, SIGNAL(clicked()), this, SLOT(download()));
+    connect(closeButton, SIGNAL(clicked()), this, SLOT(close()));
+    connect(dateRangeAll, SIGNAL(toggled(bool)), this, SLOT(dateRangeAllSettingChanged(bool)));
+    connect(dateRangeLastMeasure, SIGNAL(toggled(bool)), this, SLOT(dateRangeLastSettingChanged(bool)));
+    connect(dateRangeManual, SIGNAL(toggled(bool)), this, SLOT(dateRangeManualSettingChanged(bool)));
+
+    // don't allow options which are not authorized
+    QString strToken =appsettings->cvalue(context->athlete->cyclist, GC_WITHINGS_TOKEN, "").toString();
+    QString strSecret= appsettings->cvalue(context->athlete->cyclist, GC_WITHINGS_SECRET, "").toString();
+
+    if (strToken == "" && strSecret == "") {
+        downloadWithings->setEnabled(false);
+    }
+
+    QString token = appsettings->cvalue(context->athlete->cyclist, GC_TODAYSPLAN_TOKEN, "").toString();
+    if (token == "") {
+        downloadTP->setEnabled(false);
+    }
+    // select the default checked
+    if (downloadWithings->isEnabled()) {
+        downloadWithings->setChecked(true);
+    } else if (downloadTP->isEnabled()) {
+        downloadTP->setChecked(true);
+    } else {
+        downloadCSV->setChecked(true);
+    }
+
+    // initialize the downloader
+    withingsDownload = new WithingsDownload(context);
+    todaysPlanBodyMeasureDownload = new TodaysPlanBodyMeasures(context);
+
+    // connect the progress bar
+    connect(todaysPlanBodyMeasureDownload, SIGNAL(downloadStarted(int)), this, SLOT(downloadProgressStart(int)));
+    connect(todaysPlanBodyMeasureDownload, SIGNAL(downloadProgress(int)), this, SLOT(downloadProgress(int)));
+    connect(todaysPlanBodyMeasureDownload, SIGNAL(downloadEnded(int)), this, SLOT(downloadProgressEnd(int)));
+
+    connect(withingsDownload, SIGNAL(downloadStarted(int)), this, SLOT(downloadProgressStart(int)));
+    connect(withingsDownload, SIGNAL(downloadProgress(int)), this, SLOT(downloadProgress(int)));
+    connect(withingsDownload, SIGNAL(downloadEnded(int)), this, SLOT(downloadProgressEnd(int)));
+}
+
+BodyMeasuresDownload::~BodyMeasuresDownload() {
+
+    delete withingsDownload;
+    delete todaysPlanBodyMeasureDownload;
+
+}
+
+
+void
+BodyMeasuresDownload::download() {
+
+   // de-activate the buttons
+   downloadButton->setEnabled(false);
+   closeButton->setEnabled(false);
+
+   progressBar->setMaximum(1);
+   progressBar->setValue(0);
+
+   // do the job
+   QList<BodyMeasure> current = context->athlete->bodyMeasures();
+   QList<BodyMeasure> bodyMeasures;
+   QDateTime fromDate;
+   QDateTime toDate;
+   QDateTime firstRideDate;
+   QString err = "";
+   bool downloadOk = false;
+
+   // get the date of first ride as potential "from" value
+   QList<QDateTime> rideDates = context->athlete->rideCache->getAllDates();
+   if (rideDates.count() > 0) {
+       firstRideDate = rideDates.at(0);
+   }  else {
+       firstRideDate = QDateTime::fromSecsSinceEpoch(0);
+   };
+
+   // determine the date range
+   if (dateRangeAll->isChecked()) {
+       fromDate = firstRideDate;
+       toDate = QDateTime::currentDateTimeUtc();
+   } else if (dateRangeLastMeasure->isChecked()) {
+       if (current.count() > 0) {
+           fromDate = current.last().when.addSecs(3600);
+       } else {
+           // use a reasonable default
+           fromDate = firstRideDate;
+       }
+       toDate = QDateTime::currentDateTimeUtc();
+   } else if (dateRangeManual->isChecked()) {
+       if (manualFromDate->dateTime() > manualToDate->dateTime()) {
+           QMessageBox::warning(this, tr("Body Measures"), tr("Invalid date range - please check your input"));
+           // re-activate the buttons
+           downloadButton->setEnabled(true);
+           closeButton->setEnabled(true);
+           return;
+       }
+       fromDate = manualFromDate->dateTime();
+       toDate = manualToDate->dateTime();
+       fromDate.setTime(QTime(0,0));
+       toDate.setTime(QTime(23, 59));
+   } else return;
+
+   // do the download
+   if (downloadWithings->isChecked()) {
+     downloadOk = withingsDownload->getBodyMeasures(err, fromDate, toDate, bodyMeasures);
+   } else if (downloadTP->isChecked()) {
+     downloadOk = todaysPlanBodyMeasureDownload->getBodyMeasures(err, fromDate, toDate, bodyMeasures);
+   } else if (downloadCSV->isChecked()) {
+        QMessageBox::information(this, tr("Body Measures"), tr("CSV Import is currently in development and will be added with a later version"));
+        err = tr("Import from CSV not yet implemented");
+   } else return;
+
+   if (downloadOk) {
+
+       // we discard only if we have new data loaded - otherwise keep what is there
+       if (discardExistingMeasures->isChecked()) current.clear();
+
+       // if exists, merge current data with new data - new data has preferences
+       // no merging of weight data which has the same time stamp - new wins
+       if (current.count() > 0) {
+           // remove entry from current list if a new entry with same timestamp exists
+           QMutableListIterator<BodyMeasure> i(current);
+           BodyMeasure c;
+           while (i.hasNext()) {
+               c = i.next();
+               foreach(BodyMeasure m, bodyMeasures) {
+                   if (m.when == c.when) {
+                       i.remove();
+                   }
+               }
+           }
+           // combine the result (without duplicates)
+           bodyMeasures.append(current);
+       }
+
+       // update measures in cache and on file store
+       context->athlete->rideCache->cancel();
+
+       // store in athlete
+       context->athlete->setBodyMeasures(bodyMeasures);
+
+       // now save data away if we actually got something !
+       // doing it here means we don't overwrite previous responses
+       // when we fail to get any data (e.g. errors / network problems)
+       BodyMeasureParser::serialize(QString("%1/bodymeasures.json").arg(context->athlete->home->activities().canonicalPath()), context->athlete->bodyMeasures());
+
+       // do a refresh, it will check if needed
+       context->athlete->rideCache->refresh();
+
+   } else {
+       // handle error document in err String
+       QMessageBox::warning(this, tr("Body Measures"), tr("Downloading of body measures failed with error: %1").arg(err));
+   }
+
+   // re-activate the buttons
+   downloadButton->setEnabled(true);
+   closeButton->setEnabled(true);
+
+}
+
+void
+BodyMeasuresDownload::close() {
+
+    accept();
+
+}
+
+void
+BodyMeasuresDownload::dateRangeAllSettingChanged(bool checked) {
+
+    if (checked) {
+        manualFromDate->setEnabled(false);
+        manualToDate->setEnabled(false);
+    }
+}
+
+
+void
+BodyMeasuresDownload::dateRangeLastSettingChanged(bool checked) {
+
+    if (checked) {
+        manualFromDate->setEnabled(false);
+        manualToDate->setEnabled(false);
+    }
+}
+
+void
+BodyMeasuresDownload::dateRangeManualSettingChanged(bool checked) {
+
+    if (checked) {
+        manualFromDate->setEnabled(true);
+        manualToDate->setEnabled(true);
+    }
+}
+
+void
+BodyMeasuresDownload::downloadProgressStart(int total) {
+    progressBar->setMaximum(total);
+}
+void
+BodyMeasuresDownload::downloadProgress(int current) {
+    progressBar->setValue(current);
+}
+
+void
+BodyMeasuresDownload::downloadProgressEnd(int final) {
+    progressBar->setValue(final);
+}

--- a/src/Cloud/BodyMeasuresDownload.cpp
+++ b/src/Cloud/BodyMeasuresDownload.cpp
@@ -170,7 +170,7 @@ BodyMeasuresDownload::download() {
    if (rideDates.count() > 0) {
        firstRideDate = rideDates.at(0);
    }  else {
-       firstRideDate = QDateTime::fromSecsSinceEpoch(0);
+       firstRideDate = QDateTime::fromMSecsSinceEpoch(0);
    };
 
    // determine the date range

--- a/src/Cloud/BodyMeasuresDownload.h
+++ b/src/Cloud/BodyMeasuresDownload.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2017 Joern Rischmueller (joern.rm@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef _Gc_BodyMeasuresDownload_h
+#define _Gc_BodyMeasuresDownload_h
+
+#include "Context.h"
+#include "WithingsDownload.h"
+#include "TodaysPlanBodyMeasures.h"
+
+#include <QDialog>
+#include <QCheckBox>
+#include <QRadioButton>
+#include <QDateEdit>
+#include <QLabel>
+#include <QProgressBar>
+
+
+class BodyMeasuresDownload : public QDialog
+{
+    Q_OBJECT
+
+public:
+    BodyMeasuresDownload(Context *context);
+    ~BodyMeasuresDownload();
+
+private:
+
+     Context *context;
+
+     WithingsDownload *withingsDownload;
+     TodaysPlanBodyMeasures *todaysPlanBodyMeasureDownload;
+
+     QPushButton *downloadButton;
+     QPushButton *closeButton;
+
+     QCheckBox *discardExistingMeasures;
+
+     // withings, todaysplan, csv file
+     QRadioButton *downloadWithings;
+     QRadioButton *downloadTP;
+     QRadioButton *downloadCSV;
+
+     //  all, from last measure, manual date interval
+     QRadioButton *dateRangeAll;
+     QRadioButton *dateRangeLastMeasure;
+     QRadioButton *dateRangeManual;
+
+     QDateEdit *manualFromDate;
+     QDateEdit *manualToDate;
+
+     // Progress Bar
+     QProgressBar *progressBar;
+
+private slots:
+     void download();
+     void close();
+     void dateRangeAllSettingChanged(bool);
+     void dateRangeLastSettingChanged(bool);
+     void dateRangeManualSettingChanged(bool);
+
+     void downloadProgressStart(int);
+     void downloadProgress(int);
+     void downloadProgressEnd(int);
+
+};
+
+
+#endif

--- a/src/Cloud/TodaysPlanBodyMeasures.cpp
+++ b/src/Cloud/TodaysPlanBodyMeasures.cpp
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2017 Joern Rischmueller (joern.rm@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "TodaysPlanBodyMeasures.h"
+#include "Settings.h"
+#include "Athlete.h"
+
+#include <QDialog>
+#include <QVBoxLayout>
+#include <QBitArray>
+#include <QJsonDocument>
+#include <QJsonArray>
+#include <QJsonObject>
+#include <QJsonValue>
+#include <QNetworkReply>
+
+
+TodaysPlanBodyMeasures::TodaysPlanBodyMeasures(Context *context) : context(context) {
+
+    nam = new QNetworkAccessManager(this);
+    connect(nam, SIGNAL(sslErrors(QNetworkReply*, const QList<QSslError> & )), this, SLOT(onSslErrors(QNetworkReply*, const QList<QSslError> & )));
+
+}
+
+TodaysPlanBodyMeasures::~TodaysPlanBodyMeasures() {
+    delete nam;
+}
+
+
+void
+TodaysPlanBodyMeasures::onSslErrors(QNetworkReply *reply, const QList<QSslError>&)
+{
+    reply->ignoreSslErrors();
+}
+
+
+bool
+TodaysPlanBodyMeasures::getBodyMeasures(QString &error, QDateTime from, QDateTime to, QList<BodyMeasure> &data) {
+
+    // do we have a token
+    QString token = appsettings->cvalue(context->athlete->cyclist, GC_TODAYSPLAN_TOKEN, "").toString();
+    if (token == "") {
+        error = tr("You must authorise with Today's Plan first");
+        return false;
+    }
+
+    // Do Paginated Access to the Activities List
+    const int pageSize = 100;
+    int offset = 0;
+    int resultCount = INT_MAX;
+
+    while (offset < resultCount) {
+
+        QString url;
+        QString searchCommand;
+        if (offset == 0) {
+            // fist call
+            searchCommand = "search";
+        } else {
+            // subsequent pages
+            searchCommand = "page";
+        }
+
+        url = QString("%1/rest/users/day/%2/%3/%4")
+                .arg(appsettings->cvalue(context->athlete->cyclist, GC_TODAYSPLAN_URL, "https://whats.todaysplan.com.au").toString())
+                .arg(searchCommand)
+                .arg(QString::number(offset))
+                .arg(QString::number(pageSize));;
+
+        // request using the bearer token
+        QNetworkRequest request(url);
+        QNetworkReply *reply;
+        request.setRawHeader("Authorization", (QString("Bearer %1").arg(token)).toLatin1());
+        if (offset == 0) {
+
+            // Prepare the Search Payload for First Call to Search
+            QString userId = appsettings->cvalue(context->athlete->cyclist, GC_TODAYSPLAN_ATHLETE_ID, "").toString();
+            // application/json
+            QByteArray jsonString;
+            jsonString += "{\"criteria\": { ";
+            if (userId.length()>0)
+                jsonString += " \"userIds\": [ "+ QString("%1").arg(userId) +" ], ";
+            jsonString += "\"ranges\": [ {";
+            jsonString += "\"floorTs\": \""+ QString("%1").arg(from.toMSecsSinceEpoch()) +"\", ";
+            jsonString += "\"ceilTs\": \"" + QString("%1").arg(to.addDays(1).addSecs(-1).toMSecsSinceEpoch()) +"\"";
+            jsonString += "} ] }, ";
+            jsonString += "\"fields\": [\"att.ts\",\"att.weight\", \"att.fat\",\"att.muscleMass\",\"att.boneMass\",\"att.fatMass\", \"att.height\" ] ";
+            jsonString += "}";
+
+            QByteArray jsonStringDataSize = QByteArray::number(jsonString.size());
+
+            request.setHeader(QNetworkRequest::ContentTypeHeader,"application/json");
+            request.setRawHeader("Content-Length", jsonStringDataSize);
+            reply = nam->post(request, jsonString);
+        } else {
+            // get further pages of the Search
+            reply = nam->get(request);
+        }
+
+        // blocking request
+        QEventLoop loop;
+        connect(reply, SIGNAL(finished()), &loop, SLOT(quit()));
+        loop.exec();
+
+        // did we get a good response ?
+        QByteArray r = reply->readAll();
+
+        QJsonParseError parseError;
+        QJsonDocument document = QJsonDocument::fromJson(r, &parseError);
+
+        // if path was returned all is good, lets set root
+        if (parseError.error == QJsonParseError::NoError) {
+
+            // number of Result Items
+            if (offset == 0) {
+                resultCount = document.object()["cnt"].toInt();
+                emit downloadStarted(resultCount);
+            }
+
+            // results ?
+            QJsonObject result = document.object()["result"].toObject();
+            QJsonArray results = result["results"].toArray();
+
+            // lets look at that then
+            for(int i=0; i<results.size(); i++) {
+                QJsonObject each = results.at(i).toObject();
+                // check if we have attributes
+                if (!each.contains("atts")) continue;
+                // we have an array of attributes for a day
+                QJsonArray atts = each["atts"].toArray();
+                for (int j=0; j<atts.size(); j++) {
+                    QJsonObject record = atts.at(j).toObject();
+                    if (record.contains("ts") && record.contains("weight")) {
+                        BodyMeasure add;
+                        add.when = QDateTime::fromMSecsSinceEpoch(record["ts"].toDouble());
+                        add.weightkg = record["weight"].toDouble();
+                        add.boneskg = record["boneMass"].toDouble();
+                        add.fatkg = record["fatMass"].toDouble();
+                        add.musclekg = record["muscleMass"].toDouble();
+                        add.fatpercent = record["fat"].toDouble();
+                        data.append(add);
+                    }
+
+                }
+            }
+            // next page
+            offset += pageSize;
+            emit downloadProgress(offset);
+        } else {
+            // we had a parsing error - so something is wrong - stop requesting more data
+            error = tr("Response parsing error: %1").arg(parseError.errorString());
+            return false;
+        }
+    }
+    // all good
+    emit downloadEnded(resultCount);
+    return true;
+}
+
+
+
+

--- a/src/Cloud/TodaysPlanBodyMeasures.h
+++ b/src/Cloud/TodaysPlanBodyMeasures.h
@@ -1,0 +1,54 @@
+/*
+ *  * Copyright (c) 2017 Joern Rischmueller (joern.rm@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef GC_TodaysPlanBodyMeasures_h
+#define GC_TodaysPlanBodyMeasures_h
+
+#include "Context.h"
+#include "BodyMeasures.h"
+
+#include <QNetworkAccessManager>
+#include <QNetworkRequest>
+
+class TodaysPlanBodyMeasures : public QObject {
+
+    Q_OBJECT
+
+    public:
+
+        TodaysPlanBodyMeasures(Context *context);
+        ~TodaysPlanBodyMeasures();
+
+        // get the data
+        bool getBodyMeasures(QString &error, QDateTime from, QDateTime to, QList<BodyMeasure> &data);
+
+    signals:
+        void downloadStarted(int);
+        void downloadProgress(int);
+        void downloadEnded(int);
+
+    private:
+        Context *context;
+
+        QNetworkAccessManager *nam;
+        QNetworkReply *reply;
+
+    private slots:
+        void onSslErrors(QNetworkReply *reply, const QList<QSslError>&error);
+};
+#endif

--- a/src/Cloud/WithingsDownload.cpp
+++ b/src/Cloud/WithingsDownload.cpp
@@ -96,8 +96,8 @@ WithingsDownload::getBodyMeasures(QString &error, QDateTime from, QDateTime to, 
         KQOAuthParameters params;
         params.insert("action", "getmeas");
         params.insert("userid", appsettings->cvalue(context->athlete->cyclist, GC_WIUSER, "").toString());
-        params.insert("startdate", QString::number(from.toSecsSinceEpoch()));
-        params.insert("enddate", QString::number(to.toSecsSinceEpoch()));
+        params.insert("startdate", QString::number(from.toMSecsSinceEpoch()/1000));
+        params.insert("enddate", QString::number(to.toMSecsSinceEpoch()/1000));
 
         // Hack...
         // Why should we add params manually (GET) ????
@@ -139,8 +139,8 @@ WithingsDownload::getBodyMeasures(QString &error, QDateTime from, QDateTime to, 
                                  .arg(server)
                                  .arg(appsettings->cvalue(context->athlete->cyclist, GC_WIUSER, "").toString())
                                  .arg(appsettings->cvalue(context->athlete->cyclist, GC_WIKEY, "").toString())
-                                 .arg(QString::number(from.toSecsSinceEpoch()))
-                                 .arg(QString::number(to.toSecsSinceEpoch()));
+                                 .arg(QString::number(from.toMSecsSinceEpoch()/1000))
+                                 .arg(QString::number(to.toMSecsSinceEpoch()/1000));
 
         emit downloadStarted(100);
         QNetworkReply *reply = nam->get(QNetworkRequest(QUrl(request)));

--- a/src/Cloud/WithingsDownload.cpp
+++ b/src/Cloud/WithingsDownload.cpp
@@ -21,6 +21,7 @@
 #include "Athlete.h"
 #include "RideCache.h"
 #include "Secrets.h"
+#include "BodyMeasures.h"
 #include <QMessageBox>
 
 #ifdef GC_HAVE_KQOAUTH
@@ -38,16 +39,18 @@ WithingsDownload::WithingsDownload(Context *context) : context(context)
     oauthRequest = new KQOAuthRequest();
     oauthManager = new KQOAuthManager();
 
-    connect(oauthManager, SIGNAL(requestReady(QByteArray)),
-            this, SLOT(onRequestReady(QByteArray)));
     connect(oauthManager, SIGNAL(authorizedRequestDone()),
             this, SLOT(onAuthorizedRequestDone()));
+    connect(oauthManager, SIGNAL(requestReady(QByteArray)),
+            this, SLOT(onRequestReady(QByteArray)));
+
     #endif
 }
 
 bool
-WithingsDownload::download()
+WithingsDownload::getBodyMeasures(QString &error, QDateTime from, QDateTime to, QList<BodyMeasure> &data)
 {
+    response = "";
     // New API (OAuth)
     QString strToken = "";
     QString strSecret = "";
@@ -93,6 +96,8 @@ WithingsDownload::download()
         KQOAuthParameters params;
         params.insert("action", "getmeas");
         params.insert("userid", appsettings->cvalue(context->athlete->cyclist, GC_WIUSER, "").toString());
+        params.insert("startdate", QString::number(from.toSecsSinceEpoch()));
+        params.insert("enddate", QString::number(to.toSecsSinceEpoch()));
 
         // Hack...
         // Why should we add params manually (GET) ????
@@ -115,8 +120,14 @@ WithingsDownload::download()
 
         oauthRequest->setAdditionalParameters(params);
 
+        emit downloadStarted(100);
         oauthManager->executeRequest(oauthRequest);
+        emit downloadProgress(50);
 
+        // blocking request
+        loop.exec(); // we go on after receiving the data in SLOT(onRequestReady(QByteArray))
+
+        emit downloadEnded(100);
         #endif
     } else  {
 
@@ -124,81 +135,81 @@ WithingsDownload::download()
         QString server = appsettings->cvalue(context->athlete->cyclist, GC_WIURL, "http://wbsapi.withings.net").toString();
         if (server.endsWith("/")) server=server.mid(0, server.length()-1);
 
-        QString request = QString("%1/measure?action=getmeas&userid=%2&publickey=%3")
+        QString request = QString("%1/measure?action=getmeas&userid=%2&publickey=%3&startdate=%4&enddate=%5")
                                  .arg(server)
                                  .arg(appsettings->cvalue(context->athlete->cyclist, GC_WIUSER, "").toString())
-                                 .arg(appsettings->cvalue(context->athlete->cyclist, GC_WIKEY, "").toString());
+                                 .arg(appsettings->cvalue(context->athlete->cyclist, GC_WIKEY, "").toString())
+                                 .arg(QString::number(from.toSecsSinceEpoch()))
+                                 .arg(QString::number(to.toSecsSinceEpoch()));
 
-
+        emit downloadStarted(100);
         QNetworkReply *reply = nam->get(QNetworkRequest(QUrl(request)));
 
+        emit downloadProgress(50);
+        // blocking request
+        loop.exec(); // we go on after receiving the data in SLOT(downloadFinished(QNetworkReply))
+
+        emit downloadEnded(100);
         if (reply->error() != QNetworkReply::NoError) {
             QMessageBox::warning(context->mainWindow, tr("Withings Data Download"), reply->errorString());
             return false;
         }
-        return true;
     }
-    return false;
+
+    QStringList errors;
+    if (response.contains("\"status\":0", Qt::CaseInsensitive))
+    {
+        parse(response, errors, data);
+    } else {
+        QMessageBox oautherr(QMessageBox::Critical, tr("Error"),
+                             tr("There was an error during fetching. Please check the error description."));
+        oautherr.setDetailedText(response); // probably blank
+        oautherr.exec();
+        return false;
+
+    }
+    if (errors.count() > 0) {
+        error = errors.join(", ");
+        return false;
+    };
+    return true;
 }
+
+
+void
+WithingsDownload::parse(QString text, QStringList &errors, QList<BodyMeasure> &bodyMeasures)
+{
+
+    // parse it
+    parser->parse(text, errors);
+    if (errors.count() > 0) return;
+
+    // convert from Withings to general format
+    foreach(WithingsReading r, parser->readings()) {
+        BodyMeasure w;
+        // we just take
+        if (r.weightkg > 0 && r.when.isValid()) {
+            w.when =  r.when;
+            w.comment = r.comment;
+            w.weightkg = r.weightkg;
+            w.fatkg = r.fatkg;
+            w.leankg = r.leankg;
+            w.fatpercent = r.fatpercent;
+            bodyMeasures.append(w);
+        }
+    }
+
+}
+
+// SLOTs for asynchronous calls
 
 void
 WithingsDownload::downloadFinished(QNetworkReply *reply)
 {
-
-    if (reply->error() != QNetworkReply::NoError) {
-       QMessageBox::warning(context->mainWindow, tr("Network Problem"), tr("No Withings Data downloaded"));
-       return;
-    }
-    parse(reply->readAll());
+    response = reply->readAll();
+    loop.exit(0);
 }
 
-void
-WithingsDownload::parse(QString text)
-{
-    QStringList errors;
-
-    // parse it
-    parser->parse(text, errors);
-
-    int allMeasures = context->athlete->withings().count();
-    int receivedMeasures = parser->readings().count();
-    int newMeasures = receivedMeasures - allMeasures;
-
-    if (receivedMeasures == 0) {
-        newMeasures = 0;
-    }
-
-    QString status = tr("No new measurements");
-    if (newMeasures > 0) status = QString(tr("%1 new measurements received.")).arg(newMeasures);
-
-    QMessageBox::information(context->mainWindow, tr("Withings Data Download"), status);
-
-    // hacky for now, just refresh for all dates where we have withings data
-    // will go with SQL shortly.
-    if (newMeasures) {
-
-        // if refresh is running cancel it !
-        context->athlete->rideCache->cancel();
-
-        // store in athlete
-        context->athlete->setWithings(parser->readings());
-
-        // now save data away if we actually got something !
-        // doing it here means we don't overwrite previous responses
-        // when we fail to get any data (e.g. errors / network problems)
-        QFile withingsJSON(QString("%1/withings.json").arg(context->athlete->home->cache().canonicalPath()));
-        if (withingsJSON.open(QFile::WriteOnly)) {
-
-            QTextStream stream(&withingsJSON);
-            stream << text;
-            withingsJSON.close();
-        }
-
-        // do a refresh, it will check if needed
-        context->athlete->rideCache->refresh();
-    }
-    return;
-}
 
 #ifdef GC_HAVE_KQOAUTH
 void
@@ -207,22 +218,11 @@ WithingsDownload::onAuthorizedRequestDone() {
 }
 
 void
-WithingsDownload::onRequestReady(QByteArray response) {
+WithingsDownload::onRequestReady(QByteArray r) {
     //qDebug() << "Response from the Withings's service: " << response;
 
-    QString r = response;
-
-    if (r.contains("\"status\":0", Qt::CaseInsensitive))
-    {
-        parse(response);
-    } else {
-        QMessageBox oautherr(QMessageBox::Critical, tr("Error"),
-                     tr("There was an error during fetching. Please check the error description."));
-                     oautherr.setDetailedText(r); // probably blank
-                 oautherr.exec();
-    }
-
-
+    response = r;
+    loop.exit(0);
 
 }
 #endif

--- a/src/Cloud/WithingsDownload.h
+++ b/src/Cloud/WithingsDownload.h
@@ -23,9 +23,11 @@
 #include <QObject>
 #include <QNetworkAccessManager>
 #include <QNetworkReply>
+
 #include "Context.h"
 #include "Settings.h"
 #include "WithingsParser.h"
+#include "BodyMeasures.h"
 
 #ifdef GC_HAVE_KQOAUTH
 #include <kqoauthmanager.h>
@@ -39,27 +41,30 @@ class WithingsDownload : public QObject
 
 public:
     WithingsDownload(Context *context);
-    bool download();
+    bool getBodyMeasures(QString &error, QDateTime from, QDateTime to, QList<BodyMeasure> &data);
 
-public slots:
-    void downloadFinished(QNetworkReply *reply);
+signals:
+    void downloadStarted(int);
+    void downloadProgress(int);
+    void downloadEnded(int);
 
 private:
     Context *context;
     QNetworkAccessManager *nam;
     WithingsParser *parser;
-
-    int allMeasures;
-    int newMeasures;
+    QString response;
 
     #ifdef GC_HAVE_KQOAUTH
     KQOAuthManager *oauthManager;
     KQOAuthRequest *oauthRequest;
+    QEventLoop loop;
     #endif
 
-    void parse(QString text);
+    void parse(QString text, QStringList &errors, QList<BodyMeasure> &bodyMeasures);
 
 private slots:
+
+    void downloadFinished(QNetworkReply *reply);
     #ifdef GC_HAVE_KQOAUTH
     void onRequestReady(QByteArray);
     void onAuthorizedRequestDone();

--- a/src/Core/Athlete.h
+++ b/src/Core/Athlete.h
@@ -19,6 +19,8 @@
 #ifndef _GC_Athlete_h
 #define _GC_Athlete_h 1
 
+#include "BodyMeasures.h"
+
 #include <QDir>
 #include <QSqlDatabase>
 #include <QTreeWidget>
@@ -27,8 +29,6 @@
 #include <QNetworkReply>
 #include <QHeaderView>
 
-// for WithingsReading
-#include "WithingsParser.h"
 
 class Zones;
 class HrZones;
@@ -36,7 +36,6 @@ class PaceZones;
 class RideFile;
 class ErgFile;
 class RideMetadata;
-class WithingsDownload;
 class CalendarDownload;
 class ICalendar;
 class CalDAV;
@@ -99,7 +98,7 @@ class Athlete : public QObject
         Routes *routes;
         QList<RideFileCache*> cpxCache;
         RideCache *rideCache;
-        QList<WithingsReading> withings_;
+        QList<BodyMeasure> bodyMeasures_;
 
         // Estimates
         PDEstimate getPDEstimateFor(QDate, QString model, bool wpk);
@@ -117,7 +116,6 @@ class Athlete : public QObject
 
         // athlete's calendar
         CalendarDownload *calendarDownload;
-        WithingsDownload *withingsDownload;
 #ifdef GC_HAVE_ICAL
         ICalendar *rideCalendar;
         CalDAV *davCalendar;
@@ -140,11 +138,12 @@ class Athlete : public QObject
 
         Context *context;
 
-        // work with withings data
-        void setWithings(QList<WithingsReading>&x);
-        QList<WithingsReading>& withings() { return withings_; }
-        double getWithingsWeight(QDate date, int type=WITHINGS_WEIGHT);
-        void getWithings(QDate date, WithingsReading&);
+        // work with weight data from Withings, and other sources
+        void setBodyMeasures(QList<BodyMeasure>&x);
+
+        QList<BodyMeasure>& bodyMeasures() { return bodyMeasures_; }
+        double getBodyMeasure(QDate date, int type=BODY_WEIGHT_KG);
+        void getBodyMeasure(QDate date,BodyMeasure&);
 
         // ride collection
         void selectRideFile(QString);

--- a/src/Core/RideItem.cpp
+++ b/src/Core/RideItem.cpp
@@ -674,35 +674,37 @@ RideItem::refresh()
 double
 RideItem::getWeight(int type)
 {
-    // get any withings first
-    context->athlete->getWithings(dateTime.date(), withings);
+    // get any body measures first
+    context->athlete->getBodyMeasure(dateTime.date(), weightData);
 
     // return what was asked for!
     switch(type) {
 
-        default: // just get weight in kilos
-        case WITHINGS_WEIGHT : 
-        {
-            // get weight from whatever we got
-            weight = withings.weightkg;
+    default: // just get weight in kilos
+    case BODY_WEIGHT_KG:
+    {
+        // get weight from whatever we got
+        weight = weightData.weightkg;
 
-            // from metadata
-            if (!weight) weight = metadata_.value("Weight", "0.0").toDouble();
+        // from metadata
+        if (!weight) weight = metadata_.value("Weight", "0.0").toDouble();
 
-            // global options and if not set default to 75 kg.
-            if (!weight) weight = appsettings->cvalue(context->athlete->cyclist, GC_WEIGHT, "75.0").toString().toDouble();
-    
-            // No weight default is weird, we'll set to 80kg
-            if (weight <= 0.00) weight = 80.00;
+        // global options and if not set default to 75 kg.
+        if (!weight) weight = appsettings->cvalue(context->athlete->cyclist, GC_WEIGHT, "75.0").toString().toDouble();
 
-            return weight;
-        }
+        // No weight default is weird, we'll set to 80kg
+        if (weight <= 0.00) weight = 80.00;
 
-        // all the other weight measures supported by withings
-        case WITHINGS_FATKG : return withings.fatkg;
-        case WITHINGS_FATPERCENT : return withings.fatpercent;
-        case WITHINGS_LEANKG : return withings.leankg;
-        case WITHINGS_HEIGHT : return withings.sizemeter;
+        return weight;
+    }
+
+    // all the other weight measures supported by BodyMetrics
+    case BODY_WEIGHT_FAT_KG : return weightData.fatkg;
+    case BODY_WEIGHT_MUSCLE_KG : return weightData.musclekg;
+    case BODY_WEIGHT_BONES_KG : return weightData.boneskg;
+    case BODY_WEIGHT_LEAN_KG : return weightData.leankg;
+    case BODY_WEIGHT_FAT_PERCENT : return weightData.fatpercent;
+
     }
     return weight;
 }

--- a/src/Core/RideItem.h
+++ b/src/Core/RideItem.h
@@ -22,7 +22,7 @@
 #include "GoldenCheetah.h"
 
 #include "RideMetric.h"
-#include "WithingsParser.h"
+#include "BodyMeasures.h"
 
 #include <QString>
 #include <QMap>
@@ -154,7 +154,7 @@ class RideItem : public QObject
         double weight; // what weight was used ?
 
         // access to the cached data !
-        WithingsReading withings;
+        BodyMeasure weightData;
         RideFile *ride(bool open=true);
         RideFileCache *fileCache();
         QVector<double> &metrics() { return metrics_; }

--- a/src/Gui/HelpWhatsThis.cpp
+++ b/src/Gui/HelpWhatsThis.cpp
@@ -122,6 +122,8 @@ HelpWhatsThis::getText(GCHelp chapter) {
         return text.arg("Menu%20Bar_Tools").arg(tr("Estimation of critical power using the Monod/Scherrer power model"));
     case MenuBar_Tools_AirDens_EST:
         return text.arg("Menu%20Bar_Tools").arg(tr("Estimation of Air Density (Rho)"));
+    case MenuBar_Tools_Download_BodyMeasures:
+        return text.arg("Menu%20Bar_Tools").arg(tr("Downloading of Body Measures (e.g. weight) from multiple sources"));
     case MenuBar_Tools_VDOT_CALC:
         return text.arg("Menu%20Bar_Tools").arg(tr("Calculation of VDOT and Threshold Pace according to Daniels' Running Formula"));
     case MenuBar_Tools_Download_ERGDB:

--- a/src/Gui/HelpWhatsThis.h
+++ b/src/Gui/HelpWhatsThis.h
@@ -63,6 +63,7 @@ Q_OBJECT
                  MenuBar_Tools_CP_EST,
                  MenuBar_Tools_AirDens_EST,
                  MenuBar_Tools_VDOT_CALC,
+                 MenuBar_Tools_Download_BodyMeasures,
                  MenuBar_Tools_Download_ERGDB,
                  MenuBar_Tools_Download_TP,
                  MenuBar_Tools_CreateWorkout,

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -70,7 +70,7 @@
 #endif
 #include "ShareDialog.h"
 #include "TodaysPlan.h"
-#include "WithingsDownload.h"
+#include "BodyMeasuresDownload.h"
 #include "WorkoutWizard.h"
 #include "ErgDBDownloadDialog.h"
 #include "AddDeviceWizard.h"
@@ -486,8 +486,8 @@ MainWindow::MainWindow(const QDir &home)
     optionsMenu->addAction(tr("VDOT and T-Pace Calculator..."), this, SLOT(showVDOTCalculator()));
 
     optionsMenu->addSeparator();
-    optionsMenu->addAction(tr("Get &Withings Data..."), this,
-                        SLOT (downloadMeasures()));
+    optionsMenu->addAction(tr("Get &Body Measures..."), this,
+                        SLOT (downloadBodyMeasures()));
     optionsMenu->addSeparator();
     optionsMenu->addAction(tr("Create a new workout..."), this, SLOT(showWorkoutWizard()));
     optionsMenu->addAction(tr("Download workouts from ErgDB..."), this, SLOT(downloadErgDB()));
@@ -2244,9 +2244,12 @@ MainWindow::configChanged(qint32)
  *--------------------------------------------------------------------*/
 
 void
-MainWindow::downloadMeasures()
+MainWindow::downloadBodyMeasures()
 {
-    currentTab->context->athlete->withingsDownload->download();
+
+    BodyMeasuresDownload dialog(currentTab->context);
+    dialog.exec();
+
 }
 
 void

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -203,7 +203,7 @@ class MainWindow : public QMainWindow
 #endif
 
         // Measures View
-        void downloadMeasures();
+        void downloadBodyMeasures();
 
         // Activity Collection
         void addIntervals(); // pass thru to tab

--- a/src/Metrics/BasicRideMetrics.cpp
+++ b/src/Metrics/BasicRideMetrics.cpp
@@ -521,13 +521,13 @@ class AthleteWeight : public RideMetric {
         setImperialUnits(tr("lbs"));
         setPrecision(2);
         setConversion(LB_PER_KG);
-        setDescription(tr("Weight in kg or lbs: first from Withings data, then from Activity metadata and last from Athlete configuration with 75kg default"));
+        setDescription(tr("Weight in kg or lbs: first from downloaded Body Measure data, then from Activity metadata and last from Athlete configuration with 75kg default"));
     }
 
     void compute(RideItem *item, Specification, const QHash<QString,RideMetric*> &) {
 
-        // withings first
-        double weight = item->context->athlete->getWithingsWeight(item->dateTime.date());
+        // body measures first
+        double weight = item->context->athlete->getBodyMeasure(item->dateTime.date());
 
         // from metadata
         if (!weight) weight = item->getText("Weight", "0.0").toDouble();
@@ -570,15 +570,15 @@ class AthleteFat : public RideMetric {
         setImperialUnits(tr("lbs"));
         setPrecision(2);
         setConversion(LB_PER_KG);
-        setDescription(tr("Bodyfat in kg or lbs from Withings data"));
+        setDescription(tr("Bodyfat in kg or lbs from downloaded Body Measure data"));
     }
 
     void compute(RideItem *item, Specification, const QHash<QString,RideMetric*> &) {
 
-        WithingsReading here;
+        BodyMeasure here;
 
-        // withings first
-        item->context->athlete->getWithings(item->dateTime.date(), here);
+        // body measures first
+        item->context->athlete->getBodyMeasure(item->dateTime.date(), here);
         setValue(here.fatkg);
     }
 
@@ -611,15 +611,15 @@ class AthleteLean : public RideMetric {
         setImperialUnits(tr("lbs"));
         setPrecision(2);
         setConversion(LB_PER_KG);
-        setDescription(tr("Lean Weight in kg or lbs from Withings data"));
+        setDescription(tr("Lean Weight in kg or lbs from downloaded Body Measure data"));
     }
 
     void compute(RideItem *item, Specification, const QHash<QString,RideMetric*> &) {
 
-        WithingsReading here;
+        BodyMeasure here;
 
-        // withings first
-        item->context->athlete->getWithings(item->dateTime.date(), here);
+        // body measures first
+        item->context->athlete->getBodyMeasure(item->dateTime.date(), here);
         setValue(here.leankg);
     }
 
@@ -651,15 +651,15 @@ class AthleteFatP : public RideMetric {
         setMetricUnits(tr("%"));
         setImperialUnits(tr("%"));
         setPrecision(1);
-        setDescription(tr("Bodyfat Percent from Withings data"));
+        setDescription(tr("Bodyfat Percent from downloaded Body Measure data"));
     }
 
     void compute(RideItem *item, Specification, const QHash<QString,RideMetric*> &) {
 
-        WithingsReading here;
+        BodyMeasure here;
 
-        // withings first
-        item->context->athlete->getWithings(item->dateTime.date(), here);
+        // body measures first
+        item->context->athlete->getBodyMeasure(item->dateTime.date(), here);
         setValue(here.fatpercent);
     }
 
@@ -671,7 +671,6 @@ class AthleteFatP : public RideMetric {
 static bool athleteFatPAdded =
     RideMetricFactory::instance().addMetric(AthleteFatP());
 
-//        case WITHINGS_LEANKG : return withings.leankg;
 //////////////////////////////////////////////////////////////////////////////
 
 class ElevationGain : public RideMetric {

--- a/src/src.pro
+++ b/src/src.pro
@@ -689,8 +689,10 @@ HEADERS += Charts/Aerolab.h Charts/AerolabWindow.h Charts/AllPlot.h Charts/AllPl
 }
 
 # cloud services
-HEADERS += Cloud/CalendarDownload.h Cloud/FileStore.h Cloud/LocalFileStore.h Cloud/OAuthDialog.h Cloud/ShareDialog.h \
-           Cloud/SportPlusHealthUploader.h Cloud/TrainingstagebuchUploader.h Cloud/VeloHeroUploader.h Cloud/WithingsDownload.h
+HEADERS += Cloud/BodyMeasures.h Cloud/BodyMeasuresDownload.h Cloud/CalendarDownload.h Cloud/FileStore.h Cloud/LocalFileStore.h \
+           Cloud/OAuthDialog.h Cloud/ShareDialog.h Cloud/SportPlusHealthUploader.h Cloud/TodaysPlanBodyMeasures.h \
+           Cloud/TrainingstagebuchUploader.h Cloud/VeloHeroUploader.h Cloud/WithingsDownload.h
+
 # core data 
 HEADERS += Core/Athlete.h Core/Context.h Core/DataFilter.h Core/FreeSearch.h Core/GcCalendarModel.h Core/GcUpgrade.h \
            Core/IdleTimer.h Core/IntervalItem.h Core/NamedSearch.h Core/RideCache.h Core/RideCacheModel.h Core/RideDB.h \
@@ -776,8 +778,9 @@ SOURCES += Charts/Aerolab.cpp Charts/AerolabWindow.cpp Charts/AllPlot.cpp Charts
 }
 
 ## Cloud Services / Web resources
-SOURCES += Cloud/CalendarDownload.cpp Cloud/FileStore.cpp Cloud/LocalFileStore.cpp Cloud/OAuthDialog.cpp Cloud/ShareDialog.cpp \
-           Cloud/SportPlusHealthUploader.cpp Cloud/TrainingstagebuchUploader.cpp Cloud/VeloHeroUploader.cpp Cloud/WithingsDownload.cpp
+SOURCES += Cloud/BodyMeasures.cpp Cloud/BodyMeasuresDownload.cpp Cloud/CalendarDownload.cpp Cloud/FileStore.cpp Cloud/LocalFileStore.cpp \
+           Cloud/OAuthDialog.cpp Cloud/ShareDialog.cpp Cloud/SportPlusHealthUploader.cpp Cloud\TodaysPlanBodyMeasures.cpp \
+           Cloud/TrainingstagebuchUploader.cpp Cloud/VeloHeroUploader.cpp Cloud/WithingsDownload.cpp
 
 ## Core Data Structures
 SOURCES += Core/Athlete.cpp Core/Context.cpp Core/DataFilter.cpp Core/FreeSearch.cpp Core/GcUpgrade.cpp Core/IdleTimer.cpp \


### PR DESCRIPTION
... body measures are weight data as provided by multiple fitness platform (one of the being the already support Withings platform)
... all access to Weight from external platforms is done through the body measures model - not direct use of Withings any more
... not all platform deliver all measures - but (hopefully) all are providing "weight in kg" as a minimum data

General Download Dialog for Body Measures
... allowing to select the source and the daterange for which data is downloaded (e.g. only the new data since last available measure)
... Support existing Withings Download
... Support new Today's Plan as data source (which is able to receive measures from other sits - e.g. Garmin Connect)
... Support CSV files as data source

Store Body Measures Data in one fix file under /activities (not in /cache like Withings) (so that e.g. backup works like before).

What's open:

... CSV File Import (Info Message on missing feature)
... Test of "old" Withings Download API (since I can't do this)