### PR TITLE
Change gear ratio precision to hundredths.

### DIFF
--- a/src/Charts/AllPlot.cpp
+++ b/src/Charts/AllPlot.cpp
@@ -7018,18 +7018,19 @@ AllPlot::pointHover(QwtPlotCurve *curve, int index)
         }
 
         // need to scale for W' bal
-        if (curve->title().text().contains("W'")) yvalue /= 1000.0f;
+        if (curve->title().text().contains("W'"))
+            yvalue /= 1000.0f;
 
         // output the tooltip
-    int precision;
-    if (curve->title().text().contains("Hb")){
-      precision = 2;
-    } else {
-      if (curve->title().text().contains("R-R")){
-          precision = 3;}
-      else
-        {precision = 1;}
-    }
+        int precision = 1; //< default to tens precision
+        if (curve->title().text() == tr("Hb")) {
+            precision = 2;
+        } else if (curve->title().text() == tr("R-R")) {
+            precision = 3;
+        } else if (curve->title().text() == tr("Gear Ratio")) {
+            precision = 2;
+        }
+        
         QString text = QString("%1 %2%5\n%3 %4")
                         .arg(yvalue, 0, 'f', precision)
                         .arg(this->axisTitle(curve->yAxis()).text())

--- a/src/FileIO/RideFile.cpp
+++ b/src/FileIO/RideFile.cpp
@@ -2382,23 +2382,10 @@ RideFile::recalculateDerivedSeries(bool force)
             // but only if ride point has power, cadence and speed > 0 otherwise calculation will give a random result
             if (p->watts > 0.0f && p->cad > 0.0f && p->kph > 0.0f) {
                 p->gear = (1000.00f * p->kph) / (p->cad * 60.00f * wheelsize);
-                // do the rounding
-                double rounding = 0.0f;
-                if (p->gear < 1.0f) {
-                  rounding = 0.05f;
-                }
-                else if (p->gear >= 1.0f && p->gear < 3.0f) {
-                    rounding = 0.1f;
-                } else {
-                    rounding = 0.5f;
-                }
-                double mod = fmod(p->gear, rounding);
-                double factor = trunc(p->gear / rounding);
-                if (mod < rounding) p->gear = factor * rounding;
-                else p->gear = (factor+1) * rounding;
 
+                // Round Gear ratio to the hundreths.
                 // final rounding to 2 decimals
-                p->gear = round(p->gear * 100.00f) / 100.00f;
+                p->gear = floor(p->gear * 100.00f +.5) / 100.00f;
             }
             else {
                 p->gear = 0.0f; // to be filled up with previous gear later


### PR DESCRIPTION
** Fix comparison of headers which simply used ‘contains’ rather than equals and would cause incorrect precision to be selected if a translation/title is not found.

Tooltip in ‘Ride’ view will now show hundredths due to precision selection.
Change rounding of gear ratio in derived series to hundredths.
@liversedge does this make it into the JSon or out into CSVs?

See request:
https://github.com/GoldenCheetah/GoldenCheetah/issues/2379#issuecomment-290926521