### PR TITLE
Issue 3048: Teach fix distance to use length on spline path

### DIFF
--- a/src/FileIO/FixDeriveDistance.cpp
+++ b/src/FileIO/FixDeriveDistance.cpp
@@ -36,6 +36,9 @@ class FixDeriveDistanceConfig : public DataProcessorConfig
     friend class ::FixDeriveDistance;
     protected:
         QHBoxLayout *layout;
+
+        QCheckBox *useCubicSplines;
+
         QLabel *bikeWeightLabel;
         QDoubleSpinBox *bikeWeight;
         QLabel *crrLabel;
@@ -48,6 +51,10 @@ class FixDeriveDistanceConfig : public DataProcessorConfig
             parent->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Edit_EstimateDistanceValues));
 
             layout = new QHBoxLayout(this);
+
+            useCubicSplines = new QCheckBox(tr("Use Cubic Splines"), this);
+            useCubicSplines->setCheckState(Qt::Checked);
+            layout->addWidget(useCubicSplines);
 
             layout->setContentsMargins(0,0,0,0);
             setContentsMargins(0,0,0,0);
@@ -66,10 +73,11 @@ class FixDeriveDistanceConfig : public DataProcessorConfig
 
         QString explain() {
             return(QString(tr("Derive distance based on "
-                              "GPS position\n\n"
-                              "Some unit doesn't record distance without "
-                              "a speedometer but record position "
-                              "(eg Timex Cycle Trainer)\n\n")));
+                              "ridefile's GPS locations\n\n"
+                              "This process will populate distance information (and override existing distance information if present.)"
+                              "The cubic splines processing estimates distance across polynomial curve, "
+                              "otherwise this feature will compute geometric arc distance between ride points."
+                              "\n\n")));
         }
 
 };
@@ -104,29 +112,99 @@ double _deg2rad(double deg) {
   return (deg * pi / 180);
 }
 
