### PR TITLE
Issue 3283: Use tangent vector to compute interpolated grade.

### DIFF
--- a/src/Core/BlinnSolver.cpp
+++ b/src/Core/BlinnSolver.cpp
@@ -19,6 +19,28 @@
 #include "BlinnSolver.h"
 #include "cmath"
 
+// 0 == A*x + B
+Roots LinearSolver(double A, double B)
+{
+    if (A == 0) {
+        if (B == 0) return Roots({ 0,1 });
+        return Roots();
+    }
+
+    return Roots({ -B / A, 1 });
+}
+
+// 0 == A*x^2 + B*x + C
+Roots QuadraticSolver(double A, double B, double C)
+{
+    if (A == 0) return LinearSolver(B, C);
+
+    double det = sqrt(B*B - 4 * A*C);
+    double r0 = (-B + det) / (2 * A);
+    double r1 = (-B - det) / (2 * A);
+    return Roots({ r0, 1 }, { r1, 1 });
+}
+
 // Cubic solver as described by James F. Blinn's EPIC paper:
 // 'How to Solve A Cubic Equation', all 5 parts are awesome
 // but part 5 provides the algorithmic conclusion that I used
@@ -40,6 +62,11 @@
 Roots
 BlinnCubicSolver(double A, double B, double C, double D)
 {
+    if (A == 0)
+    {
+        return QuadraticSolver(B, C, D);
+    }
+
     // Make Monic.
     B = B / A;
     C = C / A;

--- a/src/FileIO/FixGPS.cpp
+++ b/src/FileIO/FixGPS.cpp
@@ -1001,7 +1001,7 @@ bool FixGPS::postProcess(RideFile *ride, DataProcessorConfig *config, QString op
                 }
             }
 
-            geolocation interpLoc = gpi.Interpolate(km);
+            geolocation interpLoc = gpi.Location(km);
 
             ride->command->setPointValue(i, RideFile::lat, interpLoc.Lat());
             ride->command->setPointValue(i, RideFile::lon, interpLoc.Long());

--- a/src/FileIO/LocationInterpolation.cpp
+++ b/src/FileIO/LocationInterpolation.cpp
@@ -17,7 +17,7 @@
 */
 
 #include "LocationInterpolation.h"
-#include "blinnsolver.h"
+#include "BlinnSolver.h"
 
 static double radianstodegrees(double r) { return r * (360.0 / (2 * M_PI)); }
 static double degreestoradians(double d) { return d * (2 * M_PI / 360.0); }

--- a/src/FileIO/LocationInterpolation.cpp
+++ b/src/FileIO/LocationInterpolation.cpp
@@ -45,7 +45,7 @@ xyz geolocation::toxyz() const
     double lat = degreestoradians(Lat());
     double lon = degreestoradians(Long());
     double alt = Alt();
-    double n = a / sqrt(1 - e2*sin(lat)*sin(lat));
+    double n = a / sqrt(1 - e2 * sin(lat)*sin(lat));
     double dx = ((n + alt)*cos(lat)*cos(lon));           //ECEF x
     double dy = ((n + alt)*cos(lat)*sin(lon));           //ECEF y
     double dz = ((n*(1 - e2) + alt)*sin(lat));           //ECEF z
@@ -82,9 +82,9 @@ geolocation xyz::togeolocation() const
     double y = xyz::y();
     double z = xyz::z();
     double zp = std::abs(z);
-    double w2 = x*x + y*y;
+    double w2 = x * x + y * y;
     double w = sqrt(w2);
-    double r2 = w2 + z*z;
+    double r2 = w2 + z * z;
     double r = sqrt(r2);
 
     double retLong;
@@ -92,33 +92,33 @@ geolocation xyz::togeolocation() const
     double retAlt;
 
     retLong = atan2(y, x);    // Lon (final)
