### PR TITLE
FIT : Add Hammerhead as manufacturer

### DIFF
--- a/src/FileIO/FitRideFile.cpp
+++ b/src/FileIO/FitRideFile.cpp
@@ -522,6 +522,13 @@ struct FitFileReaderState
         } else if (manu == 284) {
             // Rouvy
             return "Rouvy";
+        } else if (manu == 289) {
+            // Hammerhead
+            // currently not setting product ids
+            switch (prod) {
+                case -1: return "Hammerhead";
+                default: return QString("Hammerhead %1").arg(prod);
+            }
         } else {
             QString name = "Unknown FIT Device";
             return name + QString(" %1:%2").arg(manu).arg(prod);


### PR DESCRIPTION
Added Hammerhead (manu id 289) to the list of recognised devices.

They currently do not set product ids as there is only one device (Hammerhead Karoo). However, this might change in the future...

Sticking to the invalid product id handling scheme suggested in PR#3099.