### PR TITLE
Add option to caculate new speed and distance using FixGPS

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -200,7 +200,7 @@
 #define GC_MOXY_FIX_SMO2                "<global-general>dataprocess/fixmoxydata/fix_smo2"
 #define GC_MOXY_FIX_THB                 "<global-general>dataprocess/fixmoxydata/fix_thb"
 #define GC_MOXY_FIX_THB_MAX             "<global-general>dataprocess/fixmoxydata/fix_thb_max"
-
+#define GC_DPGPS_SPEED                  "<global-general>dataprocess/fixgps/set_speed"
 
 // device Configurations NAME/SPEC/TYPE/DEFI/DEFR all get a number appended
 // to them to specify which configured device i.e. devices1 ... devicesn where

--- a/src/FileIO/FixGPS.cpp
+++ b/src/FileIO/FixGPS.cpp
@@ -20,6 +20,7 @@
 #include "Settings.h"
 #include "Units.h"
 #include "HelpWhatsThis.h"
+#include "FixGPS.h"
 #include <algorithm>
 #include <QVector>
 
@@ -30,12 +31,22 @@ class FixGPSConfig : public DataProcessorConfig
     Q_DECLARE_TR_FUNCTIONS(FixGPSConfig)
     friend class ::FixGPS;
     protected:
+        QHBoxLayout *layout;
+        QCheckBox *adjustSpeed;
     public:
         // there is no config
         FixGPSConfig(QWidget *parent) : DataProcessorConfig(parent) {
 
             HelpWhatsThis *help = new HelpWhatsThis(parent);
             parent->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Edit_FixGPSErrors));
+
+            layout = new QHBoxLayout(this);
+            layout->setContentsMargins(0,0,0,0);
+            setContentsMargins(0,0,0,0);
+
+            adjustSpeed = new QCheckBox(tr("Adjust distance and speed"));
+            layout->addWidget(adjustSpeed);
+            layout->addStretch();
         }
 
         QString explain() {
@@ -44,8 +55,13 @@ class FixGPSConfig : public DataProcessorConfig
                            "or the data that was recorded is invalid.")));
         }
 
-        void readConfig() {}
-        void saveConfig() {}
+        void readConfig() {
+            bool SetSpeed = appsettings->value(NULL, GC_DPGPS_SPEED, Qt::Unchecked).toBool();
+            adjustSpeed->setCheckState(SetSpeed ? Qt::Checked : Qt::Unchecked);
+        }
+        void saveConfig() {
+            appsettings->setValue(GC_DPGPS_SPEED, adjustSpeed->checkState());
+        }
 };
 
 
@@ -79,17 +95,24 @@ static bool fixGPSAdded = DataProcessorFactory::instance().registerProcessor(QSt
 bool
 FixGPS::postProcess(RideFile *ride, DataProcessorConfig *config, QString op)
 {
-    Q_UNUSED(config)
     Q_UNUSED(op)
 
     // ignore null or files without GPS data
     if (!ride || ride->areDataPresent()->lat == false || ride->areDataPresent()->lon == false)
         return false;
 
-    int errors=0;
+    bool setSpeed;
+
+    if (config == NULL) { // beging called automatically
+        setSpeed = appsettings->value(NULL, GC_DPGPS_SPEED, Qt::Unchecked).toBool();
+    }
+    else { // being called manually
+        setSpeed = (bool) ((FixGPSConfig*)(config))->adjustSpeed->checkState();
+    }
 
     ride->command->startLUW("Fix GPS Errors");
 
+    int errors=0;
     int lastgood = -1;  // where did we last have decent GPS data?
     for (int i=0; i<ride->dataPoints().count(); i++) {
         // is this one decent?
@@ -101,10 +124,36 @@ FixGPS::postProcess(RideFile *ride, DataProcessorConfig *config, QString op)
                 // then set last good to here
                 double deltaLat = (ride->dataPoints()[i]->lat - ride->dataPoints()[lastgood]->lat) / double(i-lastgood);
                 double deltaLon = (ride->dataPoints()[i]->lon - ride->dataPoints()[lastgood]->lon) / double(i-lastgood);
+
+                double _dist, _old_dist, _avg_speed;
+
+                if (setSpeed) {
+                    _old_dist = ride->dataPoints()[lastgood]->km - ride->dataPoints()[i]->km;
+                    if (deltaLat == 0.0 && deltaLon == 0.0){
+                        _dist = 0.0;
+                    }
+                    else {
+                        _dist = sin(_deg2rad(ride->dataPoints()[lastgood]->lat)) * sin(_deg2rad(ride->dataPoints()[i]->lat));
+                        _dist += cos(_deg2rad(ride->dataPoints()[lastgood]->lat)) * cos(_deg2rad(ride->dataPoints()[i]->lat)) * cos(_deg2rad(deltaLon));
+                        _dist = acos(_dist) * 6371;
+                    }
+                    _avg_speed = _dist / (ride->dataPoints()[i]->secs - ride->dataPoints()[lastgood]->secs) * 3600;
+                    _dist /= double(i-lastgood);
+                }
+
                 for (int j=lastgood+1; j<i; j++) {
+                    if (setSpeed) {
+                        ride->command->setPointValue(j, RideFile::kph, _avg_speed);
+                        ride->command->setPointValue(j, RideFile::km, ride->dataPoints()[lastgood]->km + (double(j-lastgood)*_dist));
+                    }
                     ride->command->setPointValue(j, RideFile::lat, ride->dataPoints()[lastgood]->lat + (double(j-lastgood)*deltaLat));
                     ride->command->setPointValue(j, RideFile::lon, ride->dataPoints()[lastgood]->lon + (double(j-lastgood)*deltaLon));
                     errors++;
+                }
+                if (setSpeed && errors>0) {
+                    for (int j=i; j<ride->dataPoints().count(); j++) {
+                        ride->command->setPointValue(j, RideFile::km, ride->dataPoints()[j]->km + _dist - _old_dist);
+                    }
                 }
             } else if (lastgood == -1) {
                 // fill to front

--- a/src/FileIO/FixGPS.h
+++ b/src/FileIO/FixGPS.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2008 Sean C. Rhea (srhea@srhea.net)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#define pi 3.14159265358979323846
+
+double _deg2rad(double deg);


### PR DESCRIPTION
I sometimes have odd gps measurements that are causing extreme speed values. By clearing (Ctrl - 0) the Latitude and Longitude for any marked segment I can interpolate new gps coordinates using FixGPS.The speed values are still wrong, but by using the added option in this commit it will updated both speed and distance accordingly. 