### PR TITLE
Issue 3376: FIT files as workout.

### DIFF
--- a/src/FileIO/LocationInterpolation.cpp
+++ b/src/FileIO/LocationInterpolation.cpp
@@ -321,14 +321,15 @@ geolocation GeoPointInterpolator::Location(double distance, double &slope)
     double rise = l1.Alt() - l0.Alt();
 
     // Tangent vector's magnitude is velocity in terms of distance spline.
-    // Will be unit vector when distance spline has constant rate.
+    // Will be unit vector when distance spline has constant rate. Can have
+    // zero length when processing points without motion.
     double hyp = tangentVector.magnitude();
 
     // Compute adjacent speed.
-    double run = sqrt(fabs((hyp * hyp) - (rise * rise)));
+    double adj = fabs((hyp * hyp) - (rise * rise));
 
     // Gradient.
-    slope = run ? rise / run : 0;
+    slope = (adj > 0.) ? rise / sqrt(adj) : 0.;
 
     // No matter what we still don't permit slopes above 40%.
     slope = std::min(slope,  .4);

--- a/src/FileIO/LocationInterpolation.h
+++ b/src/FileIO/LocationInterpolation.h
@@ -752,7 +752,7 @@ public:
         // Remove frame speed from tangent vector.
         double frameSpeed = m_DistanceWindow.FrameSpeed(bracketRatio);
         double tangentSpeed = tangentVector.magnitude();
-        double correctionScale = frameSpeed / (tangentSpeed * tangentSpeed);
+        double correctionScale = tangentSpeed ? (frameSpeed / (tangentSpeed * tangentSpeed)) : 1.;
 
         // This rescale converts tangent vector into a unit vector
         // WRT parametric route velocity.

--- a/src/Train/ErgFile.cpp
+++ b/src/Train/ErgFile.cpp
@@ -125,18 +125,6 @@ void ErgFile::reload()
     // like we do with ride files if we end up with lots of different formats
     if      (filename.endsWith(".pgmf",   Qt::CaseInsensitive)) parseTacx();
     else if (filename.endsWith(".zwo",    Qt::CaseInsensitive)) parseZwift();
-
-    //else if (filename.endsWith(".bin",    Qt::CaseInsensitive)) parseFactory();
-    //else if (filename.endsWith(".bin2",   Qt::CaseInsensitive)) parseFactory();
-    //else if (filename.endsWith(".fit",    Qt::CaseInsensitive)) parseFactory();
-    //else if (filename.endsWith(".fitlog", Qt::CaseInsensitive)) parseFactory();
-    //else if (filename.endsWith(".hrm",    Qt::CaseInsensitive)) parseFactory();
-    //else if (filename.endsWith(".pwx",    Qt::CaseInsensitive)) parseFactory();
-    //else if (filename.endsWith(".srd",    Qt::CaseInsensitive)) parseFactory();
-    //else if (filename.endsWith(".srm",    Qt::CaseInsensitive)) parseFactory();
-    //else if (filename.endsWith(".tcx",    Qt::CaseInsensitive)) parseFactory();
-    //else if (filename.endsWith(".wko",    Qt::CaseInsensitive)) parseFactory();
-
     else if (fact.exactMatch(filename))                         parseFromRideFileFactory();
     else if (filename.endsWith(".erg2",   Qt::CaseInsensitive)) parseErg2();
     else if (filename.endsWith(".tts",    Qt::CaseInsensitive)) parseTTS();

--- a/src/Train/ErgFile.h
+++ b/src/Train/ErgFile.h
@@ -106,18 +106,18 @@ class ErgFile
         static ErgFile *fromContent(QString, Context *); // read from memory *.erg
         static ErgFile *fromContent2(QString, Context *); // read from memory *.erg2
 
-        static bool isWorkout(QString); // is this a supported workout?
+        static bool isWorkout(QString);         // is this a supported workout?
 
-        void reload();          // reload after messed about
+        void reload();                          // reload after messed about
 
         void parseComputrainer(QString p = ""); // its an erg,crs or mrc file
-        void parseTacx();       // its a pgmf file
-        void parseZwift();      // its a zwo file (zwift xml)
-        void parseGpx();        // its a gpx...
-        void parseErg2(QString p = "");       // ergdb
-        void parseTTS();        // its ahh tts
+        void parseTacx();                       // its a pgmf file
+        void parseZwift();                      // its a zwo file (zwift xml)
+        void parseFromRideFileFactory();        // rideable and ingestable by ridefile factory
+        void parseErg2(QString p = "");         // ergdb
+        void parseTTS();                        // its ahh tts
 
-        bool isValid();         // is the file valid or not?
+        bool isValid();                         // is the file valid or not?
 
         double Cp;
         int format;                      // ERG, CRS, MRC, ERG2 currently supported

--- a/src/Train/VideoSyncFile.cpp
+++ b/src/Train/VideoSyncFile.cpp
@@ -58,7 +58,6 @@ void VideoSyncFile::reload()
     // which parser to call?
     if (filename.endsWith(".rlv", Qt::CaseInsensitive)) parseRLV();
     if (filename.endsWith(".tts", Qt::CaseInsensitive)) parseTTS();
-//TODO    else if (filename.endsWith(".gpx", Qt::CaseInsensitive)) parseGPX();
 }
 
 void VideoSyncFile::parseTTS()


### PR DESCRIPTION
Issue 3376. Add ability to use FIT file as workout.

This is trivial since both GPX and FIT are loaded to ridefile and parsegpx merely populates ergfile from ridefile. We can now easily support training with any other file types that RideFile can load.

My test case exposed errors in location interpolation where it would not tolerate immobile point data, causing slope and distance to become NaN.

Small change to improve slope calc precision.

Main problem was an existing issue in ErgFile::parseGpx where file was being opened once in parse and again in ridefile instantiation, on same object, with different read flags.