-    double s2 = z*z / r2;
+    double s2 = z * z / r2;
     double c2 = w2 / r2;
     double u = a2 / r;
     double v = a3 - a4 / r;
     double s, ss, c;
     if (c2 > 0.3) {
-        s = (zp / r)*(1.0 + c2*(a1 + u + s2*v) / r);
+        s = (zp / r)*(1.0 + c2 * (a1 + u + s2 * v) / r);
         retLat = asin(s);      //Lat
-        ss = s*s;
+        ss = s * s;
         c = sqrt(1.0 - ss);
     }
     else {
-        c = (w / r)*(1.0 - s2*(a5 - u - c2*v) / r);
+        c = (w / r)*(1.0 - s2 * (a5 - u - c2 * v) / r);
         retLat = acos(c);      //Lat
-        ss = 1.0 - c*c;
+        ss = 1.0 - c * c;
         s = sqrt(ss);
     }
-    double g = 1.0 - e2*ss;
+    double g = 1.0 - e2 * ss;
     double rg = a / sqrt(g);
-    double rf = a6*rg;
-    u = w - rg*c;
-    v = zp - rf*s;
-    double f = c*u + s*v;
-    double m = c*v - s*u;
+    double rf = a6 * rg;
+    u = w - rg * c;
+    v = zp - rf * s;
+    double f = c * u + s * v;
+    double m = c * v - s * u;
     double p = m / (rf / g + f);
     retLat = retLat + p;            //Lat
-    retAlt = f + m*p / 2.0;         //Altitude
+    retAlt = f + m * p / 2.0;         //Altitude
     if (z < 0.0) {
         retLat = retLat * -1.0;     //Lat
     }
@@ -206,9 +206,16 @@ UnitCatmullRomInterpolator::UnitCatmullRomInterpolator(double pm1, double p0, do
     Init(pm1, p0, p1, p2);
 }
 
-double UnitCatmullRomInterpolator::Interpolate(double u)
+double UnitCatmullRomInterpolator::T()
 {
-    // assert u in range 0 <= u <= 1.0
+    static const double s_T = 0.5; // Control curvature: 0 is linear, 1 is pretty loopy, most people like 0.5.
+
+    return s_T;
+}
+
+double UnitCatmullRomInterpolator::Location(double u)
+{
+    static const double s_T = T();
 
     double p0 = std::get<0>(m_p);
     double p1 = std::get<1>(m_p);
@@ -218,9 +225,32 @@ double UnitCatmullRomInterpolator::Interpolate(double u)
     // Curvature-parameterized CatmullRom equation courtesy of wolfram alpha:
     // [1, u, u ^ 2, u ^ 3] * [[0, 1, 0, 0], [-t, 0, t, 0], [2 * t, t - 3, 3 - 2t, -t], [-t, 2 - t, t - 2, t]] * [p0, p1, p2, p3]
 
-    static const double t = 0.5; // Control curvature: 0 is linear, 1 is pretty loopy, most people like 0.5.
-    double retval = p0 * u * (u * (2 * t - t * u) - t) +
-        u * (u * (u * (p1 * (-t) + 2 * p1 + p2 * (t - 2) + p3 * t) + p1 * t - 3 * p1 + p2 * (3 - 2 * t) - p3 * t) + p2 * t) + p1;
+    double retval = p0 * u * (u * (2 * s_T - s_T * u) - s_T) +
+        u * (u * (u * (p1 * (-s_T) + 2 * p1 + p2 * (s_T - 2) + p3 * s_T) + p1 * s_T - 3 * p1 + p2 * (3 - 2 * s_T) - p3 * s_T) + p2 * s_T) + p1;
+
+    return retval;
+}
+
+double UnitCatmullRomInterpolator::Tangent(double u)
+{
+    static const double s_T = T();
+
+    double p0 = std::get<0>(m_p);
+    double p1 = std::get<1>(m_p);
+    double p2 = std::get<2>(m_p);
+    double p3 = std::get<3>(m_p);
+
+    // Curvature-parameterized CatmullRom equation courtesy of wolfram alpha:
+    // [1, u, u ^ 2, u ^ 3] * [[0, 1, 0, 0], [-t, 0, t, 0], [2 * t, t - 3, 3 - 2t, -t], [-t, 2 - t, t - 2, t]] * [p0, p1, p2, p3]
+
+    // dx/du
+
+    // Closed form slope for cubic at point u in 0..1.
+    double retval = p0 * u * (2 * s_T - 2 * s_T * u)
+        + p0 * (u * (2 * s_T - s_T * u) - s_T)
+        + u * (u * (p1 * (-s_T) + 2 * p1 + p2 * (s_T - 2) + p3 * s_T) + p1 * s_T - 3 * p1 + p2 * (3 - 2 * s_T) - p3 * s_T)
+        + u * (2 * u * (p1 * (-s_T) + 2 * p1 + p2 * (s_T - 2) + p3 * s_T) + p1 * s_T - 3 * p1 + p2 * (3 - 2 * s_T) - p3 * s_T)
+        + p2 * s_T;
 
     return retval;
 }
