### PR TITLE
Make the +/- buttons render consistently

### DIFF
--- a/src/Train/Library.cpp
+++ b/src/Train/Library.cpp
@@ -263,13 +263,17 @@ LibrarySearchDialog::LibrarySearchDialog(Context *context) : context(context)
     findMedia->setChecked(true);
     findVideoSyncs = new QCheckBox(tr("VideoSync files (.rlv)"), this);
     findVideoSyncs->setChecked(true);
-    addPath = new QPushButton("+", this);
-    removePath = new QPushButton("-", this);
-    removeRef = new QPushButton("-", this);
+    addPath = new QPushButton(tr("+"), this);
+    removePath = new QPushButton(tr("-"), this);
+    removeRef = new QPushButton(tr("-"), this);
 #ifndef Q_OS_MAC
     addPath->setFixedSize(20*dpiXFactor,20*dpiYFactor);
     removePath->setFixedSize(20*dpiXFactor,20*dpiYFactor);
     removeRef->setFixedSize(20*dpiXFactor,20*dpiYFactor);
+#else
+    addPath->setMinimumSize(QPB_MINIMUM_WIDTH, QPB_MINIMUM_HEIGHT);
+    removePath->setMinimumSize(QPB_MINIMUM_WIDTH, QPB_MINIMUM_HEIGHT);
+    removeRef->setMinimumSize(QPB_MINIMUM_WIDTH, QPB_MINIMUM_HEIGHT);
 #endif
 
     searchPathTable = new QTreeWidget(this);

--- a/src/Train/Library.h
+++ b/src/Train/Library.h
@@ -31,6 +31,11 @@
 #include <QTreeWidgetItem>
 #include <QThread>
 
+
+// Pushbuttons smaller than this will change from rounded to square look and feel
+#define QPB_MINIMUM_WIDTH 50
+#define QPB_MINIMUM_HEIGHT 30
+
 class Library : QObject
 {
     Q_OBJECT


### PR DESCRIPTION
See #2432 for an earlier concept that was closed.

The root cause is that the size of the "-" button is less that 50x30 and so Qt changes from a rounded button to a square button.

https://doc.qt.io/qt-5/qpushbutton.html

"Note that when a button's width becomes smaller than 50 or its height becomes smaller than 30, the button's corners are changed from round to square. Use the setMinimumSize() function to prevent this behavior."
