### PR TITLE
LTMSidebar: Load most recently selected phase on GC start

### DIFF
--- a/src/Gui/LTMSidebar.cpp
+++ b/src/Gui/LTMSidebar.cpp
@@ -447,6 +447,7 @@ LTMSidebar::resetSeasons()
             Phase phase = season.phases.at(j);
             QTreeWidgetItem *addPhase = new QTreeWidgetItem(addSeason, phase.getType());
             if (phase.id().toString() == id) {
+                addSeason->setExpanded(true);
                 addPhase->setSelected(true);
             }
             addPhase->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsDragEnabled);

--- a/src/Gui/LTMSidebar.cpp
+++ b/src/Gui/LTMSidebar.cpp
@@ -400,7 +400,9 @@ LTMSidebar::dateRangeTreeWidgetSelectionChanged()
 
         // make sure they fit
         eventTree->header()->resizeSections(QHeaderView::ResizeToContents);
-        appsettings->setCValue(context->athlete->cyclist, GC_LTM_LAST_DATE_RANGE, dateRange->id().toString());
+
+        QString lastDateSel = phase ? phase->id().toString() : dateRange->id().toString();
+        appsettings->setCValue(context->athlete->cyclist, GC_LTM_LAST_DATE_RANGE, lastDateSel);
 
     }
 


### PR DESCRIPTION
This PR saves the most recently selected phase in GC_LTM_LAST_DATE_RANGE, so it can be loaded and selected on the next GC start. (This is already implemented for seasons/date ranges but not phases so far.)
Also: The season containing the selected phase is expanded on GC start.