### PR TITLE
Changed LTMPlot to use name to retrieve metadata fields

### DIFF
--- a/src/Charts/LTMPlot.cpp
+++ b/src/Charts/LTMPlot.cpp
@@ -2649,7 +2649,7 @@ LTMPlot::createMetricData(Context *context, LTMSettings *settings, MetricDetail 
         // value for day
         double value;
         if (metricDetail.type == METRIC_META)
-            value = ride->getText(metricDetail.symbol, "0.0").toDouble();
+            value = ride->getText(metricDetail.name, "0.0").toDouble();
         else
             value = ride->getForSymbol(metricDetail.symbol);
 

--- a/src/Charts/LTMTool.cpp
+++ b/src/Charts/LTMTool.cpp
@@ -223,7 +223,8 @@ LTMTool::LTMTool(Context *context, LTMSettings *settings) : QWidget(context->mai
             metametric.smooth = false;
             metametric.trendtype = 0;
             metametric.topN = 1;
-            metametric.uname = metametric.name = sp.displayName(field.name);
+            metametric.name = field.name; // used to retrieve metadata value
+            metametric.uname = sp.displayName(field.name);
             metametric.units = "";
             metametric.uunits = "";
             metrics.append(metametric);


### PR DESCRIPTION
Instead of symbol which has spaces replaced by underscores so getText fails.
Fixes #2561