### PR TITLE
Update AvgLTE, AvgRTE, AvgLPS, and AvgRPS in BasicRideMetrics.cpp

### DIFF
--- a/src/Metrics/BasicRideMetrics.cpp
+++ b/src/Metrics/BasicRideMetrics.cpp
@@ -2787,7 +2787,7 @@ class AvgLTE : public RideMetric {
     void compute(RideItem *item, Specification spec, const QHash<QString,RideMetric*> &) {
 
         // no ride or no samples
-        if (spec.isEmpty(item->ride()) || !item->ride()->areDataPresent()->lte) {
+        if (spec.isEmpty(item->ride()) || !item->ride()->areDataPresent()->watts || !item->ride()->areDataPresent()->lte) {
             setValue(RideFile::NIL);
             setCount(0);
             return;
@@ -2800,7 +2800,7 @@ class AvgLTE : public RideMetric {
         while (it.hasNext()) {
             struct RideFilePoint *point = it.next();
 
-            if (point->lte) {
+            if (point->lte && point->watts > 0.0f && point->cad && point->lrbalance > 0.0f && point->lrbalance < 100.0f) {
                 samples ++;
                 total += point->lte;
             }
@@ -2842,7 +2842,7 @@ class AvgRTE : public RideMetric {
     void compute(RideItem *item, Specification spec, const QHash<QString,RideMetric*> &) {
 
         // no ride or no samples
-        if (spec.isEmpty(item->ride()) || !item->ride()->areDataPresent()->rte) {
+        if (spec.isEmpty(item->ride()) || !item->ride()->areDataPresent()->watts || !item->ride()->areDataPresent()->rte) {
             setValue(RideFile::NIL);
             setCount(0);
             return;
@@ -2854,7 +2854,7 @@ class AvgRTE : public RideMetric {
         RideFileIterator it(item->ride(), spec);
         while (it.hasNext()) {
             struct RideFilePoint *point = it.next();
-            if (point->rte) {
+            if (point->rte && point->watts > 0.0f && point->cad && point->lrbalance > 0.0f && point->lrbalance < 100.0f) {
                 samples ++;
                 total += point->rte;
             }
@@ -2896,7 +2896,7 @@ class AvgLPS : public RideMetric {
     void compute(RideItem *item, Specification spec, const QHash<QString,RideMetric*> &) {
 
         // no ride or no samples
-        if (spec.isEmpty(item->ride()) || !item->ride()->areDataPresent()->lps) {
+        if (spec.isEmpty(item->ride()) || !item->ride()->areDataPresent()->watts || !item->ride()->areDataPresent()->lps) {
             setValue(RideFile::NIL);
             setCount(0);
             return;
@@ -2908,7 +2908,7 @@ class AvgLPS : public RideMetric {
         RideFileIterator it(item->ride(), spec);
         while (it.hasNext()) {
             struct RideFilePoint *point = it.next();
-            if (point->lps) {
+            if (point->lps && point->watts > 0.0f && point->cad && point->lrbalance > 0.0f && point->lrbalance < 100.0f) {
                 samples ++;
                 total += point->lps;
             }
@@ -2950,7 +2950,7 @@ class AvgRPS : public RideMetric {
     void compute(RideItem *item, Specification spec, const QHash<QString,RideMetric*> &) {
 
         // no ride or no samples
-        if (spec.isEmpty(item->ride()) || !item->ride()->areDataPresent()->rps) {
+        if (spec.isEmpty(item->ride()) || !item->ride()->areDataPresent()->watts || !item->ride()->areDataPresent()->rps) {
             setValue(RideFile::NIL);
             setCount(0);
             return;
@@ -2962,7 +2962,7 @@ class AvgRPS : public RideMetric {
         RideFileIterator it(item->ride(), spec);
         while (it.hasNext()) {
             struct RideFilePoint *point = it.next();
-            if (point->rps) {
+            if (point->rps && point->watts > 0.0f && point->cad && point->lrbalance > 0.0f && point->lrbalance < 100.0f) {
                 samples ++;
                 total += point->rps;
             }


### PR DESCRIPTION
As for the L/R balance (see https://github.com/GoldenCheetah/GoldenCheetah/pull/3098) there are issues in the Torque Effectiveness and Pedal Smoothness computation when using Favero Assioma DUO pedals. In some cases, values for LTE, RTE, LPS, and/or RPS are stored in the file while the power and/or cadence data shows that the correspondent stroke was either void or no power generating (see the attached image in https://github.com/GoldenCheetah/GoldenCheetah/issues/3102). This was not taken into account in the code, as the only check was the existence of LTE, RTE, LPS, and RPS data greater than zero. I've made the necessary changes in order to check if the stroke was a power generator by verifying if the cadence, power and lrbalance values are valid (it is SUPPOSED that all files that contain LTE, RTE, LPS, and /or RPS contain also power, cadence, and lrbalance data, as they are necessary for the LTE, RTE, LPS, and RPS values computation)