### PR TITLE
Fix incorrect prompt for Wind Heading

### DIFF
--- a/src/FileIO/FixDerivePower.cpp
+++ b/src/FileIO/FixDerivePower.cpp
@@ -113,7 +113,7 @@ class FixDerivePowerConfig : public DataProcessorConfig
                               "CRR parameter is the coefficient of rolling "
                               "resistance, it depends on tires and surface\n"
                               "wind speed shall be indicated in kph\n"
-                              "wind heading (origin) unit is degrees "
+                              "wind direction (origin) unit is degrees "
                               "from -179 to +180 (-90=W, 0=N, 90=E, 180=S)\n"
                               "Note: if the ride file already contain wind data\n"
                               "      it will be overridden if wind is entered manually")));

--- a/src/FileIO/FixRunningPower.cpp
+++ b/src/FileIO/FixRunningPower.cpp
@@ -115,7 +115,7 @@ class FixRunningPowerConfig : public DataProcessorConfig
                               "to adjust for drafting, 1 is no drafting "
                               " and 0.7 seems legit for drafting in a group\n\n"
                               "wind speed shall be indicated in kph\n"
-                              "wind heading (origin) unit is degrees "
+                              "wind direction (origin) unit is degrees "
                               "from -179 to +180 (-90=W, 0=N, 90=E, 180=S)\n"
                               "Note: if the file already contain wind data "
                               "it will be overridden if wind is entered")));

--- a/src/Resources/translations/gc_cs.ts
+++ b/src/Resources/translations/gc_cs.ts
@@ -10062,7 +10062,7 @@ Some unit doesn&apos;t record distance without a speedometer but record position
     </message>
     <message>
         <location filename="../../FileIO/FixDerivePower.cpp" line="65"/>
-        <source>, heading</source>
+        <source>, direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10073,7 +10073,7 @@ Bike Weight parameter is added to athlete&apos;s weight to compound total mass, 
 
 CRR parameter is the coefficient of rolling resistance, it depends on tires and surface
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the ride file already contain wind data
       it will be overridden if wind is entered manually</source>
         <translation type="unfinished"></translation>
@@ -10355,7 +10355,7 @@ Equipment Weight parameter is added to athlete&apos;s weight to compound total m
 Draft Mult. parameter is the multiplier to adjust for drafting, 1 is no drafting  and 0.7 seems legit for drafting in a group
 
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the file already contain wind data it will be overridden if wind is entered</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/Resources/translations/gc_de.ts
+++ b/src/Resources/translations/gc_de.ts
@@ -9501,7 +9501,7 @@ Einige Geräte zeichnen ohne Geschwindigkeitsmesser keine Distanz, aber die Posi
     </message>
     <message>
         <location filename="../../FileIO/FixDerivePower.cpp" line="65"/>
-        <source>, heading</source>
+        <source>, direction</source>
         <translation>, Richtung</translation>
     </message>
     <message>
@@ -9512,7 +9512,7 @@ Bike Weight parameter is added to athlete&apos;s weight to compound total mass, 
 
 CRR parameter is the coefficient of rolling resistance, it depends on tires and surface
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the ride file already contain wind data
       it will be overridden if wind is entered manually</source>
         <translation>Schätzung der Leistung aufgrund von Geschwindigkeit/Höhe/Gewicht usw.
@@ -9810,7 +9810,7 @@ Equipment Weight parameter is added to athlete&apos;s weight to compound total m
 Draft Mult. parameter is the multiplier to adjust for drafting, 1 is no drafting  and 0.7 seems legit for drafting in a group
 
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the file already contain wind data it will be overridden if wind is entered</source>
         <translation>Schätzung der Leistung (Laufen) aufgrund von Geschwindigkeit/Höhe/Gewicht usw. unter Verwendung der &apos;di Prampero&apos; Koeffizienten
 

--- a/src/Resources/translations/gc_es.ts
+++ b/src/Resources/translations/gc_es.ts
@@ -9839,7 +9839,7 @@ Algunas unidades no registran la distancia sin un cuenta kilómetros pero regist
     </message>
     <message>
         <location filename="../../FileIO/FixDerivePower.cpp" line="65"/>
-        <source>, heading</source>
+        <source>, direction</source>
         <translation>, dirección</translation>
     </message>
     <message>