@@ -237,14 +267,40 @@ UnitCatmullRomInterpolator3D::UnitCatmullRomInterpolator3D(xyz pm1, xyz p0, xyz 
     Init(pm1, p0, p1, p2);
 }
 
-xyz UnitCatmullRomInterpolator3D::Interpolate(double frac)
+xyz UnitCatmullRomInterpolator3D::Location(double frac)
 {
-    return xyz(x.Interpolate(frac), y.Interpolate(frac), z.Interpolate(frac));
+    return xyz(x.Location(frac), y.Location(frac), z.Location(frac));
 }
 
-geolocation GeoPointInterpolator::Interpolate(double distance)
+xyz UnitCatmullRomInterpolator3D::Tangent(double frac)
 {
-    return DistancePointInterpolator<SphericalTwoPointInterpolator>::Interpolate(distance).togeolocation();
+    return xyz(x.Tangent(frac), y.Tangent(frac), z.Tangent(frac));
+}
+
+geolocation GeoPointInterpolator::Location(double distance)
+{
+    xyz l0xyz = DistancePointInterpolator<SphericalTwoPointInterpolator>::Location(distance);
+    geolocation l0 = l0xyz.togeolocation();
+    return l0;
+}
+
+geolocation GeoPointInterpolator::Location(double distance, double &slope)
+{
+    xyz tangentVector;
+    xyz l0xyz = DistancePointInterpolator<SphericalTwoPointInterpolator>::Location(distance, tangentVector);
+
+    // Compute earth gradient from location and tangent.
+    geolocation l1 = xyz(l0xyz.add(tangentVector.normalize())).togeolocation();
+    geolocation l0 = l0xyz.togeolocation();
+
+    double a0 = l0.Alt();
+    double a1 = l1.Alt();
+    double rise = a1 - a0;
+    double run = sqrt(1 - fabs(rise)); // length of adjacent
+
+    slope = run ? rise / run : 0;
+
+    return l0;
 }
 
 void GeoPointInterpolator::Push(double distance, geolocation point)

--- a/src/FileIO/LocationInterpolation.h
+++ b/src/FileIO/LocationInterpolation.h
@@ -39,13 +39,13 @@ public:
     double  y() const { return std::get<1>(m_t); }
     double  z() const { return std::get<2>(m_t); }
 
-    double& x()       { return std::get<0>(m_t); }
-    double& y()       { return std::get<1>(m_t); }
-    double& z()       { return std::get<2>(m_t); }
+    double& x() { return std::get<0>(m_t); }
+    double& y() { return std::get<1>(m_t); }
+    double& z() { return std::get<2>(m_t); }
 
     v3 add(const v3 &a)      const { return v3(x() + a.x(), y() + a.y(), z() + a.z()); }
     v3 subtract(const v3 &a) const { return v3(x() - a.x(), y() - a.y(), z() - a.z()); }
-    v3 scale(double d)       const { return v3(x() * d,     y() * d,     z() * d); }
+    v3 scale(double d)       const { return v3(x() * d, y() * d, z() * d); }
 
     double magnitude()       const { return sqrt(dot(*this)); }
 
@@ -117,10 +117,10 @@ struct geolocation : v3
         return dist;
     }
 
-    bool IsReasonableGeoLocation () const {
-        return  (this->Lat() &&  this->Lat()  >= double(-90)  && this->Lat()  <= double(90) &&
-                 this->Long() && this->Long() >= double(-180) && this->Long() <= double(180) &&
-                 this->Alt() >= -1000 && this->Alt() < 10000);
+    bool IsReasonableGeoLocation() const {
+        return  (this->Lat() && this->Lat() >= double(-90) && this->Lat() <= double(90) &&
+            this->Long() && this->Long() >= double(-180) && this->Long() <= double(180) &&
+            this->Alt() >= -1000 && this->Alt() < 10000);
     }
 
 };
