### PR TITLE
2nd version with option to choose: logarithmic/linear scale for speed chart, like CS #2647

### DIFF
--- a/src/Charts/CPPlot.h
+++ b/src/Charts/CPPlot.h
@@ -80,6 +80,7 @@ class CPPlot : public QwtPlot
         void setSport(bool run, bool swim) { isRun = run; isSwim = swim; }
         void setSeries(CriticalPowerWindow::CriticalSeriesType);
         void setPlotType(int index);
+        void showXAxisLinear(bool x);
         void setModel(int sanI1, int sanI2, int anI1, int anI2,
                       int aeI1, int aeI2, int laeI1, int laeI2, int model, int variant);
 
@@ -173,6 +174,7 @@ class CPPlot : public QwtPlot
         bool showDeltaPercent; // only in compare mode
         double shadingCP; // the CP value we use to draw the shade
         int plotType;
+        bool xAxisLinearOnSpeed;
 
         // Curves
         QList<QwtPlotCurve*> bestsCurves;

--- a/src/Charts/CriticalPowerWindow.cpp
+++ b/src/Charts/CriticalPowerWindow.cpp
@@ -244,6 +244,11 @@ CriticalPowerWindow::CriticalPowerWindow(Context *context, bool rangemode) :
     QLabel *shadies = new QLabel(tr("Shade Intervals"));
     cl->addRow(shadies, shadeIntervalsCheck);
 
+    showCSLinearCheck = new QCheckBox(this);
+    showCSLinearCheck->setChecked(true); // default on
+    showCSLinearLabel = new QLabel(tr("Show time scale linear"));
+    cl->addRow(showCSLinearLabel, showCSLinearCheck);
+
     ridePlotStyleCombo = new QComboBox(this);
     ridePlotStyleCombo->addItem(tr("Activity Mean Max"));
     ridePlotStyleCombo->addItem(tr("Activity Centile"));
@@ -519,6 +524,7 @@ CriticalPowerWindow::CriticalPowerWindow(Context *context, bool rangemode) :
     connect(shadeIntervalsCheck, SIGNAL(stateChanged(int)), this, SLOT(shadeIntervalsChanged(int)));
     connect(showEffortCheck, SIGNAL(stateChanged(int)), this, SLOT(showEffortChanged(int)));
     connect(showHeatCheck, SIGNAL(stateChanged(int)), this, SLOT(showHeatChanged(int)));
+    connect(showCSLinearCheck, SIGNAL(stateChanged(int)), this, SLOT(showCSLinearChanged(int)));
     connect(rHeat, SIGNAL(stateChanged(int)), this, SLOT(rHeatChanged(int)));
     connect(rDelta, SIGNAL(stateChanged(int)), this, SLOT(rDeltaChanged()));
     connect(rDeltaPercent, SIGNAL(stateChanged(int)), this, SLOT(rDeltaChanged()));
@@ -838,8 +844,7 @@ CriticalPowerWindow::modelParametersChanged()
     // need a helper any more ?
     if (seriesCombo->currentIndex() >= 0) {
         CriticalSeriesType series = static_cast<CriticalSeriesType>(seriesCombo->itemData(seriesCombo->currentIndex()).toInt());
-        if ((series == watts || series == wattsKg || series == kph) && modelCombo->currentIndex() >= 1) helperWidget()->show();
-        else helperWidget()->hide();
+        updateOptions(series);
     }
 
     // tell the plot
@@ -901,8 +906,7 @@ CriticalPowerWindow::forceReplot()
 
         // show helper if we're showing power
         CriticalSeriesType series = static_cast<CriticalSeriesType>(seriesCombo->itemData(seriesCombo->currentIndex()).toInt());
-        if ((series == watts || series == wattsKg || series == kph) && modelCombo->currentIndex() >= 1) helperWidget()->show();
-        else helperWidget()->hide();
+        updateOptions(series);
 
         // these are allowed outside of compare mode
         rPercent->show();
@@ -1285,8 +1289,7 @@ CriticalPowerWindow::setSeries(int index)
             CPLabel->hide();
         }
 
-        if ((series == watts || series == wattsKg || series == kph) && modelCombo->currentIndex() >= 1) helperWidget()->show();
-        else helperWidget()->hide();
+        updateOptions(series);
 
         if (rangemode) {
 
@@ -1538,6 +1541,25 @@ CriticalPowerWindow::addSeries()
     }
 }
 
