### PR TITLE
Support for SRM manual zero offset calibration

### DIFF
--- a/src/ANT/ANT.h
+++ b/src/ANT/ANT.h
@@ -521,6 +521,11 @@ public:
         return calibration.getZeroOffset();
     }
 
+    uint16_t getCalibrationSlope()
+    {
+        return calibration.getSlope();
+    }
+
     uint16_t getCalibrationSpindownTime()
     {
         return calibration.getZeroOffset();
@@ -544,6 +549,11 @@ public:
     void setCalibrationZeroOffset(uint16_t offset)
     {
         calibration.setZeroOffset(offset);
+    }
+
+    void setCalibrationSlope(uint16_t slope)
+    {
+        calibration.setSlope(slope);
     }
 
     void setCalibrationSpindownTime(uint16_t time)

--- a/src/ANT/ANTChannel.h
+++ b/src/ANT/ANTChannel.h
@@ -162,12 +162,17 @@ class ANTChannel : public QObject {
         bool is_moxy; // bool
         bool is_cinqo; // bool
         bool is_old_cinqo; // bool, set for cinqo needing separate control channel
+        bool is_srm;
         bool is_fec;
         bool is_alt; // is alternative channel for power
         bool is_master; // is a master channel (for remote control)
 
         int search_type;
-        int srm_offset;
+
+        int      srm_offset;
+        int      srm_offset_instant;
+        double   srm_calibration_timestamp;
+        uint16_t srm_slope;
 
         ANTChannel(int number, ANT *parent);
 
@@ -208,6 +213,7 @@ class ANTChannel : public QObject {
         void sendCinqoSuccess();
         void checkCinqo();
         void checkMoxy();
+        void checkSRM();
 
         void setAlt(bool value) { is_alt = value; }
 

--- a/src/ANT/ANTlocalController.cpp
+++ b/src/ANT/ANTlocalController.cpp
@@ -180,6 +180,12 @@ ANTlocalController::getCalibrationZeroOffset()
     return myANTlocal->getCalibrationZeroOffset();
 }
 
+uint16_t
+ANTlocalController::getCalibrationSlope()
+{
+    return myANTlocal->getCalibrationSlope();
+}
+
 void
 ANTlocalController::setCalibrationState(uint8_t state)
 {

--- a/src/ANT/ANTlocalController.h
+++ b/src/ANT/ANTlocalController.h
@@ -73,6 +73,7 @@ public:
     void     setCalibrationState(uint8_t);
     uint16_t getCalibrationSpindownTime();
     uint16_t getCalibrationZeroOffset();
+    uint16_t getCalibrationSlope();
     void     resetCalibrationState();
 
 signals:

--- a/src/Train/CalibrationData.cpp
+++ b/src/Train/CalibrationData.cpp
@@ -34,7 +34,7 @@ void CalibrationData::resetCalibrationState()
         requested[i] = false;
     }
     state = CALIBRATION_STATE_IDLE;
-    activechannel = targetspeed = spindowntime = zerooffset = 0;
+    activechannel = targetspeed = spindowntime = zerooffset = slope = 0;
 }
 
 uint8_t CalibrationData::getType()
@@ -90,6 +90,19 @@ void CalibrationData::setZeroOffset(uint16_t offset)
     if (this->zerooffset != offset) {
         qDebug() << "Calibration zero offset changing to" << offset;
         this->zerooffset = offset;
+    }
+}
+
+uint16_t CalibrationData::getSlope()
+{
+    return this->slope;
+}
+
+void CalibrationData::setSlope(uint16_t slope)
+{
+    if (this->slope != slope) {
+        qDebug() << "Calibration slope changing to" << slope;
+        this->slope = slope;
     }
 }
 

--- a/src/Train/CalibrationData.h
+++ b/src/Train/CalibrationData.h
@@ -21,10 +21,11 @@
 
 #include <stdint.h> // uint8_t etc
 
-#define CALIBRATION_TYPE_NOT_SUPPORTED  0x00
-#define CALIBRATION_TYPE_COMPUTRAINER   0x01
-#define CALIBRATION_TYPE_ZERO_OFFSET    0x02
-#define CALIBRATION_TYPE_SPINDOWN       0x04
+#define CALIBRATION_TYPE_NOT_SUPPORTED      0x00
+#define CALIBRATION_TYPE_COMPUTRAINER       0x01
+#define CALIBRATION_TYPE_ZERO_OFFSET        0x02
+#define CALIBRATION_TYPE_ZERO_OFFSET_SRM    0x04
+#define CALIBRATION_TYPE_SPINDOWN           0x08
 
 #define CALIBRATION_STATE_IDLE          0x00
 #define CALIBRATION_STATE_PENDING       0x01
@@ -59,6 +60,9 @@ public:
     double getTargetSpeed();
     void setTargetSpeed(double speed);
 
+    uint16_t getSlope();
+    void setSlope(uint16_t slope);
+
     void    resetCalibrationState(void);
     void    setRequested(uint8_t channel, bool required);
     void    setTimestamp(uint8_t channel, double time);
@@ -77,6 +81,7 @@ private:
     uint8_t  state;
     uint16_t zerooffset;
     uint16_t spindowntime;
+    uint16_t slope;
     double   targetspeed;
 
 };

--- a/src/Train/RealtimeController.h
+++ b/src/Train/RealtimeController.h
@@ -68,6 +68,7 @@ public:
     virtual void     setCalibrationState(uint8_t) {return; }
     virtual uint16_t getCalibrationSpindownTime() { return 0; }
     virtual uint16_t getCalibrationZeroOffset() { return 0; }
+    virtual uint16_t getCalibrationSlope() {return 0; }
     virtual void     resetCalibrationState() { return; }
 
     void   setCalibrationTimestamp();

--- a/src/Train/TrainSidebar.h
+++ b/src/Train/TrainSidebar.h
@@ -265,7 +265,7 @@ class TrainSidebar : public GcWindow
         bool     startCalibration, restartCalibration, finishCalibration;
         int      calibrationDeviceIndex;
         uint8_t  calibrationType, calibrationState;
-        uint16_t calibrationSpindownTime, calibrationZeroOffset;
+        uint16_t calibrationSpindownTime, calibrationZeroOffset, calibrationSlope;
         double   calibrationTargetSpeed, calibrationCurrentSpeed;
         double   calibrationCadence, calibrationTorque;
 


### PR DESCRIPTION
As there is no notification of calibration completion in the SRM profile,
we progress the calibration state on to completion five seconds after we
start receiving calibration messages.

Temporarily removes support for auto-zero, as was not used, and current
code did not follow the standards set in the ANT+ documentation.