### PR TITLE
VC2017/Qt 5.12.1 - Fix 64Bit Build Problem

### DIFF
--- a/src/FileIO/LocationInterpolation.cpp
+++ b/src/FileIO/LocationInterpolation.cpp
@@ -240,15 +240,10 @@ xyz UnitCatmullRomInterpolator3D::Interpolate(double frac)
 
 geolocation GeoPointInterpolator::Interpolate(double distance)
 {
-    return DistancePointInterpolator::Interpolate(distance).togeolocation();
-}
-
-bool GeoPointInterpolator::GetBracket(double &d0, double &d1)
-{
-    return DistancePointInterpolator::GetBracket(d0, d1);
+    return DistancePointInterpolator<SphericalTwoPointInterpolator>::Interpolate(distance).togeolocation();
 }
 
 void GeoPointInterpolator::Push(double distance, geolocation point)
 {
-    DistancePointInterpolator::Push(distance, point.toxyz());
+    DistancePointInterpolator<SphericalTwoPointInterpolator>::Push(distance, point.toxyz());
 }

--- a/src/FileIO/LocationInterpolation.cpp
+++ b/src/FileIO/LocationInterpolation.cpp
@@ -243,6 +243,11 @@ geolocation GeoPointInterpolator::Interpolate(double distance)
     return DistancePointInterpolator::Interpolate(distance).togeolocation();
 }
 
+bool GeoPointInterpolator::GetBracket(double &d0, double &d1)
+{
+    return DistancePointInterpolator::GetBracket(d0, d1);
+}
+
 void GeoPointInterpolator::Push(double distance, geolocation point)
 {
     DistancePointInterpolator::Push(distance, point.toxyz());

--- a/src/FileIO/LocationInterpolation.h
+++ b/src/FileIO/LocationInterpolation.h
@@ -492,6 +492,7 @@ public:
     GeoPointInterpolator() : DistancePointInterpolator() {}
 
     geolocation Interpolate(double distance);
+    bool GetBracket(double &d0, double &d1);
 
     void Push(double distance, geolocation point);
 };


### PR DESCRIPTION
... with windows / VC2017 / 64Bit the code does not build / cannot resolve a overwritten function when using QT 5.12.1
... adding the newly introduced function similar to the other function resolves the compile problem