### PR TITLE
Body & HRV Measures - MacOS

### DIFF
--- a/src/Cloud/BodyMeasuresDownload.cpp
+++ b/src/Cloud/BodyMeasuresDownload.cpp
@@ -304,6 +304,13 @@ BodyMeasuresDownload::download() {
        // do a refresh, it will check if needed
        context->athlete->rideCache->refresh();
 
+#ifdef Q_MAC_OS
+       // since progressBar on MacOS does not show the % values
+       QMessageBox msgBox;
+       msgBox.setText(tr("Download completed."));
+       msgBox.exec();
+#endif
+
    } else {
        // handle error document in err String
        QMessageBox::warning(this, tr("Body Measurements"), tr("Downloading of body measurements failed with error: %1").arg(err));

--- a/src/Cloud/HrvMeasuresDownload.cpp
+++ b/src/Cloud/HrvMeasuresDownload.cpp
@@ -195,6 +195,13 @@ HrvMeasuresDownload::download() {
 
        updateMeasures(context, hrvMeasures, discardExistingMeasures->isChecked());
 
+#ifdef Q_MAC_OS
+       // since progressBar on MacOS does not show the % values
+       QMessageBox msgBox;
+       msgBox.setText(tr("Download completed."));
+       msgBox.exec();
+#endif
+
    } else {
        // handle error document in err String
        QMessageBox::warning(this, tr("HRV Measurements"), tr("Downloading of HRV measurements failed with error: %1").arg(err));


### PR DESCRIPTION
... add Popup when download is complete, since QProgressBar does not show % values (following some Mac Style Guidelines)
... since Windows/Linux UI shows 100% in progress bar, the additional Popup is only displayed on Mac