### PR TITLE
PythonConsole: Print expression value when executing simple statements

### DIFF
--- a/src/Charts/PythonChart.cpp
+++ b/src/Charts/PythonChart.cpp
@@ -197,7 +197,7 @@ void PythonConsole::keyPressEvent(QKeyEvent *e)
                 line = line.replace("$$", chartid);
 
                 python->cancelled = false;
-                python->runline(ScriptContext(context), line);
+                python->runline(ScriptContext(context, nullptr, nullptr, Specification(), true), line);
 
                 // the run command should result in some messages being generated
                 putData(GColor(CPLOTMARKER), python->messages.join(""));

--- a/src/Python/PythonEmbed.cpp
+++ b/src/Python/PythonEmbed.cpp
@@ -311,7 +311,17 @@ void PythonEmbed::runline(ScriptContext scriptContext, QString line)
 
     // run and generate errors etc
     messages.clear();
-    PyRun_SimpleString(line.toStdString().c_str());
+
+    if (scriptContext.interactiveShell) {
+        PyObject *m, *d, *v;
+        m = PyImport_AddModule("__main__");
+        d = PyModule_GetDict(m);
+        v = PyRun_StringFlags(line.toStdString().c_str(), Py_single_input, d, d, 0);
+        if (v) Py_DECREF(v);
+    } else {
+        PyRun_SimpleString(line.toStdString().c_str());
+    }
+
     PyErr_Print();
     PyErr_Clear(); //and clear them !
 

--- a/src/Python/PythonEmbed.h
+++ b/src/Python/PythonEmbed.h
@@ -36,12 +36,14 @@ extern PythonEmbed *python;
 class ScriptContext {
     public:
 
-        ScriptContext(Context *context=NULL, RideItem *item=NULL, const QHash<QString,RideMetric*> *metrics=NULL, Specification spec=Specification()) : context(context), item(item), metrics(metrics), spec(spec) {}
+        ScriptContext(Context *context=NULL, RideItem *item=NULL, const QHash<QString,RideMetric*> *metrics=NULL, Specification spec=Specification(), bool interactiveShell=false)
+            : context(context), item(item), metrics(metrics), spec(spec), interactiveShell(interactiveShell) {}
 
         Context *context;
         RideItem *item;
         const QHash<QString,RideMetric*> *metrics;
         Specification spec;
+        bool interactiveShell;
 };
 
 // a plain C++ class, no QObject stuff


### PR DESCRIPTION
This PR makes the Python console behave more like a proper REPL shell in that it now prints the value of any expression entered automatically on the next line, e.g.:
```
>>> 1+1
2
>>> "Hello World"
'Hello World'
>>>
```