### PR TITLE
Trainmode must honor slope unless ergfile opts out.

### DIFF
--- a/src/Train/ErgFile.cpp
+++ b/src/Train/ErgFile.cpp
@@ -54,7 +54,7 @@ bool ErgFile::isWorkout(QString name)
     return false;
 }
 ErgFile::ErgFile(QString filename, int mode, Context *context) :
-    filename(filename), mode(mode), context(context)
+    filename(filename), mode(mode), context(context), StrictGradient(true)
 {
     if (context->athlete->zones(false)) {
         int zonerange = context->athlete->zones(false)->whichRange(QDateTime::currentDateTime().date());
@@ -63,7 +63,7 @@ ErgFile::ErgFile(QString filename, int mode, Context *context) :
     reload();
 }
 
-ErgFile::ErgFile(Context *context) : mode(0), context(context)
+ErgFile::ErgFile(Context *context) : mode(0), context(context), StrictGradient(true)
 {
     if (context->athlete->zones(false)) {
         int zonerange = context->athlete->zones(false)->whichRange(QDateTime::currentDateTime().date());
@@ -705,6 +705,9 @@ void ErgFile::parseGpx()
     Points.clear();
     Laps.clear();
 
+    // TTS File Gradient Should be smoothly interpolated from Altitude.
+    StrictGradient = false;
+
     static double km = 0;
 
     QFile gpxFile(filename);
@@ -828,6 +831,9 @@ void ErgFile::parseTTS()
     format = mode = CRS;
     Points.clear();
     Laps.clear();
+
+    // TTS File Gradient Should be smoothly interpolated from Altitude.
+    StrictGradient = false;
 
     QFile ttsFile(filename);
     if (ttsFile.open(QIODevice::ReadOnly) == false) {

--- a/src/Train/ErgFile.h
+++ b/src/Train/ErgFile.h
@@ -148,6 +148,7 @@ class ErgFile
         int     MaxWatts;       // maxWatts in this ergfile (scaling)
         bool valid;             // did it parse ok?
         int mode;
+        bool    StrictGradient; // should gradient be strict or smoothed?
 
         int leftPoint, rightPoint;     // current points we are between
         int interpolatorReadIndex;     // next point to be fed to interpolator

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -1746,22 +1746,24 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
                 // Trust ergFile for location data, if available.
                 bool fAltitudeSet = false;
                 if (ergFile) {
+                    if (!ergFile->StrictGradient) {
+                        // Attempt to obtain location and derived slope from altitude in ergfile.
+                        geolocation geoloc;
+                        if (ergFile->locationAt(displayWorkoutDistance * 1000, displayWorkoutLap, geoloc, slope)) {
+                            displayLatitude = geoloc.Lat();
+                            displayLongitude = geoloc.Long();
+                            displayAltitude = geoloc.Alt();
 
-                    // Obtain slope recorded in ergfile.
-                    slope = ergFile->gradientAt(displayWorkoutDistance * 1000, displayWorkoutLap);
-
-                    // Attempt to obtain location and derive slope from altitude in ergfile.
-                    geolocation geoloc;
-                    if (ergFile->locationAt(displayWorkoutDistance * 1000, displayWorkoutLap, geoloc, slope)) {
-                        displayLatitude  = geoloc.Lat();
-                        displayLongitude = geoloc.Long();
-                        displayAltitude  = geoloc.Alt();
-
-                        if (displayLatitude && displayLongitude) {
-                            rtData.setLatitude(displayLatitude);
-                            rtData.setLongitude(displayLongitude);
+                            if (displayLatitude && displayLongitude) {
+                                rtData.setLatitude(displayLatitude);
+                                rtData.setLongitude(displayLongitude);
+                            }
+                            fAltitudeSet = true;
                         }
-                        fAltitudeSet = true;
+                    }
+
+                    if (ergFile->StrictGradient || !fAltitudeSet) {
+                        slope = ergFile->gradientAt(displayWorkoutDistance * 1000, displayWorkoutLap);
                     }
 
                     rtData.setSlope(slope);


### PR DESCRIPTION
I was testing some physics and realize that with my last change I broke the strict slope based CRS training, causing them to use interpolated gradient.

With this change ergfile has a new bool StrictGradient which defaults to true. If StrictGradient is true then stored slope is always used.

GPX and TTS load to ergfile set StrictGradient to false so train mode will use interpolated gradient.
