### PR TITLE
Handle gaps in estimate data in LTMPlot #2534

### DIFF
--- a/src/Charts/LTMPlot.cpp
+++ b/src/Charts/LTMPlot.cpp
@@ -45,6 +45,7 @@
 #include <qwt_legend.h>
 #include <qwt_legend_label.h>
 #include <qwt_plot_curve.h>
+#include <qwt_plot_gapped_curve.h>
 #include <qwt_plot_canvas.h>
 #include <qwt_curve_fitter.h>
 #include <qwt_plot_grid.h>
@@ -437,7 +438,9 @@ LTMPlot::setData(LTMSettings *set)
         if (count <= 0) continue;
 
         // Create a curve
-        QwtPlotCurve *current = new QwtPlotCurve(metricDetail.uname);
+        QwtPlotCurve *current = metricDetail.type == METRIC_ESTIMATE
+                ? new QwtPlotGappedCurve(metricDetail.uname, 1)
+                : new QwtPlotCurve(metricDetail.uname);
         current->setVisible(!metricDetail.hidden);
         settings->metrics[m].curve = current;
         if (metricDetail.type == METRIC_BEST || metricDetail.type == METRIC_STRESS)
@@ -589,7 +592,9 @@ LTMPlot::setData(LTMSettings *set)
         //qDebug()<<"Create curve data.."<<timer.elapsed();
 
         // Create a curve
-        QwtPlotCurve *current = new QwtPlotCurve(metricDetail.uname);
+        QwtPlotCurve *current = metricDetail.type == METRIC_ESTIMATE
+                ? new QwtPlotGappedCurve(metricDetail.uname, 1)
+                : new QwtPlotCurve(metricDetail.uname);
         current->setVisible(!metricDetail.hidden);
         settings->metrics[m].curve = current;
         if (metricDetail.type == METRIC_BEST || metricDetail.type == METRIC_STRESS)

--- a/src/Charts/LTMPlot.cpp
+++ b/src/Charts/LTMPlot.cpp
@@ -53,6 +53,8 @@
 
 #include <cmath> // for isinf() isnan()
 
