### PR TITLE
removal of compiler warnings

### DIFF
--- a/levmar/misc_core.c
+++ b/levmar/misc_core.c
@@ -788,12 +788,12 @@ register LM_REAL sum0=0.0, sum1=0.0, sum2=0.0, sum3=0.0;
        */ 
 
       switch(n - i){ 
-        case 7 : e[i]=-y[i]; sum0+=e[i]*e[i]; ++i;
-        case 6 : e[i]=-y[i]; sum1+=e[i]*e[i]; ++i;
-        case 5 : e[i]=-y[i]; sum2+=e[i]*e[i]; ++i;
-        case 4 : e[i]=-y[i]; sum3+=e[i]*e[i]; ++i;
-        case 3 : e[i]=-y[i]; sum0+=e[i]*e[i]; ++i;
-        case 2 : e[i]=-y[i]; sum1+=e[i]*e[i]; ++i;
+        case 7 : e[i]=-y[i]; sum0+=e[i]*e[i]; ++i; // intentional fallthrough
+        case 6 : e[i]=-y[i]; sum1+=e[i]*e[i]; ++i; // intentional fallthrough
+        case 5 : e[i]=-y[i]; sum2+=e[i]*e[i]; ++i; // intentional fallthrough
+        case 4 : e[i]=-y[i]; sum3+=e[i]*e[i]; ++i; // intentional fallthrough
+        case 3 : e[i]=-y[i]; sum0+=e[i]*e[i]; ++i; // intentional fallthrough
+        case 2 : e[i]=-y[i]; sum1+=e[i]*e[i]; ++i; // intentional fallthrough
         case 1 : e[i]=-y[i]; sum2+=e[i]*e[i]; //++i;
       }
     }

