### PR TITLE
Fix issue with font being "white on white" in dark-mode on Mac

### DIFF
--- a/src/Charts/BlankState.cpp
+++ b/src/Charts/BlankState.cpp
@@ -77,8 +77,10 @@ BlankStatePage::BlankStatePage(Context *context) : GcWindow(context), context(co
     mainLayout->addLayout(bottomRow);
 
     dontShow = new QCheckBox(tr("Don't show this next time."), this);
+    dontShow->setStyleSheet("QCheckBox {color: black}");
     dontShow->setFocusPolicy(Qt::NoFocus);
     closeButton = new QPushButton(tr("Close"), this);
+    closeButton->setStyleSheet("QPushButton {color: black }");
     closeButton->setFocusPolicy(Qt::NoFocus);
     bottomRow->addWidget(dontShow);
     bottomRow->addStretch();
@@ -129,7 +131,7 @@ BlankStatePage::addToShortCuts(ShortCut shortCut)
     shortCutButton->setIconSize(QSize(40,40));
     //importButton->setToolButtonStyle(Qt::ToolButtonTextBesideIcon);
     //importButton->setStyleSheet("QToolButton {text-align: left;color : blue;background: transparent}");
-    shortCutButton->setStyleSheet("QPushButton {border-radius: 10px;border-style: outset; background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #DDDDDD, stop: 1 #BBBBBB); border-width: 1px; border-color: #555555;} QPushButton:pressed {background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #BBBBBB, stop: 1 #999999);}");
+    shortCutButton->setStyleSheet("QPushButton {color: black; border-radius: 10px;border-style: outset; background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #DDDDDD, stop: 1 #BBBBBB); border-width: 1px; border-color: #555555;} QPushButton:pressed {background-color: qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #BBBBBB, stop: 1 #999999);}");
     shortCutButton->setFixedSize(200*dpiXFactor, 60*dpiYFactor);
     leftLayout->addWidget(shortCutButton);
 


### PR DESCRIPTION
The "Blank" screens had some issues with using white fonts on white background when using darkmode on Mac.