### PR TITLE
Enable BT on Windows

### DIFF
--- a/src/Train/BT40Device.cpp
+++ b/src/Train/BT40Device.cpp
@@ -39,11 +39,11 @@ QMap<QBluetoothUuid, btle_sensor_type_t> BT40Device::supportedServices = {
 BT40Device::BT40Device(QObject *parent, QBluetoothDeviceInfo devinfo) : parent(parent), m_currentDevice(devinfo)
 {
     m_control = new QLowEnergyController(m_currentDevice, this);
-    connect(m_control, SIGNAL(connected()), this, SLOT(deviceConnected()));
+    connect(m_control, SIGNAL(connected()), this, SLOT(deviceConnected()), Qt::QueuedConnection);
     connect(m_control, SIGNAL(error(QLowEnergyController::Error)), this, SLOT(controllerError(QLowEnergyController::Error)));
-    connect(m_control, SIGNAL(disconnected()), this, SLOT(deviceDisconnected()));
-    connect(m_control, SIGNAL(serviceDiscovered(QBluetoothUuid)), this, SLOT(serviceDiscovered(QBluetoothUuid)));
-    connect(m_control, SIGNAL(discoveryFinished()), this, SLOT(serviceScanDone()));
+    connect(m_control, SIGNAL(disconnected()), this, SLOT(deviceDisconnected()), Qt::QueuedConnection);
+    connect(m_control, SIGNAL(serviceDiscovered(QBluetoothUuid)), this, SLOT(serviceDiscovered(QBluetoothUuid)), Qt::QueuedConnection);
+    connect(m_control, SIGNAL(discoveryFinished()), this, SLOT(serviceScanDone()), Qt::QueuedConnection);
 
     connected = false;
     prevWheelTime = 0;

--- a/src/Train/DeviceTypes.cpp
+++ b/src/Train/DeviceTypes.cpp
@@ -42,12 +42,10 @@ DeviceTypes::DeviceTypes()
         "speed or cadence meters via a Garmin ANT+ USB1 or USB2 stick") ,
         ":images/devices/garminusb.png" },
 #endif
-#ifndef WIN32
 #ifdef QT_BLUETOOTH_LIB
       { DEV_BT40,    DEV_BTLE,     (char *) "Bluetooth 4.0", true,   false,
         tr("Bluetooth Low Energy devices such as KK Inride, Stages PM, Blue HR and Blue SC"),
         ":images/devices/btle.png" },
-#endif
 #endif
       { DEV_CT,       DEV_SERIAL,  (char *) "Racermate Computrainer",true,    false,
         tr("Racermate Computrainer Lab or Pro bike trainer with the handlebar controller "


### PR DESCRIPTION
Here's a branch that enables BLE on Windows. It requires that the migration to Qt 5.14.2 is completed before it will work, since Qt 5.9 currently used don't have the backend QtConnectivity support.

Qt states the following on [its info page](https://doc.qt.io/qt-5/qtbluetooth-index.html):

> Qt 5.14 adds a native Win32 port supporting Classic Bluetooth on Windows 7 or newer, and Bluetooth LE on Windows 8 or newer. It must be enabled at build time by configuration option -native-win32-bluetooth. The UWP backend is used by default if this option is not set and the Win32 target platform supports the required UWP APIs (minimal requirement is Windows 10 version 1507, with slightly improved service discovery since Windows 10 version 1607).

I believe the UWP backend is the default, so I suspect that Windows 10 version 1607 or later is recommended.