### PR TITLE
Fix estimator not running for runs, if there are no bike rides

### DIFF
--- a/src/Metrics/Estimator.cpp
+++ b/src/Metrics/Estimator.cpp
@@ -207,9 +207,9 @@ Estimator::run()
 
     // if we don't have 2 rides or more then skip this but add a blank estimate
     if (from == to || to == QDate()) {
-        printd("Estimator ends, less than 2 rides with power data.\n");
+        printd("%s Estimator ends, less than 2 rides with power data.\n", isRun ? "Run" : "Bike");
         est << PDEstimate();
-        return;
+        continue;
     }
 
     // set up the models we support


### PR DESCRIPTION
If there are no bike rides, the estimator:run() will exit. Instead of it, it should continue the loop to estimate runs