### PR TITLE
Adding file type selection when saving workout (#2767)

### DIFF
--- a/src/Train/WorkoutWindow.cpp
+++ b/src/Train/WorkoutWindow.cpp
@@ -433,7 +433,7 @@ WorkoutWindow::saveAs()
 {
     QString filename = QFileDialog::getSaveFileName(this, tr("Save Workout File"),
                                                     appsettings->value(this, GC_WORKOUTDIR, "").toString(),
-                                                    "New Workout.erg (*.erg)");
+                                                    "ERG workout (*.erg);;Zwift workout (*.zwo)")");
 
     // if they didn't select, give up.
     if (filename.isEmpty()) {


### PR DESCRIPTION
Ensure the correct file extension is appended during workout save. Adds a drop down to select file type as shown below - the selected extension is appended to the filename entered by user if necessary by Qt/system inbuilt functionality.

![screen shot 2018-01-29 at 08 41 26](https://user-images.githubusercontent.com/804578/35501946-5b36dbb2-04d3-11e8-905d-23972a23d995.png)