@@ -9850,7 +9850,7 @@ Bike Weight parameter is added to athlete&apos;s weight to compound total mass, 
 
 CRR parameter is the coefficient of rolling resistance, it depends on tires and surface
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the ride file already contain wind data
       it will be overridden if wind is entered manually</source>
         <translation>Derivar potencia estimada en base a velocidad/altimetría/peso, etc
@@ -10152,7 +10152,7 @@ Equipment Weight parameter is added to athlete&apos;s weight to compound total m
 Draft Mult. parameter is the multiplier to adjust for drafting, 1 is no drafting  and 0.7 seems legit for drafting in a group
 
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the file already contain wind data it will be overridden if wind is entered</source>
         <translation>Deriva datos de potencia estimada en base a velocidad/altimetría/peso, etc utilizando los coeficientes de di Prampero
 

--- a/src/Resources/translations/gc_fr.ts
+++ b/src/Resources/translations/gc_fr.ts
@@ -11323,7 +11323,7 @@ Certains équipements n&apos;enregistrent pas la distance mais la position (ex: 
     </message>
     <message>
         <location filename="../../FileIO/FixDerivePower.cpp" line="65"/>
-        <source>, heading</source>
+        <source>, direction</source>
         <translation>, de face</translation>
     </message>
     <message>
@@ -11334,7 +11334,7 @@ Bike Weight parameter is added to athlete&apos;s weight to compound total mass, 
 
 CRR parameter is the coefficient of rolling resistance, it depends on tires and surface
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the ride file already contain wind data
       it will be overridden if wind is entered manually</source>
         <translation>Estime la puissance en fonction de la vitesse, de l&apos;altitude, du poids, etc.
@@ -11653,7 +11653,7 @@ Equipment Weight parameter is added to athlete&apos;s weight to compound total m
 Draft Mult. parameter is the multiplier to adjust for drafting, 1 is no drafting  and 0.7 seems legit for drafting in a group
 
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the file already contain wind data it will be overridden if wind is entered</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/Resources/translations/gc_it.ts
+++ b/src/Resources/translations/gc_it.ts
@@ -9958,7 +9958,7 @@ Alcune unita&apos; non registrano la distanza senza un misuratore di velocita&ap
     </message>
     <message>
         <location filename="../../FileIO/FixDerivePower.cpp" line="65"/>
-        <source>, heading</source>
+        <source>, direction</source>
         <translation>, direzione</translation>
     </message>
     <message>
@@ -9969,7 +9969,7 @@ Bike Weight parameter is added to athlete&apos;s weight to compound total mass, 
 
 CRR parameter is the coefficient of rolling resistance, it depends on tires and surface
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the ride file already contain wind data
       it will be overridden if wind is entered manually</source>
         <translation>Ottieni dati di potenza stimata basata sulla velocita&apos;/altitudine/peso ecc.
@@ -10270,7 +10270,7 @@ Equipment Weight parameter is added to athlete&apos;s weight to compound total m
 Draft Mult. parameter is the multiplier to adjust for drafting, 1 is no drafting  and 0.7 seems legit for drafting in a group
 
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the file already contain wind data it will be overridden if wind is entered</source>
         <translation>Ottieni stima dei dati di potenza di corsa basati sulla velocita&apos;/altitudine/peso ecc. usando i coefficienti di Prampero
 

--- a/src/Resources/translations/gc_ja.ts
+++ b/src/Resources/translations/gc_ja.ts
@@ -10176,7 +10176,7 @@ Some unit doesn&apos;t record distance without a speedometer but record position
     </message>
     <message>
         <location filename="../../FileIO/FixDerivePower.cpp" line="65"/>
-        <source>, heading</source>
+        <source>, direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10187,7 +10187,7 @@ Bike Weight parameter is added to athlete&apos;s weight to compound total mass, 
 
 CRR parameter is the coefficient of rolling resistance, it depends on tires and surface
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the ride file already contain wind data
       it will be overridden if wind is entered manually</source>
         <translation type="unfinished"></translation>
@@ -10468,7 +10468,7 @@ Equipment Weight parameter is added to athlete&apos;s weight to compound total m
 Draft Mult. parameter is the multiplier to adjust for drafting, 1 is no drafting  and 0.7 seems legit for drafting in a group
 
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the file already contain wind data it will be overridden if wind is entered</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/Resources/translations/gc_nl.ts
+++ b/src/Resources/translations/gc_nl.ts
@@ -9966,7 +9966,7 @@ Sommige apparaten nemen de afstand op zonder een snelheidsmeter maar leggen wel 
     </message>
     <message>
         <location filename="../../FileIO/FixDerivePower.cpp" line="65"/>
-        <source>, heading</source>
+        <source>, direction</source>
         <translation>Windrichting</translation>
     </message>
     <message>
@@ -9977,7 +9977,7 @@ Bike Weight parameter is added to athlete&apos;s weight to compound total mass, 
 
 CRR parameter is the coefficient of rolling resistance, it depends on tires and surface
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the ride file already contain wind data
       it will be overridden if wind is entered manually</source>
         <translation>Leidt geschat vermogen af van snelheid/hoogte/gewicht etc.
@@ -10280,7 +10280,7 @@ Equipment Weight parameter is added to athlete&apos;s weight to compound total m
 Draft Mult. parameter is the multiplier to adjust for drafting, 1 is no drafting  and 0.7 seems legit for drafting in a group
 
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the file already contain wind data it will be overridden if wind is entered</source>
         <translation>Het afleiden van het geschatte hardloopvermogen gebaseerd op snelheid/hoogte/gewicht etc. met gebruikmaking van di Prampero coëfficiënten
 

--- a/src/Resources/translations/gc_pt-br.ts
+++ b/src/Resources/translations/gc_pt-br.ts
@@ -9850,7 +9850,7 @@ Some unit doesn&apos;t record distance without a speedometer but record position
     </message>
     <message>
         <location filename="../../FileIO/FixDerivePower.cpp" line="65"/>
-        <source>, heading</source>
+        <source>, direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -9861,7 +9861,7 @@ Bike Weight parameter is added to athlete&apos;s weight to compound total mass, 
 
 CRR parameter is the coefficient of rolling resistance, it depends on tires and surface
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the ride file already contain wind data
       it will be overridden if wind is entered manually</source>
         <translation type="unfinished"></translation>
@@ -10142,7 +10142,7 @@ Equipment Weight parameter is added to athlete&apos;s weight to compound total m
 Draft Mult. parameter is the multiplier to adjust for drafting, 1 is no drafting  and 0.7 seems legit for drafting in a group
 
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the file already contain wind data it will be overridden if wind is entered</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/Resources/translations/gc_pt.ts
+++ b/src/Resources/translations/gc_pt.ts
@@ -10263,7 +10263,7 @@ Some unit doesn&apos;t record distance without a speedometer but record position
     </message>
     <message>
         <location filename="../../FileIO/FixDerivePower.cpp" line="65"/>
-        <source>, heading</source>
+        <source>, direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10274,7 +10274,7 @@ Bike Weight parameter is added to athlete&apos;s weight to compound total mass, 
 
 CRR parameter is the coefficient of rolling resistance, it depends on tires and surface
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the ride file already contain wind data
       it will be overridden if wind is entered manually</source>
         <translation type="unfinished"></translation>
@@ -10554,7 +10554,7 @@ Equipment Weight parameter is added to athlete&apos;s weight to compound total m
 Draft Mult. parameter is the multiplier to adjust for drafting, 1 is no drafting  and 0.7 seems legit for drafting in a group
 
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the file already contain wind data it will be overridden if wind is entered</source>
         <translation type="unfinished"></translation>
     </message>

--- a/src/Resources/translations/gc_ru.ts
+++ b/src/Resources/translations/gc_ru.ts
@@ -10082,7 +10082,7 @@ Some unit doesn&apos;t record distance without a speedometer but record position
     </message>
     <message>
         <location filename="../../FileIO/FixDerivePower.cpp" line="65"/>
-        <source>, heading</source>
+        <source>, direction</source>
         <translation>, направление</translation>
     </message>
     <message>
@@ -10093,7 +10093,7 @@ Bike Weight parameter is added to athlete&apos;s weight to compound total mass, 
 
 CRR parameter is the coefficient of rolling resistance, it depends on tires and surface
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the ride file already contain wind data
       it will be overridden if wind is entered manually</source>
         <translation>Оценка мощности основана на скорости, наборе высоты, весе и др. параметрах
@@ -10406,7 +10406,7 @@ Equipment Weight parameter is added to athlete&apos;s weight to compound total m
 Draft Mult. parameter is the multiplier to adjust for drafting, 1 is no drafting  and 0.7 seems legit for drafting in a group
 
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the file already contain wind data it will be overridden if wind is entered</source>
         <translation>Оценка мощности при беге основана на скорости, наборе высоты, весе и др. параметрах, с использованием коэффициентов di Prampero.
 

--- a/src/Resources/translations/gc_sv.ts
+++ b/src/Resources/translations/gc_sv.ts
@@ -9988,7 +9988,7 @@ Vissa GPS-er beräknar inte distans utan hastighetsmätare, men sparar positione
     </message>
     <message>
         <location filename="../../FileIO/FixDerivePower.cpp" line="65"/>
-        <source>, heading</source>
+        <source>, direction</source>
         <translation>, vindrikning</translation>
     </message>
     <message>
@@ -9999,7 +9999,7 @@ Bike Weight parameter is added to athlete&apos;s weight to compound total mass, 
 
 CRR parameter is the coefficient of rolling resistance, it depends on tires and surface
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the ride file already contain wind data
       it will be overridden if wind is entered manually</source>
         <translation>Beräkna effektvärden baserat på hastighet, höjd över havet, vikt mm.
@@ -10298,7 +10298,7 @@ Equipment Weight parameter is added to athlete&apos;s weight to compound total m
 Draft Mult. parameter is the multiplier to adjust for drafting, 1 is no drafting  and 0.7 seems legit for drafting in a group
 
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the file already contain wind data it will be overridden if wind is entered</source>
         <translation>Beräknar löpeffekt utifrån &apos;di Prampero&apos; koefficienterna och data om hastighet, höjdförändringar, vikt mm
 

--- a/src/Resources/translations/gc_zh-cn.ts
+++ b/src/Resources/translations/gc_zh-cn.ts
@@ -10169,7 +10169,7 @@ Some unit doesn&apos;t record distance without a speedometer but record position
     </message>
     <message>
         <location filename="../../FileIO/FixDerivePower.cpp" line="65"/>
-        <source>, heading</source>
+        <source>, direction</source>
         <translation>风向</translation>
     </message>
     <message>
@@ -10180,7 +10180,7 @@ Bike Weight parameter is added to athlete&apos;s weight to compound total mass, 
 
 CRR parameter is the coefficient of rolling resistance, it depends on tires and surface
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the ride file already contain wind data
       it will be overridden if wind is entered manually</source>
         <translation>根据速度/爬升/重量等估计功率数据
@@ -10477,7 +10477,7 @@ Equipment Weight parameter is added to athlete&apos;s weight to compound total m
 Draft Mult. parameter is the multiplier to adjust for drafting, 1 is no drafting  and 0.7 seems legit for drafting in a group
 
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the file already contain wind data it will be overridden if wind is entered</source>
         <translation>根据速度/海拔/重量等、使用di Prampero系数估算得到的跑步功率
 

--- a/src/Resources/translations/gc_zh-tw.ts
+++ b/src/Resources/translations/gc_zh-tw.ts
@@ -10310,7 +10310,7 @@ Some unit doesn&apos;t record distance without a speedometer but record position
     </message>
     <message>
         <location filename="../../FileIO/FixDerivePower.cpp" line="65"/>
-        <source>, heading</source>
+        <source>, direction</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
@@ -10321,7 +10321,7 @@ Bike Weight parameter is added to athlete&apos;s weight to compound total mass, 
 
 CRR parameter is the coefficient of rolling resistance, it depends on tires and surface
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the ride file already contain wind data
       it will be overridden if wind is entered manually</source>
         <translation type="unfinished"></translation>
@@ -10604,7 +10604,7 @@ Equipment Weight parameter is added to athlete&apos;s weight to compound total m
 Draft Mult. parameter is the multiplier to adjust for drafting, 1 is no drafting  and 0.7 seems legit for drafting in a group
 
 wind speed shall be indicated in kph
-wind heading (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
+wind direction (origin) unit is degrees from -179 to +180 (-90=W, 0=N, 90=E, 180=S)
 Note: if the file already contain wind data it will be overridden if wind is entered</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
This patch closes #2216 which incorrectly prompts for 'Wind Heading
(origin)' when estimating power.  The correct term for origin of wind is
'Wind Direction'.