### PR TITLE
Disabled Linux OpenGL acceleration if OpenGL lower than 2.0

### DIFF
--- a/src/Charts/OverviewWindow.cpp
+++ b/src/Charts/OverviewWindow.cpp
@@ -65,8 +65,10 @@ OverviewWindow::OverviewWindow(Context *context) :
     view->setFrameStyle(QFrame::NoFrame);
     view->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
 #ifdef Q_OS_LINUX
-    view->setViewport(new QGLWidget(QGLFormat(QGL::SampleBuffers)));
-    view->setViewportUpdateMode(QGraphicsView::FullViewportUpdate);
+    if (QGLFormat::openGLVersionFlags().testFlag(QGLFormat::OpenGL_Version_2_0)) {
+        view->setViewport(new QGLWidget(QGLFormat(QGL::SampleBuffers)));
+        view->setViewportUpdateMode(QGraphicsView::FullViewportUpdate);
+    }
 #endif
     view->setScene(scene);
 

--- a/src/Charts/RCanvas.cpp
+++ b/src/Charts/RCanvas.cpp
@@ -51,9 +51,11 @@ RCanvas::RCanvas(Context *context, QWidget *parent) : QGraphicsView(parent), con
     setFrameStyle(QFrame::NoFrame);
 
 #ifdef Q_OS_LINUX // mac and windows both have issues. sigh.
-    //disabled for now as Linux also has issues on High DPI screen
-    setViewport(new QGLWidget( QGLFormat(QGL::SampleBuffers)));
-    setViewportUpdateMode(QGraphicsView::FullViewportUpdate);
+    // Enabled on Linux depending on Open GL version
+    if (QGLFormat::openGLVersionFlags().testFlag(QGLFormat::OpenGL_Version_2_0)) {
+        setViewport(new QGLWidget( QGLFormat(QGL::SampleBuffers)));
+        setViewportUpdateMode(QGraphicsView::FullViewportUpdate);
+    }
 #endif
 
     // allow to click and drag


### PR DESCRIPTION
I don't know if 2.0 is the minimum version required or it needs to be higher, mine is 1.4 and it doesn't work.