### PR TITLE
Derived stats for sim bicycle config screen

### DIFF
--- a/src/Gui/Pages.cpp
+++ b/src/Gui/Pages.cpp
@@ -2296,6 +2296,68 @@ SimBicyclePage::AddSpecBox(int ePart)
     m_SpinBoxArr[ePart] = pSpinBox;
 }
 
+void
+SimBicyclePage::SetStatsLabelArray(double d)
+{
+    double riderMassKG = 0;
+
+    const double bicycleMassWithoutWheelsG = m_SpinBoxArr[SimBicyclePage::BicycleWithoutWheelsG]->value();
+    const double bareFrontWheelG           = m_SpinBoxArr[SimBicyclePage::FrontWheelG          ]->value();
+    const double frontSpokeCount           = m_SpinBoxArr[SimBicyclePage::FrontSpokeCount      ]->value();
+    const double frontSpokeNippleG         = m_SpinBoxArr[SimBicyclePage::FrontSpokeNippleG    ]->value();
+    const double frontWheelOuterRadiusM    = m_SpinBoxArr[SimBicyclePage::FrontOuterRadiusM    ]->value();
+    const double frontRimInnerRadiusM      = m_SpinBoxArr[SimBicyclePage::FrontRimInnerRadiusM ]->value();
+    const double frontRimG                 = m_SpinBoxArr[SimBicyclePage::FrontRimG            ]->value();
+    const double frontRotorG               = m_SpinBoxArr[SimBicyclePage::FrontRotorG          ]->value();
+    const double frontSkewerG              = m_SpinBoxArr[SimBicyclePage::FrontSkewerG         ]->value();
+    const double frontTireG                = m_SpinBoxArr[SimBicyclePage::FrontTireG           ]->value();
+    const double frontTubeOrSealantG       = m_SpinBoxArr[SimBicyclePage::FrontTubeSealantG    ]->value();
+    const double bareRearWheelG            = m_SpinBoxArr[SimBicyclePage::RearWheelG           ]->value();
+    const double rearSpokeCount            = m_SpinBoxArr[SimBicyclePage::RearSpokeCount       ]->value();
+    const double rearSpokeNippleG          = m_SpinBoxArr[SimBicyclePage::RearSpokeNippleG     ]->value();
+    const double rearWheelOuterRadiusM     = m_SpinBoxArr[SimBicyclePage::RearOuterRadiusM     ]->value();
+    const double rearRimInnerRadiusM       = m_SpinBoxArr[SimBicyclePage::RearRimInnerRadiusM  ]->value();
+    const double rearRimG                  = m_SpinBoxArr[SimBicyclePage::RearRimG             ]->value();
+    const double rearRotorG                = m_SpinBoxArr[SimBicyclePage::RearRotorG           ]->value();
+    const double rearSkewerG               = m_SpinBoxArr[SimBicyclePage::RearSkewerG          ]->value();
+    const double rearTireG                 = m_SpinBoxArr[SimBicyclePage::RearTireG            ]->value();
+    const double rearTubeOrSealantG        = m_SpinBoxArr[SimBicyclePage::RearTubeSealantG     ]->value();
+    const double cassetteG                 = m_SpinBoxArr[SimBicyclePage::CassetteG            ]->value();
+
+    const double frontWheelG = bareFrontWheelG + frontRotorG + frontSkewerG + frontTireG + frontTubeOrSealantG;
+    const double frontWheelRotatingG = frontRimG + frontTireG + frontTubeOrSealantG + (frontSpokeCount * frontSpokeNippleG);
+    const double frontWheelCenterG = frontWheelG - frontWheelRotatingG;
+
+    BicycleWheel frontWheel(frontWheelOuterRadiusM, frontRimInnerRadiusM, frontWheelG / 1000, frontWheelCenterG /1000, frontSpokeCount, frontSpokeNippleG/1000);
+
+    const double rearWheelG = bareRearWheelG + cassetteG + rearRotorG + rearSkewerG + rearTireG + rearTubeOrSealantG;
+    const double rearWheelRotatingG = rearRimG + rearTireG + rearTubeOrSealantG + (rearSpokeCount * rearSpokeNippleG);
+    const double rearWheelCenterG = rearWheelG - rearWheelRotatingG;
+
+    BicycleWheel rearWheel (rearWheelOuterRadiusM,  rearRimInnerRadiusM,  rearWheelG / 1000,  rearWheelCenterG / 1000,  rearSpokeCount,  rearSpokeNippleG/1000);
+
+    BicycleConstants constants(
+        m_SpinBoxArr[SimBicyclePage::CRR]->value(),
+        m_SpinBoxArr[SimBicyclePage::Cm] ->value(),
+        m_SpinBoxArr[SimBicyclePage::Cd] ->value(),
+        m_SpinBoxArr[SimBicyclePage::Am2]->value(),
+        m_SpinBoxArr[SimBicyclePage::Tk] ->value());
+
+    Bicycle bicycle(NULL, constants, riderMassKG, bicycleMassWithoutWheelsG / 1000., frontWheel, rearWheel);
+
+    m_StatsLabelArr[StatsLabel]              ->setText(QString(tr("------ Derived Stats -------")));
+    m_StatsLabelArr[StatsTotalKEMass]        ->setText(QString(tr("Total KEMass:         \t%1g")).arg(bicycle.KEMass()));
+    m_StatsLabelArr[StatsFrontWheelKEMass]   ->setText(QString(tr("FrontWheel KEMass:    \t%1g")).arg(bicycle.FrontWheel().KEMass() * 1000));
+    m_StatsLabelArr[StatsFrontWheelMass]     ->setText(QString(tr("FrontWheel Mass:      \t%1g")).arg(bicycle.FrontWheel().MassKG() * 1000));
+    m_StatsLabelArr[StatsFrontWheelEquivMass]->setText(QString(tr("FrontWheel EquivMass: \t%1g")).arg(bicycle.FrontWheel().EquivalentMassKG() * 1000));
+    m_StatsLabelArr[StatsFrontWheelI]        ->setText(QString(tr("FrontWheel I:         \t%1")).arg(bicycle.FrontWheel().I()));
+    m_StatsLabelArr[StatsRearWheelKEMass]    ->setText(QString(tr("Rear Wheel KEMass:    \t%1g")).arg(bicycle.RearWheel().KEMass() * 1000));
+    m_StatsLabelArr[StatsRearWheelMass]      ->setText(QString(tr("Rear Wheel Mass:      \t%1g")).arg(bicycle.RearWheel().MassKG() * 1000));
+    m_StatsLabelArr[StatsRearWheelEquivMass] ->setText(QString(tr("Rear Wheel EquivMass: \t%1g")).arg(bicycle.RearWheel().EquivalentMassKG() * 1000));
+    m_StatsLabelArr[StatsRearWheelI]         ->setText(QString(tr("Rear Wheel I:         \t%1")).arg(bicycle.RearWheel().I()));
+}
+
+
 SimBicyclePage::SimBicyclePage(QWidget *parent, Context *context) : QWidget(parent), context(context)
 {
     QVBoxLayout *all = new QVBoxLayout(this);
@@ -2348,7 +2410,7 @@ SimBicyclePage::SimBicyclePage(QWidget *parent, Context *context) : QWidget(pare
                                "slope mode' option is set on the training preferences\n"
                                " tab."), row, column, alignment);
 
