### PR TITLE
Today's Plan RPE - fixes

### DIFF
--- a/src/Charts/OverviewWindow.cpp
+++ b/src/Charts/OverviewWindow.cpp
@@ -1281,8 +1281,9 @@ static QColor FosterColors[11]={
 void
 RPErating::setValue(QString value)
 {
+    // RPE values from other sources (e.g. TodaysPlan) are "double"
     this->value = value;
-    int v = value.toInt();
+    int v = qRound(value.toDouble());
     if (v <0 || v>10) {
         color = GColor(CPLOTMARKER);
         description = QObject::tr("Invalid");
@@ -1420,7 +1421,7 @@ RPErating::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
     // paint the blocks
     double width = geom.width() / 13; // always a block each side for a margin
     int i=0;
-    for(; i<= value.toInt(); i++) {
+    for(; i<= qRound(value.toDouble()); i++) {
 
         // draw a rectangle with a 5px gap
         painter->setPen(Qt::NoPen);

--- a/src/Cloud/TodaysPlan.cpp
+++ b/src/Cloud/TodaysPlan.cpp
@@ -292,7 +292,7 @@ TodaysPlan::readdir(QString path, QStringList &errors, QDateTime from, QDateTime
                 if (suffix == "") suffix = "json";
 
 
-                //TodaysPlan has full path, we just want the file name
+                //TodaysPlan's Label may contain the FileName, or Descriptive Text (whatever is shown/edited on the TP's UI)
                 add->label = QFileInfo(each["name"].toString()).fileName();
                 add->id = QString("%1").arg(each["fileId"].toInt());
                 add->isDir = false;
@@ -300,7 +300,8 @@ TodaysPlan::readdir(QString path, QStringList &errors, QDateTime from, QDateTime
                 add->duration = each["training"].toInt();
                 add->name = QDateTime::fromMSecsSinceEpoch(each["startTs"].toDouble()).toString("yyyy_MM_dd_HH_mm_ss")+"."+suffix;
 
-                replyActivity.insert(add->label, each);
+                // only our own name is a reliable key
+                replyActivity.insert(add->name, each);
 
                 //add->size
                 //add->modified


### PR DESCRIPTION
... "name" does not always contain the real file name and is editable - use our filename instead
... RPE may be double (e.g. when set in TP)  - round to int for Overview Widget