### PR TITLE
Make the +/- buttons render consistently

### DIFF
--- a/src/Train/Library.cpp
+++ b/src/Train/Library.cpp
@@ -263,13 +263,17 @@ LibrarySearchDialog::LibrarySearchDialog(Context *context) : context(context)
     findMedia->setChecked(true);
     findVideoSyncs = new QCheckBox(tr("VideoSync files (.rlv)"), this);
     findVideoSyncs->setChecked(true);
-    addPath = new QPushButton("+", this);
-    removePath = new QPushButton("-", this);
-    removeRef = new QPushButton("-", this);
+    addPath = new QPushButton(tr("+"), this);
+    removePath = new QPushButton(tr("-"), this);
+    removeRef = new QPushButton(tr("-"), this);
 #ifndef Q_OS_MAC
     addPath->setFixedSize(20*dpiXFactor,20*dpiYFactor);
     removePath->setFixedSize(20*dpiXFactor,20*dpiYFactor);
     removeRef->setFixedSize(20*dpiXFactor,20*dpiYFactor);
+#else
+    addPath->setText(tr("Add"));
+    removePath->setText(tr("Delete"));
+    removeRef->setText(tr("Delete"));
 #endif
 
     searchPathTable = new QTreeWidget(this);


### PR DESCRIPTION

There is an issue with native lnf rendering a QPushButton on OSX with small text labels (a very bizarre issue IMO).  E.g. as you can see in the screenshot, the QPushButton with a "-" renders with an ugly lnf. Whereas the "+" renders properly. The cause seems to be the width of the text label - ` - ` renders with a native lnf, but `-` renders with a default toolkit lnf.

QT: 5.8.0
QWT: 6.1.1
OS: Mac OSX 10.12

I have copied the setup pattern from src/Gui/Pages.cpp - I can't comment on whether it is a sane pattern or not.

### Before

<img width="137" alt="screen shot 2017-04-02 at 11 38 55 am" src="https://cloud.githubusercontent.com/assets/47446/24583834/644c854c-179b-11e7-9f2a-59e8d8787740.png">

### After

<img width="156" alt="screen shot 2017-04-02 at 11 50 51 am" src="https://cloud.githubusercontent.com/assets/47446/24583838/6afff748-179b-11e7-94bc-010757c54e61.png">

### Future work

It seems like this is a common metaphor through the app - "addition and removal" of list items.

Doing a search for `QPushButton("` (for untranslated buttons yields 23 hits - mostly `<`, `>`, `+`, `-` - and it seems some authors have used ` - ` to work around the rendering bug in the workout scanner.

```
$ grep -ir 'QPushButton("' src
src/Charts/AllPlotWindow.cpp:    addCustomButton = new QPushButton("+");
src/Charts/AllPlotWindow.cpp:    deleteCustomButton = new QPushButton("-");
src/Charts/AllPlotWindow.cpp:    scrollLeft = new QPushButton("<", this);
src/Charts/AllPlotWindow.cpp:    scrollRight = new QPushButton(">", this);
src/Charts/ExhaustionDialog.cpp:    deleteRefButton = new QPushButton(" - ");
src/Charts/LTMTool.cpp:    addCustomButton = new QPushButton("+");
src/Charts/LTMTool.cpp:    deleteCustomButton = new QPushButton("-");
src/Charts/LTMWindow.cpp:    scrollLeft = new QPushButton("<", this);
src/Charts/LTMWindow.cpp:    scrollRight = new QPushButton(">", this);
src/Charts/ReferenceLineDialog.cpp:    deleteRefButton = new QPushButton(" - ");
src/FileIO/XDataDialog.cpp:    addXData = new QPushButton("+", this);
src/FileIO/XDataDialog.cpp:    removeXData = new QPushButton("-", this);
src/FileIO/XDataDialog.cpp:    addXDataSeries = new QPushButton("+", this);
src/FileIO/XDataDialog.cpp:    removeXDataSeries = new QPushButton("-", this);
src/Gui/ColorButton.cpp:ColorButton::ColorButton(QWidget *parent, QString name, QColor color) : QPushButton("", parent), color(color), name(name)
src/Gui/Pages.cpp:    leftButton = new QPushButton("<");
src/Gui/Pages.cpp:    rightButton = new QPushButton(">");
src/Gui/Pages.cpp:    leftButton = new QPushButton("<");
src/Gui/Pages.cpp:    rightButton = new QPushButton(">");
src/Gui/Pages.cpp:    leftButton = new QPushButton("<");
src/Gui/Pages.cpp:    rightButton = new QPushButton(">");
src/Train/TrainSidebar.cpp:    cancelButton = new QPushButton("Cancel", this);
src/Train/TrainSidebar.cpp:    applyButton = new QPushButton("Apply", this);
```



