### PR TITLE
Allow Banister to use other performance metric besides Power Index

### DIFF
--- a/src/Charts/LTMPlot.cpp
+++ b/src/Charts/LTMPlot.cpp
@@ -3568,7 +3568,7 @@ LTMPlot::createBanisterData(Context *context, LTMSettings *settings, MetricDetai
                                               QVector<double>&x,QVector<double>&y,int&n, bool)
 {
     // banister model
-    Banister *banister = context->athlete->getBanisterFor(metricDetail.symbol, 50,11);
+    Banister *banister = context->athlete->getBanisterFor(metricDetail.symbol, metricDetail.perfSymbol, 50,11);
 
     // should never happen...
     if (banister==NULL) {

--- a/src/Charts/LTMSettings.cpp
+++ b/src/Charts/LTMSettings.cpp
@@ -233,6 +233,7 @@ QDataStream &operator<<(QDataStream &out, const LTMSettings &settings)
         out<<metric.tests;
         out<<metric.perfs;
         out<<metric.submax;
+        out<<metric.perfSymbol;
     }
     out<<settings.showData;
     out<<settings.stack;
@@ -370,6 +371,7 @@ while(counter-- && !in.atEnd()) {
             in >> m.perfs;
         }
         if (version >= 19) in >> m.submax;
+        if (version >= 21) in >> m.perfSymbol;
 
         bool keep=true;
         // check for deprecated things and set keep=false if

--- a/src/Charts/LTMSettings.h
+++ b/src/Charts/LTMSettings.h
@@ -54,8 +54,9 @@ class RideBest;
 // 18        05 Jan 2018 Mark Liversedge  Performance tests and weekly performances
 // 19        07 Jan 2018 Mark Liversedge  Flagged as possibly submaximal weekly best
 // 20        15 Apr 2019 Ale Martinez     Added run flag to Estimate
+// 21        31 Jul 2019 Ale Martinez     Added perfSymbol for Banister
 
-#define LTM_VERSION_NUMBER 20
+#define LTM_VERSION_NUMBER 21
 
 // group by settings
 #define LTM_DAY     1
@@ -117,7 +118,7 @@ class MetricDetail {
     public:
 
     MetricDetail() : type(METRIC_DB), stack(false), hidden(false), model(""), formulaType(RideMetric::Average), name(""), 
-                     metric(NULL), stressType(0), measureGroup(0), measureField(0), tests(true), perfs(true),
+                     metric(NULL), stressType(0), measureGroup(0), measureField(0), tests(true), perfs(true), perfSymbol("power_index"),
                      smooth(false), trendtype(0), topN(0), lowestN(0), topOut(0), baseline(0.0), 
                      curveStyle(QwtPlotCurve::Lines), symbolStyle(QwtSymbol::NoSymbol),
                      penColor(Qt::black), penAlpha(0), penWidth(1.0), penStyle(0),
@@ -162,6 +163,9 @@ class MetricDetail {
     bool tests;
     bool perfs;
     bool submax;
+
+    // for Banister
+    QString perfSymbol;
 
     // GENERAL SETTINGS FOR A METRIC
     QString uname, uunits; // user specified name and units (axis choice)

--- a/src/Charts/LTMTool.cpp
+++ b/src/Charts/LTMTool.cpp
@@ -1953,14 +1953,30 @@ EditMetricDetailDialog::EditMetricDetailDialog(Context *context, LTMTool *ltmToo
     banisterTypeSelect->addItem(tr("Predicted CP (Watts)"),  BANISTER_CP);
     banisterTypeSelect->setCurrentIndex(metricDetail->stressType < 4 ? metricDetail->stressType : 2);
 
+    // banister performance metric
+    banisterPerfMetric = new QComboBox(this);
+    foreach(MetricDetail metric, ltmTool->metrics)
+        if (metric.metric != NULL && metric.metric->type() == RideMetric::Peak)
+            banisterPerfMetric->addItem(metric.name,  metric.symbol);
+    banisterPerfMetric->setCurrentIndex(banisterPerfMetric->findData(metricDetail->perfSymbol));
+
     banisterWidget = new QWidget(this);
     banisterWidget->setContentsMargins(0,0,0,0);
-    QHBoxLayout *banisterLayout = new QHBoxLayout(banisterWidget);
-    banisterLayout->setContentsMargins(0,0,0,0);
-    banisterLayout->setSpacing(5 *dpiXFactor);
-    banisterLayout->addWidget(new QLabel(tr("Curve Type"), this));
-    banisterLayout->addWidget(banisterTypeSelect);
+    QVBoxLayout *banisterLayout = new QVBoxLayout(banisterWidget);
 
+    QHBoxLayout *banisterTypeLayout = new QHBoxLayout();
+    banisterTypeLayout->setContentsMargins(0,0,0,0);
+    banisterTypeLayout->setSpacing(5 *dpiXFactor);
+    banisterTypeLayout->addWidget(new QLabel(tr("Curve Type"), this));
+    banisterTypeLayout->addWidget(banisterTypeSelect);
+    banisterLayout->addLayout(banisterTypeLayout);
+
+    QHBoxLayout *banisterPerfLayout = new QHBoxLayout();
+    banisterPerfLayout->setContentsMargins(0,0,0,0);
+    banisterPerfLayout->setSpacing(5 *dpiXFactor);
+    banisterPerfLayout->addWidget(new QLabel(tr("Perf. Metric"), this));
+    banisterPerfLayout->addWidget(banisterPerfMetric);
+    banisterLayout->addLayout(banisterPerfLayout);
 
     metricWidget = new QWidget(this);
     metricWidget->setContentsMargins(0,0,0,0);
@@ -2369,7 +2385,7 @@ EditMetricDetailDialog::banisterName()
     if (chooseBanister->isChecked() == false) return;
 
     // re-use bestSymbol like PMC does
-    metricDetail->bestSymbol = metricDetail->symbol;
+    metricDetail->bestSymbol = metricDetail->symbol+"_"+metricDetail->perfSymbol;
 
     // append type
     switch(banisterTypeSelect->currentIndex()) {
@@ -2589,7 +2605,10 @@ EditMetricDetailDialog::applyClicked()
     metricDetail->stack = stack->isChecked();
     metricDetail->trendtype = trendType->currentIndex();
     if (chooseStress->isChecked()) metricDetail->stressType = stressTypeSelect->currentIndex();
-    if (chooseBanister->isChecked()) metricDetail->stressType = banisterTypeSelect->currentIndex();
+    if (chooseBanister->isChecked()) {
+        metricDetail->stressType = banisterTypeSelect->currentIndex();
+        metricDetail->perfSymbol = banisterPerfMetric->currentData().toString();
+    }
     metricDetail->formula = formulaEdit->toPlainText();
     metricDetail->formulaType = static_cast<RideMetric::MetricType>(formulaType->itemData(formulaType->currentIndex()).toInt());
     metricDetail->measureGroup = measureGroupSelect->currentIndex();

--- a/src/Charts/LTMTool.h
+++ b/src/Charts/LTMTool.h
@@ -215,6 +215,7 @@ class EditMetricDetailDialog : public QDialog
 
         // banister
         QComboBox *banisterTypeSelect; // PTE, NTE, Performance
+        QComboBox *banisterPerfMetric; // default Power Index
 
         // formula
         DataFilterEdit *formulaEdit; // edit your formula

--- a/src/Charts/LTMWindow.h
+++ b/src/Charts/LTMWindow.h
@@ -200,7 +200,7 @@ class LTMWindow : public GcChartWindow
         // show the banister helper
         void showBanister(bool relevant);    // show banister helper if relevant to plot
         void tuneBanister();                 // when t1/t2 change
-        void refreshBanister(int);           // refresh banister helper
+        void refreshBanister();              // refresh banister helper
 
         void refreshPlot();         // normal mode
         void refreshCompare();      // compare mode
@@ -306,9 +306,10 @@ class LTMWindow : public GcChartWindow
 
         // banister helper
         QComboBox *banCombo;
+        QComboBox *banPerf;
         QDoubleSpinBox *banT1;
         QDoubleSpinBox *banT2;
-        QLabel *ilabel, *plabel, *peaklabel, *t1label1, *t1label2, *t2label1, *t2label2, *RMSElabel;
+        QLabel *ilabel, *plabel, *peaklabel, *t1label1, *t1label2, *t2label1, *t2label2, *RMSElabel, *perflabel;
 
         QTime lastRefresh;
         bool firstshow;

--- a/src/Core/Athlete.cpp
+++ b/src/Core/Athlete.cpp
@@ -525,19 +525,19 @@ Athlete::getHeight(RideFile *ride)
 
 // working with Banister data series
 Banister *
-Athlete::getBanisterFor(QString metricName, int t1 , int t2)
+Athlete::getBanisterFor(QString metricName, QString perfMetricName, int t1 , int t2)
 {
     Banister *returning = NULL;
 
     // if we don't already have one, create it
-    returning = banisterData.value(metricName, NULL); // we do
+    returning = banisterData.value(metricName+perfMetricName, NULL); // we do
     if (!returning) {
 
         // specification is blank and passes for all
-        returning = new Banister(context, metricName, t1, t2); // we don't seed t1/t2 yet. (maybe never will)
+        returning = new Banister(context, metricName, perfMetricName, t1, t2); // we don't seed t1/t2 yet. (maybe never will)
 
         // add to our collection
-        banisterData.insert(metricName, returning);
+        banisterData.insert(metricName+perfMetricName, returning);
     }
 
     return returning;

--- a/src/Core/Athlete.h
+++ b/src/Core/Athlete.h
@@ -113,7 +113,7 @@ class Athlete : public QObject
         QMap<QString, PMCData*> pmcData; // all the different PMC series
 
         // Banister Data
-        Banister *getBanisterFor(QString metricName, int t1, int t2); // t1/t2 not used yet
+        Banister *getBanisterFor(QString metricName, QString perfMetricName, int t1, int t2); // t1/t2 not used yet
         QMap<QString, Banister*> banisterData;
 
         // athlete measures

--- a/src/Metrics/Banister.h
+++ b/src/Metrics/Banister.h
@@ -76,15 +76,16 @@ class Banister : public QObject {
 
 public:
 
-    Banister(Context *context, QString symbol, double t1, double t2, double k1=0, double k2=0);
+    Banister(Context *context, QString symbol, QString perf_symbol, double t1, double t2, double k1=0, double k2=0);
     double value(QDate date, int type);
 
     // utility
-    QDate getPeakCP(QDate from, QDate to, int &CP);
+    QDate getPeakPerf(QDate from, QDate to, double &perf, int &CP);
     double RMSE(QDate from, QDate to, int &n); // only look at it for a date range
 
     // model parameters - initial 'priors' to use
     QString symbol;         // load metric
+    QString perf_symbol;    // performance metric
     double k1, k2;          // nte/pte coefficients
     double t1, t2;          // nte/pte decay constants
 

--- a/src/Metrics/BasicRideMetrics.cpp
+++ b/src/Metrics/BasicRideMetrics.cpp
@@ -1991,7 +1991,7 @@ class MinSmO2 : public RideMetric {
         setName(tr("Min SmO2"));
         setMetricUnits(tr("%"));
         setImperialUnits(tr("%"));
-        setType(RideMetric::Peak);
+        setType(RideMetric::Low);
         setDescription(tr("Minimum Muscle Oxygen Saturation, the percentage of hemoglobin that is carrying oxygen."));
     }
 
@@ -2139,7 +2139,7 @@ class MinHr : public RideMetric {
         setName(tr("Min Heartrate"));
         setMetricUnits(tr("bpm"));
         setImperialUnits(tr("bpm"));
-        setType(RideMetric::Peak);
+        setType(RideMetric::Low);
         setDescription(tr("Minimum Heart Rate."));
     }
 
@@ -2402,7 +2402,7 @@ class MinTemp : public RideMetric {
         setName(tr("Min Temp"));
         setMetricUnits(tr("C"));
         setImperialUnits(tr("F"));
-        setType(RideMetric::Peak);
+        setType(RideMetric::Low);
         setPrecision(1);
         setConversion(FAHRENHEIT_PER_CENTIGRADE);
         setConversionSum(FAHRENHEIT_ADD_CENTIGRADE);

--- a/src/Metrics/Estimator.cpp
+++ b/src/Metrics/Estimator.cpp
@@ -205,10 +205,9 @@ Estimator::run()
         }
     }
 
-    // if we don't have 2 rides or more then skip this but add a blank estimate
+    // if we don't have 2 rides or more then skip this
     if (from == to || to == QDate()) {
         printd("%s Estimator ends, less than 2 rides with power data.\n", isRun ? "Run" : "Bike");
-        est << PDEstimate();
         continue;
     }
 
@@ -337,9 +336,6 @@ Estimator::run()
         // go forward a week
         date = date.addDays(7);
     }
-
-    // add a dummy entry if we have no estimates to stop constantly trying to refresh
-    if (est.count() == 0)  est << PDEstimate();
 
     // filter performances
     perfs = filter(perfs);

--- a/travis/linux/before_install.sh
+++ b/travis/linux/before_install.sh
@@ -15,8 +15,8 @@ sudo add-apt-repository -y ppa:jonathonf/vlc
 sudo apt-get update -qq
 sudo apt-get install -qq vlc libvlc-dev libvlccore-dev
 
-# R 3.5
-sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E084DAB9
+# R 3.6
+sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys E298A3A825C0D65DFD57CBB651716619E084DAB9
 sudo add-apt-repository -y "deb https://cloud.r-project.org/bin/linux/ubuntu xenial-cran35/"
 sudo apt-get update -qq
 sudo apt-get install r-base-dev


### PR DESCRIPTION
Performance metric can be selected from any Peak metric in LTM Charts, default to Power Index.
Datafilter now is banister(load_metric, perf_metric, ...)