### PR TITLE
Added Time Recording and use it for Time in Zone Percentages

### DIFF
--- a/src/Charts/LTMPopup.cpp
+++ b/src/Charts/LTMPopup.cpp
@@ -368,6 +368,7 @@ LTMPopup::setSummaryHTML(RideItem *item)
     // main totals
     const QStringList totalColumn = QStringList()
         << "workout_time"
+        << "time_recording"
         << "time_riding"
         << (item->isSwim ? "distance_swim" : "total_distance")
         << "total_work"

--- a/src/Charts/RideSummaryWindow.cpp
+++ b/src/Charts/RideSummaryWindow.cpp
@@ -473,6 +473,7 @@ RideSummaryWindow::htmlSummary()
     static const QStringList columnNames = QStringList() << tr("Totals") << tr("Averages") << tr("Maximums") << tr("Metrics");
     static const QStringList totalColumn = QStringList()
         << "workout_time"
+        << "time_recording"
         << "time_riding"
         << "total_distance"
         << "ride_count"
@@ -1626,6 +1627,7 @@ RideSummaryWindow::htmlCompareSummary() const
     static const QStringList columnNames = QStringList() << tr("Totals") << tr("Averages") << tr("Maximums") << tr("Metrics*");
     static const QStringList totalColumn = QStringList()
         << "workout_time"
+        << "time_recording"
         << "time_riding"
         << "total_distance"
         << "ride_count"