--- a/levmar/misc_core.c
+++ b/levmar/misc_core.c
@@ -334,7 +334,6 @@ int fvec_sz=n, fjac_sz=n*m, pp_sz=m, fvecp_sz=n;
 static int LEVMAR_PSEUDOINVERSE(LM_REAL *A, LM_REAL *B, int m)
 {
 LM_REAL *buf=NULL;
-int buf_sz=0;
 static LM_REAL eps=LM_CNST(-1.0);
 
 register int i, j;
@@ -352,8 +351,7 @@ int info, rank, worksz, *iwork, iworksz;
 
   tot_sz=(a_sz + u_sz + s_sz + vt_sz + worksz)*sizeof(LM_REAL) + iworksz*sizeof(int); /* should be arranged in that order for proper doubles alignment */
 
-    buf_sz=tot_sz;
-    buf=(LM_REAL *)malloc(buf_sz);
+    buf=(LM_REAL *)malloc(tot_sz);
     if(!buf){
       fprintf(stderr, RCAT("memory allocation in ", LEVMAR_PSEUDOINVERSE) "() failed!\n");
       return 0; /* error */
@@ -426,7 +424,6 @@ int info, rank, worksz, *iwork, iworksz;
 static int LEVMAR_LUINVERSE(LM_REAL *A, LM_REAL *B, int m)
 {
 void *buf=NULL;
-int buf_sz=0;
 
 register int i, j, k, l;
 int *idx, maxi=-1, idx_sz, a_sz, x_sz, work_sz, tot_sz;
@@ -439,7 +436,6 @@ LM_REAL *a, *x, *work, max, sum, tmp;
   work_sz=m;
   tot_sz=(a_sz + x_sz + work_sz)*sizeof(LM_REAL) + idx_sz*sizeof(int); /* should be arranged in that order for proper doubles alignment */
 
-  buf_sz=tot_sz;
   buf=(void *)malloc(tot_sz);
   if(!buf){
     fprintf(stderr, RCAT("memory allocation in ", LEVMAR_LUINVERSE) "() failed!\n");

--- a/qwt/src/qwt_date.cpp
+++ b/qwt/src/qwt_date.cpp
@@ -577,6 +577,7 @@ int QwtDate::utcOffset( const QDateTime &dateTime )
         case Qt::OffsetFromUTC:
         {
             seconds = dateTime.utcOffset();
+            break;
         }
         default:
         {

--- a/qwt/src/qwt_picker_machine.cpp
+++ b/qwt/src/qwt_picker_machine.cpp
@@ -218,7 +218,7 @@ QList<QwtPickerMachine::Command> QwtPickerClickRectMachine::transition(
     {
         case QEvent::MouseButtonPress:
         {
-            if ( eventPattern.mouseMatch( QwtEventPattern::MouseSelect1, 
+            if ( eventPattern.mouseMatch( QwtEventPattern::MouseSelect1,
                 static_cast<const QMouseEvent *>( event ) ) )
             {
                 switch ( state() )
@@ -242,6 +242,7 @@ QList<QwtPickerMachine::Command> QwtPickerClickRectMachine::transition(
                     }
                 }
             }
+            break;
         }
         case QEvent::MouseMove:
         case QEvent::Wheel:

--- a/qwt/src/qwt_plot_axis.cpp
+++ b/qwt/src/qwt_plot_axis.cpp
@@ -121,6 +121,7 @@ public:
                     name = "QwtPlotAxisXBottom";
                     break;
                 case QwtAxis::xTop:
+                default:
                     align = QwtScaleDraw::TopScale;
                     name = "QwtPlotAxisXTop";
                     break;

--- a/qwt/src/qwt_plot_canvas.cpp
+++ b/qwt/src/qwt_plot_canvas.cpp
@@ -937,7 +937,7 @@ void QwtPlotCanvas::drawBorder( QPainter *painter )
     else
     {
 #if QT_VERSION >= 0x040500
-        QStyleOptionFrameV3 opt;
+        QStyleOptionFrame opt;
         opt.init(this);
 
         int frameShape  = frameStyle() & QFrame::Shape_Mask;

--- a/qxt/src/qxtspanslider.cpp
+++ b/qxt/src/qxtspanslider.cpp
@@ -200,6 +200,7 @@ void QxtSpanSliderPrivate::triggerAction(QAbstractSlider::SliderAction action, b
     case QAbstractSlider::SliderMove:
         if ((main && mainControl == QxtSpanSlider::UpperHandle) || (!main && altControl == QxtSpanSlider::UpperHandle))
             up = true;
+        break;
     case QAbstractSlider::SliderNoAction:
         no = true;
         break;

--- a/src/Charts/GoldenCheetah.h
+++ b/src/Charts/GoldenCheetah.h
@@ -196,7 +196,7 @@ public:
     virtual bool isCompare() const { return false;}
 
     // for sorting... we look at x
-    bool operator< (GcWindow right) const { return geometry().x() < right.geometry().x(); }
+    bool operator< (const GcWindow &right) const { return geometry().x() < right.geometry().x(); }
 
     // we paint a heading if there is space in the top margin
     void paintEvent (QPaintEvent * event);

--- a/src/Charts/IndendPlotMarker.cpp
+++ b/src/Charts/IndendPlotMarker.cpp
@@ -30,19 +30,6 @@ inline QwtIndPlotMarker::Matrix::~Matrix()
     reset();
 }
 
-QwtIndPlotMarker::Matrix::Matrix(const Matrix& m) {
-
-    if((m_rows!=m.rows())||(m_cols!=m.cols())) {
-        resize(m.rows(),m.cols());
-    }
-
-    for(unsigned long i=0;i<m.rows();i++){
-        for (unsigned long j = 0; j < m.cols(); j++) {
-        m_data[i*m_cols+j]=m(i,j);
-        }
-    }
-}
-
 /* UNUSED
 QwtIndPlotMarker::Matrix& QwtIndPlotMarker::Matrix::operator=(const Matrix& m){
     if((m_rows!=m.rows())||(m_cols!=m.cols())) {

--- a/src/Charts/IndendPlotMarker.h
+++ b/src/Charts/IndendPlotMarker.h
@@ -89,8 +89,6 @@ private:
             bool  operator() (unsigned long row, unsigned long col) const;
             /** Destructor */
             ~Matrix();
-            /** Copy Constructor */
-            Matrix(const Matrix& m);
             /** C++11 Move constructor */
             /* Matrix(Matrix&&); */
             /**Copy assignment operator */

--- a/src/Charts/LTMOutliers.h
+++ b/src/Charts/LTMOutliers.h
@@ -31,7 +31,7 @@ class LTMOutliers
         int pos;
         double deviation;
 
-        bool operator< (xdev right) const {
+        bool operator< (const xdev &right) const {
             return (deviation > right.deviation);  // sort ascending! (.gt not .lt)
         }
     };

--- a/src/Charts/LTMSettings.h
+++ b/src/Charts/LTMSettings.h
@@ -124,7 +124,7 @@ class MetricDetail {
                      penColor(Qt::black), penAlpha(0), penWidth(1.0), penStyle(0),
                      brushColor(Qt::black), brushAlpha(0), fillCurve(false), labels(false), curve(NULL) {}
 
-    bool operator< (MetricDetail right) const { return name < right.name; }
+    bool operator< (const MetricDetail &right) const { return name < right.name; }
 
     int type;
     bool stack; // should this be stacked?

--- a/src/Cloud/WithingsReading.h
+++ b/src/Cloud/WithingsReading.h
@@ -57,7 +57,7 @@ public:
             sizemeter;      // height ?
 
     // used by qSort()
-    bool operator< (WithingsReading right) const {
+    bool operator< (const WithingsReading &right) const {
         return (when < right.when);
     }
 };

--- a/src/Core/IntervalItem.h
+++ b/src/Core/IntervalItem.h
@@ -89,7 +89,7 @@ class IntervalItem
         RideFileInterval *rideInterval;
 
         // used by qSort()
-        bool operator< (IntervalItem right) const {
+        bool operator< (const IntervalItem &right) const {
             return (start < right.start);
         }
 };

--- a/src/Core/Measures.h
+++ b/src/Core/Measures.h
@@ -43,7 +43,7 @@ public:
     QString originalSource; // if delivered from the cloud service
 
     // used by qSort()
-    bool operator< (Measure right) const {
+    bool operator< (const Measure &right) const {
         return (when < right.when);
     }
     // calculate a CRC for the Measure data - used to see if

--- a/src/Core/RideCache.h
+++ b/src/Core/RideCache.h
@@ -162,7 +162,7 @@ class AthleteBest
     QDate date;
 
     // for qsort
-    bool operator< (AthleteBest right) const { return (nvalue < right.nvalue); }
+    bool operator< (const AthleteBest &right) const { return (nvalue < right.nvalue); }
 };
 
 #endif // _GC_RideCache_h

--- a/src/Core/RideItem.h
+++ b/src/Core/RideItem.h
@@ -214,8 +214,8 @@ class RideItem : public QObject
         void setStartTime(QDateTime);
 
         // sorting
-        bool operator<(RideItem right) const { return dateTime < right.dateTime; }
-        bool operator>(RideItem right) const { return dateTime < right.dateTime; }
+        bool operator<(const RideItem &right) const { return dateTime < right.dateTime; }
+        bool operator>(const RideItem &right) const { return dateTime < right.dateTime; }
 
     private:
         void updateIntervals();

--- a/src/Core/Route.cpp
+++ b/src/Core/Route.cpp
@@ -340,7 +340,7 @@ Routes::readRoutes()
 
     QXmlInputSource source( &routeFile );
     QXmlSimpleReader xmlReader;
-    RouteParser( handler );
+    RouteParser handler;
     xmlReader.setContentHandler(&handler);
     xmlReader.setErrorHandler(&handler);
     xmlReader.parse( source );

--- a/src/FileIO/CsvRideFile.cpp
+++ b/src/FileIO/CsvRideFile.cpp
@@ -194,7 +194,7 @@ RideFile *CsvFileReader::openRideFile(QFile &file, QStringList &errors, QList<Ri
     bool dfpmExists   = false;
     int iBikeVersion  = 0;
 
-    int xTrainVersion  = 0;
+    //UNUSED int xTrainVersion;
 
     //UNUSED int timestampIndex=-1;
     int secsIndex=-1;
@@ -272,7 +272,7 @@ RideFile *CsvFileReader::openRideFile(QFile &file, QStringList &errors, QList<Ri
                     rideFile->setDeviceType("xtrainCSV");
                     rideFile->setFileFormat("xtrainCSV");
                     unitsHeader = 2;
-                    xTrainVersion = line.section( ',', 1, 1 ).toInt();
+                    //UNUSED xTrainVersion = line.section( ',', 1, 1 ).toInt();
 
                     ++lineno;
                     continue;

--- a/src/FileIO/HrvMeasuresCsvImport.cpp
+++ b/src/FileIO/HrvMeasuresCsvImport.cpp
@@ -117,7 +117,8 @@ HrvMeasuresCsvImport::getHrvMeasures(QString &error, QDateTime from, QDateTime t
               if (!m.when.isValid()) {
                   // try 12hr format (HRV4Training for iPhone variant...)
                   m.when = QDateTime::fromString(i.left(19).trimmed(), "yyyy-MM-dd h:mm:ss");
-                  if (i.contains("p", Qt::CaseInsensitive)) m.when.addSecs(12*3600);
+                  if (i.contains("p", Qt::CaseInsensitive))
+                      m.when = m.when.addSecs(12*3600);
               }
               if (m.when.isValid()) {
                   // skip line if not in date range

--- a/src/FileIO/LocationInterpolation.h
+++ b/src/FileIO/LocationInterpolation.h
@@ -205,11 +205,11 @@ template <size_t T_bitsize> class MyBitset
 
     unsigned popcnt(unsigned x) const {
         x = x - ((x >> 1) & 0x55555555);
-        x = (x & 0x33333333) + ((x >> 2) & 0x33333333);  
-        return ((x + (x >> 4) & 0xF0F0F0F) * 0x1010101) >> 24;
+        x = (x & 0x33333333) + ((x >> 2) & 0x33333333);
+        return (((x + (x >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24;
     }
 
-    void truncate() { m_mask &= (((unsigned)(-1 << (32 - T_bitsize))) >> (32 - T_bitsize)); }
+    void truncate() { m_mask &= ((((unsigned)-1) << (32 - T_bitsize)) >> (32 - T_bitsize)); }
 
 public:
 

--- a/src/FileIO/MoxyDevice.cpp
+++ b/src/FileIO/MoxyDevice.cpp
@@ -77,7 +77,7 @@ class MoxyData {
     QDateTime timestamp;
     QString line;
 
-    bool operator<(MoxyData right) const { return timestamp < right.timestamp; }
+    bool operator<(const MoxyData &right) const { return timestamp < right.timestamp; }
 };
 
 bool

--- a/src/FileIO/RideFile.h
+++ b/src/FileIO/RideFile.h
@@ -126,12 +126,21 @@ class RideFileInterval
         type(type), start(start), stop(stop), name(name), test(test), color(color) {}
 
 
-        // order bu start time (and stop+name for QMap)
-        bool operator< (RideFileInterval right) const { return start < right.start ||
-                                                        (start == right.start && stop < right.stop) ||
-                                                        (start == right.start && stop == right.stop && name < right.name); }
-        bool operator== (RideFileInterval right) const { return start == right.start && stop == right.stop && name == right.name; }
-        bool operator!= (RideFileInterval right) const { return start != right.start || stop != right.stop; }
+        // order by start time (and stop+name for QMap)
+        bool operator< (const RideFileInterval &right) const
+        {
+            return start < right.start ||
+              (start == right.start && stop < right.stop) ||
+              (start == right.start && stop == right.stop && name < right.name);
+        }
+        bool operator== (const RideFileInterval &right) const
+        {
+            return start == right.start && stop == right.stop && name == right.name;
+        }
+        bool operator!= (const RideFileInterval &right) const
+        {
+            return start != right.start || stop != right.stop;
+        }
 
         bool isPeak() const;
         bool isMatch() const;
@@ -149,8 +158,11 @@ struct RideFileCalibration
     RideFileCalibration(double start, int value, QString name) :
         start(start), value(value), name(name) {}
 
-    // order bu start time
-    bool operator< (RideFileCalibration right) const { return start < right.start; }
+    // order by start time
+    bool operator< (const RideFileCalibration &right) const
+    {
+        return start < right.start;
+    }
 };
 
 class RideFile : public QObject // QObject to emit signals

--- a/src/FileIO/Serial.cpp
+++ b/src/FileIO/Serial.cpp
@@ -203,7 +203,7 @@ operator-=(struct timeval &left, const struct timeval &right)
 }
 
 static bool
-operator<(struct timeval &left, const struct timeval &right)
+operator<(const struct timeval &left, const struct timeval &right)
 {
     if (left.tv_sec < right.tv_sec)
         return true;

--- a/src/Gui/Pages.cpp
+++ b/src/Gui/Pages.cpp
@@ -4301,7 +4301,7 @@ struct schemeitem {
     QString name, desc;
     int lo;
     double trimp;
-    bool operator<(schemeitem right) const { return lo < right.lo; }
+    bool operator<(const schemeitem &right) const { return lo < right.lo; }
 };
 
 ZoneScheme
@@ -5859,7 +5859,7 @@ struct paceschemeitem {
     QString name, desc;
     int lo;
     double trimp;
-    bool operator<(paceschemeitem right) const { return lo < right.lo; }
+    bool operator<(const paceschemeitem &right) const { return lo < right.lo; }
 };
 
 PaceZoneScheme

--- a/src/Gui/RideNavigatorProxy.h
+++ b/src/Gui/RideNavigatorProxy.h
@@ -54,7 +54,7 @@ private:
         double row;
         double value;
 
-        bool operator< (rankx right) const {
+        bool operator< (const rankx &right) const {
             return (value > right.value);  // sort ascending! (.gt not .lt)
         }
         static bool sortByRow(const rankx &left, const rankx &right) {

--- a/src/Metrics/HrZones.h
+++ b/src/Metrics/HrZones.h
@@ -46,7 +46,7 @@ struct HrZoneInfo {
         name(n), desc(d), lo(l), hi(h), trimp(t) {}
 
     // used by qSort()
-    bool operator< (HrZoneInfo right) const {
+    bool operator< (const HrZoneInfo &right) const {
         return ((lo < right.lo) || ((lo == right.lo) && (hi < right.hi)));
     }
 };
@@ -71,7 +71,7 @@ struct HrZoneRange {
         begin(b), end(e), lt(_lt), restHr(_restHr), maxHr(_maxHr), hrZonesSetFromLT(false) {}
 
     // used by qSort()
-    bool operator< (HrZoneRange right) const {
+    bool operator< (const HrZoneRange &right) const {
         return (((! right.begin.isNull()) &&
                 (begin.isNull() || begin < right.begin )) ||
                 ((begin == right.begin) && (! end.isNull()) &&

--- a/src/Metrics/PaceZones.h
+++ b/src/Metrics/PaceZones.h
@@ -49,7 +49,7 @@ struct PaceZoneInfo {
         name(n), desc(d), lo(l), hi(h) {}
 
     // used by qSort()
-    bool operator< (PaceZoneInfo right) const {
+    bool operator< (const PaceZoneInfo &right) const {
         return ((lo < right.lo) || ((lo == right.lo) && (hi < right.hi)));
     }
 };
@@ -71,7 +71,7 @@ struct PaceZoneRange {
         begin(b), end(e), cv(_cv), zonesSetFromCV(false) {}
 
     // used by qSort()
-    bool operator< (PaceZoneRange right) const {
+    bool operator< (const PaceZoneRange &right) const {
         return (((! right.begin.isNull()) &&
                 (begin.isNull() || begin < right.begin )) ||
                 ((begin == right.begin) && (! end.isNull()) &&

--- a/src/Metrics/UserMetricSettings.h
+++ b/src/Metrics/UserMetricSettings.h
@@ -45,7 +45,7 @@ class UserMetricSettings {
 
     public:
 
-        bool operator!= (UserMetricSettings right) const {
+        bool operator!= (const UserMetricSettings &right) const {
 
             // mostly used to see if it changed when editing
             if (this->symbol != right.symbol ||

--- a/src/Metrics/Zones.h
+++ b/src/Metrics/Zones.h
@@ -45,7 +45,7 @@ struct ZoneInfo {
         name(n), desc(d), lo(l), hi(h) {}
 
     // used by qSort()
-    bool operator< (ZoneInfo right) const {
+    bool operator< (const ZoneInfo &right) const {
         return ((lo < right.lo) || ((lo == right.lo) && (hi < right.hi)));
     }
 };
@@ -70,7 +70,7 @@ struct ZoneRange {
         begin(b), end(e), cp(_cp), ftp(_ftp), wprime(_wprime), pmax(pmax), zonesSetFromCP(false) {}
 
     // used by qSort()
-    bool operator< (ZoneRange right) const {
+    bool operator< (const ZoneRange &right) const {
         return (((! right.begin.isNull()) &&
                 (begin.isNull() || begin < right.begin )) ||
                 ((begin == right.begin) && (! end.isNull()) &&

--- a/src/Python/SIP/Bindings.cpp
+++ b/src/Python/SIP/Bindings.cpp
@@ -99,7 +99,7 @@ PyObject* Bindings::athlete() const
 class gcZoneConfig {
     public:
     gcZoneConfig(QString sport) : sport(sport), date(QDate(01,01,01)), cp(0), wprime(0), pmax(0), ftp(0),lthr(0),rhr(0),hrmax(0),cv(0) {}
-    bool operator<(gcZoneConfig rhs) const { return date < rhs.date; }
+    bool operator<(const gcZoneConfig &rhs) const { return date < rhs.date; }
     QString sport;
     QDate date;
     QList<int> zoneslow;

--- a/src/R/RLibrary.h
+++ b/src/R/RLibrary.h
@@ -75,16 +75,16 @@ extern int GC_R_registerRoutines(DllInfo *info, const R_CMethodDef * const crout
                           const R_FortranMethodDef * const fortranRoutines,
                           const R_ExternalMethodDef * const externalRoutines);
 #ifndef WIN32
-extern void (*(*ptr_GC_ptr_R_Suicide))(const char *);
-extern void (*(*ptr_GC_ptr_R_ShowMessage))(const char *);
-extern int  (*(*ptr_GC_ptr_R_ReadConsole))(const char *, unsigned char *, int, int);
-extern void (*(*ptr_GC_ptr_R_WriteConsole))(const char *, int);
-extern void (*(*ptr_GC_ptr_R_WriteConsoleEx))(const char *, int, int);
-extern void (*(*ptr_GC_ptr_R_ResetConsole))(void);
-extern void (*(*ptr_GC_ptr_R_FlushConsole))(void);
-extern void (*(*ptr_GC_ptr_R_ClearerrConsole))(void);
-extern void (*(*ptr_GC_ptr_R_ProcessEvents))(void);
-extern void (*(*ptr_GC_ptr_R_Busy))(int);
+extern void (**ptr_GC_ptr_R_Suicide)(const char *);
+extern void (**ptr_GC_ptr_R_ShowMessage)(const char *);
+extern int  (**ptr_GC_ptr_R_ReadConsole)(const char *, unsigned char *, int, int);
+extern void (**ptr_GC_ptr_R_WriteConsole)(const char *, int);
+extern void (**ptr_GC_ptr_R_WriteConsoleEx)(const char *, int, int);
+extern void (**ptr_GC_ptr_R_ResetConsole)(void);
+extern void (**ptr_GC_ptr_R_FlushConsole)(void);
+extern void (**ptr_GC_ptr_R_ClearerrConsole)(void);
+extern void (**ptr_GC_ptr_R_ProcessEvents)(void);
+extern void (**ptr_GC_ptr_R_Busy)(int);
 extern int *pGC_R_interrupts_pending;
 #else
 typedef char *(*Prot_GC_getDLLVersion)(void);

--- a/src/R/RTool.cpp
+++ b/src/R/RTool.cpp
@@ -447,7 +447,7 @@ RTool::athlete()
 class gcZoneConfig {
     public:
     gcZoneConfig(QString sport) : sport(sport), date(QDate(01,01,01)), cp(0), wprime(0), pmax(0), ftp(0),lthr(0),rhr(0),hrmax(0),cv(0) {}
-    bool operator<(gcZoneConfig rhs) const { return date < rhs.date; }
+    bool operator<(const gcZoneConfig &rhs) const { return date < rhs.date; }
     QString sport;
     QDate date;
     QList<int> zoneslow;

--- a/src/Train/DialWindow.cpp
+++ b/src/Train/DialWindow.cpp
@@ -573,6 +573,8 @@ void DialWindow::seriesChanged()
     case RealtimeData::VI:
     case RealtimeData::SkibaVI:
     case RealtimeData::Slope:
+    case RealtimeData::Latitude:
+    case RealtimeData::Longitude:
     case RealtimeData::None:
             foreground = GColor(CDIAL);
             break;


### PR DESCRIPTION
simple code cleaning:
- unused variables/constructor
- cases/breaks/fallthroughs in switches
- parentheses

actual fix:
- use of QDateTime::addSecs