### PR TITLE
Fix Strava temperature series import

### DIFF
--- a/src/Cloud/Strava.cpp
+++ b/src/Cloud/Strava.cpp
@@ -437,15 +437,7 @@ Strava::addSamples(RideFile* ret, QString remoteid)
     QString urlstr = QString("https://www.strava.com/api/v3/activities/%1/streams/%2")
           .arg(remoteid).arg(streamsList);
 
-#if QT_VERSION > 0x050000
-    QUrlQuery params;
-#else
-    QUrl params;
-#endif
-
-    params.addQueryItem("series_type", "time");
-
-    QUrl url = QUrl( urlstr + params.toString() );
+    QUrl url = QUrl( urlstr );
     printd("url:%s\n", url.url().toStdString().c_str());
 
     // request using the bearer token


### PR DESCRIPTION
This was mangling the temp series name. With this commit, Strava requests will also include the temp series.

The API docs indicate this parameter only has an effect when also specifying resolution, and in any case it needs to be sent as POST data - not appended to the URL.

See also https://strava.github.io/api/v3/streams/#activity