### PR TITLE
Add XDG categories

### DIFF
--- a/travis/linux/deploy.sh
+++ b/travis/linux/deploy.sh
@@ -18,6 +18,7 @@ Name=GoldenCheetah
 Comment=Cycling Power Analysis Software.
 Exec=GoldenCheetah
 Icon=gc
+Categories=Science;Sports;
 EOF
 # Icon
 cp ./src/Resources/images/gc.png appdir/


### PR DESCRIPTION
This adds XDG categories that are needed so that the application shows up properly in the menu and can be added to https://appimage.github.io/.

Sports is not a standalone category as per https://standards.freedesktop.org/menu-spec/latest/apas02.html

Reference:
https://github.com/AppImage/appimage.github.io/pull/1193