### PR TITLE
Move cursor in PythonChart to correct start point

### DIFF
--- a/src/Charts/PythonChart.cpp
+++ b/src/Charts/PythonChart.cpp
@@ -121,7 +121,15 @@ void PythonConsole::keyPressEvent(QKeyEvent *e)
     // you can only delete or move left from past first character
     case Qt::Key_Left:
     case Qt::Key_Backspace:
-        if (textCursor().position() - textCursor().block().position() > 4) QTextEdit::keyPressEvent(e);
+        if (textCursor().positionInBlock() > promptStartIndex) QTextEdit::keyPressEvent(e);
+        break;
+
+    case Qt::Key_Home:
+        {
+            QTextCursor moveHome = textCursor();
+            moveHome.setPosition(textCursor().block().position() + promptStartIndex, QTextCursor::MoveAnchor);
+            setTextCursor(moveHome);
+        }
         break;
 
     case Qt::Key_Escape: // R typically uses ESC to cancel
@@ -162,7 +170,7 @@ void PythonConsole::keyPressEvent(QKeyEvent *e)
         setTextCursor(move);
 
         QString line = currentLine();
-        if (line.length() > 4) line = line.mid(4, line.length()-4);
+        if (line.length() > promptStartIndex) line = line.mid(promptStartIndex, line.length() - promptStartIndex);
         else line = "";
 
         putData("\n");

--- a/src/Charts/PythonChart.h
+++ b/src/Charts/PythonChart.h
@@ -75,6 +75,7 @@ private:
     Context *context;
     bool localEchoEnabled;
     PythonChart *parent;
+    int promptStartIndex = 4;
 };
 
 // the chart


### PR DESCRIPTION
Again one small layout fix. Home key press jumped to line start.

And I used http://doc.qt.io/qt-5/qtextcursor.html#positionInBlock