### PR TITLE
Bt40 power and speed and cadence combination support

### DIFF
--- a/src/Train/BT40Device.cpp
+++ b/src/Train/BT40Device.cpp
@@ -97,8 +97,20 @@ void BT40Device::deviceDisconnected() {
 
 void BT40Device::serviceDiscovered(QBluetoothUuid uuid) {
     if (supportedServiceUuids.contains(uuid)) {
-	qDebug() << "Discovering details for service" << uuid << "for device" << m_currentDevice.name();
 	QLowEnergyService *service = m_control->createServiceObject(uuid, this);
+	m_services.append(service);
+    }
+}
+
+void BT40Device::serviceScanDone()
+{
+    qDebug() << "Service scan done for device" << m_currentDevice.name();
+    bool has_power = false;
+    bool has_csc = false;
+    QLowEnergyService* csc_service;
+    foreach (QLowEnergyService* const &service, m_services) {
+	qDebug() << "Discovering details for service" << service->serviceUuid() <<
+	    "for device" << m_currentDevice.name();
 	connect(service, SIGNAL(stateChanged(QLowEnergyService::ServiceState)),
 		this, SLOT(serviceStateChanged(QLowEnergyService::ServiceState)));
 	connect(service, SIGNAL(characteristicChanged(QLowEnergyCharacteristic,QByteArray)),
@@ -108,13 +120,7 @@ void BT40Device::serviceDiscovered(QBluetoothUuid uuid) {
 	connect(service, SIGNAL(error(QLowEnergyService::ServiceError)),
 		this, SLOT(serviceError(QLowEnergyService::ServiceError)));
 	service->discoverDetails();
-	m_services.append(service);
     }
-}
-
-void BT40Device::serviceScanDone()
-{
-    qDebug() << "Service scan done" << "for device" << m_currentDevice.name();
 }
 
 void BT40Device::serviceStateChanged(QLowEnergyService::ServiceState s)

--- a/src/Train/BT40Device.cpp
+++ b/src/Train/BT40Device.cpp
@@ -119,7 +119,26 @@ void BT40Device::serviceScanDone()
 		this, SLOT(confirmedDescriptorWrite(QLowEnergyDescriptor,QByteArray)));
 	connect(service, SIGNAL(error(QLowEnergyService::ServiceError)),
 		this, SLOT(serviceError(QLowEnergyService::ServiceError)));
-	service->discoverDetails();
+	if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::CyclingPower)) {
+	    has_power = true;
+	    service->discoverDetails();
+	}
+	else if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::CyclingSpeedAndCadence)) {
+	    has_csc = true;
+	    csc_service = service;
+	}
+	else {
+	    service->discoverDetails();
+	}
+    }
+    if (has_csc && !has_power) {
+	// Only connect to CSC service if the same device doesn't provide a power service
+	// since the power service also provides the same readings.
+	qDebug() << "Connecting to the CSC service for device" << m_currentDevice.name();
+	csc_service->discoverDetails();
+    }
+    else {
+	qDebug() << "Ignoring the CSC service for device" << m_currentDevice.name();
     }
 }
 


### PR DESCRIPTION
This adds support for devices that provide the same data over both the power and speed and cadence BT services, such as Elite trainers. I assume they do this somewhat strange thing for compatibility with devices that only support SC, not power.

The solution is to see if a device supports both services, and if so only connecting to power. This is slightly hacky, but can be cleaned up after the refactoring tracked in #974.