### PR TITLE
Settings: Allow using different global conf file name

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -28,7 +28,9 @@
  */
 
 #define GC_SETTINGS_CO                        "goldencheetah.org"
+#ifndef GC_SETTINGS_APP
 #define GC_SETTINGS_APP                       "GoldenCheetah"
+#endif
 #define GC_SETTINGS_BESTS_METRICS_DEFAULT "5s_critical_power,1m_critical_power,5m_critical_power,20m_critical_power,60m_critical_power,3m_critical_pace,20m_critical_pace,3m_critical_pace_swim,20m_critical_pace_swim"
 #define GC_SETTINGS_SUMMARY_METRICS_DEFAULT "triscore,skiba_xpower,skiba_relative_intensity,xPace,swimscore_xpace,trimp_points,aerobic_decoupling"
 #define GC_SETTINGS_INTERVAL_METRICS_DEFAULT "workout_time,total_distance,total_work,average_power,average_hr,average_cad,average_speed,pace,pace_swim,distance_swim"

--- a/src/gcconfig.pri.in
+++ b/src/gcconfig.pri.in
@@ -46,6 +46,10 @@
 #RCC_DIR = ./.rcc
 #UI_DIR = ./.ui
 
+# Global conf file name: If you'd like to use a different global config file
+# name than the default (e.g. for testing purposes), set it here.
+#DEFINES += GC_SETTINGS_APP=\\\"GoldenCheetahTest\\\"
+
 # If you want a console window to appear on Windows machines
 # then uncomment the following two lines.
 #CONFIG += console


### PR DESCRIPTION
This enables setting a different global conf file name for testing purposes. The default (./config/goldencheetah.org/GoldenCheetah.ini) might be used for "production" instance of GC. Using a different .ini file allows testing without compromising the "production" settings and data.