+//#include <QDebug>
+
 LTMPlot::LTMPlot(LTMWindow *parent, Context *context, bool first) : 
     bg(NULL), parent(parent), context(context), highlighter(NULL), first(first), isolation(false)
 {
@@ -3058,6 +3060,11 @@ LTMPlot::createEstimateData(Context *context, LTMSettings *settings, MetricDetai
         // skip if no in our time period
         if (est.to < settings->start.date() || est.from > settings->end.date()) continue;
 
+//        for (int i = est.from.toJulianDay(); i <= est.to.toJulianDay(); i++) {
+//            QDate d = QDate::fromJulianDay(i);
+//            qDebug() << d.toString("dd.MM.yyyy") << "\t" << est.PMax;
+//        }
+
         // get dat for first and last
         QDate from = est.from < settings->start.date() ? settings->start.date() : est.from;
         QDate to = est.to > settings->end.date() ? settings->end.date() : est.to;
@@ -3068,6 +3075,20 @@ LTMPlot::createEstimateData(Context *context, LTMSettings *settings, MetricDetai
         for (int i = 0; i < timeforward && n <= maxdays; i++) {
             // the following works for non-aggregates as well
             flushAggregateEstimateData(x, y, xCount, yTotal, n);
+
+//            int prevN = n - 1;
+//            QDate d;
+//            if (settings->groupBy == LTM_MONTH) {
+//                d = settings->start.addMonths(prevN).date();
+//            } else if (settings->groupBy == LTM_YEAR) {
+//                d = settings->start.addYears(prevN).date();
+//            } else if (settings->groupBy == LTM_WEEK) {
+//                d = settings->start.addDays(prevN * 7).date();
+//            } else if (settings->groupBy == LTM_DAY) {
+//                d = settings->start.addDays(prevN).date();
+//            }
+
+//            qDebug() << d.toString("dd.MM.yyyy") << "\t" << prevN << "\t" << x[prevN] << "\t" << y[prevN];
         }
 
         // save this estimate's end date (for gap fill up)
@@ -3161,6 +3182,16 @@ LTMPlot::createEstimateData(Context *context, LTMSettings *settings, MetricDetai
                  // data of next period of estimates is available,
                  // so calculate the current period and switch forward to next
                  flushAggregateEstimateData(x, y, xCount, yTotal, n);
+
+//                 int prevN = n - 1;
+//                 QDate d;
+//                 if (settings->groupBy == LTM_MONTH) {
+//                     d = settings->start.addMonths(prevN).date();
+//                 } else if (settings->groupBy == LTM_YEAR) {
+//                     d = settings->start.addYears(prevN).date();
+//                 }
+
+//                 qDebug() << d.toString("dd.MM.yyyy") << "\t" << prevN << "\t" << x[prevN] << "\t" << y[prevN];
              };
              // store for calculation
              yTotal[n] += value;
@@ -3176,6 +3207,11 @@ LTMPlot::createEstimateData(Context *context, LTMSettings *settings, MetricDetai
                 x[n] = n;
                 y[n] = value;
                 n++;
+
+//                int prevN = n - 1;
+//                QDate d = settings->start.addDays(prevN).date();
+//                qDebug() << d.toString("dd.MM.yyyy") << "\t" << prevN << "\t" << x[prevN] << "\t" << y[prevN];
+
                 int currentDay = groupForDate(from, settings->groupBy);
                 int nextDay = groupForDate(to, settings->groupBy);
                 while (n <= maxdays && nextDay > currentDay) { // i.e. not the same day
@@ -3183,6 +3219,10 @@ LTMPlot::createEstimateData(Context *context, LTMSettings *settings, MetricDetai
                     y[n] = value;
                     n++;
                     currentDay++;
+
+//                    int prevN = n - 1;
+//                    QDate d = settings->start.addDays(prevN).date();
+//                    qDebug() << d.toString("dd.MM.yyyy") << "\t" << prevN << "\t" << x[prevN] << "\t" << y[prevN];
                 }
             }
             break;
@@ -3196,6 +3236,10 @@ LTMPlot::createEstimateData(Context *context, LTMSettings *settings, MetricDetai
                 x[n] = n;
                 y[n] = value;
                 n++;
+
+//                int prevN = n - 1;
+//                QDate d = settings->start.addDays(prevN * 7).date();
+//                qDebug() << d.toString("dd.MM.yyyy") << "\t" << prevN << "\t" << x[prevN] << "\t" << y[prevN];
             }
             break;
         }
@@ -3210,6 +3254,16 @@ LTMPlot::createEstimateData(Context *context, LTMSettings *settings, MetricDetai
         case LTM_YEAR:
         case LTM_ALL:
             flushAggregateEstimateData(x, y, xCount, yTotal, n);
+
+//            int prevN = n - 1;
+//            QDate d;
+//            if (settings->groupBy == LTM_MONTH) {
+//                d = settings->start.addMonths(prevN).date();
+//            } else if (settings->groupBy == LTM_YEAR) {
+//                d = settings->start.addYears(prevN).date();
+//            }
+
+//            qDebug() << d.toString("dd.MM.yyyy") << "\t" << prevN << "\t" << x[prevN] << "\t" << y[prevN];
         }
     }
     // always seems to be one too many ...

--- a/src/Charts/LTMPlot.h
+++ b/src/Charts/LTMPlot.h
@@ -121,6 +121,8 @@ class LTMPlot : public QwtPlot
 
         // create curve data from estimate
         void createEstimateData(Context *,LTMSettings *, MetricDetail, QVector<double>&, QVector<double>&, int&, bool=false);
+        void flushAggregateEstimateData(QVector<double> &x, QVector<double> &y,
+                                        QVector<double> &xCount, QVector<double> &yTotal, int &n);
 
         // create curve data from metadata or metric (from ridecache)
         void createMetricData(Context *,LTMSettings *, MetricDetail, QVector<double>&, QVector<double>&, int&, bool=false);


### PR DESCRIPTION
This PR makes the plotting of model estimate data more robust against gaps in the estimate data. Normally estimate data (CP, W' Prime, ...) is stored sequentially without gaps (each point in time from a defined start to a defined end date has a model estimate). However, if this is for some reason (bug?) not the case, LTMPlot.cpp would still plot the data without leaving the proper gap (See #2534). This PR inserts 0s in LTMPlot for time spans without estimate data.