### PR TITLE
Added ScriptContext for Python APIs called from DataFilter scripts

### DIFF
--- a/src/Charts/PythonChart.cpp
+++ b/src/Charts/PythonChart.cpp
@@ -197,7 +197,7 @@ void PythonConsole::keyPressEvent(QKeyEvent *e)
                 line = line.replace("$$", chartid);
 
                 python->cancelled = false;
-                python->runline(context, line);
+                python->runline(ScriptContext(context), line);
 
                 // the run command should result in some messages being generated
                 putData(GColor(CPLOTMARKER), python->messages.join(""));
@@ -471,7 +471,7 @@ PythonChart::setState(QString)
 void
 PythonChart::execScript(PythonChart *chart)
 {
-    python->runline(chart->context, chart->script->toPlainText());
+    python->runline(ScriptContext(chart->context), chart->script->toPlainText());
 }
 
 void

--- a/src/Core/DataFilter.cpp
+++ b/src/Core/DataFilter.cpp
@@ -1718,7 +1718,7 @@ void DataFilter::configChanged(qint32)
     rt.dataSeriesSymbols = RideFile::symbols();
 }
 
-Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideFilePoint *p, const QHash<QString,RideMetric*> *c)
+Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideFilePoint *p, const QHash<QString,RideMetric*> *c, Specification s)
 {
     // if error state all bets are off
     //if (inerror) return Result(0);
@@ -1733,26 +1733,26 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
         switch (leaf->op) {
             case AND :
             {
-                Result left = eval(df, leaf->lvalue.l, x, m, p, c);
+                Result left = eval(df, leaf->lvalue.l, x, m, p, c, s);
                 if (left.isNumber && left.number) {
-                    Result right = eval(df, leaf->rvalue.l, x, m, p, c);
+                    Result right = eval(df, leaf->rvalue.l, x, m, p, c, s);
                     if (right.isNumber && right.number) return Result(true);
                 }
                 return Result(false);
             }
             case OR :
             {
-                Result left = eval(df, leaf->lvalue.l, x, m, p, c);
+                Result left = eval(df, leaf->lvalue.l, x, m, p, c, s);
                 if (left.isNumber && left.number) return Result(true);
 
-                Result right = eval(df, leaf->rvalue.l, x, m, p, c);
+                Result right = eval(df, leaf->rvalue.l, x, m, p, c, s);
                 if (right.isNumber && right.number) return Result(true);
 
                 return Result(false);
             }
 
             default : // parenthesis
-                return (eval(df, leaf->lvalue.l, x, m, p, c));
+                return (eval(df, leaf->lvalue.l, x, m, p, c, s));
         }
     }
     break;
@@ -1777,7 +1777,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
                 return Result(0);
             }
 
-            Result res = eval(df, df->functions.value(leaf->function), x, m, p, c);
+            Result res = eval(df, df->functions.value(leaf->function), x, m, p, c, s);
 
             // pop stack - if we haven't overflowed and reset
             if (df->stack > 0) df->stack -= 1;
@@ -1910,7 +1910,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
                 default:
                 case Leaf::Function :
                 {
-                    duration = eval(df, leaf->lvalue.l, x, m, p, c).number; // duration will be zero if string
+                    duration = eval(df, leaf->lvalue.l, x, m, p, c, s).number; // duration will be zero if string
                 }
                 break;
 
