### PR TITLE
Run make silently for Mac builds

### DIFF
--- a/travis/osx/script.sh
+++ b/travis/osx/script.sh
@@ -3,5 +3,5 @@ set -ev
 CC=clang CXX=clang++ /usr/local/opt/qt5/bin/qmake -makefile -recursive QMAKE_CXXFLAGS_WARN_ON+="-Wno-unused-private-field -Wno-c++11-narrowing"
 CC=clang CXX=clang++ make qmake_all
 CC=clang CXX=clang++ make -j4 sub-qwt --silent
-CC=clang CXX=clang++ make -j4 sub-src
+CC=clang CXX=clang++ make -j4 sub-src --silent || CC=clang CXX=clang++ make sub-src
 exit


### PR DESCRIPTION
And force it to run again if it crashes so we can see what went wrong.
Travis-CI log is too large.