### PR TITLE
Preserve XData on Activity Split&Combine

### DIFF
--- a/src/Gui/MergeActivityWizard.cpp
+++ b/src/Gui/MergeActivityWizard.cpp
@@ -408,6 +408,16 @@ MergeActivityWizard::combine()
             last = add;
         }
 
+        // Just preserve XData from first ride and add XData from the second,
+        // if not already present, in the future we could let the user to
+        // choose, like for standard series
+        foreach (XDataSeries *xdata, ride1->xdata())
+            combined->addXData(xdata->name, new XDataSeries (*xdata));
+        foreach (XDataSeries *xdata, ride2->xdata()) {
+            if (!combined->xdata().contains(xdata->name))
+                combined->addXData(xdata->name, new XDataSeries (*xdata));
+        }
+
         // now realign the intervals, first we need to
         // clear what we already have in combined
         combined->clearIntervals();

--- a/src/Gui/SplitActivityWizard.cpp
+++ b/src/Gui/SplitActivityWizard.cpp
@@ -792,10 +792,29 @@ SplitConfirm::createRideFile(long start, long stop)
                                p->interval);
     }
 
+    double startTime = ride->dataPoints().at(start)->secs;
+    double stopTime = ride->dataPoints().at(stop)->secs;
+
+    // and the XData Series, check in bounds too!
+    foreach (XDataSeries *xdata, ride->xdata()) {
+        XDataSeries* xd = new XDataSeries(*xdata);
+        xd->datapoints.clear();
+        foreach (XDataPoint *point, xdata->datapoints) {
+            if (point->secs >= startTime && point->secs <= stopTime) {
+                XDataPoint *pt = new XDataPoint(*point);
+                pt->secs = point->secs - offset;
+                pt->km = point->km - distanceoffset;
+                xd->datapoints.append(pt);
+            }
+        }
+        if (xd->datapoints.count() > 0)
+            returning->addXData(xd->name, xd);
+        else
+            delete xd;
+    }
+
     // lets keep intervals that start in our section truncating them
     // if neccessary (some folks want to keep lap markers)
-    double startTime = wizard->rideItem->ride()->dataPoints().at(start)->secs;
-    double stopTime = wizard->rideItem->ride()->dataPoints().at(stop)->secs;
     foreach (RideFileInterval *interval, wizard->rideItem->ride()->intervals()) {
 
         if (interval->start >= startTime && interval->start <= stopTime) {


### PR DESCRIPTION
Part 1 - Split
Part 2 - Combine (Join)
Part 3 - Combine (Merge)
Just preserve XData from first ride and add XData from the second, if not already present, for Merge. In the future we could let the user to choose, like for standard series, but I think it is good enough for now.
Fixes #2406