### PR TITLE
Remove ampersand from menu and button text before compare

### DIFF
--- a/src/Charts/HomeWindow.cpp
+++ b/src/Charts/HomeWindow.cpp
@@ -188,9 +188,11 @@ HomeWindow::rightClick(const QPoint & /*pos*/)
 void
 HomeWindow::addChartFromMenu(QAction*action)
 {
+    // & removed to avoid issues with kde AutoCheckAccelerators
+    QString actionText = QString(action->text()).replace("&", "");
     GcWinID id = GcWindowTypes::None;
     for (int i=0; GcWindows[i].relevance; i++) {
-        if (GcWindows[i].name == action->text()) {
+        if (GcWindows[i].name == actionText) {
             id = GcWindows[i].id;
             break;
         }

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -820,9 +820,11 @@ MainWindow::setChartMenu(QMenu *menu)
 void
 MainWindow::addChart(QAction*action)
 {
+    // & removed to avoid issues with kde AutoCheckAccelerators
+    QString actionText = QString(action->text()).replace("&", "");
     GcWinID id = GcWindowTypes::None;
     for (int i=0; GcWindows[i].relevance; i++) {
-        if (GcWindows[i].name == action->text()) {
+        if (GcWindows[i].name == actionText) {
             id = GcWindows[i].id;
             break;
         }
@@ -2099,8 +2101,10 @@ MainWindow::uploadCloud(QAction *action)
 {
     // upload current ride, if we have one
     if (currentTab->context->ride) {
+        // & removed to avoid issues with kde AutoCheckAccelerators
+        QString actionText = QString(action->text()).replace("&", "");
 
-        if (action->text() == "University of Kent") {
+        if (actionText == "University of Kent") {
 #if QT_VERSION > 0x50000
             CloudService *db = CloudServiceFactory::instance().newService(action->data().toString(), currentTab->context);
             KentUniversityUploadDialog uploader(this, db, currentTab->context->ride);

--- a/src/Gui/RideImportWizard.cpp
+++ b/src/Gui/RideImportWizard.cpp
@@ -957,7 +957,8 @@ RideImportWizard::abortClicked()
     // NOTE: abort button morphs into save and finish button later - so all 3 variants are processed here
 
     // if done when labelled abort we kill off this dialog
-    QString label = abortButton->text();
+    // & removed to avoid issues with kde AutoCheckAccelerators
+    QString label = QString(abortButton->text()).replace("&", "");
 
     // Process "ABORT"
     if (label == tr("Abort")) {


### PR DESCRIPTION
To avoid issues with kde injecting them, it is not pretty
but simple and safe.
Fixes #1852
Fixes #2930