### PR TITLE
Re-introduced vector expressions

### DIFF
--- a/doc/user/formula-syntax.txt
+++ b/doc/user/formula-syntax.txt
@@ -23,6 +23,10 @@ isinf(p1)
 isnan(p1)
 
 LIST / VECTOR REDUCE FUNCTIONS
+Vectors are about collecting data from across a date range, specified as
+    expression[[Date_From:Date_To]]
+where dates can be absolute s.t. 2017/09/19 or relative s.t. Date-7
+you can use them within a formula using the following functions:
 sum(...)
 mean(...)
 max(...)

--- a/src/Core/DataFilter.cpp
+++ b/src/Core/DataFilter.cpp
@@ -2847,7 +2847,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
         // so you can use them within a formula for simple kinds of
         // operations; e.g. how much of todays' workouts in time
         // does this workout represent would be:
-        // Duration / Duration[today:today] * 100.00
+        // Duration / Duration[[today:today]] * 100.00
 
         Specification spec;
 

--- a/src/Core/DataFilter.l
+++ b/src/Core/DataFilter.l
@@ -84,6 +84,8 @@ int DataFiltercolumn = 1;
 "||"                                        DataFilterlval.op = OR; return OR;
 [Oo][Rr]                                    DataFilterlval.op = OR; return OR;
 
+"[["                                        return LSB; /* start date range */
+"]]"                                        return RSB; /* end date range */
 
 [0-9]+                                      return DF_INTEGER;
 [0-9]+e-[0-9]+                              return DF_FLOAT;

--- a/src/Core/DataFilter.y
+++ b/src/Core/DataFilter.y
@@ -63,6 +63,9 @@ extern Leaf *DataFilterroot; // root node for parsed statement
 %token <op> MATCHES ENDSWITH BEGINSWITH CONTAINS
 %type <op> AND OR;
 
+// Date Range markers for vector expressions
+%token <op> LSB RSB
+
 %union {
    Leaf *leaf;
    QList<Leaf*> *comp;
@@ -78,6 +81,7 @@ extern Leaf *DataFilterroot; // root node for parsed statement
 
 %right '?' ':'
 %right '[' ']'
+%right LSB RSB
 %right AND OR
 %right EQ NEQ LT LTE GT GTE MATCHES ENDSWITH CONTAINS
 %left ADD SUBTRACT
@@ -253,16 +257,13 @@ lexpr:
                                                   $$->rvalue.l = $5;
                                                   $$->cond.l = $1;
                                                 }
-/* DEPRECATED (TEMPORARILY?)
-        | lexpr '[' lexpr ':' lexpr ']' { $$ = new Leaf(@1.first_column, @6.last_column);
+        | lexpr LSB lexpr ':' lexpr RSB { $$ = new Leaf(@1.first_column, @6.last_column);
                                                   $$->type = Leaf::Vector;
                                                   $$->lvalue.l = $1;
                                                   $$->fparms << $3;
                                                   $$->fparms << $5;
                                                   $$->op = 0;
                                                 }
-*/
-
         | '!' lexpr %prec OR                    { $$ = new Leaf(@1.first_column, @2.last_column);
                                                   $$->type = Leaf::UnaryOperation;
                                                   $$->lvalue.l = $2;


### PR DESCRIPTION
Using |Date_From:Date_To| instead of [Date_From:Date_To] to
avoid conflicts with array indexing
Fixes #2278