### PR TITLE
Remove trailing whitespace from "Lap StartTime" in tcx files

### DIFF
--- a/src/FileIO/TcxParser.cpp
+++ b/src/FileIO/TcxParser.cpp
@@ -81,7 +81,7 @@ TcxParser::startElement( const QString&, const QString&, const QString& qName, c
         lastLength = 0.0;
 
     } else if (qName == "Lap") {
-        lap_start_time = convertToLocalTime(qAttributes.value("StartTime"));
+        lap_start_time = convertToLocalTime(qAttributes.value("StartTime").trimmed());
         lapSecs = 0.0;
         lapTrigger = ltManual;
 


### PR DESCRIPTION
Have some tcx files from a concept2 rowing machine that fails to read due a trailing white space in lap StarTime as given below. 

```
<Activity Sport="Other">
  <Id>2017-09-12T23:27:00Z</Id>
    <Lap StartTime="2017-09-12T23:27:00Z ">
```

The commit will remove white space on both sides of the attribute StartTime. 
