### PR TITLE
Fix broken build on MAC in AddCloudWizard.cpp

### DIFF
--- a/src/Cloud/AddCloudWizard.cpp
+++ b/src/Cloud/AddCloudWizard.cpp
@@ -24,6 +24,8 @@
 #include "Colors.h"
 #include "CloudService.h"
 
+#include <QMessageBox>
+
 // WIZARD FLOW
 //
 // 01. Select Service Class (e.g. Activities, Measures, Calendar)


### PR DESCRIPTION
Some recent updates in code caused the build to break in Xcode w/o this header.