### PR TITLE
QwtPlotGappedCurve: Include the last point in the plot

### DIFF
--- a/qtsolutions/qwtcurve/qwt_plot_gapped_curve.cpp
+++ b/qtsolutions/qwtcurve/qwt_plot_gapped_curve.cpp
@@ -29,7 +29,7 @@ void QwtPlotGappedCurve::drawSeries(QPainter *painter, const QwtScaleMap &xMap,
         return;
 
     if (to < 0)
-        to = dataSize() - 1;
+        to = dataSize();
 
     int i = from;
     double last = 0;


### PR DESCRIPTION
The last line in QwtPlotGappedCurve is omitted, which leaves the graph unfinished as can be seen in this graph of PMax (CP History):
![screenshot from 2017-10-31 11-34-46](https://user-images.githubusercontent.com/759436/32480840-f40d06b0-c390-11e7-80e0-c0174db69708.png)

Extending the upper bound to include all data points fixes this.
QwtPlotGappedCurve is also used for the power plot in AllPlot. However, the effect on AllPlot is minimal (if not even beneficial):
![lastptinclcompare](https://user-images.githubusercontent.com/759436/32291332-02596bb2-bf3d-11e7-97e8-bac8f4046d1e.png)
