### PR TITLE
fix missing break in switch/case statement

### DIFF
--- a/src/FileIO/FitRideFile.cpp
+++ b/src/FileIO/FitRideFile.cpp
@@ -2802,6 +2802,7 @@ struct FitFileReaderState
                 case 53: /* speed zone */
                 case 55: /* monitoring */
                 case 72: /* training file (undocumented) : new since garmin 800 */
+                    break;
                 case HRV_MSG_NUM:
 		  decodeHRV(def, values);
 		  break; /* hrv */


### PR DESCRIPTION
when HRV have been added no break was inserted in the switch/case directive.
All other messages are thereby decoded as HRV messages