### PR TITLE
QwtPlotGappedCurve: Don't draw a steep line after a gap

### DIFF
--- a/qtsolutions/qwtcurve/qwt_plot_gapped_curve.h
+++ b/qtsolutions/qwtcurve/qwt_plot_gapped_curve.h
@@ -29,6 +29,9 @@ public:
     virtual void drawSeries(QPainter *painter, const QwtScaleMap &xMap,
                                                 const QwtScaleMap &yMap, const QRectF &canvRect, int from, int to) const;
 
+    virtual void drawLines(QPainter *p, const QwtScaleMap &xMap, const QwtScaleMap &yMap,
+                           const QRectF &canvasRect, int from, int to ) const;
+
     void setNAValue(double x) { naValue_=x; }
 
 private:


### PR DESCRIPTION
This PR addresses 2 issues with QwtPlotGappedCurve:

1. Leading steep lines after gap:
QwtPlotGappedCurve draws a steep line after each gap that connects the last point of the gap with the first point of the next segment. This line is now excluded from the plot.
![steep_lines_compare](https://user-images.githubusercontent.com/759436/32481122-483d62ba-c392-11e7-8d0f-83671b6bc9a0.png)

2. QwtPlotGappedCurve constructs the plot by drawing 2 consecutive points each iteration, which results in a not-so-smooth line being drawn. This PR changes the behavior, so that the whole segment between two gaps is drawn in one go. This presumably has also performance benefits, because the underlying `drawSeries` method is not invoked each iteration, but only when a segment is complete. Here is a comparison of the line smoothness between old and new code:
![smooth_line_compare](https://user-images.githubusercontent.com/759436/32414437-04a53c92-c227-11e7-9aee-49fccce0df17.png)

Additional notes:
QwtPlotGappedCurve is used in LTMPlot.cpp and AllPlot.cpp. The fix improves the appearance of LTMPlot, but doesn't have much of an impact on AllPlot:
![qwtplotgappedcurvecompare](https://user-images.githubusercontent.com/759436/32288745-2e78b25a-bf35-11e7-8888-cc810615c3f8.png)
