### PR TITLE
Fix for issue #3293 (Python class CatchOutErr missing flush function)

### DIFF
--- a/src/Python/PythonEmbed.cpp
+++ b/src/Python/PythonEmbed.cpp
@@ -242,6 +242,8 @@ PythonEmbed::PythonEmbed(const bool verbose, const bool interactive) : verbose(v
                                      "        self.value = ''\n"
                                      "    def write(self, txt):\n"
                                      "        self.value += txt\n"
+                                     "    def flush(self):\n"
+                                     "       pass\n"
                                      "catchOutErr = CatchOutErr()\n"
                                      "sys.stdout = catchOutErr\n"
                                      "sys.stderr = catchOutErr\n"

--- a/src/Python/PythonEmbed.cpp
+++ b/src/Python/PythonEmbed.cpp
@@ -243,7 +243,7 @@ PythonEmbed::PythonEmbed(const bool verbose, const bool interactive) : verbose(v
                                      "    def write(self, txt):\n"
                                      "        self.value += txt\n"
                                      "    def flush(self):\n"
-                                     "        self.flush\n"
+                                     "        pass\n"
                                      "catchOutErr = CatchOutErr()\n"
                                      "sys.stdout = catchOutErr\n"
                                      "sys.stderr = catchOutErr\n"

--- a/src/Python/PythonEmbed.cpp
+++ b/src/Python/PythonEmbed.cpp
@@ -243,7 +243,7 @@ PythonEmbed::PythonEmbed(const bool verbose, const bool interactive) : verbose(v
                                      "    def write(self, txt):\n"
                                      "        self.value += txt\n"
                                      "    def flush(self):\n"
-                                     "       pass\n"
+                                     "        self.flush\n"
                                      "catchOutErr = CatchOutErr()\n"
                                      "sys.stdout = catchOutErr\n"
                                      "sys.stderr = catchOutErr\n"


### PR DESCRIPTION
add flush function to CatchOutErr. This support an better integration with plotly dash (flask server)

Please review if there needs more functionality behind the flush function currently only pass trough.