@@ -173,12 +173,15 @@ class UnitCatmullRomInterpolator
 {
     std::tuple<double, double, double, double> m_p;
 
+    static double T(); // rounding coefficient
+
 public:
 
     void Init(double pm1, double p0, double p1, double p2);
     UnitCatmullRomInterpolator();
     UnitCatmullRomInterpolator(double pm1, double p0, double p1, double p2);
-    double Interpolate(double u);
+    double Location(double u);
+    double Tangent(double u);
 };
 
 class UnitCatmullRomInterpolator3D
@@ -190,7 +193,8 @@ public:
     void Init(xyz pm1, xyz p0, xyz p1, xyz p2);
     UnitCatmullRomInterpolator3D() : x(), y(), z() {}
     UnitCatmullRomInterpolator3D(xyz pm1, xyz p0, xyz p1, xyz p2);
-    xyz Interpolate(double frac);
+    xyz Location(double frac);
+    xyz Tangent(double frac);
 };
 
 // Visual studio has an error in how it compiles bitset that prevents
@@ -199,13 +203,13 @@ public:
 template <size_t T_bitsize> class MyBitset
 {
     static_assert(T_bitsize <= 32, "T_bitsize must be <= 32.");
-    static_assert(T_bitsize >= 1,  "T_bitsize must be >= 1.");
+    static_assert(T_bitsize >= 1, "T_bitsize must be >= 1.");
 
     unsigned m_mask;
 
     unsigned popcnt(unsigned x) const {
         x = x - ((x >> 1) & 0x55555555);
-        x = (x & 0x33333333) + ((x >> 2) & 0x33333333);  
+        x = (x & 0x33333333) + ((x >> 2) & 0x33333333);
         return ((x + (x >> 4) & 0xF0F0F0F) * 0x1010101) >> 24;
     }
 
@@ -214,10 +218,10 @@ template <size_t T_bitsize> class MyBitset
 public:
 
     MyBitset(unsigned m) : m_mask(m) {}
-    void reset()                           { m_mask = 0; }
-    bool test(unsigned u) const            { return ((m_mask >> u) & 1) != 0; }
-    void set(unsigned u)                   { m_mask |= (1 << u); truncate(); }
-    unsigned count() const                 { return popcnt(m_mask); }
+    void reset() { m_mask = 0; }
+    bool test(unsigned u) const { return ((m_mask >> u) & 1) != 0; }
+    void set(unsigned u) { m_mask |= (1 << u); truncate(); }
+    unsigned count() const { return popcnt(m_mask); }
     MyBitset<T_bitsize>& operator <<=(unsigned u) { m_mask <<= u; truncate(); return (*this); }
 };
 
@@ -238,10 +242,10 @@ public:
 
     unsigned Count() const { return (unsigned)m_ElementExists.count(); }
 
-    T& pm1()               { return std::get<0>(m_Window); }
-    T& p0()                { return std::get<1>(m_Window); }
-    T& p1()                { return std::get<2>(m_Window); }
-    T& p2()                { return std::get<3>(m_Window); }
+    T& pm1() { return std::get<0>(m_Window); }
+    T& p0() { return std::get<1>(m_Window); }
+    T& p1() { return std::get<2>(m_Window); }
+    T& p2() { return std::get<3>(m_Window); }
 
     T  pm1()         const { return std::get<0>(m_Window); }
     T  p0()          const { return std::get<1>(m_Window); }
@@ -418,14 +422,23 @@ public:
     // Interpolate between points[1] and points[2].
     // If points[0] and points[3] dont exist then
     // create them.
-    xyz Interpolate(double frac)
+    xyz Location(double frac)
     {
         // Ensure interpolator has current state - synthesize fake points if needed.
         update();
 
-        // assert frac in range 0-1.
+        return m_Interpolator.Location(frac);
+    }
 
