### PR TITLE
xdata: Fix min/max of spinbox in xdata editor

### DIFF
--- a/src/Charts/RideEditor.cpp
+++ b/src/Charts/RideEditor.cpp
@@ -1331,6 +1331,8 @@ QWidget *XDataCellDelegate::createEditor(QWidget *parent, const QStyleOptionView
     default:
     {
         QDoubleSpinBox *valueEdit = new QDoubleSpinBox(parent);
+        valueEdit->setMaximum(std::numeric_limits<double>::max());
+        valueEdit->setMinimum(-std::numeric_limits<double>::max());
         connect(valueEdit, SIGNAL(editingFinished()), this, SLOT(commitAndCloseEditor()));
         return valueEdit;
     }


### PR DESCRIPTION
Allow manually setting xdata values beyond min 0 and max 99.9