### PR TITLE
Detect Garmin Express blocking ANT stick

### DIFF
--- a/src/ANT/ANT.cpp
+++ b/src/ANT/ANT.cpp
@@ -487,6 +487,12 @@ ANT::start()
 int
 ANT::setup()
 {
+    if (channels == 0)
+    {
+        // we obviously have not managed to open an ANT stick, fail fast
+        return 0;
+    }
+
     uint8_t attempts = 0;
     do
     {

--- a/src/ANT/ANT.h
+++ b/src/ANT/ANT.h
@@ -41,6 +41,7 @@
 #include <QElapsedTimer>
 #include <QProgressDialog>
 #include <QFile>
+#include <QSemaphore>
 
 //
 // Time
@@ -672,7 +673,7 @@ public:
     qint64 getElapsedTime();
 
 private:
-
+    QSemaphore portInitDone;
     void run();
 
     RealtimeData telemetry;

--- a/src/ANT/ANTlocalController.cpp
+++ b/src/ANT/ANTlocalController.cpp
@@ -68,11 +68,13 @@ ANTlocalController::start()
     // Before we do the low level device opening, check for an active Garmin Service
     if (GarminServiceHelper::isServiceRunning())
     {
-       int dialogStatus = QMessageBox::warning(parent, tr("Found Garmin Express service"),
-                                               tr("The Garmin Express service is active on your computer.\n"
-                                                  "This can block GoldenCheetah from accessing your ANT+ stick.\n\n"
-                                                  "Do you want to temporarily disable the service?"),
-                                               QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Ok);
+        // HACK the event loop gets very angry when we open a dialog in response to a UI event
+        QApplication::processEvents();
+        int dialogStatus = QMessageBox::warning(parent, tr("Found Garmin Express service"),
+                                                tr("The Garmin Express service is active on your computer.\n"
+                                                   "This can block GoldenCheetah from accessing your ANT+ stick.\n\n"
+                                                   "Do you want to temporarily disable the service?"),
+                                                QMessageBox::Ok | QMessageBox::Cancel, QMessageBox::Ok);
 
         if (dialogStatus == QMessageBox::Ok)
         {

--- a/src/Train/GarminServiceHelper.cpp
+++ b/src/Train/GarminServiceHelper.cpp
@@ -115,6 +115,8 @@ bool GarminServiceHelper::stopService()
 
 #elif defined(__APPLE__)
 
+#include <QThread>
+
 #include <vector>
 #include <string>
 
@@ -177,7 +179,13 @@ bool GarminServiceHelper::stopService()
 {
     pid_t pid = findProcess(GARMIN_SERVICE_EXECUTABLE);
     if (pid != -1)
-        return killpg(getpgid(pid), SIGTERM) != -1;
+    {
+        if (killpg(getpgid(pid), SIGTERM) == -1)
+            return false;
+        // Wait for the ANT stick to be freed
+        QThread::sleep(3);
+        return true;
+    }
     return false;
 }
 

--- a/src/Train/GarminServiceHelper.cpp
+++ b/src/Train/GarminServiceHelper.cpp
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2017 Stefan Schake
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#include "GarminServiceHelper.h"
+#include <QDebug>
+
+#if defined(_MSC_VER)
+#pragma comment(lib, "advapi32.lib")
+#include <windows.h>
+
+static LPCWSTR GARMIN_SERVICE_NAME = L"Garmin Device Interaction Service";
+
+bool GarminServiceHelper::isServiceRunning()
+{
+    SC_HANDLE manager = OpenSCManager(NULL, NULL, 0);
+    if (manager == NULL)
+        goto fail;
+
+    SC_HANDLE service = OpenService(manager, GARMIN_SERVICE_NAME, SERVICE_QUERY_STATUS);
+    if (service == NULL)
+        goto fail;
+
+    SERVICE_STATUS serviceStatus;
+    if (QueryServiceStatus(service, &serviceStatus) == 0)
+        goto fail;
+
+    CloseServiceHandle(service);
+    CloseServiceHandle(manager);
+    return serviceStatus.dwCurrentState == SERVICE_RUNNING
+            || serviceStatus.dwCurrentState == SERVICE_START_PENDING;
+
+    fail:
+    if (service != NULL)
+        CloseServiceHandle(service);
+    if (manager != NULL)
+        CloseServiceHandle(manager);
+    return false;
+}
+
+static void restartGarminService()
+{
+    SC_HANDLE manager = OpenSCManager(NULL, NULL, 0);
+    if (manager == NULL)
+        goto cleanup;
+
+    SC_HANDLE service = OpenService(manager, GARMIN_SERVICE_NAME, SERVICE_START);
+    if (service == NULL)
+        goto cleanup;
+
+    // we don't care if this works out
+    StartService(service, 0, NULL);
+
+    cleanup:
+    if (service != NULL)
+        CloseServiceHandle(service);
+    if (manager != NULL)
+        CloseServiceHandle(manager);
+}
+
+bool GarminServiceHelper::stopService()
+{
+    SC_HANDLE manager = OpenSCManager(NULL, NULL, 0);
+    if (manager == NULL)
+        goto fail;
+
+    SC_HANDLE service = OpenService(manager, GARMIN_SERVICE_NAME, SERVICE_STOP);
+    if (service == NULL)
+        goto fail;
+
+    SERVICE_STATUS serviceStatus;
+    // this unfortunately blocks until the service is stopped, but the Garmin service is generally well behaved
+    if (ControlService(service, SERVICE_CONTROL_STOP, &serviceStatus) == 0)
+        goto fail;
+
+    bool success = serviceStatus.dwCurrentState == SERVICE_STOPPED
+            || serviceStatus.dwCurrentState == SERVICE_STOP_PENDING;
+
+    if (success)
+    {
+        atexit(restartGarminService);
+    }
+
+    CloseServiceHandle(manager);
+    CloseServiceHandle(service);
+    return success;
+
+    fail:
+    if (service != NULL)
+        CloseServiceHandle(service);
+    if (manager != NULL)
+        CloseServiceHandle(manager);
+    return false;
+}
+
+#else
+
+bool GarminServiceHelper::isServiceRunning()
+{
+    return false;
+}
+
+bool GarminServiceHelper::stopService()
+{
+    return false;
+}
+
+#endif

--- a/src/Train/GarminServiceHelper.cpp
+++ b/src/Train/GarminServiceHelper.cpp
@@ -119,6 +119,7 @@ bool GarminServiceHelper::stopService()
 
 #include <vector>
 #include <string>
+#include <cstddef>
 
 #include <sys/sysctl.h>
 #include <signal.h>
@@ -131,27 +132,27 @@ static pid_t findProcess(const std::string& pattern)
 
     int maxArgSize = 0;
     size_t size = sizeof(maxArgSize);
-    if (sysctl(queryArgMax, 2, &maxArgSize, &size, nullptr, 0) == -1)
+    if (sysctl(queryArgMax, 2, &maxArgSize, &size, NULL, 0) == -1)
         return -1;
 
     size_t processInfoSize;
-    if (sysctl(queryProcAll, 3, nullptr, &processInfoSize, nullptr, 0) < 0)
+    if (sysctl(queryProcAll, 3, NULL, &processInfoSize, NULL, 0) < 0)
         return -1;
 
     std::vector<struct kinfo_proc> processInfo(processInfoSize / sizeof(struct kinfo_proc));
-    if (sysctl(queryProcAll, 3, processInfo.data(), &processInfoSize, nullptr, 0) < 0)
+    if (sysctl(queryProcAll, 3, processInfo.data(), &processInfoSize, NULL, 0) < 0)
         return -1;
 
     std::vector<char> argumentsBuffer(maxArgSize);
-    for (auto& process : processInfo)
+    for (int i = 0; i < processInfo.size(); i++)
     {
-        pid_t pid = process.kp_proc.p_pid;
+        pid_t pid = processInfo[i].kp_proc.p_pid;
         if (pid == 0)
             continue;
 
         size = maxArgSize;
         int queryProcArgs2[] = { CTL_KERN, KERN_PROCARGS2, pid };
-        if (sysctl(queryProcArgs2, 3, argumentsBuffer.data(), &size, nullptr, 0) < 0)
+        if (sysctl(queryProcArgs2, 3, argumentsBuffer.data(), &size, NULL, 0) < 0)
         {
             // this generally happens if we don't have enough privileges
             // therefore not a fatal error

--- a/src/Train/GarminServiceHelper.h
+++ b/src/Train/GarminServiceHelper.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2017 Stefan Schake
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+#ifndef _GC_GarminServiceHelper_h
+#define _GC_GarminServiceHelper_h 1
+
+class GarminServiceHelper
+{
+public:
+    static bool isServiceRunning();
+    static bool stopService();
+};
+
+#endif

--- a/src/Train/TrainBottom.cpp
+++ b/src/Train/TrainBottom.cpp
@@ -206,7 +206,7 @@ TrainBottom::TrainBottom(TrainSidebar *trainSidebar, QWidget *parent) :
     connect(m_trainSidebar->context, SIGNAL(stop()), this, SLOT(updatePlayButtonIcon()));
     //connect(hideOnIdle, SIGNAL(stateChanged(int)), this, SLOT(autoHideCheckboxChanged(int)));
     connect(m_trainSidebar, SIGNAL(statusChanged(int)), this, SLOT(statusChanged(int)));
-    connect(m_connectButton, SIGNAL(clicked()), m_trainSidebar, SLOT(toggleConnect()));
+    connect(m_connectButton, SIGNAL(released()), m_trainSidebar, SLOT(toggleConnect()));
     connect(cal, SIGNAL(clicked()), m_trainSidebar, SLOT(Calibrate()));
 
     connect(loadUp, SIGNAL(clicked()), m_trainSidebar, SLOT(Higher()));

--- a/src/src.pro
+++ b/src/src.pro
@@ -748,7 +748,7 @@ HEADERS += Train/AddDeviceWizard.h Train/CalibrationData.h Train/ComputrainerCon
            Train/DeviceTypes.h Train/DialWindow.h Train/ErgDBDownloadDialog.h Train/ErgDB.h Train/ErgFile.h Train/ErgFilePlot.h \
            Train/Library.h Train/LibraryParser.h Train/MeterWidget.h Train/NullController.h Train/RealtimeController.h \
            Train/RealtimeData.h Train/RealtimePlot.h Train/RealtimePlotWindow.h Train/RemoteControl.h Train/SpinScanPlot.h \
-           Train/SpinScanPlotWindow.h Train/SpinScanPolarPlot.h
+           Train/SpinScanPlotWindow.h Train/SpinScanPolarPlot.h Train/GarminServiceHelper.h
 
 greaterThan(QT_MAJOR_VERSION, 4) {
     HEADERS += Train/TodaysPlanWorkoutDownload.h
@@ -845,7 +845,7 @@ SOURCES += Train/AddDeviceWizard.cpp Train/CalibrationData.cpp Train/Computraine
            Train/DeviceTypes.cpp Train/DialWindow.cpp Train/ErgDB.cpp Train/ErgDBDownloadDialog.cpp Train/ErgFile.cpp Train/ErgFilePlot.cpp \
            Train/Library.cpp Train/LibraryParser.cpp Train/MeterWidget.cpp Train/NullController.cpp Train/RealtimeController.cpp \
            Train/RealtimeData.cpp Train/RealtimePlot.cpp Train/RealtimePlotWindow.cpp Train/RemoteControl.cpp Train/SpinScanPlot.cpp \
-           Train/SpinScanPlotWindow.cpp Train/SpinScanPolarPlot.cpp
+           Train/SpinScanPlotWindow.cpp Train/SpinScanPolarPlot.cpp Train/GarminServiceHelper.cpp
 
 greaterThan(QT_MAJOR_VERSION, 4) {
     SOURCES  += Train/TodaysPlanWorkoutDownload.cpp


### PR DESCRIPTION
Trainer season is coming up and I've learned that Garmin Express (certainly on Windows) has a new trick up its sleeve: it registers an always on-in-the-background service that will block the ANT stick. This is separate from the Garmin Express app that has the tray icon and no longer starts automatically.

So now on Windows to use ANT+ in GC, you have to go into the services manager, find the Garmin Device Interaction Service and stop it manually. That is if you know to do that :)

This PR checks if the Garmin Express service is running before connecting to the ANT+ stick and offers to stop the service temporarily, for both Windows and MacOS (where at least you still have an icon in the menu bar). It also removes the fixed 500 ms delay and fails faster when we couldn't open the ANT+ stick.