### PR TITLE
LTM Reveal Window

### DIFF
--- a/src/Charts/LTMWindow.cpp
+++ b/src/Charts/LTMWindow.cpp
@@ -215,6 +215,7 @@ LTMWindow::LTMWindow(Context *context) :
             << tr("All");
     rGroupBy->setStrings(strings);
     rGroupBy->setValue(0);
+    rGroupBy->setMinimumWidth(100);
 
     revealLayout->addWidget(rGroupBy);
     rData = new QCheckBox(tr("Data Table"), this);


### PR DESCRIPTION
- avoid "cut off" text for translated period strings