### PR TITLE
More flexible HRV CSV file parsing

### DIFF
--- a/src/FileIO/BodyMeasuresCsvImport.h
+++ b/src/FileIO/BodyMeasuresCsvImport.h
@@ -52,7 +52,7 @@ class CsvString : public QString
     public:
     CsvString(QString other) : QString(other) {}
 
-    // we just reimplement split, to process "," in a string
+    // we just reimplement split, to process "," and ";" in a string
     QStringList split() {
 
     enum State {Normal, Quote} state = Normal;
@@ -64,7 +64,7 @@ class CsvString : public QString
 
         if (state == Normal) { // Normal state
 
-            if (current == ',') {
+            if (current == ',' || current == ';') {
                 // Save field
                 returning.append(value);
                 value.clear();

--- a/src/FileIO/HrvMeasuresCsvImport.h
+++ b/src/FileIO/HrvMeasuresCsvImport.h
@@ -45,7 +45,6 @@ class HrvMeasuresCsvImport : public QObject {
 
     private:
         Context *context;
-        QStringList allowedHeaders;
 
 };
 


### PR DESCRIPTION
-Allows lines ending in CR as generated by HRV4Training iPhone app.
-Allows ";" additionally to "," as separator.
-Skip unsupported columns.
-Skip empty lines and values.
-Recognize the alternative names generated by HRV4Training when
orthostatic test is selected.