### PR TITLE
OSM - Tile Server Handling Changed

### DIFF
--- a/src/Charts/RideMapWindow.h
+++ b/src/Charts/RideMapWindow.h
@@ -127,8 +127,6 @@ class RideMapWindow : public GcChartWindow
     Q_PROPERTY(bool showintervals READ showIntervals WRITE setShowIntervals USER true)
     Q_PROPERTY(int osmts READ osmTS WRITE setOsmTS USER true)
     Q_PROPERTY(QString styleoptions READ getStyleOptions WRITE setStyleOptions  USER false)
-    Q_PROPERTY(QString osmtsurl READ osmTSUrl WRITE setOsmTSUrl USER true)
-
 
     public:
         typedef enum {
@@ -160,12 +158,8 @@ class RideMapWindow : public GcChartWindow
 
         int osmTS() const { return ( tileCombo->itemData(tileCombo->currentIndex()).toInt()); }
         void setOsmTS(int x) {
-            tileCombo->setCurrentIndex(tileCombo->findData(x)); /*setTileServerUrlForTileType(x);*/
-        }
-
-        QString osmTSUrl() const { return osmCustomTSUrl->text(); }
-        void setOsmTSUrl(QString x) {
-            osmCustomTSUrl->setText(x);
+            tileCombo->setCurrentIndex(tileCombo->findData(x));
+            setTileServerUrlForTileType(x);
         }
 
         QString getStyleOptions() const { return styleoptions; }
@@ -178,7 +172,6 @@ class RideMapWindow : public GcChartWindow
         void showFullPlotChanged(int value);
         void showIntervalsChanged(int value);
         void osmCustomTSURLEditingFinished();
-        void osmCustomTSURLTextChanged(QString text);
 
 
         void forceReplot();
@@ -198,8 +191,8 @@ class RideMapWindow : public GcChartWindow
 
         QComboBox *mapCombo, *tileCombo;
         QCheckBox *showMarkersCk, *showFullPlotCk, *showInt;
-        QLabel *osmCustomTSTitle, *osmCustomTSLabel, *osmCustomTSUrlLabel;
-        QLineEdit *osmCustomTSUrl;
+        QLabel *osmTSTitle, *osmTSLabel, *osmTSUrlLabel;
+        QLineEdit *osmTSUrl;
 
         Context *context;
         QVBoxLayout *layout;

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -270,6 +270,13 @@
 // Default view on Diary
 #define GC_DIARY_VIEW                   "<athlete-preferences>diaryview"
 
+// OSM Tileserver
+#define GC_OSM_TS_DEFAULT               "<athlete-preferences>osmts/default"
+#define GC_OSM_TS_A                     "<athlete-preferences>osmts/a"
+#define GC_OSM_TS_B                     "<athlete-preferences>osmts/b"
+#define GC_OSM_TS_C                     "<athlete-preferences>osmts/c"
+
+
 #define GC_RWGPSUSER                    "<athlete-private>rwgps/user"
 #define GC_RWGPSPASS                    "<athlete-private>rwgps/pass"
 #define GC_TTBUSER                      "<athlete-private>ttb/user"


### PR DESCRIPTION
... all Tile Servers are configurable by the user - there is only a default for the "standard" OSM Tile Server, but even this default can be overwritten
... there are no dedicated Tile Servers Sources named / hard-coded, but in addition to the default OSM server 3 additional options are available for the user to configure

Why:
... tile servers either change their URL or their T&C - which happened for some of the "hard-coded" once recently - since this may happen again in future the recent change de-couples the code from the Tile Server URL - and the availability of certain organisations providing free tile servers