### PR TITLE
Fixes: #3007 by specifying HFS+ for fs type

### DIFF
--- a/travis/osx/after_success.sh
+++ b/travis/osx/after_success.sh
@@ -4,7 +4,7 @@ cd src
 echo "Checking GoldenCheetah.app can execute"
 GoldenCheetah.app/Contents/MacOS/GoldenCheetah --help
 echo "About to create dmg file and fix up"
-/usr/local/opt/qt5/bin/macdeployqt GoldenCheetah.app -verbose=2 -dmg
+/usr/local/opt/qt5/bin/macdeployqt GoldenCheetah.app -verbose=2 -fs hfs+ -dmg
 python ../travis/macdeployqtfix.py GoldenCheetah.app /usr/local/opt/qt5
 echo "Cleaning up installed QT libraries from qt5"
 brew remove qt5


### PR DESCRIPTION
Follow guidelines from https://doc.qt.io/qt-5.9/osx-deployment.html to use HFS+ to enable reading the DMG on MacOS versions prior to high sierra.