### PR TITLE
Add Import Chart menu to Main Window and Chart Bar

### DIFF
--- a/src/Charts/ChartBar.cpp
+++ b/src/Charts/ChartBar.cpp
@@ -122,6 +122,8 @@ ChartBar::ChartBar(Context *context) : QWidget(context->mainWindow), context(con
     barMenu = new QMenu("Add");
     chartMenu = barMenu->addMenu(tr("Add Chart"));
 
+    barMenu->addAction(tr("Import Chart..."), context->mainWindow, SLOT(importChart()));
+
 #ifdef GC_HAS_CLOUD_DB
     barMenu->addAction(tr("Upload Chart..."), context->mainWindow, SLOT(exportChartToCloudDB()));
     barMenu->addAction(tr("Download Chart..."), context->mainWindow, SLOT(addChartFromCloudDB()));

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -554,6 +554,7 @@ MainWindow::MainWindow(const QDir &home)
 #endif
     viewMenu->addSeparator();
     subChartMenu = viewMenu->addMenu(tr("Add Chart"));
+    viewMenu->addAction(tr("Import Chart..."), this, SLOT(importChart()));
 #ifdef GC_HAS_CLOUD_DB
     viewMenu->addAction(tr("Upload Chart..."), this, SLOT(exportChartToCloudDB()));
     viewMenu->addAction(tr("Download Chart..."), this, SLOT(addChartFromCloudDB()));
@@ -818,6 +819,18 @@ MainWindow::addChart(QAction*action)
     }
     if (id != GcWindowTypes::None)
         currentTab->addChart(id); // called from MainWindow to inset chart
+}
+
+void
+MainWindow::importChart()
+{
+    QString fileName = QFileDialog::getOpenFileName(this, tr("Select Chart file to import"), "", tr("GoldenCheetah Chart Files (*.gchart)"));
+
+    if (fileName.isEmpty()) {
+        QMessageBox::critical(this, tr("Import Chart"), tr("No chart file selected!"));
+    } else {
+        importCharts(QStringList()<<fileName);
+    }
 }
 
 #ifdef GC_HAS_CLOUD_DB

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -166,6 +166,7 @@ class MainWindow : public QMainWindow
         void setSubChartMenu();
         void setChartMenu(QMenu *);
         void addChart(QAction*);
+        void importChart();
 
         // menus to reflect cloud
         void setUploadMenu();


### PR DESCRIPTION
It allows to import .gchart files from menus as an alternative
to drag&drop, for completeness and to reduce end user questions.