### PR TITLE
FilterHRV: Recalculate rest HR based on filtered AVNN. Fixes #2797

### DIFF
--- a/src/FileIO/FilterHRV.cpp
+++ b/src/FileIO/FilterHRV.cpp
@@ -283,10 +283,12 @@ FilterHrvOutliers::postProcess(RideFile *ride, DataProcessorConfig *config=0, QS
         if (setRestHrv) {
             RideItem *rideItem = ride->context->rideItem();
 
+            double avnn = rideItem->getForSymbol("AVNN");
+
             HrvMeasure hrvMeasure;
             hrvMeasure.when = rideItem->dateTime;
-            hrvMeasure.hr = rideItem->getForSymbol("average_hr");
-            hrvMeasure.avnn = rideItem->getForSymbol("AVNN");
+            hrvMeasure.hr = !qFuzzyIsNull(avnn) ? 60000 / avnn : 0;
+            hrvMeasure.avnn = avnn;
             hrvMeasure.sdnn = rideItem->getForSymbol("SDNN");
             hrvMeasure.rmssd = rideItem->getForSymbol("rMSSD");
             hrvMeasure.pnn50 = rideItem->getForSymbol("pNN50");


### PR DESCRIPTION
This PR changes the behavior of the R-R HRV filter tool. Previously the rest HR was calculated from the "average_hr" metric of the data series imported. This metric was not subjected to the filter of the R-R HRV filter tool and thus yielded skewed rest HR values because of the relatively short time spans of HRV measurements. This PR changes the behavior so that HR is derived from AVNN which is calculated based on filtered R-R values only.
Also an option has been added to correct HR values of past measurements.