### PR TITLE
Allow slope up to 40% instead of only 20% and remove rounding effect from smoothing

### DIFF
--- a/src/FileIO/RideFile.cpp
+++ b/src/FileIO/RideFile.cpp
@@ -2493,7 +2493,7 @@ RideFile::recalculateDerivedSeries(bool force)
                 } else {
                     p->slope = 0;
                 }
-                if (p->slope > 20 || p->slope < -20) {
+                if (p->slope > 40 || p->slope < -40) {
                     p->slope = lastP->slope;
                 }
             }
@@ -2631,6 +2631,10 @@ RideFile::recalculateDerivedSeries(bool force)
         for (int i=dataPoints_.count()-1; i>=smoothPoints; i--) {
             double here = dataPoints_[i]->slope;
             dataPoints_[i]->slope = rtot / smoothPoints;
+            // remove rounding effect 0.01% is flat ;)
+            if (dataPoints_[i]->slope < 0.01f && dataPoints_[i]->slope > -0.01f) {
+                dataPoints_[i]->slope = 0;
+            }
             rtot -= here;
             rtot += dataPoints_[i-smoothPoints]->slope;
         }


### PR DESCRIPTION
I figured out, that the slope value is limited to 20% 
But there are a couple of paved roads which are steeper :) And and the strave GAP curve goes up to 34% with the interpolation function in DanielsPoints calculation we have reasonable values up to 40%.

An other issue I saw: 
after smoothing the slope value, there are rounding effects like 1e-12 instead of 0, which causes the function running_grade_adjusted() to calculate instead of returning 0.
See for e.g. 8.881779999999 e-17
![slope_closeto_zero](https://user-images.githubusercontent.com/3055774/36115180-9cd9f620-1032-11e8-8e95-a0f989f0910a.png)
