### PR TITLE
Fix variant check to ensure default URL is used in Cloud Service wizard

### DIFF
--- a/src/Cloud/CloudService.h
+++ b/src/Cloud/CloudService.h
@@ -564,7 +564,7 @@ class CloudServiceFactory {
             if (i.key() == CloudService::Combo1) { sname = i.value().split("::").at(0); }
 
             // populate from appsetting configuration
-            QVariant value = appsettings->cvalue(context->athlete->cyclist, sname, QVariant());
+            QVariant value = appsettings->cvalue(context->athlete->cyclist, sname, "");
 
             // apply default url
             if (i.key() == CloudService::URL && value == "") {


### PR DESCRIPTION
With this fix in place, the default URL correctly showed up on a new athlete.