### PR TITLE
Strava upload: always set activityNamePart body

### DIFF
--- a/src/Cloud/Strava.cpp
+++ b/src/Cloud/Strava.cpp
@@ -280,7 +280,8 @@ Strava::writeFile(QByteArray &data, QString remotename, RideFile *ride)
     // use metadata config if the user selected it
     QString fieldname = getSetting(GC_STRAVA_ACTIVITY_NAME, QVariant("")).toString();
     QString activityName = "";
-    if (fieldname != "") activityName = ride->getTag(fieldname, "").toLatin1();
+    if (fieldname != "") activityName = ride->getTag(fieldname, "");
+    activityNamePart.setBody(activityName.toLatin1());
 
     QHttpPart dataTypePart;
     dataTypePart.setHeader(QNetworkRequest::ContentDispositionHeader, QVariant("form-data; name=\"data_type\""));


### PR DESCRIPTION
This fixes an issue with #2504 spotted by @amtriathlon 

My apologies for the oversight. I've confirmed that the configured tag is now used as activity name, and, when none is set, the Strava generated name.