--- a/src/Metrics/BasicRideMetrics.cpp
+++ b/src/Metrics/BasicRideMetrics.cpp
@@ -143,7 +143,7 @@ class WorkoutTime : public RideMetric {
         setName(tr("Duration"));
         setMetricUnits(tr("seconds"));
         setImperialUnits(tr("seconds"));
-        setDescription(tr("Total Duration"));
+        setDescription(tr("Total Duration including pauses a.k.a. Elapsed Time"));
     }
 
     void compute(RideItem *item, Specification spec, const QHash<QString,RideMetric*> &) {
@@ -173,6 +173,54 @@ class WorkoutTime : public RideMetric {
 
 static bool workoutTimeAdded =
     RideMetricFactory::instance().addMetric(WorkoutTime());
+
+//////////////////////////////////////////////////////////////////////////////
+
+class TimeRecording : public RideMetric {
+    Q_DECLARE_TR_FUNCTIONS(TimeRecording)
+    double secsRecording;
+
+    public:
+
+    TimeRecording() : secsRecording(0.0)
+    {
+        setSymbol("time_recording");
+        setInternalName("Time Recording");
+    }
+
+    bool isTime() const { return true; }
+
+    void initialize() {
+        setName(tr("Time Recording"));
+        setMetricUnits(tr("seconds"));
+        setImperialUnits(tr("seconds"));
+        setDescription(tr("Time when device was recording, excludes gaps in recording due to pauses or missing samples"));
+    }
+
+    void compute(RideItem *item, Specification spec, const QHash<QString,RideMetric*> &) {
+
+        // no ride or no samples
+        if (spec.isEmpty(item->ride())) {
+            setValue(RideFile::NIL);
+            setCount(0);
+            return;
+        }
+
+        secsRecording = 0;
+
+        // loop through and count
+        for (RideFileIterator it(item->ride(), spec); it.hasNext(); it.next())
+            secsRecording += item->ride()->recIntSecs();
+        setValue(secsRecording);
+    }
+
+    MetricClass classification() const { return Undefined; }
+    MetricValidity validity() const { return Unknown; }
+    RideMetric *clone() const { return new TimeRecording(*this); }
+};
+
+static bool timeRecordingAdded =
+    RideMetricFactory::instance().addMetric(TimeRecording());
 
 //////////////////////////////////////////////////////////////////////////////
 

--- a/src/Metrics/HrTimeInZone.cpp
+++ b/src/Metrics/HrTimeInZone.cpp
@@ -327,10 +327,10 @@ class HrZonePTime1 : public RideMetric {
         void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_H1"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_H1")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -371,10 +371,10 @@ class HrZonePTime2 : public RideMetric {
         void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_H2"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_H2")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -415,10 +415,10 @@ class HrZonePTime3 : public RideMetric {
         void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_H3"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_H3")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -459,10 +459,10 @@ class HrZonePTime4 : public RideMetric {
         void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_H4"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_H4")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -503,10 +503,10 @@ class HrZonePTime5 : public RideMetric {
         void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_H5"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_H5")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -547,10 +547,10 @@ class HrZonePTime6 : public RideMetric {
         void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_H6"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_H6")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -591,10 +591,10 @@ class HrZonePTime7 : public RideMetric {
         void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_H7"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_H7")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -635,10 +635,10 @@ class HrZonePTime8 : public RideMetric {
         void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_H8"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_H8")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -678,10 +678,10 @@ class HrZonePTime9 : public RideMetric {
         void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_H9"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_H9")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -721,10 +721,10 @@ class HrZonePTime10 : public RideMetric {
         void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_H10"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_H10")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -751,43 +751,43 @@ static bool addAllHrZones() {
     RideMetricFactory::instance().addMetric(HrZoneTime10());
     QVector<QString> deps;
     deps.append("time_in_zone_H1");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(HrZonePTime1(), &deps);
     deps.clear();
     deps.append("time_in_zone_H2");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(HrZonePTime2(), &deps);
     deps.clear();
     deps.append("time_in_zone_H3");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(HrZonePTime3(), &deps);
     deps.clear();
     deps.append("time_in_zone_H4");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(HrZonePTime4(), &deps);
     deps.clear();
     deps.append("time_in_zone_H5");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(HrZonePTime5(), &deps);
     deps.clear();
     deps.append("time_in_zone_H6");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(HrZonePTime6(), &deps);
     deps.clear();
     deps.append("time_in_zone_H7");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(HrZonePTime7(), &deps);
     deps.clear();
     deps.append("time_in_zone_H8");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(HrZonePTime8(), &deps);
     deps.clear();
     deps.append("time_in_zone_H9");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(HrZonePTime9(), &deps);
     deps.clear();
     deps.append("time_in_zone_H10");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(HrZonePTime10(), &deps);
     return true;
 }

--- a/src/Metrics/PaceTimeInZone.cpp
+++ b/src/Metrics/PaceTimeInZone.cpp
@@ -335,10 +335,10 @@ class PaceZonePTime1 : public RideMetric {
         void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_P1"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_P1")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -379,10 +379,10 @@ class PaceZonePTime2 : public RideMetric {
         void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_P2"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_P2")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -423,10 +423,10 @@ class PaceZonePTime3 : public RideMetric {
         void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_P3"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_P3")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -467,10 +467,10 @@ class PaceZonePTime4 : public RideMetric {
         void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_P4"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_P4")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -511,10 +511,10 @@ class PaceZonePTime5 : public RideMetric {
         void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_P5"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_P5")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -555,10 +555,10 @@ class PaceZonePTime6 : public RideMetric {
         void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_P6"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_P6")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -599,10 +599,10 @@ class PaceZonePTime7 : public RideMetric {
         void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_P7"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_P7")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -643,10 +643,10 @@ class PaceZonePTime8 : public RideMetric {
         void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_P8"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_P8")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -687,10 +687,10 @@ class PaceZonePTime9 : public RideMetric {
         void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_P9"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_P9")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -731,10 +731,10 @@ class PaceZonePTime10 : public RideMetric {
         void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_P10"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_P10")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -762,43 +762,43 @@ static bool addAllZones() {
     RideMetricFactory::instance().addMetric(PaceZoneTime10());
     QVector<QString> deps;
     deps.append("time_in_zone_P1");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(PaceZonePTime1(), &deps);
     deps.clear();
     deps.append("time_in_zone_P2");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(PaceZonePTime2(), &deps);
     deps.clear();
     deps.append("time_in_zone_P3");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(PaceZonePTime3(), &deps);
     deps.clear();
     deps.append("time_in_zone_P4");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(PaceZonePTime4(), &deps);
     deps.clear();
     deps.append("time_in_zone_P5");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(PaceZonePTime5(), &deps);
     deps.clear();
     deps.append("time_in_zone_P6");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(PaceZonePTime6(), &deps);
     deps.clear();
     deps.append("time_in_zone_P7");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(PaceZonePTime7(), &deps);
     deps.clear();
     deps.append("time_in_zone_P8");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(PaceZonePTime8(), &deps);
     deps.clear();
     deps.append("time_in_zone_P9");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(PaceZonePTime9(), &deps);
     deps.clear();
     deps.append("time_in_zone_P10");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(PaceZonePTime10(), &deps);
     return true;
 }

--- a/src/Metrics/RideMetric.cpp
+++ b/src/Metrics/RideMetric.cpp
@@ -158,7 +158,8 @@
 // 148 27  Jul 2018 Ale Martinez       Changed Hrv Measures to retrun 0 when no record for the date
 // 149 04  Jan 2019 Mark Liversedge    PowerIndex metric to score performance tests/intervals/rides vs typical athlete PD curve
 // 150 28  Mar 2019 Ale Martinez       Additional Running Dynamics metrics
-int DBSchemaVersion = 150;
+// 151 14  May 2019 Ale Martinez       Added Time Recording and use it in Time in Zone Percentage
+int DBSchemaVersion = 151;
 
 RideMetricFactory *RideMetricFactory::_instance;
 QVector<QString> RideMetricFactory::noDeps;

--- a/src/Metrics/TimeInZone.cpp
+++ b/src/Metrics/TimeInZone.cpp
@@ -326,10 +326,10 @@ class ZonePTime1 : public RideMetric {
     void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_L1"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_L1")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -368,10 +368,10 @@ class ZonePTime2 : public RideMetric {
     void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_L2"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_L2")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -410,10 +410,10 @@ class ZonePTime3 : public RideMetric {
     void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_L3"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_L3")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -452,10 +452,10 @@ class ZonePTime4 : public RideMetric {
     void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_L4"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_L4")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -494,10 +494,10 @@ class ZonePTime5 : public RideMetric {
     void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_L5"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_L5")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -536,10 +536,10 @@ class ZonePTime6 : public RideMetric {
     void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_L6"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_L6")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -578,10 +578,10 @@ class ZonePTime7 : public RideMetric {
     void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_L7"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_L7")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -620,10 +620,10 @@ class ZonePTime8 : public RideMetric {
     void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_L8"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_L8")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -662,10 +662,10 @@ class ZonePTime9 : public RideMetric {
     void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_L9"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_L9")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -704,10 +704,10 @@ class ZonePTime10 : public RideMetric {
     void compute(RideItem *, Specification, const QHash<QString,RideMetric*> &deps) {
 
             assert(deps.contains("time_in_zone_L10"));
-            assert(deps.contains("workout_time"));
+            assert(deps.contains("time_recording"));
 
             // compute
-            double time = deps.value("workout_time")->value(true);
+            double time = deps.value("time_recording")->value(true);
             double inzone = deps.value("time_in_zone_L10")->value(true);
 
             if (time && inzone) setValue((inzone / time) * 100.00);
@@ -733,43 +733,43 @@ static bool addAllZones() {
     RideMetricFactory::instance().addMetric(ZoneTime10());
     QVector<QString> deps;
     deps.append("time_in_zone_L1");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(ZonePTime1(), &deps);
     deps.clear();
     deps.append("time_in_zone_L2");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(ZonePTime2(), &deps);
     deps.clear();
     deps.append("time_in_zone_L3");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(ZonePTime3(), &deps);
     deps.clear();
     deps.append("time_in_zone_L4");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(ZonePTime4(), &deps);
     deps.clear();
     deps.append("time_in_zone_L5");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(ZonePTime5(), &deps);
     deps.clear();
     deps.append("time_in_zone_L6");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(ZonePTime6(), &deps);
     deps.clear();
     deps.append("time_in_zone_L7");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(ZonePTime7(), &deps);
     deps.clear();
     deps.append("time_in_zone_L8");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(ZonePTime8(), &deps);
     deps.clear();
     deps.append("time_in_zone_L9");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(ZonePTime9(), &deps);
     deps.clear();
     deps.append("time_in_zone_L10");
-    deps.append("workout_time");
+    deps.append("time_recording");
     RideMetricFactory::instance().addMetric(ZonePTime10(), &deps);
     return true;
 }


### PR DESCRIPTION
Fixes #2745 which requests this metric plus it allows to fix the issue with
Time in Zone Percentages which don't add to 100% nor aggregate properly
when there are gaps in recording, tipically due to pauses.
When there are no gaps Time Recording equals Duration and Time in Zone
Percentages don't change.