### PR TITLE
Fixes for interpolation and gpx file load

### DIFF
--- a/src/FileIO/LocationInterpolation.cpp
+++ b/src/FileIO/LocationInterpolation.cpp
@@ -321,14 +321,15 @@ geolocation GeoPointInterpolator::Location(double distance, double &slope)
     double rise = l1.Alt() - l0.Alt();
 
     // Tangent vector's magnitude is velocity in terms of distance spline.
-    // Will be unit vector when distance spline has constant rate.
+    // Will be unit vector when distance spline has constant rate. Can have
+    // zero length when processing points without motion.
     double hyp = tangentVector.magnitude();
 
     // Compute adjacent speed.
-    double run = sqrt(fabs((hyp * hyp) - (rise * rise)));
+    double adj = fabs((hyp * hyp) - (rise * rise));
 
     // Gradient.
-    slope = run ? rise / run : 0;
+    slope = (adj > 0.) ? rise / sqrt(adj) : 0.;
 
     // No matter what we still don't permit slopes above 40%.
     slope = std::min(slope,  .4);

--- a/src/FileIO/LocationInterpolation.h
+++ b/src/FileIO/LocationInterpolation.h
@@ -752,7 +752,7 @@ public:
         // Remove frame speed from tangent vector.
         double frameSpeed = m_DistanceWindow.FrameSpeed(bracketRatio);
         double tangentSpeed = tangentVector.magnitude();
-        double correctionScale = frameSpeed / (tangentSpeed * tangentSpeed);
+        double correctionScale = tangentSpeed ? (frameSpeed / (tangentSpeed * tangentSpeed)) : 1.;
 
         // This rescale converts tangent vector into a unit vector
         // WRT parametric route velocity.

--- a/src/Train/ErgFile.cpp
+++ b/src/Train/ErgFile.cpp
@@ -125,18 +125,6 @@ void ErgFile::reload()
     // like we do with ride files if we end up with lots of different formats
     if      (filename.endsWith(".pgmf",   Qt::CaseInsensitive)) parseTacx();
     else if (filename.endsWith(".zwo",    Qt::CaseInsensitive)) parseZwift();
-
-    //else if (filename.endsWith(".bin",    Qt::CaseInsensitive)) parseFactory();
-    //else if (filename.endsWith(".bin2",   Qt::CaseInsensitive)) parseFactory();
-    //else if (filename.endsWith(".fit",    Qt::CaseInsensitive)) parseFactory();
-    //else if (filename.endsWith(".fitlog", Qt::CaseInsensitive)) parseFactory();
-    //else if (filename.endsWith(".hrm",    Qt::CaseInsensitive)) parseFactory();
-    //else if (filename.endsWith(".pwx",    Qt::CaseInsensitive)) parseFactory();
-    //else if (filename.endsWith(".srd",    Qt::CaseInsensitive)) parseFactory();
-    //else if (filename.endsWith(".srm",    Qt::CaseInsensitive)) parseFactory();
-    //else if (filename.endsWith(".tcx",    Qt::CaseInsensitive)) parseFactory();
-    //else if (filename.endsWith(".wko",    Qt::CaseInsensitive)) parseFactory();
-
     else if (fact.exactMatch(filename))                         parseFromRideFileFactory();
     else if (filename.endsWith(".erg2",   Qt::CaseInsensitive)) parseErg2();
     else if (filename.endsWith(".tts",    Qt::CaseInsensitive)) parseTTS();

--- a/src/Train/ErgFile.cpp
+++ b/src/Train/ErgFile.cpp
@@ -41,18 +41,19 @@ static bool setSupported()
     ::supported << ".pgmf";
     ::supported << ".zwo";
     ::supported << ".tts";
-
-    ::supported << ".bin";
-    ::supported << ".bin2";
-    ::supported << ".fit";
-    ::supported << ".fitlog";
     ::supported << ".gpx";
-    ::supported << ".hrm";
-    ::supported << ".pwx";
-    ::supported << ".srd";
-    ::supported << ".srm";
-    ::supported << ".tcx";
-    ::supported << ".wko";
+
+    // Additional supportable ridefile types.
+    //::supported << ".bin";
+    //::supported << ".bin2";
+    //::supported << ".fit";
+    //::supported << ".fitlog";
+    //::supported << ".hrm";
+    //::supported << ".pwx";
+    //::supported << ".srd";
+    //::supported << ".srm";
+    //::supported << ".tcx";
+    //::supported << ".wko";
 
     return true;
 }
