### PR TITLE
3227: Further optimize trends tracker table display 

### DIFF
--- a/src/Charts/LTMPlot.cpp
+++ b/src/Charts/LTMPlot.cpp
@@ -4377,7 +4377,7 @@ void LTMPlot::refreshZoneLabels(QwtAxisId axisid)
 
 bool LTMPlot::isMinutes(QString units)
 {
-    static const QHash<QString, bool> MinutesHash = { {"minutes", true}, {tr("minutes"), true} };
+    static const QSet<QString> MinutesHash = { "minutes", tr("minutes") };
 
     return MinutesHash.contains(units) || PaceZones::isPaceUnit(units);
 }

--- a/src/Charts/LTMPlot.cpp
+++ b/src/Charts/LTMPlot.cpp
@@ -4377,5 +4377,7 @@ void LTMPlot::refreshZoneLabels(QwtAxisId axisid)
 
 bool LTMPlot::isMinutes(QString units)
 {
-    return units == "minutes" || units == tr("minutes") || PaceZones::isPaceUnit(units);
+    static const QHash<QString, bool> MinutesHash = { {"minutes", true}, {tr("minutes"), true} };
+
+    return MinutesHash.contains(units) || PaceZones::isPaceUnit(units);
 }

--- a/src/Metrics/PaceZones.cpp
+++ b/src/Metrics/PaceZones.cpp
@@ -1028,10 +1028,10 @@ PaceZones::paceSetting() const
 bool
 PaceZones::isPaceUnit(QString units)
 {
-    static const QHash<QString, bool> PaceUnitHash = { {"min/km",    true}, {tr("min/km"),    true},
-                                                       {"min/mile",  true}, {tr("min/mile"),  true},
-                                                       {"min/100m",  true}, {tr("min/100m"),  true},
-                                                       {"min/100yd", true}, {tr("min/100yd"), true} };
+    static const QSet<QString> PaceUnitHash = { "min/km",    tr("min/km"),
+                                                "min/mile",  tr("min/mile"),
+                                                "min/100m",  tr("min/100m"),
+                                                "min/100yd", tr("min/100yd") };
 
     return PaceUnitHash.contains(units);
 }

--- a/src/Metrics/PaceZones.cpp
+++ b/src/Metrics/PaceZones.cpp
@@ -1028,8 +1028,10 @@ PaceZones::paceSetting() const
 bool
 PaceZones::isPaceUnit(QString units)
 {
-    return (units == "min/km") || (units == tr("min/km")) ||
-           (units == "min/mile") || (units == tr("min/mile")) ||
-           (units == "min/100m") || (units == tr("min/100m")) ||
-           (units == "min/100yd") || (units ==  tr("min/100yd"));
+    static const QHash<QString, bool> PaceUnitHash = { {"min/km",    true}, {tr("min/km"),    true},
+                                                       {"min/mile",  true}, {tr("min/mile"),  true},
+                                                       {"min/100m",  true}, {tr("min/100m"),  true},
+                                                       {"min/100yd", true}, {tr("min/100yd"), true} };
+
+    return PaceUnitHash.contains(units);
 }


### PR DESCRIPTION
Additional speedups for trends tracker table display:

convert vectors to qlist before doing prepends.
Speedup test if unit is minutes: test static const hash instead of 10 string compares and translations.
Call arg on columnsummary to further reduce string that arg acts upon for wildcard substitution.

With these changes my largish table takes less than a second to display.