### PR TITLE
TCX export: don't write bogus HR values

### DIFF
--- a/src/FileIO/TcxRideFile.cpp
+++ b/src/FileIO/TcxRideFile.cpp
@@ -88,6 +88,14 @@ TcxFileReader::toByteArray(Context *context, const RideFile *ride, bool withAlt,
     id.appendChild(text);
     activity.appendChild(id);
 
+    // notes if present
+    if (ride->getTag("Notes","") != "") {
+        QDomElement notes = doc.createElement("Notes");
+        text = doc.createTextNode(ride->getTag("Notes",""));
+        notes.appendChild(text);
+        activity.appendChild(notes);
+    }
+
     QDomElement lap = doc.createElement("Lap");
     lap.setAttribute("StartTime", ride->startTime().toUTC().toString(Qt::ISODate));
     activity.appendChild(lap);

--- a/src/FileIO/TcxRideFile.cpp
+++ b/src/FileIO/TcxRideFile.cpp
@@ -96,6 +96,16 @@ TcxFileReader::toByteArray(Context *context, const RideFile *ride, bool withAlt,
         activity.appendChild(notes);
     }
 
+    // device type if present
+    if (ride->deviceType() != "") {
+        QDomElement creator = doc.createElement("Creator");
+        QDomElement creatorName = doc.createElement("Name");
+        text = doc.createTextNode(ride->deviceType());
+        creatorName.appendChild(text);
+        creator.appendChild(creatorName);
+        activity.appendChild(creator);
+    }
+
     QDomElement lap = doc.createElement("Lap");
     lap.setAttribute("StartTime", ride->startTime().toUTC().toString(Qt::ISODate));
     activity.appendChild(lap);

--- a/src/FileIO/TcxRideFile.cpp
+++ b/src/FileIO/TcxRideFile.cpp
@@ -137,19 +137,23 @@ TcxFileReader::toByteArray(Context *context, const RideFile *ride, bool withAlt,
         lap_calories.appendChild(text);
         lap.appendChild(lap_calories);
 
-        QDomElement avg_heartrate = doc.createElement("AverageHeartRateBpm");
-        QDomElement value = doc.createElement("Value");
-        text = doc.createTextNode(QString("%1").arg((int)computed.value("average_hr")->value(true)));
-        value.appendChild(text);
-        avg_heartrate.appendChild(value);
-        lap.appendChild(avg_heartrate);
+        // optional per XSD, so only generate them if the data is to be exported and is present
+        if (withHr && ride->areDataPresent()->hr)
+        {
+            QDomElement avg_heartrate = doc.createElement("AverageHeartRateBpm");
+            QDomElement value = doc.createElement("Value");
+            text = doc.createTextNode(QString("%1").arg((int)computed.value("average_hr")->value(true)));
+            value.appendChild(text);
+            avg_heartrate.appendChild(value);
+            lap.appendChild(avg_heartrate);
 
-        QDomElement max_heartrate = doc.createElement("MaximumHeartRateBpm");
-        value = doc.createElement("Value");
-        text = doc.createTextNode(QString("%1").arg((int)computed.value("max_heartrate")->value(true)));
-        value.appendChild(text);
-        max_heartrate.appendChild(value);
-        lap.appendChild(max_heartrate);
+            QDomElement max_heartrate = doc.createElement("MaximumHeartRateBpm");
+            value = doc.createElement("Value");
+            text = doc.createTextNode(QString("%1").arg((int)computed.value("max_heartrate")->value(true)));
+            value.appendChild(text);
+            max_heartrate.appendChild(value);
+            lap.appendChild(max_heartrate);
+        }
 
         QDomElement lap_intensity = doc.createElement("Intensity");
         text = doc.createTextNode("Active");
@@ -214,7 +218,7 @@ TcxFileReader::toByteArray(Context *context, const RideFile *ride, bool withAlt,
                 trackpoint.appendChild(dist);
             }
 
-            if (withHr)  {
+            if (withHr && ride->areDataPresent()->hr)  {
                 // HeartRate hack for Garmin Training Center
                 // It needs an hr datapoint for every trackpoint or else the
                 // hr graph in TC won't display. Schema defines the datapoint


### PR DESCRIPTION
I noticed a trainer ride showed a bogus HR chart with all "1" values after I shared it from GC to Strava. I traced that back to the TCX export which always wrote HR data if *withHr* was true (which it is for every invocation in GC!).

There is a mysterious comment on a HeartRate hack, but always writing HR of 1 is clearly not correct when the ride has no heartrate info. Also, the XSD allows for this data to be omitted.

With the commits here applied, the HR chart on Strava also promptly vanished. I also added notes and device type to the exported file if the ride has them, but Strava doesn't care for them (or certainly didn't for a creator of "GoldenCheetah"). Notes are apparently only taken from their side-channel form upload..

All changes here are cross checked with the TCX XSD and should be correct.