### PR TITLE
Only listen on localhost for API calls

### DIFF
--- a/src/Resources/webservice/httpserver.ini
+++ b/src/Resources/webservice/httpserver.ini
@@ -6,3 +6,4 @@ cleanupInterval=1000
 readTimeout=60000
 maxRequestSize=16000
 maxMultiPartSize=1000000
+host=127.0.0.1


### PR DESCRIPTION
This changes the enabled by default HTTP API to only listen on localhost, not all interfaces.

The issue with listening on all interfaces is that it enables access potentially to the whole internet depending on your local network configuration. Since the API is unauthenticated and accesses are not indicated in the UI, this could result in someone silently downloading your entire training data without any notice. One added benefit of this change is that the Windows firewall popup should no longer appear.

For advanced users, listening on all network interfaces remains possible by editing the *httpserver.ini*