-        return m_Interpolator.Interpolate(frac);
+    // Interpolate between points[1] and points[2].
+    // If points[0] and points[3] dont exist then
+    // create them.
+    xyz Tangent(double frac)
+    {
+        // Ensure interpolator has current state - synthesize fake points if needed.
+        update();
+
+        return m_Interpolator.Tangent(frac);
     }
 };
 
@@ -435,10 +448,56 @@ template <typename T_TwoPointInterpolator> class DistancePointInterpolator
     SlidingWindow<double>                                      m_DistanceWindow;
     bool                                                       m_fInputComplete;
 
-    static double OffsetInRangeToFraction(double distance, double start, double end)
+    static double OffsetInRangeToRatio(double distance, double start, double end)
     {
-        // assert distance >= start && distance <= end
+        if (end == start)
+            return 0;
+
         return (distance - start) / (end - start);
+    }
+
+    // Prepare interpolation window for query at distance, then return
+    // bracket ratio for distance within current bracket.
+    double DistanceToBracketRatio(double distance)
+    {
+        // Continue to advance queue after input is complete.
+        if (m_fInputComplete) {
+            // When input is finished we must continue to advance the point state based on distance
+            while (m_DistanceWindow.hasp1() && distance >= m_DistanceWindow.p1()) {
+                m_DistanceWindow.Advance();
+                m_Interpolator.Advance();
+            }
+        }
+
+        // Determine fraction of range that this distance specifies (frac must be 0-1.)
+        double ratio = 0.0;
+        switch (m_DistanceWindow.Count())
+        {
+        case 0:
+        case 1:
+            break;
+        case 2:
+            if (!m_DistanceWindow.haspm1() && !m_DistanceWindow.hasp0()) {
+                // missing: pm1 && p0
+                // Query distance comes before any known range.
+                ratio = 1.0;
+            }
+            else if (!m_DistanceWindow.haspm1()) {
+                // missing: pm1 && p2
+                ratio = OffsetInRangeToRatio(distance, m_DistanceWindow.p0(), m_DistanceWindow.p1());
+            }
+            else {
+                // missing: p1  && p2
+                ratio = 0.0;
+            }
+            break;
+        case 3:
+        case 4:
+            ratio = OffsetInRangeToRatio(distance, m_DistanceWindow.p0(), m_DistanceWindow.p1());
+            break;
+        }
+
+        return ratio;
     }
 
 public:
@@ -482,6 +541,7 @@ public:
         return r;
     }
 
+    // Return center two points of the four point interpolation window.
     bool GetBracket(double &d0, double &d1)
     {
         if (!m_DistanceWindow.hasp0() || !m_DistanceWindow.hasp1())
@@ -493,44 +553,23 @@ public:
         return true;
     }
 
-    xyz Interpolate(double distance)
+    // Location interpolation when tangent isn't needed.
+    xyz Location(double distance)
     {
-        // Continue to advance queue after input is complete.
-        if (m_fInputComplete) {
-            // When input is finished we must continue to advance the point state based on distance
-            while (m_DistanceWindow.hasp1() && distance >= m_DistanceWindow.p1()) {
-                m_DistanceWindow.Advance();
-                m_Interpolator.Advance();
-            }
-        }
+        double ratio = DistanceToBracketRatio(distance);
+        xyz newXYZLocation = m_Interpolator.Location(ratio);
+        return newXYZLocation;
+    }
 
-        // Determine fraction of range that this distance specifies (frac must be 0-1.)
-        double frac = 0.0;
-        switch (m_DistanceWindow.Count())
-        {
-        case 0:
-        case 1:
-            break;
-        case 2:
-            if (!m_DistanceWindow.haspm1() && !m_DistanceWindow.hasp0()) {
-                // missing: pm1 && p0
-                // Query distance comes before any known range.
-                frac = 1.0;
-            } else if (!m_DistanceWindow.haspm1()) {
-                // missing: pm1 && p2
-                frac = OffsetInRangeToFraction(distance, m_DistanceWindow.p0(), m_DistanceWindow.p1());
-            } else {
-                // missing: p1  && p2
-                frac = 0.0;
-            }
-            break;
-        case 3:
-        case 4:
-            frac = OffsetInRangeToFraction(distance, m_DistanceWindow.p0(), m_DistanceWindow.p1());
-            break;
-        }
+    // Location interpolation including tangent vector computation
+    xyz Location(double distance, xyz &tangentVector)
+    {
+        double bracketRatio = DistanceToBracketRatio(distance);
 
-        return m_Interpolator.Interpolate(frac);
+        tangentVector = m_Interpolator.Tangent(bracketRatio);
+        xyz l0xyz = m_Interpolator.Location(bracketRatio);
+
+        return l0xyz;
     }
 
 private:
