### PR TITLE
ANT: HRV measurement improvements

### DIFF
--- a/src/ANT/ANTMessage.cpp
+++ b/src/ANT/ANTMessage.cpp
@@ -383,15 +383,24 @@ ANTMessage::ANTMessage(ANT *parent, const unsigned char *message) {
                 // insist upon page 0 or page 4 being present
                 switch (data_page) {
                 case 0:
+                    {
+                        // Page 0 only contains time of last heartbeat
+                        // so propagate that and
+                        lastMeasurementTime = message[8] + (message[9]<<8);
+                    }
+                break;
                 case 4:
                     {
-                        measurementTime = message[8] + (message[9]<<8);
+                        // Page 4 contains both time of last heartbeat and
+                        // the time of the previous one.
+                        lastMeasurementTime = message[8] + (message[9]<<8);
+                        prevMeasurementTime = message[6] + (message[7]<<8);
                     }
                     break;
 
                 default:
                     // ignore
-                    measurementTime = 0;
+                    lastMeasurementTime = 0;
                     break;
                 }
             }
@@ -824,7 +833,8 @@ void ANTMessage::init()
     data_page = frequency = deviceType = transmitPower = searchTimeout = 0;
     transmissionType = networkNumber = channelType = channel = 0;
     channelPeriod = deviceNumber = 0;
-    wheelMeasurementTime = crankMeasurementTime = measurementTime = 0;
+    wheelMeasurementTime = crankMeasurementTime = lastMeasurementTime = 0;
+    prevMeasurementTime = 0;
     instantHeartrate = heartrateBeats = 0;
     eventCount = 0;
     wheelRevolutions = crankRevolutions = 0;

--- a/src/ANT/ANTMessage.h
+++ b/src/ANT/ANTMessage.h
@@ -135,7 +135,7 @@ class ANTMessage {
         uint8_t eventCount;
         bool pedalPowerContribution; // power - if true, right pedal power % of contribution is filled in "pedalPower"
         uint8_t pedalPower; // power - if pedalPowerContribution is true, % contribution of right pedal
-        uint16_t measurementTime, wheelMeasurementTime, crankMeasurementTime;
+        uint16_t lastMeasurementTime, prevMeasurementTime, wheelMeasurementTime, crankMeasurementTime;
         uint8_t heartrateBeats, instantHeartrate; // heartrate
         uint16_t slope, period, torque; // power
         uint16_t sumPower, instantPower; // power


### PR DESCRIPTION
Improved handling of data page 4 for ANT+ HR.

I'm a bit worried about the check for *MeasurementTime != 0. That should lead to a loss of measurement every 1024 message on average for page 0 measurements and every 512 for page 4. Maybe it's enough to check that the number of heartbeats has increased? Anyway, that can be improved later.