+void
+CriticalPowerWindow::updateOptions(CriticalSeriesType series)
+{
+    if ((series == watts || series == wattsKg || series == kph) && modelCombo->currentIndex() >= 1) {
+        helperWidget()->show();
+    } else {
+        helperWidget()->hide();
+    }
+
+    if (series == kph) {
+        // speed series have option to display x-axis linear or log, others are defined fix in CPPlot::setSeries()
+        showCSLinearCheck->show();
+        showCSLinearLabel->show();
+    } else {
+        showCSLinearCheck->hide();
+        showCSLinearLabel->hide();
+    }
+}
+
 /*----------------------------------------------------------------------
  * Seasons stuff
  *--------------------------------------------------------------------*/
@@ -1755,6 +1777,12 @@ CriticalPowerWindow::showHeatChanged(int state)
     // redraw
     if (rangemode) dateRangeChanged(DateRange());
     else cpPlot->setRide(currentRide);
+}
+
+void
+CriticalPowerWindow::showCSLinearChanged(int state)
+{
+    cpPlot->showXAxisLinear(state);
 }
 
 void 

--- a/src/Charts/CriticalPowerWindow.h
+++ b/src/Charts/CriticalPowerWindow.h
@@ -78,6 +78,7 @@ class CriticalPowerWindow : public GcChartWindow
     Q_PROPERTY(bool showEffort READ showEffort WRITE setShowEffort USER true)
     Q_PROPERTY(bool showHeat READ showHeat WRITE setShowHeat USER true)
     Q_PROPERTY(bool showHeatByDate READ showHeatByDate WRITE setShowHeatByDate USER true)
+    Q_PROPERTY(bool showCSLinear READ showCSLinear WRITE setShowCSLinear USER true)
     Q_PROPERTY(int shadeIntervals READ shadeIntervals WRITE setShadeIntervals USER true)
     Q_PROPERTY(int ridePlotMode READ ridePlotMode WRITE setRidePlotMode USER true)
     Q_PROPERTY(int useSelected READ useSelected WRITE setUseSelected USER true) // !! must be last property !!
@@ -194,6 +195,9 @@ class CriticalPowerWindow : public GcChartWindow
         bool showHeatByDate() { return showHeatByDateCheck->isChecked(); }
         void setShowHeatByDate(bool x) { return showHeatByDateCheck->setChecked(x); }
 
+        bool showCSLinear() { return showCSLinearCheck->isChecked(); }
+        void setShowCSLinear(bool x) { return showCSLinearCheck->setChecked(x); }
+
         bool showGrid() { return showGridCheck->isChecked(); }
         void setShowGrid(bool x) { return showGridCheck->setChecked(x); }
 
@@ -218,6 +222,7 @@ class CriticalPowerWindow : public GcChartWindow
         void shadingSelected(int shading);
         void showEffortChanged(int check);
         void showHeatChanged(int check);
+        void showCSLinearChanged(int state);
         void showHeatByDateChanged(int check);
         void showPercentChanged(int check);
         void showBestChanged(int check);
@@ -288,6 +293,8 @@ class CriticalPowerWindow : public GcChartWindow
         QCheckBox *filterBestCheck;
         QCheckBox *showGridCheck;
         QCheckBox *rPercent, *rHeat, *rDelta, *rDeltaPercent;
+        QCheckBox *showCSLinearCheck;
+        QLabel *showCSLinearLabel;
         QwtPlotPicker *picker;
         QwtPlotGrid *grid;
 
@@ -306,6 +313,7 @@ class CriticalPowerWindow : public GcChartWindow
         QLabel *eiTitle, *eiValue;
 
         void addSeries();
+        void updateOptions(CriticalSeriesType series);
         Seasons *seasons;
         QList<Season> seasonsList;
         RideItem *currentRide;


### PR DESCRIPTION
Added options in to configure "linear" or "logarithmic" scale of the critical speed chart.
According amtriathlon:
"I stand my original position but, if you make the scale log/linear an option for the user, I will be glad to apply the change." see #2647

It was mainly straight forward, after I got used to Qt again.

The minor change for compiling on Ubuntu 16.04 with gcc-5.4.0 or older comes as well, its the c++11 in src.pro