@@ -638,10 +677,10 @@ public:
             const double inter1 = d0 + thirdspan + thirdspan;
 
             // Step 2
-            const xyz pm1 = this->Interpolate(d0);
-            const xyz  p0 = this->Interpolate(inter0);
-            const xyz  p1 = this->Interpolate(inter1);
-            const xyz  p2 = this->Interpolate(d1);
+            const xyz pm1 = this->Location(d0);
+            const xyz  p0 = this->Location(inter0);
+            const xyz  p1 = this->Location(inter1);
+            const xyz  p2 = this->Location(d1);
 
             // Step 3
             double linearDistance = p2.DistanceFrom(pm1);
@@ -663,7 +702,7 @@ public:
                 finalLength += arcDistance;
             } else {
                 // 5B: otherwise push the 3 new subsegments onto worklist.
-                worklist.Push(CalcSplineLengthBracketPair(d0,     inter0));
+                worklist.Push(CalcSplineLengthBracketPair(d0, inter0));
                 worklist.Push(CalcSplineLengthBracketPair(inter0, inter1));
                 worklist.Push(CalcSplineLengthBracketPair(inter1, d1));
             }
@@ -679,7 +718,8 @@ public:
 
     GeoPointInterpolator() : DistancePointInterpolator<SphericalTwoPointInterpolator>() {}
 
-    geolocation Interpolate(double distance);
+    geolocation Location(double distance);
+    geolocation Location(double distance, double &slope);
 
     void Push(double distance, geolocation point);
 };

--- a/src/Gui/MergeActivityWizard.cpp
+++ b/src/Gui/MergeActivityWizard.cpp
@@ -355,7 +355,8 @@ MergeActivityWizard::mergeRideSamplesByDistance()
         }
 
         // Compute interpolated location from current distance.
-        geolocation interpLoc = gpi.Interpolate(add.km);
+        double interpSlope = 0.;
+        geolocation interpLoc = gpi.Location(add.km, interpSlope);
 
         RideFilePoint source = *(ride2->dataPoints()[j]);
 
@@ -379,21 +380,7 @@ MergeActivityWizard::mergeRideSamplesByDistance()
                         add.setValue(io.key(), interpLoc.Alt());
                         break;
                     case RideFile::slope:
-                        {
-                            // Obtain interpolated future altitude using next unique ride1 distance
-                            // since that location is of the next altitude that will be recorded.
-                            // This is more stable than using the actual point slope at current
-                            // location and ensures that slope will match recorded altitudes.
-                            double slope = 0.0;
-                            if (ride1nextdistance != add.km)
-                            {
-                                geolocation interpLocE = gpi.Interpolate(ride1nextdistance);
-                                double altitudeDeltaM = (interpLocE.Alt() - interpLoc.Alt());
-                                double distanceDeltaM = 1000 * (ride1nextdistance - add.km);
-                                slope = 100.0 * (altitudeDeltaM / distanceDeltaM);
-                            }
-                            add.setValue(io.key(), slope);
-                        }
+                        add.setValue(io.key(), interpSlope * 100);
                         break;
                     default:
                         add.setValue(io.key(), source.value(io.key()));

--- a/src/Train/ErgFile.cpp
+++ b/src/Train/ErgFile.cpp
@@ -1140,8 +1140,8 @@ ErgFile::isValid()
     return valid;
 }
 
-int
-ErgFile::wattsAt(long x, int &lapnum)
+double
+ErgFile::wattsAt(double x, int &lapnum)
 {
     // workout what wattage load should be set for any given
     // point in time in msecs.
@@ -1199,7 +1199,7 @@ ErgFile::wattsAt(long x, int &lapnum)
 }
 
 double
