### PR TITLE
Fixed BTLE Pair page in AddDeviceWizard to avoid ANT+ dependence

### DIFF
--- a/src/Train/AddDeviceWizard.h
+++ b/src/Train/AddDeviceWizard.h
@@ -214,22 +214,9 @@ class AddPairBTLE : public QWizardPage
         bool validatePage();
         void cleanupPage();
 
-    public slots:
-
-        void getChannelValues();
-        // we found a device on a channel
-        void channelInfo(int channel, int device_number, int device_id);
-        // we failed to find a device on the channel
-        void searchTimeout(int channel);
-
-        // user interactions
-        void sensorChanged(int channel); // sensor selection changed
     private:
         AddDeviceWizard *wizard;
         QTreeWidget *channelWidget;
-        QSignalMapper *signalMapper;
-        QTimer updateValues;
-        QString cyclist;
 
 };
 

--- a/src/Train/BT40Device.cpp
+++ b/src/Train/BT40Device.cpp
@@ -20,10 +20,11 @@
 #include <QDebug>
 #include "BT40Controller.h"
 
-QList<QBluetoothUuid> BT40Device::supportedServiceUuids = QList<QBluetoothUuid>()
-    << QBluetoothUuid(QBluetoothUuid::HeartRate)
-    << QBluetoothUuid(QBluetoothUuid::CyclingPower)
-    << QBluetoothUuid(QBluetoothUuid::CyclingSpeedAndCadence);
+QMap<QBluetoothUuid, btle_sensor_type_t> BT40Device::supportedServices = {
+    { QBluetoothUuid(QBluetoothUuid::HeartRate), { "Heartrate", ":images/IconHR.png" }},
+    { QBluetoothUuid(QBluetoothUuid::CyclingPower), { "Power", ":images/IconPower.png" }},
+    { QBluetoothUuid(QBluetoothUuid::CyclingSpeedAndCadence), { "Speed + Cadence", ":images/IconCadence.png" }},
+};
 
 BT40Device::BT40Device(QObject *parent, QBluetoothDeviceInfo devinfo) : parent(parent), m_currentDevice(devinfo)
 {
@@ -105,7 +106,7 @@ void
 BT40Device::serviceDiscovered(QBluetoothUuid uuid)
 {
 
-    if (supportedServiceUuids.contains(uuid)) {
+    if (supportedServices.contains(uuid)) {
         QLowEnergyService *service = m_control->createServiceObject(uuid, this);
         m_services.append(service);
     }

--- a/src/Train/BT40Device.h
+++ b/src/Train/BT40Device.h
@@ -23,6 +23,11 @@
 #include <QLowEnergyController>
 #include <QLowEnergyService>
 
+typedef struct btle_sensor_type {
+    const char *descriptive_name;
+    const char *iconname;
+} btle_sensor_type_t;
+
 class BT40Device: public QObject
 {
     Q_OBJECT
@@ -32,6 +37,7 @@ public:
     ~BT40Device();
     void connectDevice();
     void disconnectDevice();
+    static QMap<QBluetoothUuid, btle_sensor_type_t> supportedServices;
 
 private slots:
     void deviceConnected();
@@ -50,7 +56,6 @@ private:
     QObject *parent;
     QBluetoothDeviceInfo m_currentDevice;
     QLowEnergyController *m_control;
-    static QList<QBluetoothUuid> supportedServiceUuids;
     QList<QLowEnergyService*> m_services;
     int prevCrankStaleness;
     quint16 prevCrankTime;


### PR DESCRIPTION
AddPairBTLE depends on the presence of an ANT+ dongle and sensors
to support ANT+ for detection, it looks like a copy paste of AddPair.
This works for Dual (ANT+/BTLE) sensors with an ANT+ dongle since
the sensors are detected, although is misleading since it seems to
imply you can pair them selectively, which is not true for current
BT40 GC implementation.
When an ANT+ dongle is not present (see #2771) or the sensors only
support BTLE (see #2983), the wizzard informs no sensor is dectected.
This is misleading since BT40device will dectect and use automatically
any Hr/Power/CSC sensor present at device startup.
This change replaces AddPairBTLE code with a simpler version matching
current BT40 support: it just informs the user the sensor types supported
indicating they will be autodetected on device startup.
Fixes #2771
Fixes #2983