### PR TITLE
fixes #3193 (OSM MapWindow Marker)

### DIFF
--- a/src/Charts/RideMapWindow.cpp
+++ b/src/Charts/RideMapWindow.cpp
@@ -1016,11 +1016,12 @@ RideMapWindow::createMarkers()
                                 points[0]->lon,
                                 points[points.count()-1]->lat,
                                 points[points.count()-1]->lon) < 100 ? true : false;
-
+    
+  // OSM markers anchor defaults to top left but Google defaults to middle bottom. Hard coding marker size 16,37 for OSM.
     if (loop) {
         if (mapCombo->currentIndex() == OSM) {
             code = QString("{ var latlng = new L.LatLng(%1,%2);"
-                           "var image = new L.icon({iconUrl:'qrc:images/maps/loop.png'});"
+                           "var image = new L.icon({iconUrl:'qrc:images/maps/loop.png'}, iconAnchor: [16, 37]);"
                            "var marker = new L.marker(latlng, { icon: image });"
                            "marker.addTo(map); }").arg(points[0]->lat,0,'g',GPS_COORD_TO_STRING).arg(points[0]->lon,0,'g',GPS_COORD_TO_STRING);
         } else if (mapCombo->currentIndex() == GOOGLE) {
@@ -1040,9 +1041,10 @@ RideMapWindow::createMarkers()
         if (myRideItem->isRun)
             marker = "qrc:images/maps/running.png";
 
+        // OSM markers anchor defaults to top left but Google defaults to middle bottom. Hard coding marker size 16,37 for OSM.
         if (mapCombo->currentIndex() == OSM) {
             code = QString("{ var latlng = new L.LatLng(%1,%2);"
-                           "var image = new L.icon({iconUrl:'%3'});"
+                           "var image = new L.icon({iconUrl:'%3', iconAnchor: [16, 37]});"
                            "var marker = new L.marker(latlng, { icon: image });"
                            "marker.addTo(map); }").arg(points[0]->lat,0,'g',GPS_COORD_TO_STRING).arg(points[0]->lon,0,'g',GPS_COORD_TO_STRING).arg(marker);
         } else if (mapCombo->currentIndex() == GOOGLE) {
@@ -1056,9 +1058,11 @@ RideMapWindow::createMarkers()
     #else
         view->page()->mainFrame()->evaluateJavaScript(code);
     #endif
+      
+        // OSM markers anchor defaults to top left but Google defaults to middle bottom. Hard coding marker size 16,37 for OSM.
         if (mapCombo->currentIndex() == OSM) {
             code = QString("{ var latlng = new L.LatLng(%1,%2);"
-                           "var image = new L.icon({iconUrl:'qrc:images/maps/finish.png'});"
+                           "var image = new L.icon({iconUrl:'qrc:images/maps/finish.png', iconAnchor: [16, 37]});"
                            "var marker = new L.marker(latlng, { icon: image });"
                            "marker.addTo(map); }").arg(points[points.count()-1]->lat,0,'g',GPS_COORD_TO_STRING).arg(points[points.count()-1]->lon,0,'g',GPS_COORD_TO_STRING);
         } else if (mapCombo->currentIndex() == GOOGLE) {
@@ -1116,9 +1120,10 @@ RideMapWindow::createMarkers()
                 lastlat = stoplat;
                 lastlon = stoplon;
 
+                // OSM markers anchor defaults to top left but Google defaults to middle bottom. Hard coding marker size 16,37 for OSM.
                 if (mapCombo->currentIndex() == OSM) {
                     code = QString("{ var latlng = new L.LatLng(%1,%2);"
-                                   "var image = new L.icon({iconUrl:'%3'});"
+                                   "var image = new L.icon({iconUrl:'%3', iconAnchor: [16, 37]});"
                                    "var marker = new L.marker(latlng, { icon: image });"
                                    "marker.addTo(map); }").arg(rfp->lat,0,'g',GPS_COORD_TO_STRING).arg(rfp->lon,0,'g',GPS_COORD_TO_STRING).arg(marker);
                 } else if (mapCombo->currentIndex() == GOOGLE) {


### PR DESCRIPTION
OSM markers anchor defaults to top left but Google defaults to middle bottom. Hard coding marker size 16,37 for OSM.