-ErgFile::gradientAt(long x, int &lapnum)
+ErgFile::gradientAt(double x, int &lapnum)
 {
     // workout what wattage load should be set for any given
     // point in time in msecs.
@@ -1228,12 +1228,17 @@ ErgFile::gradientAt(long x, int &lapnum)
             rightPoint++;
         }
     }
-    return Points.at(leftPoint).val;
+
+    double gradient = Points.at(leftPoint).val;
+
+    return gradient;
 }
 
 // Returns true if a location is determined, otherwise returns false.
-bool ErgFile::locationAt(long meters, int &lapnum, geolocation &geoLoc)
+bool ErgFile::locationAt(double meters, int &lapnum, geolocation &geoLoc, double &slope100)
 {
+    slope100 = -100;
+
     if (!isValid()) return false; // not a valid ergfile
 
     // is it in bounds?
@@ -1306,7 +1311,9 @@ bool ErgFile::locationAt(long meters, int &lapnum, geolocation &geoLoc)
         }
     }
 
-    geoLoc = gpi.Interpolate(meters);
+    geoLoc = gpi.Location(meters, slope100);
+
+    slope100 *= 100;
 
     return true;
 }

--- a/src/Train/ErgFile.h
+++ b/src/Train/ErgFile.h
@@ -119,10 +119,10 @@ class ErgFile
 
         bool isValid();         // is the file valid or not?
         double Cp;
-        int format;             // ERG, CRS, MRC and CRS_LOC currently supported
-        int wattsAt(long, int&);      // return the watts value for the passed msec
-        double gradientAt(long, int&);      // return the gradient value for the passed meter
-        bool locationAt(long x, int& lapnum, geolocation &geoLoc); // location at meter
+        int format;                      // ERG, CRS, MRC and CRS_LOC currently supported
+        double wattsAt   (double, int&); // return the watts value for the passed msec
+        double gradientAt(double, int&); // return the gradient value for the passed meter
+        bool locationAt  (double x, int& lapnum, geolocation &geoLoc, double &slope100); // location at meter
 
         int nextLap(long);      // return the start value (erg - time(ms) or slope - distance(m)) for the next lap
         int currentLap(long);   // return the start value (erg - time(ms) or slope - distance(m)) for the current lap

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -1704,7 +1704,7 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
                 // Trust ergFile for location data, if available.
                 if (ergFile) {
                     geolocation geoloc;
-                    if (ergFile->locationAt(displayWorkoutDistance * 1000, displayWorkoutLap, geoloc))
+                    if (ergFile->locationAt(displayWorkoutDistance * 1000, displayWorkoutLap, geoloc, slope))
                     {
                         displayLatitude = geoloc.Lat();
                         displayLongitude = geoloc.Long();
@@ -1712,6 +1712,7 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
 
                         rtData.setLatitude(displayLatitude);
                         rtData.setLongitude(displayLongitude);
+                        rtData.setSlope(slope);
                     }
                 }
 
@@ -2003,14 +2004,14 @@ void TrainSidebar::loadUpdate()
             context->notifySetNow(load_msecs);
         }
     } else {
-        slope = ergFile->gradientAt(displayWorkoutDistance*1000, curLap);
-
         geolocation geoloc;
-        if (ergFile->locationAt(displayWorkoutDistance * 1000, curLap, geoloc))
+        if (ergFile->locationAt(displayWorkoutDistance * 1000, curLap, geoloc, slope))
         {
             displayLatitude = geoloc.Lat();
             displayLongitude = geoloc.Long();
             displayAltitude = geoloc.Alt();
+        } else {
+            slope = ergFile->gradientAt(displayWorkoutDistance * 1000, curLap);
         }
 
         if(displayWorkoutLap != curLap)


### PR DESCRIPTION
This change has interpolated slope come from instant interpolated tangent vector instead of averaging slope across nearby samples. Along with correcting slope when riding ergfiles this massively improves the mergefile behavior in some cases.

Rename location interpolation method "Interpolate" to be "Location".

Change ErgFile::LocationAt and GradientAt to accept location as double instead of int. Location reporting was jumping all around when multiple gpx files were in a small area (interpolation now interpolates instead of snapping to nearest meter.)

This change helps refine training mode behavior. Should go in along with bicycle sim KE change.