### PR TITLE
Fix crash of comparison rides

### DIFF
--- a/src/Charts/AllPlot.cpp
+++ b/src/Charts/AllPlot.cpp
@@ -4971,9 +4971,6 @@ AllPlot::setDataFromPlots(QList<AllPlot *> plots)
 
                 }
         }
-
-        if (ourCurve) delete ourCurve;
-        if (ourICurve) delete ourICurve;
         
         // move on -- this is used to reference into the compareIntervals
         //            array to get the colors predominantly!


### PR DESCRIPTION
Xcode reported this as a leak however, ownership of the curve is owned by this class and will be deleted by the Qt framework as the parent is deleted.

Fixes issue I reported;
https://github.com/GoldenCheetah/GoldenCheetah/issues/2433

Sorry about that!