### PR TITLE
Fix CI-Build for Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,9 @@ version: ci.{build}
 image: Visual Studio 2015
 clone_depth: 1
 init:
-# Setup QT 5.9.3 - 64Bit
+# Setup QT 5.9.4 - 64Bit
 
-- set QTDIR=C:\Qt\5.9.3\msvc2015_64
+- set QTDIR=C:\Qt\5.9.4\msvc2015_64
 - set PATH=%QTDIR%\bin;%PATH%
 
 # Setup MSVC - VS 2015


### PR DESCRIPTION
... update to Qt 5.9.4 since 5.9.3 is not longer supported by AppVeyor