### PR TITLE
Issue 3230: Train mode compute altitude from slope

### DIFF
--- a/src/Train/ErgFile.cpp
+++ b/src/Train/ErgFile.cpp
@@ -1233,7 +1233,7 @@ bool ErgFile::locationAt(long meters, int &lapnum, geolocation &geoLoc)
     if (meters < 0 || meters > Duration) return false;
 
     // No location unless... format contains location...
-    if (format != CRS_LOC)  return 1;
+    if (format != CRS_LOC)  return false;
 
     if (Laps.count() > 0) {
         int lap = 0;

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -1535,8 +1535,6 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
     rtData.setLap(displayLap + displayWorkoutLap); // user laps + predefined workout lap
     rtData.mode = mode;
 
-
-
     // get latest telemetry from devices
     if ((status&RT_RUNNING) || (status&RT_CONNECTED)) {
 
@@ -1687,7 +1685,14 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
                 rtData.setLapDistance(displayLapDistance);
                 rtData.setLapDistanceRemaining(displayLapDistanceRemaining);
 
-                // Update location data
+                // For classic rlv with no location data:
+                // Estimate vertical change based upon time passed and slope.
+                // Note this isn't exactly right but is very close - we should use the previous slope for the time passed.
+                double altitudeDeltaMeters = slope * (10 * distanceTick); // ((slope / 100) * distanceTick) * 1000
+
+                displayAltitude += altitudeDeltaMeters;
+
+                // Trust ergFile for location data, if available.
                 if (ergFile) {
                     geolocation geoloc;
                     if (ergFile->locationAt(displayWorkoutDistance * 1000, displayWorkoutLap, geoloc))
@@ -1698,9 +1703,10 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
 
                         rtData.setLatitude(displayLatitude);
                         rtData.setLongitude(displayLongitude);
-                        rtData.setAltitude(displayAltitude);
                     }
                 }
+
+                rtData.setAltitude(displayAltitude);
 
                 // time
                 total_msecs = session_elapsed_msec + session_time.elapsed();

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -1429,6 +1429,7 @@ void TrainSidebar::Stop(int deviceStatus)        // when stop button is pressed
     displayWorkoutDistance = displayDistance = 0;
     displayLapDistance = 0;
     displayLapDistanceRemaining = -1;
+    displayAltitude = 0;
     guiUpdate();
 
     emit setNotification(tr("Stopped.."), 2);


### PR DESCRIPTION
Compute altitude from slope if train files dont have location data. This makes climb info available for classic rlv files.