### PR TITLE
Fix warnings, leaks and null pointer access

### DIFF
--- a/src/Charts/AllPlot.cpp
+++ b/src/Charts/AllPlot.cpp
@@ -4218,8 +4218,12 @@ AllPlot::setDataFromPlot(AllPlot *plot)
         } else if (scope == RideFile::lpco || scope == RideFile::rpco) {
 
             // get the min/max values for both curves
-            double min = qMin(float(thereCurve->minYValue()), float(thereCurve2->minYValue()));
-            double max = qMax(float(thereCurve->maxYValue()), float(thereCurve2->maxYValue()));
+            double min = thereCurve->minYValue();
+            double max = thereCurve->maxYValue();
+            if (thereCurve2) {
+                min = qMin(min, thereCurve2->minYValue());
+                max = qMax(max, thereCurve2->maxYValue());
+            }
             setAxisScale(QwtPlot::yLeft, min, max); // not more than 15 degrees
 
         } else if (scope == RideFile::lppb || scope == RideFile::rppb) {
@@ -4968,6 +4972,9 @@ AllPlot::setDataFromPlots(QList<AllPlot *> plots)
                 }
         }
 
+        if (ourCurve) delete ourCurve;
+        if (ourICurve) delete ourICurve;
+        
         // move on -- this is used to reference into the compareIntervals
         //            array to get the colors predominantly!
         index++;

--- a/src/Charts/CPPlot.cpp
+++ b/src/Charts/CPPlot.cpp
@@ -832,9 +832,11 @@ CPPlot::plotModel(QVector<double> vector, QColor plotColor, PDModel *baseline)
     }
 
     // set the model and load data
-    pdmodel->setIntervals(sanI1, sanI2, anI1, anI2, aeI1, aeI2, laeI1, laeI2);
-    pdmodel->setMinutes(true); // we're minutes here ...
-    pdmodel->setData(vector);
+    if (pdmodel) {
+        pdmodel->setIntervals(sanI1, sanI2, anI1, anI2, aeI1, aeI2, laeI1, laeI2);
+        pdmodel->setMinutes(true); // we're minutes here ...
+        pdmodel->setData(vector);
+    }
 
     // create curve
     QwtPlotCurve *curve = new QwtPlotCurve("Model");
