### PR TITLE
Fix the Zwift activity extension since it is not added by Zwift durin…

### DIFF
--- a/src/Cloud/TodaysPlan.cpp
+++ b/src/Cloud/TodaysPlan.cpp
@@ -289,8 +289,15 @@ TodaysPlan::readdir(QString path, QStringList &errors, QDateTime from, QDateTime
                 // file details
                 QJsonObject fileindex = each["fileindex"].toObject();
                 QString suffix = QFileInfo(fileindex["filename"].toString()).suffix();
-                if (suffix == "") suffix = "json";
-
+                if (suffix == "") {
+                    // Zwift uploads files without an extension - work ongoing to get Zwift fixed
+                    if (fileindex["filename"].toString().startsWith("zwift-activity-")) {
+                        qDebug() << "Correcting Zwift Activity extension: " << fileindex["filename"].toString();
+                        suffix = "fit";
+                    } else {
+                        suffix = "json";
+                    }
+                }
 
                 //TodaysPlan's Label may contain the FileName, or Descriptive Text (whatever is shown/edited on the TP's UI)
                 add->label = QFileInfo(each["name"].toString()).fileName();


### PR DESCRIPTION
…g automatic upload.

Zwift registers activities with Today's Plan using the filename  "zwift-activity-[id]" - when it should have a `.fit` file extension.

I hate having special cases like this - but the alternative is that GC downloads files from TodaysPlan that have no real data in them (because it doesn't recognise the zwift-activity file - and so just registers an empty shell of a ride file).

I'm going to continue badgering Zwift to fix at the source - but my first attempt at getting them to fix their upload system was unsuccessful.