### PR TITLE
Update tap for lmfit on Homebrew due to deprecation of homebrew/science

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_install:
 - brew install libsamplerate
 - brew tap homebrew/science
 - brew install r
+- brew tap brewsci/science
 - brew install lmfit
 ## Disable KML for now
 ##- brew install --HEAD travis/libkml.rb


### PR DESCRIPTION
Clean pull request on cherry picked branch. Should be used in preference to #2757 which was incorrectly created from my fork master.