### PR TITLE
CloudService - Fix Error Reading Files

### DIFF
--- a/src/Cloud/CloudService.cpp
+++ b/src/Cloud/CloudService.cpp
@@ -1261,7 +1261,7 @@ CloudServiceSyncDialog::syncNext()
                 QByteArray *data = new QByteArray;
                 store->readFile(data, curr->text(1), curr->text(8)); // filename
                 QApplication::processEvents();
-                delete data;
+                //delete data;
 
             } else {
                 curr->setText(7, tr("Uploading"));


### PR DESCRIPTION
... when asynchronously reading Files, "data" object needs to survive as it it referenced in the "buffers_"   QMap
    (this is a quick fix - I suspect there are better ways to handle this)