### PR TITLE
Allow TTS Files for VideoSync.

### DIFF
--- a/src/FileIO/LocationInterpolation.cpp
+++ b/src/FileIO/LocationInterpolation.cpp
@@ -394,7 +394,6 @@ void GeoPointInterpolator::Push(double distance, double altitude)
 
     geolocation geo(0, 0, altitude);
     xyz point = geo.toxyz();
-    point.y() = distance;
 
     DistancePointInterpolator<SphericalTwoPointInterpolator>::Push(distance, point);
 }

--- a/src/FileIO/LocationInterpolation.h
+++ b/src/FileIO/LocationInterpolation.h
@@ -793,6 +793,11 @@ public:
 
     GeoPointInterpolator() : DistancePointInterpolator<SphericalTwoPointInterpolator>(), m_locationState(Unset) {}
 
+    void Reset() {
+        m_locationState = Unset;
+        DistancePointInterpolator<SphericalTwoPointInterpolator>::Reset();
+    }
+
     geolocation Location(double distance);
     geolocation Location(double distance, double &slope);
 

--- a/src/Train/VideoSyncFile.h
+++ b/src/Train/VideoSyncFile.h
@@ -75,7 +75,8 @@ class VideoSyncFile
         static bool isVideoSync(QString); // is this a supported videosync?
 
         void reload();          // reload after messed about
-        void parseRLV();         // its a rlv file
+        void parseRLV();        // its a rlv file
+        void parseTTS();        // its a tts file
         bool isValid();         // is the file valid or not?
 
         double VideoFrameRate;


### PR DESCRIPTION
Newer tacx dvd don't include rlv, the video sync info is in the tts. This change lets TTS act as videosync.

I tried with a few files and synchronization is ok but not the laser precision I was expecting. But I don't own any newer dvds. I'd love feedback from people who do.
