### PR TITLE
LTMTool: Set symbol for measure metrics

### DIFF
--- a/src/Charts/LTMTool.cpp
+++ b/src/Charts/LTMTool.cpp
@@ -2297,6 +2297,7 @@ EditMetricDetailDialog::measureName()
         .arg(context->athlete->measures->getFieldNames(measureGroup).value(measureField));
     userName->setText(desc);
     userUnits->setText(context->athlete->measures->getFieldUnits(measureGroup, measureField));
+    metricDetail->symbol = desc.replace(" ", "_");
 }
 
 void


### PR DESCRIPTION
When adding measures to an LTMPlot with other metrics, those measures
are not cleaned up properly on replot, because they don't have a symbol.
LTMPlot uses the symbol to store them in a 'curves' dictionary. All
metrics without a symbol are then identified by the default metric
symbol value, which is: "".