### PR TITLE
Prevent GC from crashing if Bindings method return NULL PythonDataSeries

### DIFF
--- a/src/Python/SIP/Bindings.cpp
+++ b/src/Python/SIP/Bindings.cpp
@@ -773,7 +773,12 @@ PythonDataSeries::PythonDataSeries(QString name, Py_ssize_t count) : name(name),
 PythonDataSeries::PythonDataSeries() : name(QString()), count(0), data(NULL) {}
 PythonDataSeries::PythonDataSeries(PythonDataSeries *clone)
 {
-    *this = *clone;
+    if (clone) *this = *clone;
+    else {
+        name = QString();
+        count = 0;
+        data = NULL;
+    }
 }
 
 PythonDataSeries::~PythonDataSeries()


### PR DESCRIPTION
GC crashes if copy ctor in PythonDataSeries is passed NULL, which happens if any of the Bindings methods returns NULL (e.g. if an xdata series is not present). I've changed the copy ctor impl so that default values are assigned to the members of the new instance if NULL is passed.