### PR TITLE
Issue #2421 - debounce the calibrate button on the Computrainer HBC

### DIFF
--- a/src/Train/ComputrainerController.cpp
+++ b/src/Train/ComputrainerController.cpp
@@ -25,6 +25,7 @@
 ComputrainerController::ComputrainerController(TrainSidebar *parent,  DeviceConfiguration *dc) : RealtimeController(parent, dc)
 {
     myComputrainer = new Computrainer (parent, dc ? dc->portSpec : ""); // we may get NULL passed when configuring
+    f3Depressed = false;
 }
 
 
@@ -97,7 +98,13 @@ ComputrainerController::getRealtimeData(RealtimeData &rtData)
 
 	// Check CT if F3 has been pressed for Calibration mode FIRST before we do anything else
     if (Buttons&CT_F3) {
-        parent->Calibrate();
+        // We're only interested in the act of pressing the button, not it being held down
+        if (f3Depressed == false) {
+            f3Depressed = true;
+            parent->Calibrate();
+        }
+    } else {
+        f3Depressed = false; // It has been released
     }
 
     // ignore other buttons and anything else if calibrating

--- a/src/Train/ComputrainerController.h
+++ b/src/Train/ComputrainerController.h
@@ -51,6 +51,9 @@ public:
 
     // calibration
     uint8_t  getCalibrationType() { return CALIBRATION_TYPE_COMPUTRAINER; }
+
+private:
+    bool f3Depressed;
 };
 
 #endif // _GC_ComputrainerController_h


### PR DESCRIPTION
Fix for #2421 - works by preventing a held F3 button from generating more `Calibrate()` invocations until the F3 button is released.

Debouncing the other buttons didn't make sense, so I didn't over-engineer the code.