### PR TITLE
Export .fit with correct activity type instead of "Ride". Fixed exporting "Runs"

### DIFF
--- a/src/FileIO/FitRideFile.cpp
+++ b/src/FileIO/FitRideFile.cpp
@@ -3326,7 +3326,10 @@ void write_session(QByteArray *array, const RideFile *ride, QHash<QString,RideMe
     write_int32(array, value, true);
 
     // 6. sport
-    write_int8(array, 2);
+    // Export as bike, run or swim, default sport is bike. 
+    // todo: support all sports based on tag "Sport"
+    int sport = ride->isRun() ? 1 : ride->isSwim() ? 5 : 2;
+    write_int8(array, sport);
 
     // 7. sub sport
     write_int8(array, 0);
@@ -3522,7 +3525,7 @@ void write_record_definition(QByteArray *array, const RideFile *ride, QMap<int, 
         num_fields ++;
         write_field_definition(fields, 3, 1, 2); // heart_rate (3)
     }
-    if ( withCad && ride->areDataPresent()->cad ) {
+    if ( withCad && (ride->areDataPresent()->cad || (ride->isRun() && ride->areDataPresent()->rcad)) ) {
         num_fields ++;
         write_field_definition(fields, 4, 1, 2); // cadence (4)
     }
@@ -3543,7 +3546,7 @@ void write_record_definition(QByteArray *array, const RideFile *ride, QMap<int, 
         num_fields ++;
         write_field_definition(fields, 13, 1, 2); // temperature (13)
     }
-    if ( (type&2)==1 ) {
+    if ( (type&2)==2 ) {
         num_fields ++;
         write_field_definition(fields, 30, 1, 2); // left_right_balance (30)
     }
@@ -3595,6 +3598,10 @@ void write_record(QByteArray *array, const RideFile *ride, bool withAlt, bool wi
         if ( withCad && ride->areDataPresent()->cad ) {
             write_int8(ridePoint, point->cad);
         }
+        // In runs, cadence is saved in 'rcad' instead of 'cad'
+        if (withCad && ride->isRun() && ride->areDataPresent()->rcad){
+            write_int8(ridePoint, point->rcad);
+        }
         if ( ride->areDataPresent()->km ) {
             write_int32(ridePoint, point->km * 100000, true);
         }
@@ -3609,7 +3616,7 @@ void write_record(QByteArray *array, const RideFile *ride, bool withAlt, bool wi
         if ( (type&1)==1) {
             write_int8(ridePoint, point->temp);
         }
-        if ( (type&2)==1 ) {
+        if ( (type&2)==2 ) {
             write_int8(ridePoint, point->lrbalance);
         }
 


### PR DESCRIPTION
Set the type of activity to Ride(2), Run(1) or Swim(5), instead of always Ride(2).
If exporting a Run, use rcad instead of cad

Lrbalance was never exported - fixed it. This was an interesting bug - QT Creator told me: "bitwise comparison always evaluates to false" - it took me some time, to understand why 😉 
Look for yourself:  `(type&2)==1`