-    int section2FirstRow = row + 1;;
+    int section2FirstRow = row + 1;
 
     // Now add section 2.
     row = section2FirstRow;
@@ -2365,8 +2427,33 @@ SimBicyclePage::SimBicyclePage(QWidget *parent, Context *context) : QWidget(pare
         row++;
     }
 
+    // There is still room below section 2... lets put in some useful stats
+    // about the virtual bicycle.
+
+    int statsFirstRow = row + 1;
+    column = 2;
+
+    // Create Stats Labels
+    for (int i = StatsLabel; i < StatsLastPart; i++) {
+        m_StatsLabelArr[i] = new QLabel();
+    }
+
+    // Populate Stats Labels
+    SetStatsLabelArray();
+
+    row = statsFirstRow;
+    for (int i = StatsLabel; i < StatsLastPart; i++) {
+        grid->addWidget(m_StatsLabelArr[i], row, column, alignment);
+        row++;
+    }
+
     all->addLayout(grid);
     all->addStretch();
+
+    for (int i = 0; i < LastPart; i++) {
+        connect(m_SpinBoxArr[i], SIGNAL(valueChanged(double)), this, SLOT(SetStatsLabelArray(double)));
+    }
+
 }
 
 qint32

--- a/src/Gui/Pages.h
+++ b/src/Gui/Pages.h
@@ -502,17 +502,36 @@ public:
         LastPart
     };
 
