### PR TITLE
Fixed malformed JSON file due to empty metric overrides

### DIFF
--- a/src/FileIO/JsonRideFile.y
+++ b/src/FileIO/JsonRideFile.y
@@ -479,9 +479,6 @@ JsonFileReader::toByteArray(Context *, const RideFile *ride, bool withAlt, bool 
         QMap<QString,QMap<QString, QString> >::const_iterator k;
         for (k=ride->metricOverrides.constBegin(); k != ride->metricOverrides.constEnd(); k++) {
 
-            // may not contain anything
-            if (k.value().isEmpty()) continue;
-
             if (nonblanks == false) {
                 out += ",\n\t\t\"OVERRIDES\":[\n";
                 nonblanks = true;

--- a/src/Metrics/RideMetadata.cpp
+++ b/src/Metrics/RideMetadata.cpp
@@ -978,25 +978,24 @@ FormField::stateChanged(int state)
     widget->setHidden(state ? false : true);
 
     // remove from overrides if neccessary
-    QMap<QString,QString> override;
-    if (ourRideItem && ourRideItem->ride())
-        override  = ourRideItem->ride()->metricOverrides.value
-                                        (meta->sp.metricSymbol(definition.name));
-
-    // setup initial override value
-    if (state) {
-
-        // clear and reset override value for this metric
-        override.insert("value", QString("%1").arg(0.0)); // add metric value
-        if (isTime) ((QTimeEdit*)widget)->setTime(QTime(0,0,0,0));
-        else ((QDoubleSpinBox *)widget)->setValue(0.0);
-
-    } else if (override.contains("value")) // clear override value
-         override.remove("value");
-
     if (ourRideItem && ourRideItem->ride()) {
-        // update overrides for this metric in the main QMap
-        ourRideItem->ride()->metricOverrides.insert(meta->sp.metricSymbol(definition.name), override);
+
+        if (state) {
+            // setup initial override value
+            QMap<QString,QString> override = ourRideItem->ride()->metricOverrides.value(meta->sp.metricSymbol(definition.name));
+
+            // clear and reset override value for this metric
+            override.insert("value", QString("%1").arg(0.0)); // add metric value
+            // update UI
+            if (isTime) ((QTimeEdit*)widget)->setTime(QTime(0,0,0,0));
+            else ((QDoubleSpinBox *)widget)->setValue(0.0);
+            // update overrides for this metric in the main QMap
+            ourRideItem->ride()->metricOverrides.insert(meta->sp.metricSymbol(definition.name), override);
+
+        } else if (ourRideItem->ride()->metricOverrides.contains(meta->sp.metricSymbol(definition.name))) {
+            // remove existing override for this metric
+            ourRideItem->ride()->metricOverrides.remove(meta->sp.metricSymbol(definition.name));
+        }
 
         // rideFile is now dirty!
         ourRideItem->setDirty(true);


### PR DESCRIPTION
When the user check/uncheck a metric override checkbox
on RideMetadata an empty metric override is generated,
the line removed on JsonRideFile.y produces an extra ","
with errors reported at the forum

https://groups.google.com/d/msg/golden-cheetah-users/CiwAwufvQRA/ACHM0hhxAwAJ and https://groups.google.com/d/msg/golden-cheetah-users/Tpt0cUZBAbA/dQkz4R3EAwAJ

This is the minimum change to fix the issue, alternatively we could avoid the generation of an empty override on JsonRideFile.y  or at the source on RideMetadata.cpp