@@ -1740,8 +1742,10 @@ CPPlot::pointHover(QwtPlotCurve *curve, int index)
         if (criticalSeries == CriticalPowerWindow::kph) {
             if (isRun || isSwim) {
                 const PaceZones *zones = context->athlete->paceZones(isSwim);
-                bool metricPace = zones ? appsettings->value(this, zones->paceSetting(), true).toBool() : true;
-                paceStr = QString("\n%1 %2").arg(zones->kphToPaceString(yvalue, metricPace)).arg(zones->paceUnits(metricPace));
+                if (zones) {
+                    bool metricPace = appsettings->value(this, zones->paceSetting(), true).toBool();
+                    paceStr = QString("\n%1 %2").arg(zones->kphToPaceString(yvalue, metricPace)).arg(zones->paceUnits(metricPace));
+                }
             }
             double km = yvalue*xvalue/60.0; // distance in km
             if (isSwim) {

--- a/src/Charts/OverviewWindow.cpp
+++ b/src/Charts/OverviewWindow.cpp
@@ -1838,8 +1838,11 @@ BubbleViz::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
     painter->restore();
 }
 
-Sparkline::Sparkline(QGraphicsWidget *parent, int count, QString name) : QGraphicsItem(NULL), parent(parent), count(count), name(name)
+Sparkline::Sparkline(QGraphicsWidget *parent, int count, QString name)
+    : QGraphicsItem(NULL), parent(parent), name(name)
 {
+    Q_UNUSED(count)
+    
     min = max = 0.0f;
     setGeometry(20,20,100,100);
     setZValue(11);

--- a/src/Charts/OverviewWindow.cpp
+++ b/src/Charts/OverviewWindow.cpp
@@ -696,7 +696,7 @@ Card::setData(RideItem *item)
     if (type == ZONE) {
 
         // enable animation when setting values (disabled at all other times)
-        chart->setAnimationOptions(QChart::SeriesAnimations);
+        if (chart) chart->setAnimationOptions(QChart::SeriesAnimations);
 
         switch(settings.series) {
 
@@ -841,8 +841,8 @@ Card::setData(RideItem *item)
         if (miny >= 0 && ydiff > miny) miny = ydiff;
         double xdiff = (maxx-minx) / 10.0f;
         if (minx >= 0 && xdiff > minx) minx = xdiff;
-        maxx=round(maxx); minx=round(minx); xdiff=round(xdiff);
-        maxy=round(maxy); miny=round(miny); ydiff=round(ydiff);
+        maxx=round(maxx); minx=round(minx);
+        maxy=round(maxy); miny=round(miny);
 
         // set range before points to filter
         bubble->setRange(minx,maxx,miny,maxy);

--- a/src/Charts/OverviewWindow.h
+++ b/src/Charts/OverviewWindow.h
@@ -337,7 +337,6 @@ class Sparkline : public QGraphicsItem
     private:
         QGraphicsWidget *parent;
         QRectF geom;
-        int count;
         QString name;
         double min, max;
         QList<QPointF> points;

--- a/src/Charts/PfPvPlot.cpp
+++ b/src/Charts/PfPvPlot.cpp
@@ -746,7 +746,7 @@ PfPvPlot::intervalHover(IntervalItem *x)
         }
 
         // any data ?
-        if (aepfArray.size()) {
+        if (count > 0 && aepfArray.size()) {
             QwtSymbol *sym = new QwtSymbol;
             sym->setStyle(QwtSymbol::Ellipse);
             sym->setSize(4*dpiXFactor);

--- a/src/Charts/PowerHist.cpp
+++ b/src/Charts/PowerHist.cpp
@@ -1151,10 +1151,12 @@ PowerHist::binData(HistData &standard, QVector<double>&x, // x-axis for data
             x[i] = high*delta;
             y[i]  = 1e-9;  // nonzero to accommodate log plot
             sy[i] = 1e-9;  // nonzero to accommodate log plot
-            while (low < high && low<arrayLength) {
-                if (selectedArray && (*selectedArray).size()>low)
-                    sy[i] += dt * (*selectedArray)[low];
-                y[i] += dt * (*array)[low++];
+            if (array) {
+                while (low < high && low<arrayLength) {
+                    if (selectedArray && (*selectedArray).size()>low)
+                        sy[i] += dt * (*selectedArray)[low];
+                    y[i] += dt * (*array)[low++];
+                }
             }
         }
         y[i] = 1e-9;       // nonzero to accommodate log plot
@@ -2402,7 +2404,7 @@ bool PowerHist::isSelected(const RideFilePoint *p, double sample)
 
 bool PowerHist::isSelected(const double t, double sample)
 {
-    if (!rideItem) {
+    if (rideItem) {
 
         foreach (IntervalItem *interval, rideItem->intervalsSelected()) {
             if (interval->selected && t+sample>interval->start && t<interval->stop) 

--- a/src/Charts/RideEditor.cpp
+++ b/src/Charts/RideEditor.cpp
@@ -963,7 +963,7 @@ void
 RideEditor::insColumn(QString name)
 {
     // update state data
-    RideFile::SeriesType series;
+    RideFile::SeriesType series = RideFile::secs;
 
     if (name == tr("Time")) series = RideFile::secs;
     if (name == tr("Distance")) series = RideFile::km;

--- a/src/Charts/RideMapWindow.cpp
+++ b/src/Charts/RideMapWindow.cpp
@@ -1232,7 +1232,7 @@ MapWebBridge::getLatLons(int i)
         }
         return latlons;
 
-    } else {
+    } else if (rideItem) {
 
         // get latlons for entire route
         foreach (RideFilePoint *p1, rideItem->ride()->dataPoints()) {

--- a/src/Charts/RideMapWindow.cpp
+++ b/src/Charts/RideMapWindow.cpp
@@ -1077,7 +1077,6 @@ RideMapWindow::createMarkers()
                 view->page()->mainFrame()->evaluateJavaScript(code);
             #endif
 
-                stoptime=0;
             }
             stoplat=stoplon=stoptime=0;
         }

--- a/src/Charts/ScatterPlot.cpp
+++ b/src/Charts/ScatterPlot.cpp
@@ -672,7 +672,7 @@ ScatterPlot::intervalHover(IntervalItem *ri)
         }
 
         // any data ?
-        if (xArray.size()) {
+        if (count > 0 && xArray.size()) {
             QwtSymbol *sym = new QwtSymbol;
             sym->setStyle(QwtSymbol::Ellipse);
             sym->setSize(4*dpiXFactor);

--- a/src/Cloud/CloudService.cpp
+++ b/src/Cloud/CloudService.cpp
@@ -154,7 +154,6 @@ static QByteArray gUncompress(const QByteArray &data)
 
         switch (ret) {
         case Z_NEED_DICT:
-            ret = Z_DATA_ERROR;     // and fall through
         case Z_DATA_ERROR:
         case Z_MEM_ERROR:
             (void)inflateEnd(&strm);
@@ -1262,6 +1261,7 @@ CloudServiceSyncDialog::syncNext()
                 QByteArray *data = new QByteArray;
                 store->readFile(data, curr->text(1), curr->text(8)); // filename
                 QApplication::processEvents();
+                delete data;
 
             } else {
                 curr->setText(7, tr("Uploading"));
@@ -1344,6 +1344,7 @@ CloudServiceSyncDialog::downloadNext()
             QByteArray *data = new QByteArray; // gets deleted when read completes
             store->readFile(data, curr->text(1), curr->text(6));
             QApplication::processEvents();
+            delete data;
             return true;
         }
     }

--- a/src/Cloud/ShareDialog.cpp
+++ b/src/Cloud/ShareDialog.cpp
@@ -256,15 +256,17 @@ ShareDialog::ShareDialog(Context *context, RideItem *item) :
     commuteChk = new QCheckBox(tr("Commute"));
     trainerChk = new QCheckBox(tr("Trainer"));
 
-    const RideFileDataPresent *dataPresent = ride->ride()->areDataPresent();
-    altitudeChk->setEnabled(dataPresent->alt);
-    altitudeChk->setChecked(dataPresent->alt);
-    powerChk->setEnabled(dataPresent->watts);
-    powerChk->setChecked(dataPresent->watts);
-    cadenceChk->setEnabled(dataPresent->cad);
-    cadenceChk->setChecked(dataPresent->cad);
-    heartrateChk->setEnabled(dataPresent->hr);
-    heartrateChk->setChecked(dataPresent->hr);
+    if (ride) {
+        const RideFileDataPresent *dataPresent = ride->ride()->areDataPresent();
+        altitudeChk->setEnabled(dataPresent->alt);
+        altitudeChk->setChecked(dataPresent->alt);
+        powerChk->setEnabled(dataPresent->watts);
+        powerChk->setChecked(dataPresent->watts);
+        cadenceChk->setEnabled(dataPresent->cad);
+        cadenceChk->setChecked(dataPresent->cad);
+        heartrateChk->setEnabled(dataPresent->hr);
+        heartrateChk->setChecked(dataPresent->hr);
+    }
 
     QGridLayout *vbox3 = new QGridLayout();
     //vbox3->addWidget(gpsChk,0,0);

--- a/src/Cloud/SixCycle.cpp
+++ b/src/Cloud/SixCycle.cpp
@@ -193,6 +193,9 @@ SixCycle::createFolder(QString)
 QList<CloudServiceEntry*>
 SixCycle::readdir(QString path, QStringList &errors, QDateTime from, QDateTime to)
 {
+    Q_UNUSED(from)
+    Q_UNUSED(to)
+    
     printd("Sixcycle::readdir(%s)\n", path.toStdString().c_str());
 
     QList<CloudServiceEntry*> returning;

--- a/src/Core/DataFilter.cpp
+++ b/src/Core/DataFilter.cpp
@@ -2456,8 +2456,8 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
                             if (xs && m->xdata().value(xdata,QStringList()).contains(series)) {
                                 int idx = m->xdata().value(xdata,QStringList()).indexOf(series);
                                 QString units;
-                                int count = m->ride()->xdata(xdata)->unitname.count();
-                                if (idx >= 0 && idx < xs->unitname.count())
+                                const int count = xs->unitname.count();
+                                if (idx >= 0 && idx < count)
                                     units = xs->unitname[idx];
                                 return Result(units);
                             }

--- a/src/Core/IntervalItem.cpp
+++ b/src/Core/IntervalItem.cpp
@@ -181,10 +181,6 @@ EditIntervalDialog::EditIntervalDialog(QWidget *parent, IntervalItem &interval) 
 
     // Grid
     QGridLayout *grid = new QGridLayout;
-    QLabel *name = new QLabel("Name");
-    QLabel *from = new QLabel("From");
-    QLabel *to = new QLabel("To");
-    QLabel *color = new QLabel("Color");
 
     nameEdit = new QLineEdit(this);
     nameEdit->setText(interval.name);
@@ -203,15 +199,15 @@ EditIntervalDialog::EditIntervalDialog(QWidget *parent, IntervalItem &interval) 
     }
 
 
-    grid->addWidget(name, 0,0);
+    grid->addWidget(new QLabel("Name"), 0,0);
     grid->addWidget(nameEdit, 0,1);
 
     if (interval.type == RideFileInterval::USER) {
-        grid->addWidget(from, 1,0);
+        grid->addWidget(new QLabel("From"), 1,0);
         grid->addWidget(fromEdit, 1,1);
-        grid->addWidget(to, 2,0);
+        grid->addWidget(new QLabel("To"), 2,0);
         grid->addWidget(toEdit, 2,1);
-        grid->addWidget(color, 3,0);
+        grid->addWidget(new QLabel("Color"), 3,0);
         grid->addWidget(colorEdit, 3,1);
     }
 

--- a/src/Core/Route.cpp
+++ b/src/Core/Route.cpp
@@ -237,7 +237,6 @@ RouteSegment::search(RideItem *item, RideFile*ride, QList<IntervalItem*>&here)
                 }
             }
         }
-        stop = point->secs;
 
 
         if (!present) {
@@ -245,31 +244,33 @@ RouteSegment::search(RideItem *item, RideFile*ride, QList<IntervalItem*>&here)
 
             break;
 
-        } else {
-            if (n == this->getPoints().count()-1){
+        }
+        
+        stop = point->secs;
+        
+        if (n == this->getPoints().count()-1) {
 
-                // Add the interval and continue search
-                //qDebug() << "    >>> Route identified in ride: " << name << " start: " << start << " stop: " << stop << " (distance " << precision << "km)\r\n";
+            // Add the interval and continue search
+            //qDebug() << "    >>> Route identified in ride: " << name << " start: " << start << " stop: " << stop << " (distance " << precision << "km)\r\n";
 
-                IntervalItem *intervalItem = new IntervalItem(item, name,
-                                                              start, stop,
-                                                              ride->timeToDistance(start),
-                                                              ride->timeToDistance(stop),
-                                                              ++found,
-                                                              QColor(255,127,80),
-                                                              RideFileInterval::ROUTE);
-                intervalItem->route = id();
-                here << intervalItem;
+            IntervalItem *intervalItem = new IntervalItem(item, name,
+                                                          start, stop,
+                                                          ride->timeToDistance(start),
+                                                          ride->timeToDistance(stop),
+                                                          ++found,
+                                                          QColor(255,127,80),
+                                                          RideFileInterval::ROUTE);
+            intervalItem->route = id();
+            here << intervalItem;
 
-                // reset to restart find on next iteration
-                start = -1;
-                n=0;
+            // reset to restart find on next iteration
+            start = -1;
+            n=0;
 
-                // skip on a few samples to avoid finding the same
-                // segment again - this happens when a segment is very
-                // short and ends at lights or top of a hill.
-                lastpoint += 30;
-            }
+            // skip on a few samples to avoid finding the same
+            // segment again - this happens when a segment is very
+            // short and ends at lights or top of a hill.
+            lastpoint += 30;
         }
     }
 }

--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -316,13 +316,6 @@ main(int argc, char *argv[])
     // hidpi ratios -- single desktop for now
     desktop = QApplication::desktop();
 
-    // We will set screen ratio factor for sizing when a screen
-    // is greater than the Surface Pro 3 2160x1440, since its a break
-    // point with resolutions above that being devices like the
-    // 2560x1700 chromebook pixel before we get to truly hi-dpi
-    // resolutions like apples MBP retina 2880x1800 up through
-    // UHD, 4k and 5k displays at 3840x2160, 4096x2304 and 5120 x 2160.
-    QRect screenSize = desktop->availableGeometry();
 
     // since almost all dialogs are sized for a screen resolution
     // of 1280x1024, to save issues we will scale DIALOGS to the
@@ -334,6 +327,15 @@ main(int argc, char *argv[])
 
 #if QT_VERSION_MAJOR >= 5
 #ifndef Q_OS_MAC // not needed on a Mac
+
+    // We will set screen ratio factor for sizing when a screen
+    // is greater than the Surface Pro 3 2160x1440, since its a break
+    // point with resolutions above that being devices like the
+    // 2560x1700 chromebook pixel before we get to truly hi-dpi
+    // resolutions like apples MBP retina 2880x1800 up through
+    // UHD, 4k and 5k displays at 3840x2160, 4096x2304 and 5120 x 2160.
+    QRect screenSize = desktop->availableGeometry();
+
     // if we're running with dpiawareness of 0 the screen resolution
     // will be expressed taking into account the scaling applied
     // so for example a 3840x2160 screen will likely be expressed as

--- a/src/FileIO/Bin2RideFile.cpp
+++ b/src/FileIO/Bin2RideFile.cpp
@@ -51,9 +51,11 @@ struct Bin2FileReaderState
     QString deviceInfo;
 
     Bin2FileReaderState(QFile &file, QStringList &errors) :
-        file(file), errors(errors), rideFile(NULL), secs(0), km(0),
-        interval(0), last_interval_secs(0.0), interval_offset(0), jouleGPS(true), jouleGPS_GPSPlus(true),
-        stopped(true), data_version(0)
+        file(file), errors(errors), rideFile(NULL), data_version(0),
+        secs(0), km(0),
+        interval(0), last_interval_secs(0.0), interval_offset(0),
+        jouleGPS(true), jouleGPS_GPSPlus(true),
+        stopped(true)
     {
 
     }

--- a/src/FileIO/Computrainer3dpFile.cpp
+++ b/src/FileIO/Computrainer3dpFile.cpp
@@ -80,6 +80,7 @@ RideFile *Computrainer3dpFileReader::openRideFile(QFile & file,
     if(strcmp(perfStr,"perf"))
     {
         errors << "File is encrypted.";
+        delete rideFile;
         return NULL;
     }
 

--- a/src/FileIO/FilterHRV.cpp
+++ b/src/FileIO/FilterHRV.cpp
@@ -238,6 +238,7 @@ static bool FilterHrvOutliersAdded = DataProcessorFactory::instance().registerPr
 bool
 FilterHrvOutliers::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")
 {
+    Q_UNUSED(op)
 
     if (ride->areDataPresent()->hrv) {
         XDataSeries *series = ride->xdata("HRV");

--- a/src/FileIO/FixDeriveDistance.cpp
+++ b/src/FileIO/FixDeriveDistance.cpp
@@ -107,7 +107,8 @@ double _deg2rad(double deg) {
 bool
 FixDeriveDistance::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")
 {
-    Q_UNUSED(config);
+    Q_UNUSED(config)
+    Q_UNUSED(op)
 
     // if its already there do nothing !
     if (ride->areDataPresent()->km) return false;

--- a/src/FileIO/FixDeriveHeadwind.cpp
+++ b/src/FileIO/FixDeriveHeadwind.cpp
@@ -89,7 +89,8 @@ static bool FixDeriveHeadwindAdded = DataProcessorFactory::instance().registerPr
 bool
 FixDeriveHeadwind::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")
 {
-    Q_UNUSED(config);
+    Q_UNUSED(config)
+    Q_UNUSED(op)
 
     double bearing = 0; // used to compute headwind depending on wind/cyclist bearing difference
 

--- a/src/FileIO/FixDerivePower.cpp
+++ b/src/FileIO/FixDerivePower.cpp
@@ -164,6 +164,8 @@ static bool FixDerivePowerAdded = DataProcessorFactory::instance().registerProce
 bool
 FixDerivePower::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")
 {
+    Q_UNUSED(op)
+
     // get settings
     double MBik; // Bike weight kg
     double CrV;  // Coefficient of Rolling Resistance

--- a/src/FileIO/FixDeriveTorque.cpp
+++ b/src/FileIO/FixDeriveTorque.cpp
@@ -103,7 +103,9 @@ static bool FixDeriveTorqueAdded = DataProcessorFactory::instance().registerProc
 bool
 FixDeriveTorque::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")
 {
-    Q_UNUSED(config);
+    Q_UNUSED(config)
+    Q_UNUSED(op)
+
     static const double PI = 3.1415927f;
 
     // if its already there do nothing !

--- a/src/FileIO/FixElevation.cpp
+++ b/src/FileIO/FixElevation.cpp
@@ -99,8 +99,11 @@ class FixElevation : public DataProcessor {
 static bool fixElevationAdded = DataProcessorFactory::instance().registerProcessor(QString("Fix Elevation errors"), new FixElevation());
 
 bool
-FixElevation::postProcess(RideFile *ride, DataProcessorConfig *, QString op="")
+FixElevation::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")
 {
+    Q_UNUSED(config)
+    Q_UNUSED(op)
+
     // Cannot process without without GPS data
     if (!ride || ride->areDataPresent()->lat == false || ride->areDataPresent()->lon == false)
         return false;

--- a/src/FileIO/FixFreewheeling.cpp
+++ b/src/FileIO/FixFreewheeling.cpp
@@ -86,7 +86,8 @@ static bool FixFreewheelingAdded = DataProcessorFactory::instance().registerProc
 bool
 FixFreewheeling::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")
 {
-    Q_UNUSED(config);
+    Q_UNUSED(config)
+    Q_UNUSED(op)
 
     // does this ride have power and cadence ?
     if (ride->areDataPresent()->watts == false || ride->areDataPresent()->cad == false) return false;

--- a/src/FileIO/FixGPS.cpp
+++ b/src/FileIO/FixGPS.cpp
@@ -61,7 +61,7 @@ class FixGPS : public DataProcessor {
         ~FixGPS() {}
 
         // the processor
-        bool postProcess(RideFile *, DataProcessorConfig* config, QString op);
+        bool postProcess(RideFile *, DataProcessorConfig*settings=0, QString op="");
 
         // the config widget
         DataProcessorConfig* processorConfig(QWidget *parent) {
@@ -77,8 +77,11 @@ class FixGPS : public DataProcessor {
 static bool fixGPSAdded = DataProcessorFactory::instance().registerProcessor(QString("Fix GPS errors"), new FixGPS());
 
 bool
-FixGPS::postProcess(RideFile *ride, DataProcessorConfig *, QString op)
+FixGPS::postProcess(RideFile *ride, DataProcessorConfig *config, QString op)
 {
+    Q_UNUSED(config)
+    Q_UNUSED(op)
+
     // ignore null or files without GPS data
     if (!ride || ride->areDataPresent()->lat == false || ride->areDataPresent()->lon == false)
         return false;

--- a/src/FileIO/FixGaps.cpp
+++ b/src/FileIO/FixGaps.cpp
@@ -136,6 +136,8 @@ static bool fixGapsAdded = DataProcessorFactory::instance().registerProcessor(QS
 bool
 FixGaps::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")
 {
+    Q_UNUSED(op)
+
     // get settings
     double tolerance, stop;
     if (config == NULL) { // being called automatically

--- a/src/FileIO/FixGaps.cpp
+++ b/src/FileIO/FixGaps.cpp
@@ -167,8 +167,7 @@ FixGaps::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="
     for (int position = 0; position < ride->dataPoints().count(); position++) {
         RideFilePoint *point = ride->dataPoints()[position];
 
-        if (last == NULL) last = point;
-        else {
+        if (NULL != last) {
             double gap = point->secs - last->secs - ride->recIntSecs();
 
             // if we have gps and we moved, then this isn't a stop

--- a/src/FileIO/FixHRSpikes.cpp
+++ b/src/FileIO/FixHRSpikes.cpp
@@ -121,6 +121,8 @@ static bool fixHRSpikesAdded = DataProcessorFactory::instance().registerProcesso
 bool
 FixHRSpikes::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")
 {
+    Q_UNUSED(op)
+
     // does this ride have heart rate data?
     if (ride->areDataPresent()->hr == false) return false;
 

--- a/src/FileIO/FixLapSwim.cpp
+++ b/src/FileIO/FixLapSwim.cpp
@@ -116,6 +116,8 @@ static bool FixLapSwimAdded = DataProcessorFactory::instance().registerProcessor
 bool
 FixLapSwim::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")
 {
+    Q_UNUSED(op)
+
     // get settings
     double pl;
     if (config == NULL) { // being called automatically

--- a/src/FileIO/FixMoxy.cpp
+++ b/src/FileIO/FixMoxy.cpp
@@ -115,7 +115,9 @@ static bool FixMoxyAdded = DataProcessorFactory::instance().registerProcessor(QS
 bool
 FixMoxy::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")
 {
-    Q_UNUSED(config);
+    Q_UNUSED(config)
+    Q_UNUSED(op)
+
     bool isCad;
     bool isSpd;
 

--- a/src/FileIO/FixPower.cpp
+++ b/src/FileIO/FixPower.cpp
@@ -112,6 +112,8 @@ static bool FixPowerAdded = DataProcessorFactory::instance().registerProcessor(Q
 bool
 FixPower::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")
 {
+    Q_UNUSED(op)
+
     // Lets do it then!
     QString tp;
     double percentageAdjust = 0;

--- a/src/FileIO/FixRunningCadence.cpp
+++ b/src/FileIO/FixRunningCadence.cpp
@@ -82,7 +82,9 @@ static bool FixRunningCadenceAdded = DataProcessorFactory::instance().registerPr
 bool
 FixRunningCadence::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")
 {
-    Q_UNUSED(config);
+    Q_UNUSED(config)
+    Q_UNUSED(op)
+
     // does this ride have cadence?
     if (ride->areDataPresent()->cad == false && ride->areDataPresent()->rcad == false) return false;
 

--- a/src/FileIO/FixRunningPower.cpp
+++ b/src/FileIO/FixRunningPower.cpp
@@ -166,6 +166,9 @@ static bool FixRunningPowerAdded = DataProcessorFactory::instance().registerProc
 bool
 FixRunningPower::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")
 {
+    Q_UNUSED(config)
+    Q_UNUSED(op)
+
     // get settings
     double MEquip; // Equipment weight kg
     double DraftM;  // Drafting Multiplier

--- a/src/FileIO/FixSmO2.cpp
+++ b/src/FileIO/FixSmO2.cpp
@@ -86,7 +86,9 @@ static bool fixSmO2Added = DataProcessorFactory::instance().registerProcessor(QS
 bool
 FixSmO2::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")
 {
-    Q_UNUSED(config);
+    Q_UNUSED(config)
+    Q_UNUSED(op)
+    
     // does this ride have power?
     if (ride->areDataPresent()->watts == false) return false;
 

--- a/src/FileIO/FixSpeed.cpp
+++ b/src/FileIO/FixSpeed.cpp
@@ -112,6 +112,8 @@ static bool FixSpeedAdded = DataProcessorFactory::instance().registerProcessor(Q
 bool
 FixSpeed::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")
 {
+    Q_UNUSED(op)
+
     // get settings
     int ma;
     if (config == NULL) { // being called automatically

--- a/src/FileIO/FixSpikes.cpp
+++ b/src/FileIO/FixSpikes.cpp
@@ -137,6 +137,8 @@ static bool fixSpikesAdded = DataProcessorFactory::instance().registerProcessor(
 bool
 FixSpikes::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")
 {
+    Q_UNUSED(op)
+
     // does this ride have power?
     if (ride->areDataPresent()->watts == false) return false;
 

--- a/src/FileIO/FixTorque.cpp
+++ b/src/FileIO/FixTorque.cpp
@@ -110,6 +110,8 @@ static bool fixTorqueAdded = DataProcessorFactory::instance().registerProcessor(
 bool
 FixTorque::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")
 {
+    Q_UNUSED(op)
+
     // does this ride have torque?
     if (ride->areDataPresent()->nm == false) return false;
 

--- a/src/FileIO/JouleDevice.cpp
+++ b/src/FileIO/JouleDevice.cpp
@@ -343,8 +343,12 @@ JouleDevice::getUnitFreeSpace(QString &memory, QString &err)
         if (response1.payload.length()>3) {
             int empty = qByteArray2Int(response1.payload.left(2));
             int total = qByteArray2Int(response1.payload.right(2));
-            int percentage = 100 * empty / total;
-            memory = QString("%1/%2 (%3%)").arg(empty).arg(total).arg(percentage);
+            if (total > 0) {
+                int percentage = 100 * empty / total;
+                memory = QString("%1/%2 (%3%)").arg(empty).arg(total).arg(percentage);
+            } else {
+                memory = QString("Joule reports zero free space.");
+            }
 
             return true;
         }

--- a/src/FileIO/PolarRideFile.cpp
+++ b/src/FileIO/PolarRideFile.cpp
@@ -550,6 +550,7 @@ RideFile *PolarFileReader::openRideFile(QFile &file, QStringList &errors, QList<
               {
                   errors << ("This is a R-R file: \""
                              + file.fileName() + "\"");
+                  delete rideFile;
                   return NULL;
               }
 

--- a/src/FileIO/PolarRideFile.cpp
+++ b/src/FileIO/PolarRideFile.cpp
@@ -543,6 +543,7 @@ RideFile *PolarFileReader::openRideFile(QFile &file, QStringList &errors, QList<
               {
                   // Pdd file exist but it does not contain
                   // hrmFile_orig (probably been deleted)
+                  delete rideFile;
                   return NULL;
               }
           else if (hrmFile_orig == hrvFile && hrmFile != hrvFile)
@@ -584,6 +585,7 @@ RideFile *PolarFileReader::openRideFile(QFile &file, QStringList &errors, QList<
                     // If both exist only read when equal to ".hrm"
                     errors << ("This is a R-R file: \""
                                + file.fileName() + "\"");
+                    delete rideFile;
                     return NULL;
                 }
                 else {
@@ -605,6 +607,7 @@ RideFile *PolarFileReader::openRideFile(QFile &file, QStringList &errors, QList<
             {
                 errors << ("Can not find : \""
                            + file.fileName() + "\"");
+                delete rideFile;
                 return NULL;
             }
         haveGPX = gpxfile.exists();

--- a/src/FileIO/RideFile.cpp
+++ b/src/FileIO/RideFile.cpp
@@ -3134,7 +3134,7 @@ RideFile::symbolForSeries(SeriesType series)
 
 // Iterator
 RideFileIterator::RideFileIterator(RideFile *f, Specification spec, IterationSpec mode)
-    : f(f), mode(mode)
+    : f(f)
 {
     // index, start and stop are set to -1
     // if they are out of bounds or f is NULL

--- a/src/Metrics/BasicRideMetrics.cpp
+++ b/src/Metrics/BasicRideMetrics.cpp
@@ -111,6 +111,8 @@ class ElapsedTime : public RideMetric {
     }
 
     void compute(RideItem *item, Specification spec, const QHash<QString,RideMetric*> &) {
+        Q_UNUSED(item)
+
         setValue(0);
         if (spec.interval()) setValue(spec.interval()->start);
     }

--- a/src/Metrics/HrvMetrics.cpp
+++ b/src/Metrics/HrvMetrics.cpp
@@ -78,7 +78,7 @@ public:
         }
     }
 
-    bool isRelevantForRide(RideItem) const { return true; }
+    bool isRelevantForRide(const RideItem *) const { return true; }
 
     MetricClass classification() const { return Undefined; }
     MetricValidity validity() const { return Unknown; }
@@ -218,7 +218,7 @@ public:
 
     double stdmean(){ return stdmean_; }
 
-    bool isRelevantForRide(RideItem) const { return true; }
+    bool isRelevantForRide(const RideItem *) const { return true; }
 
     MetricClass classification() const { return Undefined; }
     MetricValidity validity() const { return Unknown; }
@@ -399,7 +399,7 @@ public:
         }
     }
 
-    bool isRelevantForRide(RideItem) const { return true; }
+    bool isRelevantForRide(const RideItem *) const { return true; }
 
     MetricClass classification() const { return Undefined; }
     MetricValidity validity() const { return Unknown; }
@@ -458,7 +458,7 @@ public:
         }
     }
 
-    bool isRelevantForRide(RideItem) const { return true; }
+    bool isRelevantForRide(const RideItem *) const { return true; }
 
     MetricClass classification() const { return Undefined; }
     MetricValidity validity() const { return Unknown; }
@@ -527,7 +527,7 @@ public:
     MetricClass classification() const { return Undefined; }
     MetricValidity validity() const { return Unknown; }
     RideMetric *clone() const { return new pnnx(*this); }
-    bool isRelevantForRide(RideItem) const { return true; }
+    bool isRelevantForRide(const RideItem *) const { return true; }
 };
 
 static bool addPnnx()

--- a/src/Metrics/HrvMetrics.cpp
+++ b/src/Metrics/HrvMetrics.cpp
@@ -140,7 +140,7 @@ public:
         }
     }
 
-    bool isRelevantForRide(RideItem) const { return true; }
+    bool isRelevantForRide(RideItem *) const { return true; }
 
     MetricClass classification() const { return Undefined; }
     MetricValidity validity() const { return Unknown; }

--- a/src/Metrics/HrvMetrics.cpp
+++ b/src/Metrics/HrvMetrics.cpp
@@ -140,7 +140,7 @@ public:
         }
     }
 
-    bool isRelevantForRide(RideItem *) const { return true; }
+    bool isRelevantForRide(const RideItem *) const { return true; }
 
     MetricClass classification() const { return Undefined; }
     MetricValidity validity() const { return Unknown; }

--- a/src/Metrics/HrvMetrics.cpp
+++ b/src/Metrics/HrvMetrics.cpp
@@ -316,8 +316,8 @@ public:
     }
 
     double stdmean(){ return stdmean_; }
-
-    bool isRelevantForRide(RideItem) const { return true; }
+    
+    bool isRelevantForRide(const RideItem *) const { return true; }
 
     MetricClass classification() const { return Undefined; }
     MetricValidity validity() const { return Unknown; }

--- a/src/Planning/PlanningWindow.cpp
+++ b/src/Planning/PlanningWindow.cpp
@@ -76,6 +76,7 @@ PlanningWindow::configChanged(qint32)
 bool
 PlanningWindow::eventFilter(QObject *obj, QEvent *event)
 {
+    Q_UNUSED(obj)
     bool returning = false;
 
     // we only filter out keyboard shortcuts for undo redo etc

--- a/src/Train/AddDeviceWizard.cpp
+++ b/src/Train/AddDeviceWizard.cpp
@@ -223,7 +223,9 @@ DeviceScanner::quickScan(bool deep) // scan quickly or if true scan forever, as 
     do {
 
         // can we find it automatically?
-        isfound = wizard->controller->find();
+        if (wizard->controller) {
+            isfound = wizard->controller->find();
+        }
 
         if (isfound == false && (wizard->deviceTypes.Supported[wizard->current].connector == DEV_LIBUSB ||
                             wizard->deviceTypes.Supported[wizard->current].connector == DEV_USB)) {

--- a/src/Train/Library.cpp
+++ b/src/Train/Library.cpp
@@ -830,7 +830,7 @@ WorkoutImportDialog::import()
     foreach(QString video, videos) {
 
         // if we don't already have it, add it
-        if (!l->refs.contains(video)) {
+        if (l && !l->refs.contains(video)) {
             l->refs.append(video);
             trainDB->importVideo(video);
         }

--- a/src/Train/TodaysPlanWorkoutDownload.cpp
+++ b/src/Train/TodaysPlanWorkoutDownload.cpp
@@ -416,12 +416,12 @@ TodaysPlanWorkoutDownload::getFileList(QString &error, QDateTime from, QDateTime
             for(int i=0; i<results.size(); i++) {
                 QJsonObject each = results.at(i).toObject();
                 QJsonObject scheduled = each["scheduled"].toObject();
-                TodaysPlanWorkoutListEntry *add = new TodaysPlanWorkoutListEntry();
 
                 // skip "Rest" days
                 if (scheduled["workout"].toString() == "rest" && scheduled["tscorepwr"].toDouble() == 0.0) continue;
 
                 // workout details
+                TodaysPlanWorkoutListEntry *add = new TodaysPlanWorkoutListEntry();
                 add->workoutId = QString("%1").arg(each["workoutId"].toInt());
                 add->planDate = QDateTime::fromMSecsSinceEpoch(each["startTs"].toDouble()).date();
                 add->duration = scheduled["durationSecs"].toDouble();

--- a/src/Train/WebPageWindow.cpp
+++ b/src/Train/WebPageWindow.cpp
@@ -314,6 +314,8 @@ WebPageWindow::downloadFinished()
 void
 WebPageWindow::downloadProgress(qint64 a, qint64 b)
 {
+    Q_UNUSED(a)
+    Q_UNUSED(b)
     //qDebug()<<"downloading..." << a<< b;
 }
 

--- a/src/Train/WorkoutWidget.cpp
+++ b/src/Train/WorkoutWidget.cpp
@@ -1437,6 +1437,7 @@ WorkoutWidget::ergFileSelected(ErgFile *ergFile)
             // as we goo these just increase to the last point
             if (add->x > maxWX_) maxVX_ = maxWX_ = add->x;
             if (add->y > maxY_) maxY_ = add->y;
+            delete add;
         }
 
         maxY_ *= 1.1f;

--- a/src/Train/WorkoutWizard.cpp
+++ b/src/Train/WorkoutWizard.cpp
@@ -638,11 +638,13 @@ ImportPage::ImportPage(QWidget *parent) : WorkoutPage(parent) {}
 
 void ImportPage::initializePage()
 {
+        RideItem *rideItem = hackContext->rideItem();
+        if (NULL == rideItem)
+            return;
 
         setTitle(tr("Workout Wizard"));
         setSubTitle(tr("Import current activity as a Gradient ride (slope based)"));
         setFinalPage(true);
-        QVBoxLayout *layout = new QVBoxLayout();
         plot = new WorkoutPlot();
         metricUnits = hackContext->athlete->useMetricUnits;
         QString s = (metricUnits ? tr("KM") : tr("Miles"));
@@ -651,15 +653,13 @@ void ImportPage::initializePage()
         s = (metricUnits ? tr("Meters") : tr("Feet"));
         QString elevation = QString(tr("elevation (")) + s + QString(")");
         plot->setYAxisTitle(elevation);
-        RideItem *rideItem = hackContext->rideItem();
 
-        if(rideItem == NULL)
-            return;
 
         foreach(RideFilePoint *rfp,rideItem->ride()->dataPoints())
         {
             rideData.append(QPair<double,double>(rfp->km,rfp->alt));
         }
+        QVBoxLayout *layout = new QVBoxLayout();
         layout->addWidget(plot,1);
 
         QGroupBox *spinGroupBox = new QGroupBox();
@@ -672,7 +672,6 @@ void ImportPage::initializePage()
         gradeBox->setToolTip(tr("Maximum supported grade is 8"));
         connect(gradeBox,SIGNAL(valueChanged(int)),this,SLOT(updatePlot()));
 
-        QLabel *segmentLabel = new QLabel(tr("Segment Length"));
         segmentBox = new QSpinBox();
         segmentBox->setMinimum(0);
         segmentBox->setMaximum((metricUnits ? 1000 : 5120));
@@ -685,7 +684,7 @@ void ImportPage::initializePage()
         QGridLayout *spinBoxLayout = new QGridLayout();
         spinBoxLayout->addWidget(gradeLabel,0,0);
         spinBoxLayout->addWidget(gradeBox,0,1);
-        spinBoxLayout->addWidget(segmentLabel,1,0);
+        spinBoxLayout->addWidget(new QLabel(tr("Segment Length")),1,0);
         spinBoxLayout->addWidget(segmentBox,1,1);
         spinGroupBox->setLayout(spinBoxLayout);
         bottomLayout->addWidget(spinGroupBox);

--- a/src/Train/ZwoParser.cpp
+++ b/src/Train/ZwoParser.cpp
@@ -18,11 +18,6 @@
 
 #include "ZwoParser.h"
 
-static inline QString unquote(QString quoted)
-{
-    return quoted.mid(1,quoted.length()-2);
-}
-
 bool ZwoParser::startDocument()
 {
     buffer.clear();


### PR DESCRIPTION
There are several common issues fixed such as a possible null pointer to be used, division by zero, and memory leaks to happen when a new'd object is not deleted. A smaller nit was that parameters are not marked as unused and therefore many compiler messages get output due to this condition.