### PR TITLE
Use correct units for CV hover dialog.

### DIFF
--- a/src/Charts/CPPlot.cpp
+++ b/src/Charts/CPPlot.cpp
@@ -308,7 +308,11 @@ CPPlot::setSeries(CriticalPowerWindow::CriticalSeriesType criticalSeries)
     }
 
     // set axis title
-    setAxisTitle(yLeft, QString ("%1 %2 (%3) %4").arg(prefix).arg(series).arg(units).arg(postfix));
+    setAxisTitle(yLeft, QString ("%1 %2 (%3) %4")
+                 .arg(prefix)
+                 .arg(series)
+                 .arg(units)
+                 .arg(postfix));
 
     // zap the old curves
     clearCurves();
@@ -1712,12 +1716,26 @@ CPPlot::pointHover(QwtPlotCurve *curve, int index)
         else
             units1 = ""; // time --> no units
 
-        // show percent ?
-        if ((((rangemode && context->isCompareDateRanges)
+        // no units for Heat Curve
+        if (curve == heatCurve) {
+            units2 = tr("%1 %2")
+                .arg(yvalue, 0, 'f', RideFile::decimalsFor(rideSeries))
+                .arg(tr("Activities"));
+        }
+        else  if ((((rangemode && context->isCompareDateRanges)
             || (!rangemode && context->isCompareIntervals)) && showDelta && showDeltaPercent)
-            || (curve == rideCurve && showPercent)) units2 = QString("%");
+            || (curve == rideCurve && showPercent))
+        {
+            units2 = tr("%1 %2")
+                .arg(yvalue, 0, 'f', RideFile::decimalsFor(rideSeries))
+                .arg(tr("%")); // Percent
+        }
         else if (criticalSeries == CriticalPowerWindow::veloclinicplot)
-            units2 = "J"; // Joule
+        {
+            units2 = tr("%1 %2")
+                .arg(yvalue, 0, 'f', RideFile::decimalsFor(rideSeries))
+                .arg(tr("J")); // Joule
+        }
         else if (criticalSeries == CriticalPowerWindow::kph)
         {
 
@@ -1733,7 +1751,10 @@ CPPlot::pointHover(QwtPlotCurve *curve, int index)
         }
         else
         {
-            units2 = RideFile::unitName(rideSeries, context);
+            // eg: "### watts"
+            units2 = tr("%1 %2")
+                .arg(yvalue, 0, 'f', RideFile::decimalsFor(rideSeries))
+                .arg(RideFile::unitName(rideSeries, context));
         }
         
 		// for the current ride curve, add a percent of rider's actual best.
@@ -1747,8 +1768,6 @@ CPPlot::pointHover(QwtPlotCurve *curve, int index)
 			}
 		}
 
-        // no units for Heat Curve
-        if (curve == heatCurve) units2 = QString(tr("Activities"));
 
         // for speed series add pace with units according to settings
         if (criticalSeries == CriticalPowerWindow::kph) {
@@ -1756,7 +1775,9 @@ CPPlot::pointHover(QwtPlotCurve *curve, int index)
                 const PaceZones *zones = context->athlete->paceZones(isSwim);
                 if (zones) {
                     bool metricPace = appsettings->value(this, zones->paceSetting(), true).toBool();
-                    paceStr = QString("\n%1 %2").arg(zones->kphToPaceString(yvalue, metricPace)).arg(zones->paceUnits(metricPace));
+                    paceStr = QString("\n%1 %2")
+                        .arg(zones->kphToPaceString(yvalue, metricPace))
+                        .arg(zones->paceUnits(metricPace));
                 }
             }
             double km = yvalue*xvalue/60.0; // distance in km

--- a/src/Charts/CPPlot.cpp
+++ b/src/Charts/CPPlot.cpp
@@ -1719,11 +1719,23 @@ CPPlot::pointHover(QwtPlotCurve *curve, int index)
         else if (criticalSeries == CriticalPowerWindow::veloclinicplot)
             units2 = "J"; // Joule
         else if (criticalSeries == CriticalPowerWindow::kph)
-            // yAxis doesn't obey units settings yet, remove when fixed
-            units2 = tr("kph %1 mph").arg(yvalue*MILES_PER_KM, 0, 'f', RideFile::decimalsFor(rideSeries));
-        else
-            units2 = RideFile::unitName(rideSeries, context);
+        {
 
+            // yAxis doesn't obey units settings yet, remove when fixed
+            if (context->athlete->useMetricUnits)
+            {
+                units2 = tr("%1 kph").arg(yvalue, 0, 'f', RideFile::decimalsFor(rideSeries));
+            }
+            else
+            {
+                units2 = tr("%1 mph").arg(yvalue*MILES_PER_KM, 0, 'f', RideFile::decimalsFor(rideSeries));
+            }
+        }
+        else
+        {
+            units2 = RideFile::unitName(rideSeries, context);
+        }
+        
 		// for the current ride curve, add a percent of rider's actual best.
 		if (!showPercent && curve == rideCurve && index >= 0 && getBests().count() > index) {
 			double bestY = getBests()[index];
@@ -1748,24 +1760,38 @@ CPPlot::pointHover(QwtPlotCurve *curve, int index)
                 }
             }
             double km = yvalue*xvalue/60.0; // distance in km
-            if (isSwim) {
-                paceStr += tr("\n%1 m %2 yd").arg(1000*km, 0, 'f', 0)
-                                    .arg(1000*km/METERS_PER_YARD, 0, 'f', 0);
-            } else {
-                paceStr += tr("\n%1 km %2 mi").arg(km, 0, 'f', 3)
-                                    .arg(MILES_PER_KM*km, 0, 'f', 3);
+            if (isSwim)
+            {
+                if (context->athlete->useMetricUnits)
+                {
+                    paceStr += tr("\n%1 m").arg(1000*km, 0, 'f', 0);
+                }
+                else
+                {
+                    paceStr += tr("\n%1 yd").arg(1000*km/METERS_PER_YARD, 0, 'f', 0);
+                }
+            }
+            else
+            {
+                if (context->athlete->useMetricUnits)
+                {
+                    paceStr += tr("\n%1 km").arg(km, 0, 'f', 3);
+                }
+                else
+                {
+                    paceStr += tr("\n%1 mi").arg(MILES_PER_KM*km, 0, 'f', 3);
+                }
             }
         }
 
         // output the tooltip
-        text = QString("%1%2\n%3 %4%7%5%6")
+        text = QString("%1%2\n%3 %4%5%6")
                .arg(criticalSeries == CriticalPowerWindow::veloclinicplot?QString("%1").arg(xvalue, 0, 'f', RideFile::decimalsFor(rideSeries)):interval_to_str(60.0*xvalue))
                .arg(units1)
-               .arg(yvalue, 0, 'f', RideFile::decimalsFor(rideSeries))
                .arg(units2)
-               .arg(dateStr)
                .arg(currentRidePercentStr)
-               .arg(paceStr);
+               .arg(paceStr)
+               .arg(dateStr);
 
         // set that text up
         zoomer->setText(text);


### PR DESCRIPTION
Previously shows both units, despite config in preferences. 

Before change:
<img width="619" alt="grab-cv-before-unit-fix" src="https://cloud.githubusercontent.com/assets/9326275/25168420/b42c7f38-24a0-11e7-9569-0b2336b7d53a.png">

After fix:
<img width="676" alt="grab-cv-fix-units" src="https://cloud.githubusercontent.com/assets/9326275/25168419/b42bff36-24a0-11e7-831a-9fb93c712629.png">


