### PR TITLE
Add Lap Distance and Lap Distance Remaining dials and telemetry

### DIFF
--- a/src/Train/DialWindow.cpp
+++ b/src/Train/DialWindow.cpp
@@ -241,7 +241,16 @@ DialWindow::telemetryUpdate(const RealtimeData &rtData)
         valueLabel->setText(QString("%1").arg(value, 0, 'f', 1));
         break;
 
+    // If the distance remaining is negative, it is either irrelevant, or we've passed the last lap marker
+    case RealtimeData::LapDistanceRemaining:
+        if (value < 0) {
+            valueLabel->setText("N/A");
+            break;
+        }
+        // intentional fall-through to standard distance rendering
+
     case RealtimeData::Distance:
+    case RealtimeData::LapDistance:
         if (!context->athlete->useMetricUnits) value *= MILES_PER_KM;
         valueLabel->setText(QString("%1").arg(value, 0, 'f', 3));
         break;
@@ -543,6 +552,8 @@ void DialWindow::seriesChanged()
     case RealtimeData::LapTime:
     case RealtimeData::LapTimeRemaining:
     case RealtimeData::Distance:
+    case RealtimeData::LapDistance:
+    case RealtimeData::LapDistanceRemaining:
     case RealtimeData::LRBalance:
     case RealtimeData::Lap:
     case RealtimeData::RI:

--- a/src/Train/ErgFile.h
+++ b/src/Train/ErgFile.h
@@ -112,7 +112,9 @@ class ErgFile
         int format;             // ERG, CRS or MRC currently supported
         int wattsAt(long, int&);      // return the watts value for the passed msec
         double gradientAt(long, int&);      // return the gradient value for the passed meter
-        int nextLap(long);      // return the msecs value for the next Lap marker
+
+        int nextLap(long);      // return the start value (erg - time(ms) or slope - distance(m)) for the next lap
+        int currentLap(long);   // return the start value (erg - time(ms) or slope - distance(m)) for the current lap
 
         // turn the ergfile into a series of sections rather
         // than a list of points

--- a/src/Train/RealtimeData.cpp
+++ b/src/Train/RealtimeData.cpp
@@ -106,6 +106,16 @@ void RealtimeData::setDistance(double x)
     this->distance = x;
 }
 
+void RealtimeData::setLapDistance(double x)
+{
+    this->lapDistance = x;
+}
+
+void RealtimeData::setLapDistanceRemaining(double x)
+{
+    this->lapDistanceRemaining = x;
+}
+
 void RealtimeData::setLRBalance(double x)
 {
     this->lrbalance = x;
@@ -193,6 +203,14 @@ long RealtimeData::getLapMsecs() const
 double RealtimeData::getDistance() const
 {
     return distance;
+}
+double RealtimeData::getLapDistance() const
+{
+    return lapDistance;
+}
+double RealtimeData::getLapDistanceRemaining() const
+{
+    return lapDistanceRemaining;
 }
 double RealtimeData::getLRBalance() const
 {
@@ -296,6 +314,12 @@ double RealtimeData::value(DataSeries series) const
         break;
 
     case Distance: return distance;
+        break;
+
+    case LapDistance: return lapDistance;
+        break;
+
+    case LapDistanceRemaining: return lapDistanceRemaining;
         break;
 
     case AltWatts: return altWatts;
@@ -406,6 +430,8 @@ const QList<RealtimeData::DataSeries> &RealtimeData::listDataSeries()
         seriesList << LeftPedalSmoothness;
         seriesList << RightPedalSmoothness;
         seriesList << Slope;
+        seriesList << LapDistance;
+        seriesList << LapDistanceRemaining;
     }
     return seriesList;
 }
@@ -536,6 +562,12 @@ QString RealtimeData::seriesName(DataSeries series)
         break;
 
     case Slope: return tr("Slope");
+        break;
+
+    case LapDistance: return tr("Lap Distance");
+        break;
+
+    case LapDistanceRemaining: return tr("Lap Distance Remaining");
         break;
     }
 }

--- a/src/Train/RealtimeData.h
+++ b/src/Train/RealtimeData.h
@@ -43,7 +43,8 @@ public:
                       AvgWattsLap, AvgSpeedLap, AvgCadenceLap, AvgHeartRateLap,
                       VirtualSpeed, AltWatts, LRBalance, LapTimeRemaining,
                       LeftTorqueEffectiveness, RightTorqueEffectiveness,
-                      LeftPedalSmoothness, RightPedalSmoothness, Slope};
+                      LeftPedalSmoothness, RightPedalSmoothness, Slope, 
+                      LapDistance, LapDistanceRemaining };
 
     typedef enum dataseries DataSeries;
 
@@ -75,6 +76,8 @@ public:
     void setJoules(long);
     void setXPower(long);
     void setLap(long);
+    void setLapDistance(double distance);
+    void setLapDistanceRemaining(double distance);
     void setLRBalance(double);
     void setLTE(double);
     void setRTE(double);
@@ -107,6 +110,8 @@ public:
     long getLapMsecs() const;
     double getDistance() const;
     long getLap() const;
+    double getLapDistance() const;
+    double getLapDistanceRemaining() const;
     double getLRBalance() const;
     double getLTE() const;
     double getRTE() const;
@@ -141,6 +146,8 @@ private:
 
     // derived data
     double distance;
+    double lapDistance;
+    double lapDistanceRemaining;
     double virtualSpeed;
     double wbal;
     double hhb, o2hb;

--- a/src/Train/TrainSidebar.h
+++ b/src/Train/TrainSidebar.h
@@ -247,12 +247,16 @@ class TrainSidebar : public GcWindow
         double displayLRBalance, displayLTE, displayRTE, displayLPS, displayRPS;
         double displaySMO2, displayTHB, displayO2HB, displayHHB;
         double displayDistance, displayWorkoutDistance;
+        double displayLapDistance, displayLapDistanceRemaining;
         long load;
         double slope;
         int displayLap;            // user increment for Lap
         int displayWorkoutLap;     // which Lap in the workout are we at?
         bool lapAudioEnabled;
         bool lapAudioThisLap;
+
+        void updateMetricLapDistance();
+        void updateMetricLapDistanceRemaining();
 
         // for non-zero average calcs
         int pwrcount, cadcount, hrcount, spdcount, lodcount, grdcount; // for NZ average calc


### PR DESCRIPTION
Adds new dials for the training screen that show Lap Distance and Lap Distance Remaining.

There are some slight display irregularities under test conditions - e.g. you've got 10m laps and are burning through them quickly - the lap distance can exceed the lap lengths due to how the display is updated. But when using longer laps this becomes less of an issue.

Predominantly for CRS files. 