@@ -119,7 +120,10 @@ ErgFile::fromContent2(QString contents, Context *context)
 
 void ErgFile::reload()
 {
-    QRegExp fact(".+[.](gpx|bin|bin2|fit|fit|fitlog|hrm|pwx|srd|srm|tcx|wko)$", Qt::CaseInsensitive);
+    QRegExp fact(".+[.](gpx)$", Qt::CaseInsensitive);
+
+    // Use this instead to activate all relevant ridefile types.
+    //QRegExp fact(".+[.](gpx|bin|bin2|fit|fit|fitlog|hrm|pwx|srd|srm|tcx|wko)$", Qt::CaseInsensitive);
 
     // which parser to call? NOTE: we should look at moving to an ergfile factory
     // like we do with ride files if we end up with lots of different formats

--- a/src/Train/ErgFile.cpp
+++ b/src/Train/ErgFile.cpp
@@ -46,13 +46,13 @@ static bool setSupported()
     // Additional supportable ridefile types.
     //::supported << ".bin";
     //::supported << ".bin2";
-    //::supported << ".fit";
-    //::supported << ".fitlog";
+    ::supported << ".fit";
+    ::supported << ".fitlog";
     //::supported << ".hrm";
     //::supported << ".pwx";
     //::supported << ".srd";
     //::supported << ".srm";
-    //::supported << ".tcx";
+    ::supported << ".tcx";
     //::supported << ".wko";
 
     return true;
@@ -120,10 +120,10 @@ ErgFile::fromContent2(QString contents, Context *context)
 
 void ErgFile::reload()
 {
-    QRegExp fact(".+[.](gpx)$", Qt::CaseInsensitive);
+    QRegExp fact(".+[.](gpx|fit|fitlog|tcx)$", Qt::CaseInsensitive);
 
     // Use this instead to activate all relevant ridefile types.
-    //QRegExp fact(".+[.](gpx|bin|bin2|fit|fit|fitlog|hrm|pwx|srd|srm|tcx|wko)$", Qt::CaseInsensitive);
+    //QRegExp fact(".+[.](gpx|bin|bin2|fit|fitlog|hrm|pwx|srd|srm|tcx|wko)$", Qt::CaseInsensitive);
 
     // which parser to call? NOTE: we should look at moving to an ergfile factory
     // like we do with ride files if we end up with lots of different formats

--- a/src/Train/ErgFile.h
+++ b/src/Train/ErgFile.h
@@ -106,18 +106,18 @@ class ErgFile
         static ErgFile *fromContent(QString, Context *); // read from memory *.erg
         static ErgFile *fromContent2(QString, Context *); // read from memory *.erg2
 
-        static bool isWorkout(QString); // is this a supported workout?
+        static bool isWorkout(QString);         // is this a supported workout?
 
-        void reload();          // reload after messed about
+        void reload();                          // reload after messed about
 
         void parseComputrainer(QString p = ""); // its an erg,crs or mrc file
-        void parseTacx();       // its a pgmf file
-        void parseZwift();      // its a zwo file (zwift xml)
-        void parseGpx();        // its a gpx...
-        void parseErg2(QString p = "");       // ergdb
-        void parseTTS();        // its ahh tts
+        void parseTacx();                       // its a pgmf file
+        void parseZwift();                      // its a zwo file (zwift xml)
+        void parseFromRideFileFactory();        // rideable and ingestable by ridefile factory
+        void parseErg2(QString p = "");         // ergdb
+        void parseTTS();                        // its ahh tts
 
-        bool isValid();         // is the file valid or not?
+        bool isValid();                         // is the file valid or not?
 
         double Cp;
         int format;                      // ERG, CRS, MRC, ERG2 currently supported

--- a/src/Train/VideoSyncFile.cpp
+++ b/src/Train/VideoSyncFile.cpp
@@ -58,7 +58,6 @@ void VideoSyncFile::reload()
     // which parser to call?
     if (filename.endsWith(".rlv", Qt::CaseInsensitive)) parseRLV();
     if (filename.endsWith(".tts", Qt::CaseInsensitive)) parseTTS();
-//TODO    else if (filename.endsWith(".gpx", Qt::CaseInsensitive)) parseGPX();
 }
 
 void VideoSyncFile::parseTTS()

--- a/src/Train/VideoSyncFile.h
+++ b/src/Train/VideoSyncFile.h
@@ -74,10 +74,11 @@ class VideoSyncFile
 
         static bool isVideoSync(QString); // is this a supported videosync?
 
-        void reload();          // reload after messed about
-        void parseRLV();        // its a rlv file
-        void parseTTS();        // its a tts file
-        bool isValid();         // is the file valid or not?
+        void reload();                    // reload after messed about
+        void parseRLV();                  // its a rlv file
+        void parseTTS();                  // its a tts file
+        void parseFromRideFileFactory();  // try an skrimp video sync info from a ride file.
+        bool isValid();                   // is the file valid or not?
 
         double VideoFrameRate;
 


### PR DESCRIPTION
Resubmitting previous change will all additional file types disallowed. This change is now just a set of fixes to current behavior:
- Interpolation math fixes: Slope and interpolation behave correctly when ride point location doesnt change.
- In gpx read: do not open same file twice with different read flags.

Commented the changes for additional file support in case we decide to enable in the future.