### PR TITLE
Add QT+=opengl to fix build

### DIFF
--- a/src/src.pro
+++ b/src/src.pro
@@ -52,7 +52,7 @@ lessThan(QT_MAJOR_VERSION, 5) {
 } else {
 
     ## QT5 modules we use
-    QT += widgets concurrent serialport multimedia multimediawidgets
+    QT += widgets concurrent serialport multimedia multimediawidgets opengl
 
     ## Always add debug information for Windows, MSVC
     win32-msvc* { CONFIG += force_debug_info }


### PR DESCRIPTION
I'm not sure if the plan is to make OpenGL part of other systems than linux, if not maybe the GLWidget include should be conditional which would also allow the QT+=opengl to be conditional. Otherwise this PR should be enough.