### PR TITLE
Remove unnecessary linking against libvlccore

### DIFF
--- a/src/gcconfig.pri.in
+++ b/src/gcconfig.pri.in
@@ -211,9 +211,9 @@
 # This will automatically set (Windows and Unix):
 # VLC_INCLUDE = $${VLC_INSTALL}/include 
 # For Windows
-# VLC_LIBS    = $${VLC_INSTALL}/lib/libvlc.dll.a $${VLC_INSTALL}/lib/libvlccore.dll.a
+# VLC_LIBS    = $${VLC_INSTALL}/lib/libvlc.dll.a
 # For Unix
-# VLC_LIBS    = -lvlc -lvlccore
+# VLC_LIBS    = -lvlc
 # You may override the INCLUDE and LIB files if you like.
 # You *must* define VLC_INSTALL to use this feature.
 #VLC_INSTALL = 

--- a/src/src.pro
+++ b/src/src.pro
@@ -537,7 +537,7 @@ unix:!macx {
 
         # we will work out the rest if you tell use where it is installed
         isEmpty(VLC_INCLUDE) { VLC_INCLUDE = $${VLC_INSTALL}/include }
-        isEmpty(VLC_LIBS)    { VLC_LIBS    = -L$${VLC_INSTALL}/lib -lvlc -lvlccore }
+        isEmpty(VLC_LIBS)    { VLC_LIBS    = -L$${VLC_INSTALL}/lib -lvlc }
 
         DEFINES     += GC_HAVE_VLC
         INCLUDEPATH += $${VLC_INCLUDE}


### PR DESCRIPTION
libvlccore is for plugins, but GoldenCheetah does not build a plugin. It
requires only functions available from libvlc.

Signed-off-by: Sebastian Ramacher <sramacher@debian.org>