### PR TITLE
Fix MSVC Compile Error

### DIFF
--- a/src/FileIO/FitRideFile.cpp
+++ b/src/FileIO/FitRideFile.cpp
@@ -2892,7 +2892,7 @@ struct FitFileReaderState
             QStringList uniqueDevices(deviceInfos.values());
             uniqueDevices.removeDuplicates();
             QString deviceInfo = uniqueDevices.join('\n');
-            if (not deviceInfo.isEmpty())
+            if (! deviceInfo.isEmpty())
                 rideFile->setTag("Device Info", deviceInfo);
 
             QString dataInfo;


### PR DESCRIPTION
... default settings in MSVC2015 do not support "not" operator - so change to "!"
... since this is only a single occurance in overall code