### PR TITLE
Fix gear ratio calculation when no power meter is present

### DIFF
--- a/src/FileIO/RideFile.cpp
+++ b/src/FileIO/RideFile.cpp
@@ -2492,7 +2492,7 @@ RideFile::recalculateDerivedSeries(bool force)
             // -> above ration 3, round to next 0,5 border (mainly Racebike - even wider differences)
             // speed and wheelsize in meters
             // but only if ride point has power, cadence and speed > 0 otherwise calculation will give a random result
-            if (p->watts > 0.0f && p->cad > 0.0f && p->kph > 0.0f) {
+            if ((p->watts > 0.0f || !dataPresent.watts) && p->cad > 0.0f && p->kph > 0.0f) {
                 p->gear = (1000.00f * p->kph) / (p->cad * 60.00f * wheelsize);
 
                 // Round Gear ratio to the hundreths.


### PR DESCRIPTION
Previous code do not allow to calculate gear-ratio when no power meter is used (as power > 0 is used to filter and reduce inaccurate data)
However when no power meter was used during the ride, as per my point of view, it is better to have few inaccurate data than no data at all.
In this patch I kept the existing filtering when power meter is there. Thus accuracy, when using power meter, is not affected by this patch.