### PR TITLE
Bugfix: GC crashes on DB update, fixed if paceZoneRange < 0

### DIFF
--- a/src/Metrics/DanielsPoints.cpp
+++ b/src/Metrics/DanielsPoints.cpp
@@ -175,11 +175,11 @@ private:
         double lastSecs = 0.0;
         double weighted = 0.0;
 
-	if (item->context->athlete->zones(item->isRun) == NULL || item->zoneRange < 0) {
+        if (item->context->athlete->zones(item->isRun) == NULL || item->zoneRange < 0) {
             setValue(RideFile::NIL);
             setCount(0);
             return;
-	}
+        }
         double cp = item->context->athlete->zones(item->isRun)->getCP(item->zoneRange);
 
         score = 0.0;
@@ -218,11 +218,11 @@ private:
         double weighted = 0.0;
         double recIntSecs = item->ride()->recIntSecs();
 
-	if (item->context->athlete->zones(item->isRun) == NULL || item->zoneRange < 0) {
+        if (item->context->athlete->zones(item->isRun) == NULL || item->paceZoneRange < 0) {
             setValue(RideFile::NIL);
             setCount(0);
             return;
-	}
+        }
         double cs = item->context->athlete->paceZones(item->isSwim)->getCV(item->paceZoneRange);
 
         score = 0.0;


### PR DESCRIPTION
In my previous commit, https://github.com/GoldenCheetah/GoldenCheetah/commit/0d94e0200ef7764e2233af5b2358b3700962d88b there was an error, checked "zoneRange" instead of "paceZoneRange". This causes a segmentation fault during DB update (no pace zone defined before certain date)