### PR TITLE
Fixes ZWIFT files which are not reporting local timestamp.

### DIFF
--- a/src/FileIO/RideFile.cpp
+++ b/src/FileIO/RideFile.cpp
@@ -134,6 +134,10 @@ RideFile::~RideFile()
     //!!! if (data) delete data; // need a mechanism to notify the editor
 }
 
+void RideFile::setStartTime(const QDateTime &value) {
+    startTime_ = value;
+}
+
 unsigned int
 RideFile::computeFileCRC(QString filename)
 {
@@ -838,10 +842,13 @@ RideFile *RideFileFactory::openRideFile(Context *context, QFile &file,
         // override the file ride time with that set from the filename
         // but only if it matches the GC format
         QFileInfo fileInfo(file.fileName());
-        QRegExp rx ("^((\\d\\d\\d\\d)_(\\d\\d)_(\\d\\d)_(\\d\\d)_(\\d\\d)_(\\d\\d))\\.(.+)$");
-
+        
+        // Regular expression to match either date format, including a mix of dashes and underscores
+        // yyyy-MM-dd-hh-mm-ss.extension
+        // or yyyy_MM_dd_hh_mm_ss.extension
+        // year is the only one matching for 4 digits, the rest can either be 1 or 2 digits.
+        QRegExp rx ("^((\\d{4})[-_](\\d{1,2})[-_](\\d{1,2})[-_](\\d{1,2})[-_](\\d{1,2})[-_](\\d{1,2}))\\.(.+)$");
         if (rx.exactMatch(fileInfo.fileName())) {
-
             QDate date(rx.cap(2).toInt(), rx.cap(3).toInt(),rx.cap(4).toInt());
             QTime time(rx.cap(5).toInt(), rx.cap(6).toInt(),rx.cap(7).toInt());
             QDateTime datetime(date, time);

--- a/src/FileIO/RideFile.h
+++ b/src/FileIO/RideFile.h
@@ -296,7 +296,8 @@ class RideFile : public QObject // QObject to emit signals
 
         // Working with FIRST CLASS variables
         const QDateTime &startTime() const { return startTime_; }
-        void setStartTime(const QDateTime &value) { startTime_ = value; }
+        void setStartTime(const QDateTime &value);
+    
         double recIntSecs() const { return recIntSecs_; }
         void setRecIntSecs(double value) { recIntSecs_ = value; }
         const QString &deviceType() const { return deviceType_; }

--- a/src/Gui/RideImportWizard.cpp
+++ b/src/Gui/RideImportWizard.cpp
@@ -603,7 +603,7 @@ RideImportWizard::process()
                    }
 
                    // Set Date and Time
-                   if (ride->startTime().isNull()) {
+                   if (!ride->startTime().isValid()) {
 
                        // Poo. The user needs to supply the date/time for this ride
                        blanks[i] = true;


### PR DESCRIPTION
Secondary fix for regular expression which did not catch the ZWIFT file naming convention using dashes rather than underscores.

Initial Bug report:
https://groups.google.com/forum/#!topic/golden-cheetah-users/9JXU9Z5vMrE
Tracked as:
https://github.com/GoldenCheetah/GoldenCheetah/issues/2669