@@ -1972,36 +1972,36 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
         if (fnum < 0) return Result(0);
 
         switch (fnum) {
-        case 0 : { return Result(cos(eval(df, leaf->fparms[0], x, m, p, c).number)); } // COS(x)
-        case 1 : { return Result(tan(eval(df, leaf->fparms[0], x, m, p, c).number)); } // TAN(x)
-        case 2 : { return Result(sin(eval(df, leaf->fparms[0], x, m, p, c).number)); } // SIN(x)
-        case 3 : { return Result(acos(eval(df, leaf->fparms[0], x, m, p, c).number)); } // ACOS(x)
-        case 4 : { return Result(atan(eval(df, leaf->fparms[0], x, m, p, c).number)); } // ATAN(x)
-        case 5 : { return Result(asin(eval(df, leaf->fparms[0], x, m, p, c).number)); } // ASIN(x)
-        case 6 : { return Result(cosh(eval(df, leaf->fparms[0], x, m, p, c).number)); } // COSH(x)
-        case 7 : { return Result(tanh(eval(df, leaf->fparms[0], x, m, p, c).number)); } // TANH(x)
-        case 8 : { return Result(sinh(eval(df, leaf->fparms[0], x, m, p, c).number)); } // SINH(x)
-        case 9 : { return Result(acosh(eval(df, leaf->fparms[0], x, m, p, c).number)); } // ACOSH(x)
-        case 10 : { return Result(atanh(eval(df, leaf->fparms[0], x, m, p, c).number)); } // ATANH(x)
-        case 11 : { return Result(asinh(eval(df, leaf->fparms[0], x, m, p, c).number)); } // ASINH(x)
+        case 0 : { return Result(cos(eval(df, leaf->fparms[0], x, m, p, c, s).number)); } // COS(x)
+        case 1 : { return Result(tan(eval(df, leaf->fparms[0], x, m, p, c, s).number)); } // TAN(x)
+        case 2 : { return Result(sin(eval(df, leaf->fparms[0], x, m, p, c, s).number)); } // SIN(x)
+        case 3 : { return Result(acos(eval(df, leaf->fparms[0], x, m, p, c, s).number)); } // ACOS(x)
+        case 4 : { return Result(atan(eval(df, leaf->fparms[0], x, m, p, c, s).number)); } // ATAN(x)
+        case 5 : { return Result(asin(eval(df, leaf->fparms[0], x, m, p, c, s).number)); } // ASIN(x)
+        case 6 : { return Result(cosh(eval(df, leaf->fparms[0], x, m, p, c, s).number)); } // COSH(x)
+        case 7 : { return Result(tanh(eval(df, leaf->fparms[0], x, m, p, c, s).number)); } // TANH(x)
+        case 8 : { return Result(sinh(eval(df, leaf->fparms[0], x, m, p, c, s).number)); } // SINH(x)
+        case 9 : { return Result(acosh(eval(df, leaf->fparms[0], x, m, p, c, s).number)); } // ACOSH(x)
+        case 10 : { return Result(atanh(eval(df, leaf->fparms[0], x, m, p, c, s).number)); } // ATANH(x)
+        case 11 : { return Result(asinh(eval(df, leaf->fparms[0], x, m, p, c, s).number)); } // ASINH(x)
 
-        case 12 : { return Result(exp(eval(df, leaf->fparms[0], x, m, p, c).number)); } // EXP(x)
-        case 13 : { return Result(log(eval(df, leaf->fparms[0], x, m, p, c).number)); } // LOG(x)
-        case 14 : { return Result(log10(eval(df, leaf->fparms[0], x, m, p, c).number)); } // LOG10(x)
+        case 12 : { return Result(exp(eval(df, leaf->fparms[0], x, m, p, c, s).number)); } // EXP(x)
+        case 13 : { return Result(log(eval(df, leaf->fparms[0], x, m, p, c, s).number)); } // LOG(x)
+        case 14 : { return Result(log10(eval(df, leaf->fparms[0], x, m, p, c, s).number)); } // LOG10(x)
 
-        case 15 : { return Result(ceil(eval(df, leaf->fparms[0], x, m, p, c).number)); } // CEIL(x)
-        case 16 : { return Result(floor(eval(df, leaf->fparms[0], x, m, p, c).number)); } // FLOOR(x)
-        case 17 : { return Result(round(eval(df, leaf->fparms[0], x, m, p, c).number)); } // ROUND(x)
+        case 15 : { return Result(ceil(eval(df, leaf->fparms[0], x, m, p, c, s).number)); } // CEIL(x)
+        case 16 : { return Result(floor(eval(df, leaf->fparms[0], x, m, p, c, s).number)); } // FLOOR(x)
+        case 17 : { return Result(round(eval(df, leaf->fparms[0], x, m, p, c, s).number)); } // ROUND(x)
 
-        case 18 : { return Result(fabs(eval(df, leaf->fparms[0], x, m, p, c).number)); } // FABS(x)
-        case 19 : { return Result(std::isinf(eval(df, leaf->fparms[0], x, m, p, c).number)); } // ISINF(x)
-        case 20 : { return Result(std::isnan(eval(df, leaf->fparms[0], x, m, p, c).number)); } // ISNAN(x)
+        case 18 : { return Result(fabs(eval(df, leaf->fparms[0], x, m, p, c, s).number)); } // FABS(x)
+        case 19 : { return Result(std::isinf(eval(df, leaf->fparms[0], x, m, p, c, s).number)); } // ISINF(x)
+        case 20 : { return Result(std::isnan(eval(df, leaf->fparms[0], x, m, p, c, s).number)); } // ISNAN(x)
 
         case 21 : { /* SUM( ... ) */
                     double sum=0;
 
                     foreach(Leaf *l, leaf->fparms) {
-                        sum += eval(df, l, x, m, p, c).number; // for vectors number is sum
+                        sum += eval(df, l, x, m, p, c, s).number; // for vectors number is sum
                     }
                     return Result(sum);
                   }
@@ -2012,7 +2012,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
                     int count=0;
 
                     foreach(Leaf *l, leaf->fparms) {
-                        Result res = eval(df, l, x, m, p, c); // for vectors number is sum
+                        Result res = eval(df, l, x, m, p, c, s); // for vectors number is sum
                         sum += res.number;
                         if (res.vector.count()) count += res.vector.count();
                         else count++;
@@ -2026,7 +2026,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
                     bool set=false;
 
                     foreach(Leaf *l, leaf->fparms) {
-                        Result res = eval(df, l, x, m, p, c);
+                        Result res = eval(df, l, x, m, p, c, s);
                         if (res.vector.count()) {
                             foreach(double x, res.vector) {
                                 if (set && x>max) max=x;
@@ -2047,7 +2047,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
                     bool set=false;
 
                     foreach(Leaf *l, leaf->fparms) {
-                        Result res = eval(df, l, x, m, p, c);
+                        Result res = eval(df, l, x, m, p, c, s);
                         if (res.vector.count()) {
                             foreach(double x, res.vector) {
                                 if (set && x<min) min=x;
@@ -2067,7 +2067,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
 
                     int count = 0;
                     foreach(Leaf *l, leaf->fparms) {
-                        Result res = eval(df, l, x, m, p, c);
+                        Result res = eval(df, l, x, m, p, c, s);
                         if (res.vector.count()) count += res.vector.count();
                         else count++;
                     }
@@ -2113,7 +2113,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
                     // what we looking for ?
                     QString parm = leaf->fparms[1]->type == Leaf::Symbol ? *leaf->fparms[1]->lvalue.n : "";
                     bool toDuration = parm == "" ? true : false;
-                    double duration = toDuration ? eval(df, leaf->fparms[1], x, m, p, c).number : 0;
+                    double duration = toDuration ? eval(df, leaf->fparms[1], x, m, p, c, s).number : 0;
 
                     // get the PD Estimate for this date - note we always work with the absolulte
                     // power estimates in formulas, since the user can just divide by config(weight)
@@ -2172,7 +2172,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
                     for(int i=1; i< leaf->fparms.count(); i++) {
 
                         // evaluate the parameter
-                        Result ex = eval(df, leaf->fparms[i], x, m, p, c);
+                        Result ex = eval(df, leaf->fparms[i], x, m, p, c, s);
 
                         if (ex.vector.count()) {
 
@@ -2180,7 +2180,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
                             foreach(double x, ex.vector) {
 
                                 // did it get selected?
-                                Result which = eval(df, leaf->fparms[0], x, m, p, c);
+                                Result which = eval(df, leaf->fparms[0], x, m, p, c, s);
                                 if (which.number) {
                                     returning.vector << x;
                                     returning.number += x;
@@ -2190,7 +2190,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
                         } else {
 
                             // does the parameter get selected ?
-                            Result which = eval(df, leaf->fparms[0], ex.number, m, p, c);
+                            Result which = eval(df, leaf->fparms[0], ex.number, m, p, c, s);
                             if (which.number) {
                                 returning.vector << ex.number;
                                 returning.number += ex.number;
@@ -2206,7 +2206,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
                     Result returning(0);
 
                     if (leaf->fparms.count() < 3) return returning;
-                    else returning = eval(df, leaf->fparms[2], x, m, p, c);
+                    else returning = eval(df, leaf->fparms[2], x, m, p, c, s);
 
                     if (returning.number) {
 
@@ -2224,7 +2224,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
                         if (!f) return Result(0); // eek!
 
                         // evaluate second argument, its the value
-                        Result r = eval(df, leaf->fparms[1], x, m, p, c);
+                        Result r = eval(df, leaf->fparms[1], x, m, p, c, s);
 
                         // now set an override or a tag
                         if (o_symbol != "" && e) { // METRIC OVERRIDE
@@ -2276,7 +2276,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
                     Result returning(0);
 
                     if (leaf->fparms.count() < 2) return returning;
-                    else returning = eval(df, leaf->fparms[1], x, m, p, c);
+                    else returning = eval(df, leaf->fparms[1], x, m, p, c, s);
 
                     if (returning.number) {
 
@@ -2352,7 +2352,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
 
                     if (leaf->fparms.count() != 2) return Result(0);
 
-                    return Result (60*VDOTCalculator::eqvTime(eval(df, leaf->fparms[0], x, m, p, c).number, 1000*eval(df, leaf->fparms[1], x, m, p, c).number));
+                    return Result (60*VDOTCalculator::eqvTime(eval(df, leaf->fparms[0], x, m, p, c, s).number, 1000*eval(df, leaf->fparms[1], x, m, p, c, s).number));
                 }
                 break;
 
@@ -2361,7 +2361,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
 
                     if (leaf->fparms.count() != 1 || m->fileCache() == NULL) return Result(0);
 
-                    return Result (m->fileCache()->bestTime(eval(df, leaf->fparms[0], x, m, p, c).number));
+                    return Result (m->fileCache()->bestTime(eval(df, leaf->fparms[0], x, m, p, c, s).number));
                  }
 
         case 37 :
@@ -2416,7 +2416,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
                     Result returning(0);
 
                     if (leaf->fparms.count() != 1) return returning;
-                    else returning = eval(df, leaf->fparms[0], x, m, p, c);
+                    else returning = eval(df, leaf->fparms[0], x, m, p, c, s);
 
                     if (returning.number) {
 
@@ -2440,7 +2440,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
                     Result returning(0);
 
                     if (leaf->fparms.count() < 2) return returning;
-                    else returning = eval(df, leaf->fparms[1], x, m, p, c);
+                    else returning = eval(df, leaf->fparms[1], x, m, p, c, s);
 
                     if (returning.number) {
 
@@ -2501,7 +2501,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
                 {   // MEASURE (DATE, GROUP, FIELD) get measure
                     if (leaf->fparms.count() < 3) return Result(0);
 
-                    Result days = eval(df, leaf->fparms[0], x, m, p, c);
+                    Result days = eval(df, leaf->fparms[0], x, m, p, c, s);
                     if (!days.isNumber) return Result(0); // invalid date
                     QDate date = QDate(1900,01,01).addDays(days.number);
                     if (!date.isValid()) return Result(0); // invalid date
@@ -2535,7 +2535,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
 
         // run a script
  #ifdef GC_WANT_PYTHON
-        if (leaf->function == "python")  return Result(df->runPythonScript(m->context, *leaf->lvalue.s));
+        if (leaf->function == "python")  return Result(df->runPythonScript(m->context, *leaf->lvalue.s, m, c, s));
  #endif
  #ifdef GC_WANT_R
         if (leaf->function == "R")  return Result(df->runRScript(m->context, *leaf->lvalue.s));
@@ -2672,7 +2672,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
     case Leaf::UnaryOperation :
     {
         // get result
-        Result lhs = eval(df, leaf->lvalue.l, x, m, p, c);
+        Result lhs = eval(df, leaf->lvalue.l, x, m, p, c, s);
 
         // unary minus
         if (leaf->op == '-') return Result(lhs.number * -1);
@@ -2693,12 +2693,12 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
     {
         // lhs and rhs
         Result lhs;
-        if (leaf->op != ASSIGN) lhs = eval(df, leaf->lvalue.l, x, m, p, c);
+        if (leaf->op != ASSIGN) lhs = eval(df, leaf->lvalue.l, x, m, p, c, s);
 
         // if elvis we only evaluate rhs if we are null
         Result rhs;
         if (leaf->op != ELVIS || lhs.number == 0) {
-            rhs = eval(df, leaf->rvalue.l, x, m, p, c);
+            rhs = eval(df, leaf->rvalue.l, x, m, p, c, s);
         }
 
         // NOW PERFORM OPERATION
@@ -2721,7 +2721,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
                     if (leaf->lvalue.l->seriesType == RideFile::none) {
 
                         QString symbol = *(leaf->lvalue.l->lvalue.l->lvalue.n);
-                        int index = eval(df,leaf->lvalue.l->fparms[0], x, m, p, c).number;
+                        int index = eval(df,leaf->lvalue.l->fparms[0], x, m, p, c, s).number;
 
                         // generic symbol
                         if (df->symbols.contains(symbol)) {
@@ -2868,12 +2868,12 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
         case IF_:
         case 0 :
             {
-                Result cond = eval(df, leaf->cond.l, x, m, p, c);
-                if (cond.isNumber && cond.number) return eval(df, leaf->lvalue.l, x, m, p, c);
+                Result cond = eval(df, leaf->cond.l, x, m, p, c, s);
+                if (cond.isNumber && cond.number) return eval(df, leaf->lvalue.l, x, m, p, c, s);
                 else {
 
                     // conditional may not have an else clause!
-                    if (leaf->rvalue.l) return eval(df, leaf->rvalue.l, x, m, p, c);
+                    if (leaf->rvalue.l) return eval(df, leaf->rvalue.l, x, m, p, c, s);
                     else return Result(0);
                 }
             }
@@ -2887,8 +2887,8 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
                 timer.start();
 
                 Result returning(0);
-                while (count++ < maxwhile && eval(df, leaf->cond.l, x, m, p, c).number) {
-                    returning = eval(df, leaf->lvalue.l, x, m, p, c);
+                while (count++ < maxwhile && eval(df, leaf->cond.l, x, m, p, c, s).number) {
+                    returning = eval(df, leaf->lvalue.l, x, m, p, c, s);
                 }
 
                 // we had to terminate warn user !
@@ -2923,8 +2923,8 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
         Specification spec;
 
         // get date range
-        int fromDS = eval(df, leaf->fparms[0], x, m, p, c).number;
-        int toDS = eval(df, leaf->fparms[1], x, m, p, c).number;
+        int fromDS = eval(df, leaf->fparms[0], x, m, p, c, s).number;
+        int toDS = eval(df, leaf->fparms[1], x, m, p, c, s).number;
 
         // swap dates if needed
         if (toDS < fromDS) {
@@ -2946,7 +2946,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
             count++;
 
             // calculate value
-            Result res = eval(df, leaf->lvalue.l, x, ride, p, c);
+            Result res = eval(df, leaf->lvalue.l, x, ride, p, c, s);
             if (res.isNumber) {
                 returning.number += res.number; // sum for easy access
                 returning.vector.resize(count);
@@ -2965,7 +2965,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
     case Leaf::Index :
     {
         if (!p) return Result(0); // only applies when iterating over samples
-        int index = eval(df,leaf->fparms[0], x, m, p, c).number;
+        int index = eval(df,leaf->fparms[0], x, m, p, c, s).number;
 
         // ZERO if out of bounds (save a check)
         if (index < 0 || index >= m->ride()->dataPoints().count())
@@ -2999,7 +2999,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
         Result returning(0);
 
         // evaluate each statement
-        foreach(Leaf *statement, *(leaf->lvalue.b)) returning = eval(df, statement, x, m, p, c);
+        foreach(Leaf *statement, *(leaf->lvalue.b)) returning = eval(df, statement, x, m, p, c, s);
 
         // compound statements evaluate to the value of the last statement
         return returning;
@@ -3014,7 +3014,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, float x, RideItem *m, RideF
 
 #ifdef GC_WANT_PYTHON
 double
-DataFilterRuntime::runPythonScript(Context *context, QString script)
+DataFilterRuntime::runPythonScript(Context *context, QString script, RideItem *m, const QHash<QString,RideMetric*> *metrics, Specification spec)
 {
     if (python == NULL) return(0);
 
@@ -3022,7 +3022,7 @@ DataFilterRuntime::runPythonScript(Context *context, QString script)
     pythonMutex.lock();
 
     // return result
-    double result;
+    double result = 0;
 
     // run it !!
     python->canvas = NULL;
@@ -3032,7 +3032,7 @@ DataFilterRuntime::runPythonScript(Context *context, QString script)
     try {
 
         // run it
-        python->runline(context, script);
+        python->runline(ScriptContext(context, m, metrics, spec), script);
         result = python->result;
 
     } catch(std::exception& ex) {

--- a/src/Core/DataFilter.h
+++ b/src/Core/DataFilter.h
@@ -67,9 +67,10 @@ class Leaf {
         // LTM chart - using symbols from RideItem *m
         // Ride Plot - using symbols from RideItem *m
         // Search/Filter - using symbols from RideItem *m
-        // User Metric - using symbols from QHash<..> (RideItem + Interval)
+        // User Metric - using symbols from QHash<..> (RideItem + Interval) and
+        // Spec to delimit samples in R/Python Scripts
         //
-        Result eval(DataFilterRuntime *df, Leaf *, float x, RideItem *m, RideFilePoint *p = NULL, const QHash<QString,RideMetric*> *metrics=NULL);
+        Result eval(DataFilterRuntime *df, Leaf *, float x, RideItem *m, RideFilePoint *p = NULL, const QHash<QString,RideMetric*> *metrics=NULL, Specification spec=Specification());
 
         // tree traversal etc
         void print(Leaf *, int level, DataFilterRuntime*);  // print leaf and all children
@@ -141,7 +142,7 @@ public:
 
 #ifdef GC_WANT_PYTHON
     // embedded python runtime
-    double runPythonScript(Context *context, QString script);
+    double runPythonScript(Context *context, QString script, RideItem *m, const QHash<QString,RideMetric*> *metrics, Specification spec);
 #endif
 
 #ifdef GC_WANT_R

--- a/src/Core/Specification.cpp
+++ b/src/Core/Specification.cpp
@@ -67,14 +67,14 @@ Specification::setIntervalItem(IntervalItem *it, double recintsecs)
 }
 
 double 
-Specification::secsStart()
+Specification::secsStart() const
 {
     if (it) return it->start;
     else return -1;
 }
 
 double 
-Specification::secsEnd()
+Specification::secsEnd() const
 {
     if (it) return it->stop;
     else return -1;

--- a/src/Core/Specification.h
+++ b/src/Core/Specification.h
@@ -113,8 +113,8 @@ class Specification
         // when working with intervals secs start and end
         // if no interval is set then they return -1 to indicate
         // that the entire ride is in scope
-        double secsStart();
-        double secsEnd();
+        double secsStart() const;
+        double secsEnd() const;
 
     private:
         DateRange dr;

--- a/src/Metrics/RideMetric.cpp
+++ b/src/Metrics/RideMetric.cpp
@@ -152,7 +152,8 @@
 // 142 25  Jul 2017 Ale Martinez       Added HRV metrics at rest (Measures)
 // 143 07  Feb 2018 Walter Buerki      Daniels Points using GAP when no power
 // 144 02  Apr 2018 Mark Liversedge    Force refresh for compatibility metrics
-int DBSchemaVersion = 144;
+// 145 06  Apr 2018 Ale Martinez       Python Scripts in UserMetric honor RideItem and Specification
+int DBSchemaVersion = 145;
 
 RideMetricFactory *RideMetricFactory::_instance;
 QVector<QString> RideMetricFactory::noDeps;

--- a/src/Metrics/UserMetric.cpp
+++ b/src/Metrics/UserMetric.cpp
@@ -184,7 +184,7 @@ UserMetric::isRelevantForRide(const RideItem *item) const
 {
     if (item->context && root) {
         if (frelevant) {
-            Result res = root->eval(rt, frelevant, 0, const_cast<RideItem*>(item), NULL);
+            Result res = root->eval(rt, frelevant, 0, const_cast<RideItem*>(item), NULL, NULL);
             return res.number;
         } else
             return true;
@@ -216,7 +216,7 @@ UserMetric::compute(RideItem *item, Specification spec, const QHash<QString,Ride
 
     //qDebug()<<"INIT";
     // always init first
-    if (finit) root->eval(rt, finit, 0, const_cast<RideItem*>(item), NULL, c);
+    if (finit) root->eval(rt, finit, 0, const_cast<RideItem*>(item), NULL, c, spec);
 
     //qDebug()<<"CHECK";
     // can it provide a value and is it relevant ?
@@ -232,7 +232,7 @@ UserMetric::compute(RideItem *item, Specification spec, const QHash<QString,Ride
 
         while(it.hasNext()) {
             struct RideFilePoint *point = it.next();
-            root->eval(rt, fbefore, 0, const_cast<RideItem*>(item), point, c);
+            root->eval(rt, fbefore, 0, const_cast<RideItem*>(item), point, c, spec);
         }
     }
 
@@ -243,7 +243,7 @@ UserMetric::compute(RideItem *item, Specification spec, const QHash<QString,Ride
 
         while(it.hasNext()) {
             struct RideFilePoint *point = it.next();
-            root->eval(rt, fsample, 0, const_cast<RideItem*>(item), point, c);
+            root->eval(rt, fsample, 0, const_cast<RideItem*>(item), point, c, spec);
         }
     }
 
@@ -253,7 +253,7 @@ UserMetric::compute(RideItem *item, Specification spec, const QHash<QString,Ride
 
         while(it.hasNext()) {
             struct RideFilePoint *point = it.next();
-            root->eval(rt, fafter, 0, const_cast<RideItem*>(item), point, c);
+            root->eval(rt, fafter, 0, const_cast<RideItem*>(item), point, c, spec);
         }
     }
 
@@ -261,14 +261,14 @@ UserMetric::compute(RideItem *item, Specification spec, const QHash<QString,Ride
     //qDebug()<<"VALUE";
     // value ?
     if (fvalue) {
-        Result v = root->eval(rt, fvalue, 0, const_cast<RideItem*>(item), NULL, c);
+        Result v = root->eval(rt, fvalue, 0, const_cast<RideItem*>(item), NULL, c, spec);
         setValue(v.number);
     }
 
     //qDebug()<<"COUNT";
     // count?
     if (fcount) {
-        Result n = root->eval(rt, fcount, 0, const_cast<RideItem*>(item), NULL, c);
+        Result n = root->eval(rt, fcount, 0, const_cast<RideItem*>(item), NULL, c, spec);
         setCount(n.number);
     }
 

--- a/src/Python/PythonEmbed.cpp
+++ b/src/Python/PythonEmbed.cpp
@@ -287,7 +287,7 @@ PythonEmbed::PythonEmbed(const bool verbose, const bool interactive) : verbose(v
 }
 
 // run on called thread
-void PythonEmbed::runline(Context *context, QString line)
+void PythonEmbed::runline(ScriptContext scriptContext, QString line)
 {
     PyGILState_STATE gstate;
     gstate = PyGILState_Ensure();
@@ -301,7 +301,7 @@ void PythonEmbed::runline(Context *context, QString line)
     Py_DECREF(ident);
 
     // add to the thread/context map
-    contexts.insert(threadid, context);
+    contexts.insert(threadid, scriptContext);
 
     // run and generate errors etc
     messages.clear();

--- a/src/Python/PythonEmbed.h
+++ b/src/Python/PythonEmbed.h
@@ -24,11 +24,25 @@
 #include <QMap>
 #include <QStringList>
 
+#include "RideItem.h"
+
 class Context;
 class PythonChart;
 
 class PythonEmbed;
 extern PythonEmbed *python;
+
+// Context for Python Scripts
+class ScriptContext {
+    public:
+
+        ScriptContext(Context *context=NULL, RideItem *item=NULL, const QHash<QString,RideMetric*> *metrics=NULL, Specification spec=Specification()) : context(context), item(item), metrics(metrics), spec(spec) {}
+
+        Context *context;
+        RideItem *item;
+        const QHash<QString,RideMetric*> *metrics;
+        Specification spec;
+};
 
 // a plain C++ class, no QObject stuff
 class PythonEmbed {
@@ -54,13 +68,13 @@ class PythonEmbed {
     void *clear;
 
     // run a single line from console
-    void runline(Context *, QString);
+    void runline(ScriptContext, QString);
 
     // stop current execution
     void cancel();
 
     // context for caller - can be called in a thread
-    QMap<long,Context *> contexts;
+    QMap<long, ScriptContext> contexts;
     PythonChart *chart;
     QWidget *canvas;
 

--- a/src/Python/SIP/Bindings.cpp
+++ b/src/Python/SIP/Bindings.cpp
@@ -65,7 +65,7 @@ Bindings::result(double value)
 // get athlete data
 PyObject* Bindings::athlete() const
 {
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
     if (context == NULL) return NULL;
 
     PyObject* dict = PyDict_New();
@@ -111,7 +111,7 @@ class gcZoneConfig {
 PyObject*
 Bindings::athleteZones(PyObject* date, QString sport) const
 {
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
     if (context == NULL) return NULL;
 
     // import datetime if necessary
@@ -466,7 +466,7 @@ Bindings::athleteZones(PyObject* date, QString sport) const
 PyObject*
 Bindings::activities(QString filter) const
 {
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
 
     if (context && context->athlete && context->athlete->rideCache) {
 
@@ -524,7 +524,7 @@ Bindings::activities(QString filter) const
 RideItem*
 Bindings::fromDateTime(PyObject* activity) const
 {
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
 
     // import datetime if necessary
     if (PyDateTimeAPI == NULL) PyDateTime_IMPORT;
@@ -548,16 +548,27 @@ Bindings::fromDateTime(PyObject* activity) const
 PythonDataSeries*
 Bindings::series(int type, PyObject* activity) const
 {
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
     if (context == NULL) return NULL;
 
     RideItem* item = fromDateTime(activity);
+    if (item == NULL) item = python->contexts.value(threadid()).item;
     if (item == NULL) item = const_cast<RideItem*>(context->currentRideItem());
     if (item == NULL) return NULL;
 
     RideFile* f = item->ride();
-    PythonDataSeries* ds = new PythonDataSeries(seriesName(type), f->dataPoints().count());
-    for(int i=0; i<ds->count; i++) ds->data[i] = f->dataPoints()[i]->value(static_cast<RideFile::SeriesType>(type));
+    if (f == NULL) return NULL;
+
+    // count the included points, create data series output and copy data
+    int pCount = 0;
+    RideFileIterator it(f, python->contexts.value(threadid()).spec);
+    while (it.hasNext()) { it.next(); pCount++; }
+    PythonDataSeries* ds = new PythonDataSeries(seriesName(type), pCount);
+    it.toFront();
+    for(int i=0; i<pCount && it.hasNext(); i++) {
+        struct RideFilePoint *point = it.next();
+        ds->data[i] = point->value(static_cast<RideFile::SeriesType>(type));
+    }
 
     return ds;
 }
@@ -566,10 +577,11 @@ Bindings::series(int type, PyObject* activity) const
 PythonDataSeries*
 Bindings::activityWbal(PyObject* activity) const
 {
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
     if (context == NULL) return NULL;
 
     RideItem* item = fromDateTime(activity);
+    if (item == NULL) item = python->contexts.value(threadid()).item;
     if (item == NULL) item = const_cast<RideItem*>(context->currentRideItem());
     if (item == NULL) return NULL;
 
@@ -580,8 +592,19 @@ Bindings::activityWbal(PyObject* activity) const
     WPrime *w = f->wprimeData();
     if (w == NULL) return NULL;
 
-    PythonDataSeries* ds = new PythonDataSeries("WBal", w->ydata().count());
-    for(int i=0; i<ds->count; i++) ds->data[i] = w->ydata()[i];
+    // count the included points, create data series output and copy data
+    int pCount = 0;
+    int idxStart = 0;
+    int secsStart = python->contexts.value(threadid()).spec.secsStart();
+    int secsEnd = python->contexts.value(threadid()).spec.secsEnd();
+    for(int i=0; i<w->xdata(false).count(); i++) {
+        if (w->xdata(false)[i] < secsStart) continue;
+        if (secsEnd >= 0 && w->xdata(false)[i] > secsEnd) break;
+        if (pCount == 0) idxStart = i;
+        pCount++;
+    }
+    PythonDataSeries* ds = new PythonDataSeries("WBal", pCount);
+    for(int i=0; i<pCount; i++) ds->data[i] = w->ydata()[i+idxStart];
 
     return ds;
 }
@@ -603,10 +626,11 @@ Bindings::activityXdata(QString name, QString series, QString join, PyObject* ac
         case 3: xjoin = RideFile::RESAMPLE; break;
     }
 
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
     if (context == NULL) return NULL;
 
     RideItem* item = fromDateTime(activity);
+    if (item == NULL) item = python->contexts.value(threadid()).item;
     if (item == NULL) item = const_cast<RideItem*>(context->currentRideItem());
     if (item == NULL) return NULL;
 
@@ -618,11 +642,16 @@ Bindings::activityXdata(QString name, QString series, QString join, PyObject* ac
 
     if (!xds->valuename.contains(series)) return NULL; // No shuch XData name
 
-    PythonDataSeries* ds = new PythonDataSeries(name, f->dataPoints().count());
+    // count the included points, create data series output and copy data
+    int pCount = 0;
+    RideFileIterator it(f, python->contexts.value(threadid()).spec);
+    while (it.hasNext()) { it.next(); pCount++; }
+    PythonDataSeries* ds = new PythonDataSeries(name, pCount);
+    it.toFront();
     int idx = 0;
-    for(int i=0; i<ds->count; i++) {
-        RideFilePoint *p = f->dataPoints()[i];
-        double val = f->xdataValue(p, idx, name, series, xjoin);
+    for(int i=0; i<pCount && it.hasNext(); i++) {
+        struct RideFilePoint *point = it.next();
+        double val = f->xdataValue(point, idx, name, series, xjoin);
         ds->data[i] = (val == RideFile::NA) ? sqrt(-1) : val; // NA => NaN
     }
 
@@ -645,10 +674,11 @@ bool
 Bindings::seriesPresent(int type, PyObject* activity) const
 {
 
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
     if (context == NULL) return false;
 
     RideItem* item = fromDateTime(activity);
+    if (item == NULL) item = python->contexts.value(threadid()).item;
     if (item == NULL) item = const_cast<RideItem*>(context->currentRideItem());
     if (item == NULL) return NULL;
 
@@ -676,7 +706,7 @@ PythonDataSeries::~PythonDataSeries()
 PyObject*
 Bindings::activityMetrics(bool compare) const
 {
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
     if (context == NULL) return NULL;
 
     // want a list of compares
@@ -717,7 +747,8 @@ Bindings::activityMetrics(bool compare) const
     } else {
 
         // not compare, so just return a dict
-        RideItem *item = const_cast<RideItem*>(context->currentRideItem());
+        RideItem *item = python->contexts.value(threadid()).item;
+        if (item == NULL) item = const_cast<RideItem*>(context->currentRideItem());
 
         return activityMetrics(item);
     }
@@ -726,7 +757,7 @@ Bindings::activityMetrics(bool compare) const
 PyObject*
 Bindings::activityMetrics(RideItem* item) const
 {
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
     if (context == NULL) return NULL;
 
     PyObject* dict = PyDict_New();
@@ -756,6 +787,12 @@ Bindings::activityMetrics(RideItem* item) const
 
         bool useMetricUnits = context->athlete->useMetricUnits;
         double value = item->metrics()[i] * (useMetricUnits ? 1.0f : metric->conversion()) + (useMetricUnits ? 0.0f : metric->conversionSum());
+
+        // Override if we have precomputed values in ScriptContext (UserMetric)
+        if (python->contexts.value(threadid()).metrics && python->contexts.value(threadid()).metrics->contains(symbol)) {
+            const RideMetric *metric = python->contexts.value(threadid()).metrics->value(symbol);
+            value = metric->value(useMetricUnits);
+        }
 
         // add to the dict
         PyDict_SetItemString(dict, name.toUtf8().constData(), PyFloat_FromDouble(value));
@@ -801,7 +838,7 @@ Bindings::activityMetrics(RideItem* item) const
 PyObject*
 Bindings::seasonMetrics(bool all, QString filter, bool compare) const
 {
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
     if (context == NULL) return NULL;
 
     // want a list of compares
@@ -856,7 +893,7 @@ Bindings::seasonMetrics(bool all, QString filter, bool compare) const
 PyObject*
 Bindings::seasonMetrics(bool all, DateRange range, QString filter) const
 {
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
     if (context == NULL || context->athlete == NULL || context->athlete->rideCache == NULL) return NULL;
 
     // how many rides to return if we're limiting to the
@@ -992,7 +1029,7 @@ Bindings::seasonMetrics(bool all, DateRange range, QString filter) const
 PyObject*
 Bindings::seasonIntervals(QString type, bool compare) const
 {
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
     if (context == NULL) return NULL;
 
     // want a list of compares
@@ -1047,7 +1084,7 @@ Bindings::seasonIntervals(QString type, bool compare) const
 PyObject*
 Bindings::seasonIntervals(DateRange range, QString type) const
 {
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
     if (context == NULL || context->athlete == NULL || context->athlete->rideCache == NULL) return NULL;
 
     const RideMetricFactory &factory = RideMetricFactory::instance();
@@ -1172,7 +1209,7 @@ Bindings::seasonIntervals(DateRange range, QString type) const
 PythonDataSeries*
 Bindings::metrics(QString metric, bool all, QString filter) const
 {
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
     if (context == NULL || context->athlete == NULL || context->athlete->rideCache == NULL) return NULL;
 
     // how many rides to return if we're limiting to the
@@ -1238,7 +1275,7 @@ Bindings::metrics(QString metric, bool all, QString filter) const
 PyObject*
 Bindings::activityMeanmax(bool compare) const
 {
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
     if (context == NULL) return NULL;
 
     // want a list of compares
@@ -1278,14 +1315,16 @@ Bindings::activityMeanmax(bool compare) const
     } else {
 
         // not compare, so just return a dict
-        return activityMeanmax(context->currentRideItem());
+        RideItem *item = python->contexts.value(threadid()).item;
+        if (item == NULL) item = const_cast<RideItem*>(context->currentRideItem());
+        return activityMeanmax(item);
     }
 }
 
 PyObject*
 Bindings::seasonMeanmax(bool all, QString filter, bool compare) const
 {
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
     if (context == NULL) return NULL;
 
     // want a list of compares
@@ -1341,7 +1380,7 @@ Bindings::seasonMeanmax(bool all, QString filter, bool compare) const
 PyObject*
 Bindings::seasonMeanmax(bool all, DateRange range, QString filter) const
 {
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
     if (context == NULL) return NULL;
 
     // construct the date range and then get a ridefilecache
@@ -1431,7 +1470,7 @@ Bindings::rideFileCacheMeanmax(RideFileCache* cache) const
 PyObject*
 Bindings::seasonPmc(bool all, QString metric) const
 {
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
 
     // return a dict with PMC data for all or the current season
     // XXX uses the default half-life
@@ -1532,7 +1571,7 @@ Bindings::seasonPmc(bool all, QString metric) const
 PyObject*
 Bindings::seasonMeasures(bool all, QString group) const
 {
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
 
     // return a dict with Measures data for all or the current season
     if (context && context->athlete && context->athlete->measures) {
@@ -1605,7 +1644,7 @@ Bindings::seasonMeasures(bool all, QString group) const
 PyObject*
 Bindings::season(bool all, bool compare) const
 {
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
     if (context == NULL) return NULL;
 
     // import datetime if necessary
@@ -1672,7 +1711,7 @@ Bindings::season(bool all, bool compare) const
 PyObject*
 Bindings::seasonPeaks(QString series, int duration, bool all, QString filter, bool compare) const
 {
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
     if (context == NULL) return NULL;
 
     // lets get a Map of names to series
@@ -1755,7 +1794,7 @@ Bindings::seasonPeaks(bool all, DateRange range, QString filter, QList<RideFile:
 {
     if (PyDateTimeAPI == NULL) PyDateTime_IMPORT;// import datetime if necessary
 
-    Context *context = python->contexts.value(threadid());
+    Context *context = python->contexts.value(threadid()).context;
     if (context == NULL) return NULL;
 
     // we return a dict


### PR DESCRIPTION
Carry RideItem, Specification and Metrics to consider the cases when
the script is part of a UserMetric or an LTMPlot formula
Python series, activityWbal and activityXdata honor RideItem and Specification
Python activityMetrics honors ScriptContext RideItem and Metrics
Python activityMeanMax honors ScriptContext RideItem
Force recomputation of metrics just in case Python Scripts were used before

This is the Python only version of https://github.com/GoldenCheetah/GoldenCheetah/pull/2841