### PR TITLE
Strava upload: don't use filename as fallback for activity name

### DIFF
--- a/src/Cloud/Strava.cpp
+++ b/src/Cloud/Strava.cpp
@@ -275,14 +275,12 @@ Strava::writeFile(QByteArray &data, QString remotename, RideFile *ride)
     QString filename = QFileInfo(remotename).baseName();
 
     QHttpPart activityNamePart;
-    activityNamePart.setHeader(QNetworkRequest::ContentDispositionHeader, QVariant("form-data; name=\"activity_name\""));
+    activityNamePart.setHeader(QNetworkRequest::ContentDispositionHeader, QVariant("form-data; name=\"name\""));
 
     // use metadata config if the user selected it
     QString fieldname = getSetting(GC_STRAVA_ACTIVITY_NAME, QVariant("")).toString();
-    QString meta;
-    if (fieldname != "")  meta = ride->getTag(fieldname, "");
-    if (meta == "") activityNamePart.setBody(filename.toLatin1());
-    else activityNamePart.setBody(meta.toLatin1());
+    QString activityName = "";
+    if (fieldname != "") activityName = ride->getTag(fieldname, "").toLatin1();
 
     QHttpPart dataTypePart;
     dataTypePart.setHeader(QNetworkRequest::ContentDispositionHeader, QVariant("form-data; name=\"data_type\""));
@@ -313,7 +311,9 @@ Strava::writeFile(QByteArray &data, QString remotename, RideFile *ride)
 
     multiPart->append(accessTokenPart);
     multiPart->append(activityTypePart);
-    multiPart->append(activityNamePart);
+    if (activityName != "") {
+        multiPart->append(activityNamePart);
+    }
     multiPart->append(dataTypePart);
     multiPart->append(externalIdPart);
     //XXXmultiPart->append(privatePart);


### PR DESCRIPTION
The Strava cloud service currently uses the filename if no field is configured as activity name source (but there is currently no option in the GUI to do that). This results in an activity name such as "2017_05_02_22_36_29".

The old share code didn't send an activity name at all, which results in a Strava automatically generated name. Since the filename for the majority of devices out there is autogenerated, I think this behavior is preferable. Once there is an option in the interface to set the metadata field, "no setting" should equal not sending an activity name, so I think this is the correct behavior in that instance also.

(I also noticed the form field was called "activity_name", but the Strava documentation says the correct field is called just "name": https://strava.github.io/api/v3/uploads/)