### PR TITLE
Ensure the Cloud Service wizard on top after the OAuth modal dialog closes

### DIFF
--- a/src/Cloud/AddCloudWizard.cpp
+++ b/src/Cloud/AddCloudWizard.cpp
@@ -351,6 +351,10 @@ AddAuth::doAuth()
                     message->show();
                     wizard->cloudService->message = "";
                 }
+
+                // Due to the OAuth dialog being modal, the order of the background windows can get out of order
+                // This ensures the wizard is back on top
+                wizard->raise();
             }
         }
     }


### PR DESCRIPTION
When I'm closing the OAuth dialog in the Add Cloud Wizard, the wizard is sent to the back of the z-order. This is hugely confusing as a new user (especially on Mac as you need to know Command-~ to flip windows) - and irritating once you know what is happening.

The code in the PR ensures the Wizard is brought back to the front after the OAuth dialog closes.

Steps: (Add Cloud Wizard => Today's Plan => Authorize => OAuth Dialog => Enter creds => Allow Access => OAuth successful)

I only have Macs, so it might be a peculiarity of the Mac windowing system - but I couldn't think of a good reason not to just apply the `raise()` on all operating systems.

Can supply a video if required. But I'd be surprised if other's hadn't seen this happen.