+    enum BicycleStats {
+        StatsLabel = 0,
+        StatsTotalKEMass,
+        StatsFrontWheelKEMass,
+        StatsFrontWheelMass,
+        StatsFrontWheelEquivMass,
+        StatsFrontWheelI,
+        StatsRearWheelKEMass,
+        StatsRearWheelMass,
+        StatsRearWheelEquivMass,
+        StatsRearWheelI,
+        StatsLastPart
+    };
+
     static const SimBicyclePartEntry& GetSimBicyclePartEntry(int e);
 
     static double                     GetBicyclePartValue(Context *context, int e);
 
+public slots:
+    void SetStatsLabelArray(double d = 0.);
+
 private:
     void AddSpecBox(int ePart);
+
 
     Context         *context;
 
     QLabel          *m_LabelArr  [LastPart];
     QDoubleSpinBox  *m_SpinBoxArr[LastPart];
+    QLabel          *m_StatsLabelArr[StatsLastPart];
 };
 
 class BestsMetricsPage : public QWidget

--- a/src/Train/BicycleSim.h
+++ b/src/Train/BicycleSim.h
@@ -38,6 +38,7 @@ public:
 
     BicycleWheel() {}
 
+    double KEMass()           const { return MassKG() + EquivalentMassKG(); }
     double MassKG()           const { return m_massKG; }
     double EquivalentMassKG() const { return m_equivalentMassKG; }
     double I()                const { return m_I; }
@@ -137,10 +138,6 @@ class Bicycle
 
     void Init(BicycleConstants constants, double riderWeightKG, double bicycleMassWithoutWheelsKG, BicycleWheel frontWheel, BicycleWheel rearWheel);
 
-    double MassKG() const;                   // Actual mass of bike and rider.
-    double EquivalentMassKG() const;         // Additional mass due to rotational inertia
-    double KEMass() const;                   // Total effective kinetic mass
-
     double SampleDT();                       // Gather sample time stamp and return dt (in seconds)
     double FilterWattIncrease(double watts); // Reduce power spikes by limiting power growth per sample period
 
@@ -149,6 +146,12 @@ public:
     Bicycle(Context* context, BicycleConstants constants, double riderWeightKG, double bicycleMassWithoutWheelsKG, BicycleWheel frontWheel, BicycleWheel rearWheel);
     Bicycle(Context* context);
     SpeedDistance SampleSpeed(BicycleSimState &newState);
+
+    double MassKG() const;                   // Actual mass of bike and rider.
+    double EquivalentMassKG() const;         // Additional mass due to rotational inertia
+    double KEMass() const;                   // Total effective kinetic mass
+    const BicycleWheel &FrontWheel() const { return m_frontWheel; }
+    const BicycleWheel &RearWheel() const { return m_rearWheel; }
 
     // Reset timer. This forces next sample to use 0.1s as its dt.
     void reset()


### PR DESCRIPTION
I forgot I'd stashed these changes. Should have been part of the recent ke changes. This change causes the simulated bicycle config screen to show derived stats while setting numbers. Main thing is to show the kinetic energy mass (mass + equivalent mass) but also shows the values for wheels.