### PR TITLE
update qt to 5.10.0 for AppVeyor builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
 - brew install libusb libusb-compat
 - brew install srmio
 - brew install libsamplerate
-- brew tap homebrew/science
+- brew tap brewsci/science
 - brew install r
 - brew install lmfit
 ## Disable KML for now

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,9 @@ version: ci.{build}
 image: Visual Studio 2015
 clone_depth: 1
 init:
-# Setup QT 5.9.2 - 64Bit
+# Setup QT 5.10.0 - 64Bit
 
-- set QTDIR=C:\Qt\5.9.2\msvc2015_64
+- set QTDIR=C:\Qt\5.10.0\msvc2015_64
 - set PATH=%QTDIR%\bin;%PATH%
 
 # Setup MSVC - VS 2015


### PR DESCRIPTION
Referenced Qt 5.9.2 is no longer available, that's why builds are failing:
https://www.appveyor.com/docs/build-environment/#qt  
