### PR TITLE
Fix warnings2

### DIFF
--- a/qtsolutions/json/mvjson.h
+++ b/qtsolutions/json/mvjson.h
@@ -241,8 +241,8 @@ inline void MVJSONUtils::replace(string & target,           ///< text to be modi
 )
 {
     size_t pos = 0;
-    unsigned int oldLen = oldStr.length();
-    unsigned int newLen = newStr.length();
+    const size_t oldLen = oldStr.length();
+    const size_t newLen = newStr.length();
 
     for (;;)
     {

--- a/src/Charts/Aerolab.cpp
+++ b/src/Charts/Aerolab.cpp
@@ -610,7 +610,7 @@ Aerolab::slope(
            double v
         )  {
 
-  double g = 9.80665;
+  double g = KG_FORCE_PER_METER;
 
   // Small angle version of slope calculation:
   double s = f/(m*g) - crr - cda*rho*v*v/(2.0*m*g) - a/g;
@@ -769,7 +769,7 @@ QString Aerolab::estimateCdACrr(RideItem *rideItem)
 {
     // HARD-CODED DATA: p1->kph
     const double vfactor = 3.600;
-    const double g = 9.80665;
+    const double g = KG_FORCE_PER_METER;
     RideFile *ride = rideItem->ride();
     QString errMsg;
 

--- a/src/Charts/Aerolab.cpp
+++ b/src/Charts/Aerolab.cpp
@@ -27,6 +27,7 @@
 #include "Units.h"
 #include "Colors.h"
 #include "TimeUtils.h"
+#include "Units.h"
 
 #include <cmath>
 #include <qwt_series_data.h>
@@ -451,7 +452,7 @@ Aerolab::recalc( bool new_zoom ) {
   int totalRideDistance = (int ) ceil(distanceArray[arrayLength - 1]);
 
   // If the ride is really long, then avoid it like the plague.
-  if (rideTimeSecs > 7*24*60*60) {
+  if (rideTimeSecs > SECONDS_IN_A_WEEK) {
     QVector<double> data;
 
     if (!veArray.empty()){

--- a/src/Charts/AllPlot.cpp
+++ b/src/Charts/AllPlot.cpp
@@ -1742,7 +1742,7 @@ AllPlot::recalc(AllPlotObject *objects)
 
 
     int rideTimeSecs = (int) ceil(objects->timeArray[objects->timeArray.count()-1]);
-    if (rideTimeSecs > 7*24*60*60) {
+    if (rideTimeSecs > SECONDS_IN_A_WEEK) {
 
         // clear all the curves
         QwtArray<double> data;

--- a/src/Charts/CriticalPowerWindow.cpp
+++ b/src/Charts/CriticalPowerWindow.cpp
@@ -1320,7 +1320,7 @@ CriticalPowerWindow::curve_to_point(double x, const QwtPlotCurve *curve, Critica
         if (data->size() > 0) {
             if (x < data->sample(0).x() || x > data->sample(data->size() - 1).x())
                 return 0;
-            unsigned min = 0, mid = 0, max = data->size();
+            size_t min = 0, mid = 0, max = data->size();
             while (min < max - 1) {
                 mid = (max - min) / 2 + min;
                 if (x < data->sample(mid).x()) {

--- a/src/Charts/HrPwPlot.cpp
+++ b/src/Charts/HrPwPlot.cpp
@@ -24,6 +24,7 @@
 #include "Zones.h"
 #include "Settings.h"
 #include "Colors.h"
+#include "Units.h"
 
 #include <qwt_plot_curve.h>
 #include <qwt_plot_grid.h>
@@ -165,7 +166,7 @@ HrPwPlot::recalc()
         return;
 
     int rideTimeSecs = (int) ceil(timeArray[arrayLength - 1]);
-    if (rideTimeSecs > 7*24*60*60) {
+    if (rideTimeSecs > SECONDS_IN_A_WEEK) {
         return;
     }
 

--- a/src/Charts/OverviewWindow.cpp
+++ b/src/Charts/OverviewWindow.cpp
@@ -612,7 +612,7 @@ Card::setData(RideItem *item)
             RideItem *prior = parent->context->athlete->rideCache->rides().at(index-offset);
 
             // are we still in range ?
-            int old= prior->dateTime.daysTo(item->dateTime);
+            const qint64 old = prior->dateTime.daysTo(item->dateTime);
             if (old > SPARKDAYS) break;
 
             // only activities with matching sport flags

--- a/src/Charts/PowerHist.cpp
+++ b/src/Charts/PowerHist.cpp
@@ -1356,8 +1356,8 @@ PowerHist::setData(RideFileCache *cache)
     longFromDouble(standard.wbalArray, cache->distributionArray(RideFile::wbal));
 
     if (!context->athlete->useMetricUnits) {
-        double torque_factor = (context->athlete->useMetricUnits ? 1.0 : 0.73756215);
-        double speed_factor  = (context->athlete->useMetricUnits ? 1.0 : 0.62137119);
+        double torque_factor = (context->athlete->useMetricUnits ? 1.0 : FOOT_POUNDS_PER_METER);
+        double speed_factor  = (context->athlete->useMetricUnits ? 1.0 : MILES_PER_KM);
 
         for(int i=0; i<standard.nmArray.size(); i++) standard.nmArray[i] = standard.nmArray[i] * torque_factor;
         for(int i=0; i<standard.kphArray.size(); i++) standard.kphArray[i] = standard.kphArray[i] * speed_factor;
@@ -1496,8 +1496,8 @@ PowerHist::setDataFromCompare()
 
         // convert for metric imperial types
         if (!context->athlete->useMetricUnits) {
-            double torque_factor = (context->athlete->useMetricUnits ? 1.0 : 0.73756215);
-            double speed_factor  = (context->athlete->useMetricUnits ? 1.0 : 0.62137119);
+            double torque_factor = (context->athlete->useMetricUnits ? 1.0 : FOOT_POUNDS_PER_METER);
+            double speed_factor  = (context->athlete->useMetricUnits ? 1.0 : MILES_PER_KM);
 
             for(int i=0; i<add.nmArray.size(); i++) add.nmArray[i] = add.nmArray[i] * torque_factor;
             for(int i=0; i<add.kphArray.size(); i++) add.kphArray[i] = add.kphArray[i] * speed_factor;
@@ -1916,8 +1916,8 @@ PowerHist::setArraysFromRide(RideFile *ride, HistData &standard, const Zones *zo
     standard.wbalZoneSelectedArray.resize(0);
 
     // unit conversion factor for imperial units for selected parameters
-    double torque_factor = (context->athlete->useMetricUnits ? 1.0 : 0.73756215);
-    double speed_factor  = (context->athlete->useMetricUnits ? 1.0 : 0.62137119);
+    double torque_factor = (context->athlete->useMetricUnits ? 1.0 : FOOT_POUNDS_PER_METER);
+    double speed_factor  = (context->athlete->useMetricUnits ? 1.0 : MILES_PER_KM);
 
     // cp and zones
     int zoneRange = zones ? zones->whichRange(ride->startTime().date()) : -1;

--- a/src/Charts/PowerHist.h
+++ b/src/Charts/PowerHist.h
@@ -30,6 +30,7 @@
 #include "Specification.h"
 #include "Settings.h"
 #include "Colors.h"
+#include "Units.h"
 
 #include <assert.h>
 #include <qwt_plot.h>
@@ -613,7 +614,7 @@ public:
 	int zone_range = zones ? zones->whichRange(rideItem->dateTime.date()) : -1;
 
     // unit conversion factor for imperial units
-    const double speed_factor  = (parent->context->athlete->useMetricUnits ? 1.0 : 0.62137119);
+    const double speed_factor  = (parent->context->athlete->useMetricUnits ? 1.0 : MILES_PER_KM);
 
 	if (parent->shadePaceZones() && (zone_range >= 0)) {
 	    QList <double> zone_lows = zones->getZoneLows(zone_range);
@@ -666,7 +667,7 @@ public:
 	int zone_range = zones ? zones->whichRange(rideItem->dateTime.date()) : -1;
 
     // unit conversion factor for imperial units
-    const double speed_factor  = (parent->context->athlete->useMetricUnits ? 1.0 : 0.62137119);
+    const double speed_factor  = (parent->context->athlete->useMetricUnits ? 1.0 : MILES_PER_KM);
 
 	setZ(1.0 + zone_number / 100.0);
 

--- a/src/Charts/SmallPlot.cpp
+++ b/src/Charts/SmallPlot.cpp
@@ -102,7 +102,7 @@ SmallPlot::recalc()
 {
     if (!timeArray.size()) return;
 
-    int rideTimeSecs = (long) ceil(timeArray[arrayLength - 1]);
+    long rideTimeSecs = (long) ceil(timeArray[arrayLength - 1]);
     if (rideTimeSecs < 0 || rideTimeSecs > SECONDS_IN_A_WEEK) {
         QwtArray<double> data;
         wattsCurve->setSamples(data, data);

--- a/src/Charts/SmallPlot.cpp
+++ b/src/Charts/SmallPlot.cpp
@@ -21,6 +21,7 @@
 #include "RideItem.h"
 #include "Settings.h"
 #include "Colors.h"
+#include "Units.h"
 
 #include <qwt_plot_curve.h>
 #include <qwt_plot_canvas.h>
@@ -32,8 +33,6 @@
 #include <qwt_compat.h>
 
 static double inline max(double a, double b) { if (a > b) return a; else return b; }
-
-#define MILES_PER_KM 0.62137119
 
 SmallPlot::SmallPlot(QWidget *parent) : QwtPlot(parent), d_mrk(NULL), smooth(30)
 {
@@ -104,7 +103,7 @@ SmallPlot::recalc()
     if (!timeArray.size()) return;
 
     int rideTimeSecs = (long) ceil(timeArray[arrayLength - 1]);
-    if (rideTimeSecs < 0 || rideTimeSecs > 7*24*60*60) {
+    if (rideTimeSecs < 0 || rideTimeSecs > SECONDS_IN_A_WEEK) {
         QwtArray<double> data;
         wattsCurve->setSamples(data, data);
         hrCurve->setSamples(data, data);

--- a/src/Core/RideItem.cpp
+++ b/src/Core/RideItem.cpp
@@ -1077,7 +1077,7 @@ RideItem::updateIntervals()
 
         // now the data is integrated we can look at the 
         // accumulated energy for each ride
-        for (int i=0; i<secs; i++) {
+        for (long i=0; i<secs; i++) {
 
             // start out at 30 minutes and drop back to
             // 2 minutes, anything shorter and we are done

--- a/src/Core/Units.h
+++ b/src/Core/Units.h
@@ -34,6 +34,8 @@
 #define FAHRENHEIT_PER_CENTIGRADE 1.8f
 #define FAHRENHEIT_ADD_CENTIGRADE 32.0f
 #define GPS_COORD_TO_STRING 8
+#define SECONDS_IN_A_WEEK 604800 // 7*24*60*60
+#define FOOT_POUNDS_PER_METER 0.73756215
 
 #include <QString>
 extern QString kphToPace(double kph, bool metric, bool isSwim=false);

--- a/src/Core/Units.h
+++ b/src/Core/Units.h
@@ -37,6 +37,7 @@
 #define SECONDS_IN_A_WEEK 604800 // 7*24*60*60
 #define FOOT_POUNDS_PER_METER 0.73756215f
 #define KG_FORCE_PER_METER 9.80665f
+#define MS_IN_ONE_HOUR 3600000
 
 #include <QString>
 extern QString kphToPace(double kph, bool metric, bool isSwim=false);

--- a/src/Core/Units.h
+++ b/src/Core/Units.h
@@ -27,7 +27,7 @@
 #define INCH_PER_MM 0.039370f
 #define INCH_PER_CM 0.39370f
 #define METERS_PER_FOOT 0.3047999f
-#define METERS_PER_YARD 0.9144
+#define METERS_PER_YARD 0.9144f
 #define LB_PER_KG 2.20462262f
 #define KG_PER_LB 0.45359237f
 #define FEET_LB_PER_NM 0.73756214837f
@@ -35,7 +35,8 @@
 #define FAHRENHEIT_ADD_CENTIGRADE 32.0f
 #define GPS_COORD_TO_STRING 8
 #define SECONDS_IN_A_WEEK 604800 // 7*24*60*60
-#define FOOT_POUNDS_PER_METER 0.73756215
+#define FOOT_POUNDS_PER_METER 0.73756215f
+#define KG_FORCE_PER_METER 9.80665f
 
 #include <QString>
 extern QString kphToPace(double kph, bool metric, bool isSwim=false);

--- a/src/Core/Units.h
+++ b/src/Core/Units.h
@@ -38,6 +38,7 @@
 #define FOOT_POUNDS_PER_METER 0.73756215f
 #define KG_FORCE_PER_METER 9.80665f
 #define MS_IN_ONE_HOUR 3600000
+#define MS_IN_WKO_HOURS 360000 // yes this number of ms is required to match for WKO
 
 #include <QString>
 extern QString kphToPace(double kph, bool metric, bool isSwim=false);

--- a/src/FileIO/Bin2RideFile.cpp
+++ b/src/FileIO/Bin2RideFile.cpp
@@ -682,8 +682,8 @@ struct Bin2FileReaderState
         }
         bool stop = false;
 
-        int data_size = file.size();
-        int bytes_read = 0;
+        qint64 data_size = file.size();
+        qint64 bytes_read = 0;
 
         bytes_read += read_version();
 

--- a/src/FileIO/RideFile.h
+++ b/src/FileIO/RideFile.h
@@ -536,7 +536,6 @@ class RideFileIterator {
 
     private:
         RideFile *f;
-        IterationSpec mode;
         int start, stop, index;
 };
 

--- a/src/FileIO/SyncRideFile.cpp
+++ b/src/FileIO/SyncRideFile.cpp
@@ -229,8 +229,8 @@ struct SyncFileReaderState
         }
         bool stop = false;
 
-        int data_size = file.size();
-        int bytes_read = 0;
+        qint64 data_size = file.size();
+        qint64 bytes_read = 0;
 
         while (!stop && (bytes_read < data_size)) {
             bytes_read += read_page(); // read_page(stop, errors);

--- a/src/FileIO/WkoRideFile.cpp
+++ b/src/FileIO/WkoRideFile.cpp
@@ -638,8 +638,10 @@ WkoParser::parseHeaderData(WKO_UCHAR *fb)
     } else {
 
         // date not available from filename use WKO metadata
+        // Note: WKO format sure is special, tested with file 2008_06_25_20_59_49.wko renamed to 'my.wko'. 
         QDateTime datetime(QDate::fromJulianDay(julian),
-            QTime(sincemidnight/MS_IN_ONE_HOUR, (sincemidnight%MS_IN_ONE_HOUR)/6000, (sincemidnight%6000)/100));
+            QTime(sincemidnight/MS_IN_WKO_HOURS, (sincemidnight%MS_IN_WKO_HOURS)/6000, (sincemidnight%6000)/100));
+                
         results->setStartTime(datetime);
     }
 

--- a/src/FileIO/WkoRideFile.cpp
+++ b/src/FileIO/WkoRideFile.cpp
@@ -638,7 +638,6 @@ WkoParser::parseHeaderData(WKO_UCHAR *fb)
     } else {
 
         // date not available from filename use WKO metadata
-//< I think this was a bug, incorrectly used 6 minutes of ms as calucations.
         QDateTime datetime(QDate::fromJulianDay(julian),
             QTime(sincemidnight/MS_IN_ONE_HOUR, (sincemidnight%MS_IN_ONE_HOUR)/6000, (sincemidnight%6000)/100));
         results->setStartTime(datetime);

--- a/src/FileIO/WkoRideFile.cpp
+++ b/src/FileIO/WkoRideFile.cpp
@@ -17,6 +17,8 @@
  */
 
 #include "WkoRideFile.h"
+#include "Units.h"
+
 #include <QRegExp>
 #include <QDebug>
 #include <QFile>
@@ -636,8 +638,9 @@ WkoParser::parseHeaderData(WKO_UCHAR *fb)
     } else {
 
         // date not available from filename use WKO metadata
+//< I think this was a bug, incorrectly used 6 minutes of ms as calucations.
         QDateTime datetime(QDate::fromJulianDay(julian),
-            QTime(sincemidnight/360000, (sincemidnight%360000)/6000, (sincemidnight%6000)/100));
+            QTime(sincemidnight/MS_IN_ONE_HOUR, (sincemidnight%MS_IN_ONE_HOUR)/6000, (sincemidnight%6000)/100));
         results->setStartTime(datetime);
     }
 

--- a/src/Gui/ToolsRhoEstimator.cpp
+++ b/src/Gui/ToolsRhoEstimator.cpp
@@ -25,6 +25,7 @@
 #include "Units.h"
 #include "Colors.h"
 #include "HelpWhatsThis.h"
+
 #include <QtGui>
 #include <sstream>
 #include <cmath>
@@ -242,7 +243,7 @@ double ToolsRhoEstimator::inchesmercury_to_hectopascals(double inhg) {
 }
 
 double ToolsRhoEstimator::rho_met_to_imp(double rho) {
-  return rho * ((0.30480061 * 0.30480061 * 0.30480061) / 0.45359237);
+  return rho * ((0.30480061 * 0.30480061 * 0.30480061) / KG_PER_LB);
 }
 
 double ToolsRhoEstimator::calculate_rho(double temp,

--- a/src/Metrics/RideMetric.h
+++ b/src/Metrics/RideMetric.h
@@ -298,9 +298,6 @@ public:
     // Get the value and apply conversion if needed
     double value(bool metric) const;
 
-    // The internal value of this ride metric, useful to cache and then setValue.
-    double value() const;
-
     // for averages the count of items included in the average
     double count() const; 
 
@@ -325,6 +322,8 @@ public:
     // virtual bool isLowerBetter() const { return type_ == Low ? true : false; }
 
     private:
+    
+        using RideMetric::value;
 
         // all attributes and methods are implemented in the
         // usermetric class (which uses a datafilter and has

--- a/src/Metrics/UserMetric.cpp
+++ b/src/Metrics/UserMetric.cpp
@@ -164,13 +164,6 @@ UserMetric::value(bool metric) const
     else return (value() * conversion()) + conversionSum();
 }
 
-// The internal value of this ride metric, useful to cache and then setValue.
-double
-UserMetric::value() const
-{
-    return value_;
-}
-
 // for averages the count of items included in the average
 double
 UserMetric::count() const

--- a/src/Train/DialWindow.cpp
+++ b/src/Train/DialWindow.cpp
@@ -203,8 +203,8 @@ DialWindow::telemetryUpdate(const RealtimeData &rtData)
     case RealtimeData::LapTime:
         {
         long msecs = value;
-        valueLabel->setText(QString("%1:%2:%3.%4").arg(msecs/3600000)
-                                               .arg((msecs%3600000)/60000,2,10,QLatin1Char('0'))
+        valueLabel->setText(QString("%1:%2:%3.%4").arg(msecs/MS_IN_ONE_HOUR)
+                                               .arg((msecs%MS_IN_ONE_HOUR)/60000,2,10,QLatin1Char('0'))
                                                .arg((msecs%60000)/1000,2,10,QLatin1Char('0'))
                                                .arg((msecs%1000)/100));
         }
@@ -213,8 +213,8 @@ DialWindow::telemetryUpdate(const RealtimeData &rtData)
     case RealtimeData::LapTimeRemaining:
         {
         long msecs = value;
-        valueLabel->setText(QString("%1:%2:%3").arg(msecs/3600000)
-                                               .arg((msecs%3600000)/60000,2,10,QLatin1Char('0'))
+        valueLabel->setText(QString("%1:%2:%3").arg(msecs/MS_IN_ONE_HOUR)
+                                               .arg((msecs%MS_IN_ONE_HOUR)/60000,2,10,QLatin1Char('0'))
                                                .arg((msecs%60000)/1000,2,10,QLatin1Char('0')));
         }
     break;


### PR DESCRIPTION
Another round of compiler warnings and use common constants/defines.

Wko code appeared to have a bug calculating the hours by using 360000 rather than 3600000. 