+#include "LocationInterpolation.h"
+
+#pragma optimize("", off)
+
 bool
 FixDeriveDistance::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")
 {
     Q_UNUSED(config)
     Q_UNUSED(op)
 
-    // if its already there do nothing !
-    if (ride->areDataPresent()->km) return false;
+    bool fUseCubicSplines = ((FixDeriveDistanceConfig*)(config))->useCubicSplines->isChecked();
+    bool fUseSpeedAndTime = false;
 
-    // no dice if we don't have alt and speed
-    if (!ride->areDataPresent()->lat) return false;
+    GeoPointInterpolator gpi;
+    int ii = 0; // interpolator index
+    double cubicDistanceKM = 0.0;
+
+    double distanceFromSpeedTime = 0.0;
+    double lastSecs = 0.0;
+    bool fHasSpeedTime = (ride->areDataPresent()->kph && ride->areDataPresent()->secs);
+
+    if (fUseSpeedAndTime && !fHasSpeedTime)
+        return false;
+
+    // if its already there do nothing !
+    //if (ride->areDataPresent()->km) return false;
+
+    // no dice if we don't have any gps location information.
+    if (!fUseSpeedAndTime && !ride->areDataPresent()->lat)
+        return false;
+
+    bool fHasAlt = ride->areDataPresent()->alt;
 
     // apply the change
     ride->command->startLUW("Estimate Distance");
 
-    if (ride->areDataPresent()->lat) {
+    {
         double km = 0.0;
         double lastLat = 0;
         double lastLon = 0;
 
         for (int i=0; i<ride->dataPoints().count(); i++) {
+
             RideFilePoint *p = ride->dataPoints()[i];
 
+            // Compute distance using cubic splines.
+            while (gpi.WantsInput(i)) {
+
+                // If bracket is present, always sum its length before any push.
+                // This maintains cubicDistanceKM as distance to current bracket
+                // start.
+                double d0, d1;
+                if (gpi.GetBracket(d0, d1)) {
+                    cubicDistanceKM += (gpi.SplineLength(d0, d1) / 1000.0);
+                }
+
+                if (ii >= ride->dataPoints().count()) {
+                    // Past end of ride points, continue pushing final point.
+                    RideFilePoint *pii = ride->dataPoints()[ii-1];
+                    geolocation geo(pii->lat, pii->lon, fHasAlt ? pii->alt : 0.0);
+                    if (geo.IsReasonableGeoLocation()) {
+                        gpi.Push(ii, geo);
+                        //gpi.NotifyInputComplete();
+                    }
+                } else {
+                    // Use index for distance, since we just use it as an enumeration
+                    RideFilePoint *pii = ride->dataPoints()[ii];
+                    geolocation geo(pii->lat, pii->lon, fHasAlt ? pii->alt : 0.0);
+                    if (geo.IsReasonableGeoLocation()) {
+                        gpi.Push(ii, geo);
+                        ii++;
+                    }
+                }
+            }
+
+            // Compute distance using speed and time (has high variance.)
+            // Currently computed because it is interesting to see, but no
+            // option enabled to apply it.
+            double distDelta = 0.0;
+            if (fHasSpeedTime)
+            {
+                double secs = p->secs;
+                double kph = p->kph;
+
+                double secDelta = secs - lastSecs;
+                distDelta = secDelta * kph / 3600;
+
+                distanceFromSpeedTime += distDelta;
+
+                lastSecs = secs;
+            }
+
+            // Compute distance using geometric arc length between points.
             double _theta, _dist;
             _theta = lastLon - p->lon;
             if (lastLat == 0.0 || lastLon == 0.0 || p->lat == 0.0 || p->lon == 0.0 || (_theta == 0.0 && (lastLat - p->lat) == 0.0)) {
@@ -141,7 +219,20 @@ FixDeriveDistance::postProcess(RideFile *ride, DataProcessorConfig *config=0, QS
             lastLat = p->lat;
             lastLon = p->lon;
 
-            ride->command->setPointValue(i, RideFile::km, km);
+            // Write distance into ride file.
+            double distanceKM = km;
+
+            // Select distance estimate to use
+            if (fUseSpeedAndTime) {
+                distanceKM = distanceFromSpeedTime;
+            } else if (fUseCubicSplines) {
+                distanceKM = cubicDistanceKM;
+            } else {
+                distanceKM = km;
+            }
+
+            // Apply selected distance estimate to ride file
+            ride->command->setPointValue(i, RideFile::km, distanceKM);
         }
 
         ride->setDataPresent(ride->km, true);

--- a/src/FileIO/FixDeriveDistance.cpp
+++ b/src/FileIO/FixDeriveDistance.cpp
@@ -24,8 +24,7 @@
 #include "HelpWhatsThis.h"
 #include <algorithm>
 #include <QVector>
-
-#define pi 3.14159265358979323846
+#include "LocationInterpolation.h"
 
 // Config widget used by the Preferences/Options config panes
 class FixDeriveDistance;
@@ -109,12 +108,8 @@ class FixDeriveDistance : public DataProcessor {
 static bool FixDeriveDistanceAdded = DataProcessorFactory::instance().registerProcessor(QString("Estimate Distance Values"), new FixDeriveDistance());
 
 double _deg2rad(double deg) {
-  return (deg * pi / 180);
+  return (deg * M_PI / 180);
 }
-
-#include "LocationInterpolation.h"
-
-#pragma optimize("", off)
 
 bool
 FixDeriveDistance::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")

--- a/src/FileIO/LocationInterpolation.cpp
+++ b/src/FileIO/LocationInterpolation.cpp
@@ -21,7 +21,7 @@
 static double radianstodegrees(double r) { return r * (360.0 / (2 * M_PI)); }
 static double degreestoradians(double d) { return d * (2 * M_PI / 360.0); }
 
-xyz geolocation::toxyz()
+xyz geolocation::toxyz() const
 {
     // Approach developed by:
     //
@@ -52,7 +52,7 @@ xyz geolocation::toxyz()
     return(xyz(dx, dy, dz));                             //Return x, y, z in ECEF
 }
 
-geolocation xyz::togeolocation()
+geolocation xyz::togeolocation() const
 {
     // Approach developed by:
     // (Olson, D.K. (1996).


### PR DESCRIPTION
- FixDistance will now overwrite distance (previously it would bail if distance was present.)
- FixDistance dialog now has radio box to control distance calculation, either using length on cubic spline or with previous geometric arc length between points.
- Spline length calculation is curvature based subdivision using a worklist.
