### PR TITLE
Fix Strava lap swims and expand Smart Recording

### DIFF
--- a/src/Cloud/Strava.h
+++ b/src/Cloud/Strava.h
@@ -75,6 +75,8 @@ class Strava : public CloudService {
         QByteArray* prepareResponse(QByteArray* data);
 
         void addSamples(RideFile* ret, QString remoteid);
+        void fixLapSwim(RideFile* ret, QJsonArray laps);
+        void fixSmartRecording(RideFile* ret);
 
     private slots:
         void onSslErrors(QNetworkReply *reply, const QList<QSslError>&error);

--- a/src/FileIO/FixGaps.cpp
+++ b/src/FileIO/FixGaps.cpp
@@ -94,7 +94,7 @@ class FixGapsConfig : public DataProcessorConfig
 
         void readConfig() {
             double tol = appsettings->value(NULL, GC_DPFG_TOLERANCE, "1.0").toDouble();
-            double stop = appsettings->value(NULL, GC_DPFG_STOP, "1.0").toDouble();
+            double stop = appsettings->value(NULL, GC_DPFG_STOP, "90.0").toDouble();
             tolerance->setValue(tol);
             beerandburrito->setValue(stop);
         }
@@ -142,7 +142,7 @@ FixGaps::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="
     double tolerance, stop;
     if (config == NULL) { // being called automatically
         tolerance = appsettings->value(NULL, GC_DPFG_TOLERANCE, "1.0").toDouble();
-        stop = appsettings->value(NULL, GC_DPFG_STOP, "1.0").toDouble();
+        stop = appsettings->value(NULL, GC_DPFG_STOP, "90.0").toDouble();
     } else { // being called manually
         tolerance = ((FixGapsConfig*)(config))->tolerance->value();
         stop = ((FixGapsConfig*)(config))->beerandburrito->value();
@@ -174,7 +174,7 @@ FixGaps::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="
             bool stationary = ((last->lat || last->lon) && (point->lat || point->lon)) // gps is present
                          && last->lat == point->lat && last->lon == point->lon;
 
-            // moved for less than 30 seconds ... interpolate
+            // moved for less than stop seconds ... interpolate
             if (!stationary && gap > tolerance && gap < stop) {
 
                 // what's needed?

--- a/src/FileIO/RideFile.h
+++ b/src/FileIO/RideFile.h
@@ -175,6 +175,7 @@ class RideFile : public QObject // QObject to emit signals
         friend struct JsonFileReader;
         friend class ManualRideDialog;
         friend class PolarFileReader;
+        friend class Strava;
         // split and mergers
         friend class MergeActivityWizard;
         friend class SplitActivityWizard;


### PR DESCRIPTION
Lap swims synced from Strava don't have pool length nor precise
length by length information nor stroke rate (cadence), we use
distance and time information from the informed laps to fill the
gaps and fix distance for users unable or unwilling to import the
original file, which is the recommended approach.
For all activities expand Smart Recording if enabled.
Changed default FixGap stop parameter to work with open water swims
and runs with Smart Recording, in the future we could expand during
import like we do for other file formats.
Fixes #2605