### PR TITLE
Consistency checks for seasons-phases-events, event reordering, priorities and description

### DIFF
--- a/src/Charts/LTMPlot.cpp
+++ b/src/Charts/LTMPlot.cpp
@@ -55,8 +55,8 @@
 
 //#include <QDebug>
 
-LTMPlot::LTMPlot(LTMWindow *parent, Context *context, bool first) : 
-    bg(NULL), parent(parent), context(context), highlighter(NULL), first(first), isolation(false)
+LTMPlot::LTMPlot(LTMWindow *parent, Context *context, int position) :
+    bg(NULL), parent(parent), context(context), highlighter(NULL), isolation(false), position(position)
 {
     // don't do this ..
     setAutoReplot(false);
@@ -4001,6 +4001,7 @@ class LTMPlotZoneLabel: public QwtPlotItem
     void
 LTMPlot::refreshMarkers(LTMSettings *settings, QDate from, QDate to, int groupby, QColor color)
 {
+    const int viewDepth = 4; //show markers only for the 1st of each 4 charts
     double baseday = groupForDate(from, groupby);
     QwtIndPlotMarker::resetDrawnLabels();
     // seasons and season events
@@ -4017,7 +4018,8 @@ LTMPlot::refreshMarkers(LTMSettings *settings, QDate from, QDate to, int groupby
                 mrk->setLabelAlignment(Qt::AlignRight | Qt::AlignTop);
                 mrk->setLinePen(QPen(color, 0, Qt::DashLine));
                 mrk->setValue(double(groupForDate(s.getStart(), groupby)) - baseday,0);
-                if (first) {
+
+                if (position % viewDepth == 0) {
                     QwtText text(s.getName());
                     text.setFont(QFont("Helvetica", 10, QFont::Bold));
                     text.setColor(color);
@@ -4041,7 +4043,7 @@ LTMPlot::refreshMarkers(LTMSettings *settings, QDate from, QDate to, int groupby
                     mrk->setLinePen(QPen(color, 0, Qt::SolidLine));
                     mrk->setValue(double(groupForDate(event.date, groupby)) - baseday, 10.0);
 
-                    if (first) {
+                    if (position % viewDepth == 0) {
                         QwtText text(event.name);
                         text.setFont(QFont("Helvetica", 10, QFont::Bold));
                         text.setColor(Qt::red);
@@ -4063,7 +4065,8 @@ LTMPlot::refreshMarkers(LTMSettings *settings, QDate from, QDate to, int groupby
         mrk->setLabelAlignment(Qt::AlignRight | Qt::AlignTop);
         mrk->setLinePen(QPen(color, 0, Qt::DotLine));
         mrk->setValue(double(groupForDate(today, groupby)) - baseday,0);
-        if (first) {
+
+        if (position % viewDepth == 0) {
             QwtText text(tr("Today"));
             text.setFont(QFont("Helvetica", 10, QFont::Bold));
             text.setColor(Qt::red);

--- a/src/Charts/LTMPlot.h
+++ b/src/Charts/LTMPlot.h
@@ -51,7 +51,7 @@ class LTMPlot : public QwtPlot
 
 
     public:
-        LTMPlot(LTMWindow *, Context *context, bool first=true); // first if in a stack
+        LTMPlot(LTMWindow *, Context *context, int postition=0); // position in a stack
         ~LTMPlot();
         void setData(LTMSettings *);
         void setCompareData(LTMSettings *);
@@ -145,8 +145,8 @@ class LTMPlot : public QwtPlot
         void refreshMarkers(LTMSettings *, QDate from, QDate to, int groupby, QColor color);
 
         QList<QwtAxisId> supportedAxes;
-        bool first, isolation;
-        int MAXX;
+        bool isolation;
+        int position, MAXX;
 };
 
 class CompareScaleDraw: public QwtScaleDraw

--- a/src/Charts/LTMWindow.cpp
+++ b/src/Charts/LTMWindow.cpp
@@ -76,7 +76,7 @@ LTMWindow::LTMWindow(Context *context) :
     plotLayout->setSpacing(0);
     plotLayout->setContentsMargins(0,0,0,0);
     
-    ltmPlot = new LTMPlot(this, context, true);
+    ltmPlot = new LTMPlot(this, context, 0);
     spanSlider = new QxtSpanSlider(Qt::Horizontal, this);
     spanSlider->setFocusPolicy(Qt::NoFocus);
     spanSlider->setHandleMovementMode(QxtSpanSlider::NoOverlapping);
@@ -552,7 +552,7 @@ LTMWindow::refreshCompare()
         if (m.stack) plotSetting.metrics << m;
     }
 
-    bool first = true;
+    int position = 0;
 
     // create ltmPlot with this
     if (plotSetting.metrics.count()) {
@@ -560,12 +560,9 @@ LTMWindow::refreshCompare()
         compareplotSettings << plotSetting;
 
         // create and setup the plot
-        LTMPlot *stacked = new LTMPlot(this, context, first);
+        LTMPlot *stacked = new LTMPlot(this, context, position++);
         stacked->setCompareData(&compareplotSettings.last()); // setData using the compare data
         stacked->setFixedHeight(200); // maybe make this adjustable later
-
-        // no longer first
-        first = false;
 
         // now add
         compareplotsLayout->addWidget(stacked);
@@ -585,11 +582,8 @@ LTMWindow::refreshCompare()
         compareplotSettings << plotSetting;
 
         // create and setup the plot
-        LTMPlot *plot = new LTMPlot(this, context, first);
+        LTMPlot *plot = new LTMPlot(this, context, position++);
         plot->setCompareData(&compareplotSettings.last()); // setData using the compare data
-
-        // no longer first
-        first = false;
 
         // now add
         compareplotsLayout->addWidget(plot);
@@ -661,7 +655,7 @@ LTMWindow::refreshStackPlots()
         if (m.stack) plotSetting.metrics << m;
     }
 
-    bool first = true;
+    int position = 0;
 
     // create ltmPlot with this
     if (plotSetting.metrics.count()) {
@@ -669,12 +663,9 @@ LTMWindow::refreshStackPlots()
         plotSettings << plotSetting;
 
         // create and setup the plot
-        LTMPlot *stacked = new LTMPlot(this, context, first);
+        LTMPlot *stacked = new LTMPlot(this, context, position++);
         stacked->setData(&plotSettings.last());
         stacked->setFixedHeight(200); // maybe make this adjustable later
-
-        // no longer first
-        first = false;
 
         // now add
         plotsLayout->addWidget(stacked);
@@ -694,11 +685,8 @@ LTMWindow::refreshStackPlots()
         plotSettings << plotSetting;
 
         // create and setup the plot
-        LTMPlot *plot = new LTMPlot(this, context, first);
+        LTMPlot *plot = new LTMPlot(this, context, position++);
         plot->setData(&plotSettings.last());
-
-        // no longer first
-        first = false;
 
         // now add
         plotsLayout->addWidget(plot);

--- a/src/Charts/LTMWindow.cpp
+++ b/src/Charts/LTMWindow.cpp
@@ -297,6 +297,7 @@ LTMWindow::LTMWindow(Context *context) :
     connect(context, SIGNAL(rideSaved(RideItem*)), this, SLOT(refresh(void)));
     connect(context, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));
     connect(context, SIGNAL(presetSelected(int)), this, SLOT(presetSelected(int)));
+    connect(context->athlete->seasons, SIGNAL(seasonsChanged()), this, SLOT(refreshPlot()));
 
     // custom menu item
     connect(exportData, SIGNAL(triggered()), this, SLOT(exportData()));

--- a/src/Cloud/CalDAV.h
+++ b/src/Cloud/CalDAV.h
@@ -50,6 +50,9 @@
 #include "RideFile.h"
 #include "JsonRideFile.h"
 
+// SeasonEvent
+#include "Season.h"
+
 // create a UUID
 #include <QUuid>
 
@@ -84,6 +87,10 @@ public slots:
 
     // Upload ride as a VEVENT
     bool upload(RideItem *rideItem);
+    // Upload SeasonEvent as a VEVENT
+    bool upload(SeasonEvent *seasonEvent);
+    // Upload a VEVENT
+    bool upload(QByteArray vcardtext);
 
     // Catch NAM signals ...
     void requestReply(QNetworkReply *reply);
@@ -96,16 +103,16 @@ public slots:
     // enable aynchronous up/download for Google
     // since access token is temporarily valid only, it needs refresh before access to Google CALDAV
     bool doDownload();
-    bool doUpload(RideItem *rideItem);
+    bool doUpload();
 
-    void getConfig();
+    bool getConfig();
 
 private:
 
     Context *context;
     QNetworkAccessManager *nam;
-    ActionType mode;
     CalDAVType calDavType;
+    QString url; QString calID;
     QString googleCalDAVurl;
     bool ignoreDownloadErrors;
 
@@ -113,7 +120,9 @@ private:
     QNetworkAccessManager *googleNetworkAccessManager;
     void requestGoogleAccessTokenToExecute();
     QByteArray googleCalendarAccessToken;
-    RideItem *itemForUpload;
+    ActionType mode;
+    QString fileName;
+    QByteArray vcardtext;
 
 };
 #endif

--- a/src/Cloud/OAuthDialog.h
+++ b/src/Cloud/OAuthDialog.h
@@ -64,6 +64,7 @@ public:
         STRAVA,
         DROPBOX,
         CYCLING_ANALYTICS,
+        GOOGLE_CALENDAR,
         GOOGLE_DRIVE,
         SPORTTRACKS,
         TODAYSPLAN,

--- a/src/Core/Season.cpp
+++ b/src/Core/Season.cpp
@@ -219,6 +219,7 @@ EditSeasonEventDialog::EditSeasonEventDialog(Context *context, SeasonEvent *even
     QLabel *name = new QLabel(tr("Name"));
     QLabel *date = new QLabel(tr("Date"));
     QLabel *priority = new QLabel(tr("Priority"));
+    QLabel *description = new QLabel(tr("Description"));
 
     nameEdit = new QLineEdit(this);
     nameEdit->setText(event->name);
@@ -228,9 +229,12 @@ EditSeasonEventDialog::EditSeasonEventDialog(Context *context, SeasonEvent *even
     dateEdit->setDate(event->date);
     dateEdit->setCalendarPopup(true);
 
-    priorityEdit = new QComboBox;
+    priorityEdit = new QComboBox(this);
     foreach(QString priority, SeasonEvent::priorityList()) priorityEdit->addItem(priority);
     priorityEdit->setCurrentIndex(event->priority);
+
+    descriptionEdit = new QTextEdit(this);
+    descriptionEdit->setText(event->description);
 
     grid->addWidget(name, 0,0);
     grid->addWidget(nameEdit, 0,1);
@@ -238,6 +242,8 @@ EditSeasonEventDialog::EditSeasonEventDialog(Context *context, SeasonEvent *even
     grid->addWidget(dateEdit, 1,1);
     grid->addWidget(priority, 2,0);
     grid->addWidget(priorityEdit, 2,1);
+    grid->addWidget(description, 3, 0);
+    grid->addWidget(descriptionEdit, 4,0,4,2);
 
     mainLayout->addLayout(grid);
 
@@ -266,6 +272,7 @@ EditSeasonEventDialog::applyClicked()
     event->name = nameEdit->text();
     event->date = dateEdit->date();
     event->priority = priorityEdit->currentIndex();
+    event->description = descriptionEdit->toPlainText();
     accept();
 }
 

--- a/src/Core/Season.cpp
+++ b/src/Core/Season.cpp
@@ -170,6 +170,10 @@ EditSeasonDialog::EditSeasonDialog(Context *context, Season *season) :
     // connect up slots
     connect(applyButton, SIGNAL(clicked()), this, SLOT(applyClicked()));
     connect(cancelButton, SIGNAL(clicked()), this, SLOT(cancelClicked()));
+    connect(nameEdit, SIGNAL(textChanged(const QString &)), this, SLOT(nameChanged()));
+
+    // initialize button state
+    nameChanged();
 }
 
 void
@@ -190,10 +194,15 @@ EditSeasonDialog::cancelClicked()
     reject();
 }
 
+void EditSeasonDialog::nameChanged()
+{
+    applyButton->setEnabled(!nameEdit->text().isEmpty());
+}
+
 /*----------------------------------------------------------------------
  * EDIT SEASONEVENT DIALOG
  *--------------------------------------------------------------------*/
-EditSeasonEventDialog::EditSeasonEventDialog(Context *context, SeasonEvent *event) :
+EditSeasonEventDialog::EditSeasonEventDialog(Context *context, SeasonEvent *event, Season &season) :
     QDialog(context->mainWindow, Qt::Dialog), context(context), event(event)
 {
     setWindowTitle(tr("Edit Event"));
@@ -208,6 +217,7 @@ EditSeasonEventDialog::EditSeasonEventDialog(Context *context, SeasonEvent *even
     nameEdit->setText(event->name);
 
     dateEdit = new QDateEdit(this);
+    dateEdit->setDateRange(season.getStart(), season.getEnd());
     dateEdit->setDate(event->date);
     dateEdit->setCalendarPopup(true);
 
@@ -230,6 +240,10 @@ EditSeasonEventDialog::EditSeasonEventDialog(Context *context, SeasonEvent *even
     // connect up slots
     connect(applyButton, SIGNAL(clicked()), this, SLOT(applyClicked()));
     connect(cancelButton, SIGNAL(clicked()), this, SLOT(cancelClicked()));
+    connect(nameEdit, SIGNAL(textChanged(const QString &)), this, SLOT(nameChanged()));
+
+    // initialize button state
+    nameChanged();
 }
 
 void
@@ -245,6 +259,11 @@ void
 EditSeasonEventDialog::cancelClicked()
 {
     reject();
+}
+
+void EditSeasonEventDialog::nameChanged()
+{
+    applyButton->setEnabled(!nameEdit->text().isEmpty());
 }
 
 //
@@ -566,7 +585,7 @@ Phase::Phase(QString _name, QDate _start, QDate _end) : Season()
 /*----------------------------------------------------------------------
  * EDIT PHASE DIALOG
  *--------------------------------------------------------------------*/
-EditPhaseDialog::EditPhaseDialog(Context *context, Phase *phase) :
+EditPhaseDialog::EditPhaseDialog(Context *context, Phase *phase, Season &season) :
     QDialog(context->mainWindow, Qt::Dialog), context(context), phase(phase)
 {
     setWindowTitle(tr("Edit Date Range"));
@@ -593,10 +612,12 @@ EditPhaseDialog::EditPhaseDialog(Context *context, Phase *phase) :
     typeEdit->setCurrentIndex(typeEdit->findData(phase->getType()));
 
     fromEdit = new QDateEdit(this);
+    fromEdit->setDateRange(season.getStart(), season.getEnd());
     fromEdit->setDate(phase->getStart());
     fromEdit->setCalendarPopup(true);
 
     toEdit = new QDateEdit(this);
+    toEdit->setDateRange(season.getStart(), season.getEnd());
     toEdit->setDate(phase->getEnd());
     toEdit->setCalendarPopup(true);
 
@@ -644,6 +665,10 @@ EditPhaseDialog::EditPhaseDialog(Context *context, Phase *phase) :
     // connect up slots
     connect(applyButton, SIGNAL(clicked()), this, SLOT(applyClicked()));
     connect(cancelButton, SIGNAL(clicked()), this, SLOT(cancelClicked()));
+    connect(nameEdit, SIGNAL(textChanged(const QString &)), this, SLOT(nameChanged()));
+
+    // initialize button state
+    nameChanged();
 }
 
 void
@@ -662,4 +687,9 @@ void
 EditPhaseDialog::cancelClicked()
 {
     reject();
+}
+
+void EditPhaseDialog::nameChanged()
+{
+    applyButton->setEnabled(!nameEdit->text().isEmpty());
 }

--- a/src/Core/Season.cpp
+++ b/src/Core/Season.cpp
@@ -693,3 +693,28 @@ void EditPhaseDialog::nameChanged()
 {
     applyButton->setEnabled(!nameEdit->text().isEmpty());
 }
+
+SeasonEventTreeView::SeasonEventTreeView()
+{
+    setDragDropMode(QAbstractItemView::InternalMove);
+    setDragDropOverwriteMode(true);
+}
+
+void
+SeasonEventTreeView::dropEvent(QDropEvent* event)
+{
+    // get the list of the items that are about to be dropped
+    QTreeWidgetItem* item = selectedItems()[0];
+
+    // row we started on
+    int idx1 = indexFromItem(item).row();
+
+    // the default implementation takes care of the actual move inside the tree
+    QTreeWidget::dropEvent(event);
+
+    // moved to !
+    int idx2 = indexFromItem(item).row();
+
+    // notify subscribers in some useful way
+    Q_EMIT itemMoved(item, idx1, idx2);
+}

--- a/src/Core/Season.cpp
+++ b/src/Core/Season.cpp
@@ -26,6 +26,12 @@
 #include "SeasonParser.h"
 #include <QXmlSimpleReader>
 
+QStringList
+SeasonEvent::priorityList()
+{
+    return QStringList()<<" "<<tr("A")<<tr("B")<<tr("C")<<tr("D")<<tr("E");
+}
+
 static QList<QString> _setSeasonTypes()
 {
     QList<QString> returning;
@@ -212,6 +218,7 @@ EditSeasonEventDialog::EditSeasonEventDialog(Context *context, SeasonEvent *even
     QGridLayout *grid = new QGridLayout;
     QLabel *name = new QLabel(tr("Name"));
     QLabel *date = new QLabel(tr("Date"));
+    QLabel *priority = new QLabel(tr("Priority"));
 
     nameEdit = new QLineEdit(this);
     nameEdit->setText(event->name);
@@ -221,10 +228,16 @@ EditSeasonEventDialog::EditSeasonEventDialog(Context *context, SeasonEvent *even
     dateEdit->setDate(event->date);
     dateEdit->setCalendarPopup(true);
 
+    priorityEdit = new QComboBox;
+    foreach(QString priority, SeasonEvent::priorityList()) priorityEdit->addItem(priority);
+    priorityEdit->setCurrentIndex(event->priority);
+
     grid->addWidget(name, 0,0);
     grid->addWidget(nameEdit, 0,1);
     grid->addWidget(date, 1,0);
     grid->addWidget(dateEdit, 1,1);
+    grid->addWidget(priority, 2,0);
+    grid->addWidget(priorityEdit, 2,1);
 
     mainLayout->addLayout(grid);
 
@@ -252,6 +265,7 @@ EditSeasonEventDialog::applyClicked()
     // get the values back
     event->name = nameEdit->text();
     event->date = dateEdit->date();
+    event->priority = priorityEdit->currentIndex();
     accept();
 }
 

--- a/src/Core/Season.h
+++ b/src/Core/Season.h
@@ -41,12 +41,13 @@ class SeasonEvent
     public:
         static QStringList priorityList();
 
-        SeasonEvent(QString name, QDate date, int priority=0, QString description="") : name(name), date(date), priority(priority), description(description) {}
+        SeasonEvent(QString name, QDate date, int priority=0, QString description="", QString id="") : name(name), date(date), priority(priority), description(description), id(id) {}
 
         QString name;
         QDate date;
         int priority;
         QString description;
+        QString id; // unique id
 };
 
 class Season

--- a/src/Core/Season.h
+++ b/src/Core/Season.h
@@ -28,6 +28,7 @@
 #include <QTreeWidget>
 #include <QLabel>
 #include <QLineEdit>
+#include <QTextEdit>
 
 #include "Context.h"
 
@@ -40,11 +41,12 @@ class SeasonEvent
     public:
         static QStringList priorityList();
 
-        SeasonEvent(QString name, QDate date, int priority=0) : name(name), date(date), priority(priority) {}
+        SeasonEvent(QString name, QDate date, int priority=0, QString description="") : name(name), date(date), priority(priority), description(description) {}
 
         QString name;
         QDate date;
         int priority;
+        QString description;
 };
 
 class Season
@@ -148,6 +150,7 @@ class EditSeasonEventDialog : public QDialog
         QLineEdit *nameEdit;
         QDateEdit *dateEdit;
         QComboBox *priorityEdit;
+        QTextEdit *descriptionEdit;
 };
 
 class Seasons : public QObject {

--- a/src/Core/Season.h
+++ b/src/Core/Season.h
@@ -35,11 +35,16 @@ class Phase;
 
 class SeasonEvent
 {
+    Q_DECLARE_TR_FUNCTIONS(Season)
+
     public:
-        SeasonEvent(QString name, QDate date) : name(name), date(date) {}
+        static QStringList priorityList();
+
+        SeasonEvent(QString name, QDate date, int priority=0) : name(name), date(date), priority(priority) {}
 
         QString name;
         QDate date;
+        int priority;
 };
 
 class Season
@@ -142,6 +147,7 @@ class EditSeasonEventDialog : public QDialog
         QPushButton *applyButton, *cancelButton;
         QLineEdit *nameEdit;
         QDateEdit *dateEdit;
+        QComboBox *priorityEdit;
 };
 
 class Seasons : public QObject {

--- a/src/Core/Season.h
+++ b/src/Core/Season.h
@@ -228,4 +228,17 @@ class EditPhaseDialog : public QDialog
         QDoubleSpinBox *lowEdit;
 };
 
+class SeasonEventTreeView : public QTreeWidget
+{
+    Q_OBJECT
+
+    public:
+        SeasonEventTreeView();
+
+    signals:
+        void itemMoved(QTreeWidgetItem* item, int previous, int actual);
+
+    protected:
+        void dropEvent(QDropEvent* event);
+};
 #endif /* SEASON_H_ */

--- a/src/Core/Season.h
+++ b/src/Core/Season.h
@@ -107,6 +107,7 @@ class EditSeasonDialog : public QDialog
     public slots:
         void applyClicked();
         void cancelClicked();
+        void nameChanged();
 
     private:
         Context *context;
@@ -127,11 +128,12 @@ class EditSeasonEventDialog : public QDialog
 
 
     public:
-        EditSeasonEventDialog(Context *, SeasonEvent *);
+        EditSeasonEventDialog(Context *, SeasonEvent *, Season &);
 
     public slots:
         void applyClicked();
         void cancelClicked();
+        void nameChanged();
 
     private:
         Context *context;
@@ -207,11 +209,12 @@ class EditPhaseDialog : public QDialog
 
 
     public:
-        EditPhaseDialog(Context *, Phase *);
+        EditPhaseDialog(Context *, Phase *, Season &);
 
     public slots:
         void applyClicked();
         void cancelClicked();
+        void nameChanged();
 
     private:
         Context *context;

--- a/src/Core/SeasonParser.cpp
+++ b/src/Core/SeasonParser.cpp
@@ -71,7 +71,7 @@ bool SeasonParser::endElement( const QString&, const QString&, const QString &qN
             season.setSeed(buffer.trimmed().toInt());
     } else if (qName == "event") {
 
-        season.events.append(SeasonEvent(Utils::unprotect(buffer), seasonDateToDate(dateString), priorityString.toInt(), eventDescription));
+        season.events.append(SeasonEvent(Utils::unprotect(buffer), seasonDateToDate(dateString), priorityString.toInt(), eventDescription, eventId));
 
     } else if(qName == "season") {
 
@@ -120,6 +120,7 @@ bool SeasonParser::startElement( const QString&, const QString&, const QString &
             if (attrs.qName(i) == "date") dateString=attrs.value(i);
             else if (attrs.qName(i) == "priority") priorityString=attrs.value(i);
             else if (attrs.qName(i) == "description") eventDescription = Utils::unprotect(attrs.value(i));
+            else if (attrs.qName(i) == "id") eventId = attrs.value(i);
         }
     }
 
@@ -236,11 +237,12 @@ SeasonParser::serialize(QString filename, QList<Season>Seasons)
 
             foreach(SeasonEvent x, season.events) {
 
-                out<<QString("\t\t<event date=\"%1\" priority=\"%3\" description=\"%4\">\"%2\"</event>\n")
+                out<<QString("\t\t<event date=\"%1\" priority=\"%3\" description=\"%4\" id=\"%5\">\"%2\"</event>\n")
                             .arg(x.date.toString("yyyy-MM-dd"))
                             .arg(Utils::xmlprotect(x.name))
                             .arg(x.priority)
-                            .arg(Utils::xmlprotect(x.description));
+                            .arg(Utils::xmlprotect(x.description))
+                            .arg(x.id);
             
             }
             out <<QString("\t</season>\n");

--- a/src/Core/SeasonParser.cpp
+++ b/src/Core/SeasonParser.cpp
@@ -71,7 +71,7 @@ bool SeasonParser::endElement( const QString&, const QString&, const QString &qN
             season.setSeed(buffer.trimmed().toInt());
     } else if (qName == "event") {
 
-        season.events.append(SeasonEvent(Utils::unprotect(buffer), seasonDateToDate(dateString), priorityString.toInt()));
+        season.events.append(SeasonEvent(Utils::unprotect(buffer), seasonDateToDate(dateString), priorityString.toInt(), eventDescription));
 
     } else if(qName == "season") {
 
@@ -119,6 +119,7 @@ bool SeasonParser::startElement( const QString&, const QString&, const QString &
         for(int i=0; i<attrs.count(); i++) {
             if (attrs.qName(i) == "date") dateString=attrs.value(i);
             else if (attrs.qName(i) == "priority") priorityString=attrs.value(i);
+            else if (attrs.qName(i) == "description") eventDescription = Utils::unprotect(attrs.value(i));
         }
     }
 
@@ -235,10 +236,11 @@ SeasonParser::serialize(QString filename, QList<Season>Seasons)
 
             foreach(SeasonEvent x, season.events) {
 
-                out<<QString("\t\t<event date=\"%1\" priority=\"%3\">\"%2\"</event>")
+                out<<QString("\t\t<event date=\"%1\" priority=\"%3\" description=\"%4\">\"%2\"</event>\n")
                             .arg(x.date.toString("yyyy-MM-dd"))
                             .arg(Utils::xmlprotect(x.name))
-                            .arg(x.priority);
+                            .arg(x.priority)
+                            .arg(Utils::xmlprotect(x.description));
             
             }
             out <<QString("\t</season>\n");

--- a/src/Core/SeasonParser.cpp
+++ b/src/Core/SeasonParser.cpp
@@ -71,7 +71,7 @@ bool SeasonParser::endElement( const QString&, const QString&, const QString &qN
             season.setSeed(buffer.trimmed().toInt());
     } else if (qName == "event") {
 
-        season.events.append(SeasonEvent(Utils::unprotect(buffer), seasonDateToDate(dateString)));
+        season.events.append(SeasonEvent(Utils::unprotect(buffer), seasonDateToDate(dateString), priorityString.toInt()));
 
     } else if(qName == "season") {
 
@@ -118,6 +118,7 @@ bool SeasonParser::startElement( const QString&, const QString&, const QString &
 
         for(int i=0; i<attrs.count(); i++) {
             if (attrs.qName(i) == "date") dateString=attrs.value(i);
+            else if (attrs.qName(i) == "priority") priorityString=attrs.value(i);
         }
     }
 
@@ -234,9 +235,10 @@ SeasonParser::serialize(QString filename, QList<Season>Seasons)
 
             foreach(SeasonEvent x, season.events) {
 
-                out<<QString("\t\t<event date=\"%1\">\"%2\"</event>")
+                out<<QString("\t\t<event date=\"%1\" priority=\"%3\">\"%2\"</event>")
                             .arg(x.date.toString("yyyy-MM-dd"))
-                            .arg(Utils::xmlprotect(x.name));
+                            .arg(Utils::xmlprotect(x.name))
+                            .arg(x.priority);
             
             }
             out <<QString("\t</season>\n");

--- a/src/Core/SeasonParser.h
+++ b/src/Core/SeasonParser.h
@@ -49,6 +49,6 @@ protected:
     int loadcount;
     QString dateString;
     QString priorityString;
-
+    QString eventDescription;
 };
 #endif //SeasonParser

--- a/src/Core/SeasonParser.h
+++ b/src/Core/SeasonParser.h
@@ -50,5 +50,6 @@ protected:
     QString dateString;
     QString priorityString;
     QString eventDescription;
+    QString eventId;
 };
 #endif //SeasonParser

--- a/src/Core/SeasonParser.h
+++ b/src/Core/SeasonParser.h
@@ -48,6 +48,7 @@ protected:
     Phase phase;
     int loadcount;
     QString dateString;
+    QString priorityString;
 
 };
 #endif //SeasonParser

--- a/src/Gui/LTMSidebar.cpp
+++ b/src/Gui/LTMSidebar.cpp
@@ -110,7 +110,7 @@ LTMSidebar::LTMSidebar(Context *context) : QWidget(context->mainWindow), context
     allEvents->setFlags(Qt::ItemIsEnabled | Qt::ItemIsDropEnabled);
     allEvents->setText(0, tr("Events"));
     eventTree->setFrameStyle(QFrame::NoFrame);
-    eventTree->setColumnCount(2);
+    eventTree->setColumnCount(3);
     eventTree->setSelectionMode(QAbstractItemView::SingleSelection);
     eventTree->header()->hide();
     eventTree->setIndentation(5);
@@ -400,6 +400,7 @@ LTMSidebar::dateRangeTreeWidgetSelectionChanged()
             add->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsDragEnabled);
             add->setText(0, event.name);
             add->setText(1, event.date.toString("MMM d, yyyy"));
+            add->setText(2, SeasonEvent::priorityList().at(event.priority));
         }
 
         // make sure they fit
@@ -1316,6 +1317,7 @@ LTMSidebar::addEvent()
         add->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsDragEnabled);
         add->setText(0, myevent.name);
         add->setText(1, myevent.date.toString("MMM d, yyyy"));
+        add->setText(2, SeasonEvent::priorityList().at(myevent.priority));
 
         // make sure they fit
         eventTree->header()->resizeSections(QHeaderView::ResizeToContents);
@@ -1385,9 +1387,13 @@ LTMSidebar::editEvent()
 
             if (dialog.exec()) {
 
-                // update name
+                // update event data
                 ours->setText(0, seasons->seasons[seasonindex].events[index].name);
                 ours->setText(1, seasons->seasons[seasonindex].events[index].date.toString("MMM d, yyyy"));
+                ours->setText(2, SeasonEvent::priorityList().at(seasons->seasons[seasonindex].events[index].priority));
+
+                // make sure they fit
+                eventTree->header()->resizeSections(QHeaderView::ResizeToContents);
 
                 // save changes away
                 seasons->writeSeasons();

--- a/src/Gui/LTMSidebar.cpp
+++ b/src/Gui/LTMSidebar.cpp
@@ -1198,7 +1198,7 @@ LTMSidebar::editRange()
 
     QDialog* dialog;
     if (phaseIdx> -1) {
-        dialog = new EditPhaseDialog(context, &seasons->seasons[seasonIdx].phases[phaseIdx]);
+        dialog = new EditPhaseDialog(context, &seasons->seasons[seasonIdx].phases[phaseIdx], seasons->seasons[seasonIdx]);
     } else {
         dialog = new EditSeasonDialog(context, &seasons->seasons[seasonIdx]);
     }
@@ -1301,7 +1301,7 @@ LTMSidebar::addEvent()
     }
 
     SeasonEvent myevent("", seasons->seasons[seasonindex].getEnd());
-    EditSeasonEventDialog dialog(context, &myevent);
+    EditSeasonEventDialog dialog(context, &myevent, seasons->seasons[seasonindex]);
 
     if (dialog.exec()) {
 
@@ -1376,7 +1376,7 @@ LTMSidebar::editEvent()
             QTreeWidgetItem *ours = eventTree->selectedItems().first();
             int index = allEvents->indexOfChild(ours);
 
-            EditSeasonEventDialog dialog(context, &seasons->seasons[seasonindex].events[index]);
+            EditSeasonEventDialog dialog(context, &seasons->seasons[seasonindex].events[index], seasons->seasons[seasonindex]);
 
             if (dialog.exec()) {
 
@@ -1414,7 +1414,7 @@ LTMSidebar::addPhase()
     }
 
     Phase myphase("", seasons->seasons[seasonindex].getStart(), seasons->seasons[seasonindex].getEnd());
-    EditPhaseDialog dialog(context, &myphase);
+    EditPhaseDialog dialog(context, &myphase, seasons->seasons[seasonindex]);
 
     if (dialog.exec()) {
 

--- a/src/Gui/LTMSidebar.cpp
+++ b/src/Gui/LTMSidebar.cpp
@@ -44,6 +44,7 @@
 #include "SeasonParser.h"
 #include <QXmlInputSource>
 #include <QXmlSimpleReader>
+#include "CalDAV.h" // upload Events to remote calendar
 
 // named searchs
 #include "FreeSearch.h"
@@ -1311,6 +1312,12 @@ LTMSidebar::addEvent()
     if (dialog.exec()) {
 
         active = true;
+
+        // upload to remote calendar if configured
+        if (context->athlete->davCalendar->getConfig())
+            if (!context->athlete->davCalendar->upload(&myevent))
+                QMessageBox::warning(this, tr("Add Event"), tr("The new event could not be uploaded to your remote calendar."));
+
         seasons->seasons[seasonindex].events.append(myevent);
 
         QTreeWidgetItem *add = new QTreeWidgetItem(allEvents);

--- a/src/Gui/LTMSidebar.h
+++ b/src/Gui/LTMSidebar.h
@@ -76,6 +76,7 @@ class LTMSidebar : public QWidget
         void editEvent();
         void deleteEvent();
         void addEvent();
+        void eventMoved(QTreeWidgetItem *, int, int);
 
         void addPhase();
 
@@ -128,7 +129,7 @@ class LTMSidebar : public QWidget
         QTreeWidgetItem *allCharts;
 
         GcSplitterItem *eventsWidget;
-        QTreeWidget *eventTree;
+        SeasonEventTreeView *eventTree;
         QTreeWidgetItem *allEvents;
 
         GcSplitterItem *filtersWidget;

--- a/src/Gui/Pages.h
+++ b/src/Gui/Pages.h
@@ -363,6 +363,9 @@ class CredentialsPage : public QScrollArea
         void deleteClicked();
         void editClicked();
 
+        void authoriseGoogleCalendar();
+        void dvCALDAVTypeChanged(int);
+
 
     private:
 
@@ -370,6 +373,14 @@ class CredentialsPage : public QScrollArea
         QTreeWidget *accounts;
         QPushButton *addButton, *editButton, *deleteButton;
 
+        QComboBox *dvCALDAVType;
+        QPushButton *googleCalendarAuthorise, *googleCalendarAuthorised;
+        QLineEdit *webcalURL; // url for webcal calendar (read only, TP.com, Google Calendar)
+
+        QLineEdit *dvURL; // url for calDAV calendar (read/write, e.g. Hotmail)
+        QLineEdit *dvUser;
+        QLineEdit *dvPass;
+        QLineEdit *dvGoogleCalid;
 };
 
 class deviceModel : public QAbstractTableModel


### PR DESCRIPTION
Names must be not empty
Phases must be fully included in the corresponding season
Events must belong to the corresponding season
Enable Event drag&drop in LTMSidebar to allow reordering - Fixes #565
Add priority to Season Events - Fixes #1724
Add Description to Season Events - Fixes #2617 
Refresh LTM charts when seasons change, so season boundaries and event markers are updated accordingly
Show Season/Event label in stacked LTM Charts for each 4 charts - Fixes #1943
Sync Events with Calendar if remote calendar is configured - Fixes #1979
Reenabled remote calendar configuration and autorization - To upload and download Events, tested with Google Calendar