### PR TITLE
TriScore - On zero fallback to TRIMP Zonal Points for HR base score

### DIFF
--- a/src/Metrics/RideMetric.cpp
+++ b/src/Metrics/RideMetric.cpp
@@ -153,7 +153,8 @@
 // 143 07  Feb 2018 Walter Buerki      Daniels Points using GAP when no power
 // 144 02  Apr 2018 Mark Liversedge    Force refresh for compatibility metrics
 // 145 06  Apr 2018 Ale Martinez       Python Scripts in UserMetric honor RideItem and Specification
-int DBSchemaVersion = 145;
+// 146 21  Apr 2018 Ale Martinez       TriScore Fallback to TRIMP Zonal Points
+int DBSchemaVersion = 146;
 
 RideMetricFactory *RideMetricFactory::_instance;
 QVector<QString> RideMetricFactory::noDeps;

--- a/src/Metrics/SwimScore.cpp
+++ b/src/Metrics/SwimScore.cpp
@@ -387,7 +387,7 @@ class TriScore : public RideMetric {
     void initialize() {
         setName("TriScore");
         setType(RideMetric::Total);
-        setDescription(tr("TriScore combined stress metric based on Dr. Skiba stress metrics, defined as BikeScore for cycling, GOVSS for running and SwimScore for swimming"));
+        setDescription(tr("TriScore combined stress metric based on Dr. Skiba stress metrics, defined as BikeScore for cycling, GOVSS for running and SwimScore for swimming. On zero fallback to TRIMP Zonal Points for HR based score."));
     }
     void compute(RideItem *item, Specification, const QHash<QString,RideMetric*> &deps) {
 
@@ -402,6 +402,12 @@ class TriScore : public RideMetric {
             score = deps.value("skiba_bike_score")->value(true);
         }
 
+        // On zero fallback to TRIMP Zonal Points for HR based score
+        if (score == 0.0) {
+            assert(deps.contains("trimp_zonal_points"));
+            score = deps.value("trimp_zonal_points")->value(true);
+        }
+
         setValue(score);
     }
     MetricClass classification() const { return Undefined; }
@@ -414,6 +420,7 @@ static bool addTriScore() {
     deps.append("swimscore");
     deps.append("govss");
     deps.append("skiba_bike_score");
+    deps.append("trimp_zonal_points");
     RideMetricFactory::instance().addMetric(TriScore(), &deps);
     return true;
 }


### PR DESCRIPTION
New users comming from Strava, TP, etc. expect this behavior by default
This doesn't affect single sport metrics, only the global score.
TRIMP Zonal Points are a reazonable proxy and they are configurable
via trimp-k coefficients in HR Zones.
Related to: https://groups.google.com/forum/#!topic/golden-cheetah-users/sUrrjxaMfDc