### PR TITLE
Support Custom Virtual Power Curve

### DIFF
--- a/src/Core/BlinnSolver.cpp
+++ b/src/Core/BlinnSolver.cpp
@@ -66,6 +66,10 @@ bool IsZero(double value, Args...args) {
     return RangedZeroTest<s_MantissaBitsNeeded>(value, args...);
 }
 
+bool IsZero2(double value, double arg) {
+    return IsZero(value, arg);
+}
+
 // 0 == A*x + B
 Roots LinearSolver(double A, double B) {
     if (IsZero(A, B)) {

--- a/src/Core/BlinnSolver.h
+++ b/src/Core/BlinnSolver.h
@@ -19,6 +19,11 @@
 #if !defined(_BLINNSOLVER_H)
 #define _BLINNSOLVER_H
 
+// Is value zero wrt scale of arg? Returns true if value is indistinguishable
+// from zero with respect to magnitude precision of arg. Put another way,
+// is arg + value ~= arg?
+bool IsZero2(double value, double arg);
+
 // Holds up to 3 roots.
 template <typename T> struct T_resultstruct
 {

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -223,6 +223,7 @@
 #define GC_DEV_DEF                      "<global-trainmode>devicedef"
 #define GC_DEV_WHEEL                    "<global-trainmode>devicewheel"
 #define GC_DEV_VIRTUAL                  "<global-trainmode>devicepostProcess"
+#define GC_DEV_VIRTUALPOWER             "<global-trainmode>devicevirtualPower"
 #define FORTIUS_FIRMWARE                "<global-trainmode>fortius/firmware"
 #define IMAGIC_FIRMWARE                 "<global-trainmode>imagic/firmware"
 #define TRAIN_MULTI                     "<global-trainmode>train/multi"

--- a/src/FileIO/LocationInterpolation.cpp
+++ b/src/FileIO/LocationInterpolation.cpp
@@ -254,10 +254,10 @@ bool UnitCatmullRomInterpolator::Inverse(double r, double &u) const
     // for monotonic distance mapping.
     bool ret = false;    
     for (unsigned i = 0; i < roots.resultcount(); i++) {
-        double r = roots.result(i).x / roots.result(i).w;
+        double rt = roots.result(i).x / roots.result(i).w;
         // Take the first root we find in range 0..1.
-        if (r >= 0. && r <= 1.) {
-            u = r;
+        if (rt >= 0. && rt <= 1.) {
+            u = rt;
             ret = true;
             break;
         }

--- a/src/Gui/Pages.cpp
+++ b/src/Gui/Pages.cpp
@@ -1901,7 +1901,7 @@ deviceModel::add(DeviceConfiguration &newone)
     index = deviceModel::index(0,3, QModelIndex());
     setData(index, newone.deviceProfile, Qt::EditRole);
 
-    // insert postProcess
+    // insert virtualPowerIndex
     index = deviceModel::index(0,4, QModelIndex());
     setData(index, newone.postProcess, Qt::EditRole);
 }

--- a/src/Train/AddDeviceWizard.cpp
+++ b/src/Train/AddDeviceWizard.cpp
@@ -1157,6 +1157,9 @@ AddVirtualPower::mySetTableFromComboBox(int i) {
     // Clear epsilon so fitters fit.
     fitEpsilonSpinBox->setValue(0.);
 
+    // Set new index in wizard.
+    wizard->virtualPowerIndex = virtualPower->currentIndex();
+
     drawConfig();
 
     this->blockSignals(state);

--- a/src/Train/AddDeviceWizard.h
+++ b/src/Train/AddDeviceWizard.h
@@ -51,6 +51,7 @@
 #include <QFileDialog>
 #include <QCommandLinkButton>
 #include <QScrollArea>
+#include <QtCharts>
 
 class DeviceScanner;
 
@@ -75,6 +76,11 @@ public:
     QString profile;
 
     DeviceScanner *scanner;
+
+    // Device Data
+    int virtualPowerIndex;      // index of selected virtual power function
+    int wheelSize;
+    int strideLength;
 
 public slots:
 
@@ -223,6 +229,54 @@ class AddPairBTLE : public QWizardPage
 
 };
 
+class AddVirtualPower : public QWizardPage
+{
+    Q_OBJECT
+
+public:
+    AddVirtualPower(AddDeviceWizard*);
+    void initializePage();
+
+private:
+    AddDeviceWizard* wizard;
+    RealtimeController* controller; // copy of controller, for lazy re-init
+
+    QLineEdit* name;
+    QComboBox* virtualPower;
+    QComboBox* rimSizeCombo;
+    QComboBox* tireSizeCombo;
+    QLineEdit* wheelSizeEdit;
+    QLineEdit* stridelengthEdit;
+
+    QLabel*         virtualPowerNameLabel;
+    QLineEdit*      virtualPowerNameEdit;
+    QPushButton*    virtualPowerCreateButton;
+
+    QTableWidget*   virtualPowerTableWidget;
+    QChart*         virtualPowerScatterChart;
+    QChartView*     virtualPowerScatterChartView;
+
+    QLabel*         fitOrderSpinBoxLabel;
+    QSpinBox*       fitOrderSpinBox;
+    QLabel*         fitEpsilonSpinBoxLabel;
+    QDoubleSpinBox* fitEpsilonSpinBox;
+    QLabel*         fitStdDevLabel;
+    QLabel*         fitOrderLabel;
+
+    void drawConfig();
+
+private slots:
+    void calcWheelSize();
+    void resetWheelSize();
+    void myCellChanged(int row, int col);
+    void mySpinBoxChanged(int i);
+    void myDoubleSpinBoxChanged(double d);
+    void mySortTable(int i);
+    void mySetTableFromComboBox(int i);
+    void myCreateCustomPowerCurve();
+};
+
+
 class AddFinal : public QWizardPage
 {
     Q_OBJECT
@@ -237,20 +291,10 @@ class AddFinal : public QWizardPage
         AddDeviceWizard *wizard;
 
         QLineEdit *name;
-        QComboBox *virtualPower;
-        QComboBox *rimSizeCombo;
-        QComboBox *tireSizeCombo;
-        QLineEdit *wheelSizeEdit;
-        QLineEdit *stridelengthEdit;
         QLineEdit *port;
         QLineEdit *profile;
         QGroupBox *selectDefault;
         QCheckBox *defWatts, *defBPM, *defKPH, *defRPM;
-
-    private slots:
-        void calcWheelSize();
-        void resetWheelSize();
-
 };
 
 class DeviceScanner : public QThread

--- a/src/Train/DeviceConfiguration.cpp
+++ b/src/Train/DeviceConfiguration.cpp
@@ -22,6 +22,7 @@
 #include "Settings.h"
 #include "DeviceTypes.h"
 #include "DeviceConfiguration.h"
+#include "RealtimeController.h"
 
 #define PI M_PI
 
@@ -36,8 +37,9 @@ DeviceConfiguration::DeviceConfiguration()
     defaultString="";
     wheelSize=2100;
     postProcess=0;
-    controller=NULL;
     stridelength=80;
+    controller = NULL;
+    virtualPowerDefinitionString = "";
 }
 
 
@@ -122,6 +124,10 @@ DeviceConfigurations::readConfig()
             configVal = appsettings->value(NULL, configStr);
             Entry.postProcess = configVal.toInt();
 
+            configStr = QString("%1%2").arg(GC_DEV_VIRTUALPOWER).arg(i+1);
+            configVal = appsettings->value(NULL, configStr);
+            Entry.virtualPowerDefinitionString = configVal.toString();
+
             Entries.append(Entry);
     }
     return Entries;
@@ -165,11 +171,26 @@ DeviceConfigurations::writeConfig(QList<DeviceConfiguration> Configuration)
         configStr = QString("%1%2").arg(GC_DEV_DEF).arg(i+1);
         appsettings->setValue(configStr, Configuration.at(i).defaultString);
 
-        // virtual post Process...
-        configStr = QString("%1%2").arg(GC_DEV_VIRTUAL).arg(i+1);
-        appsettings->setValue(configStr, Configuration.at(i).postProcess);
-    }
+        // virtual post Process and definition string
+        VirtualPowerTrainerManager& vptm = Configuration.at(i).controller->virtualPowerTrainerManager;
 
+        int postProcess = Configuration.at(i).postProcess;
+        bool isPredefinedPostProcess = vptm.IsPredefinedVirtualPowerTrainerIndex(postProcess);
+
+        int postProcessStoreValue = postProcess;
+        QString s = "";
+
+        if (!isPredefinedPostProcess) {
+            postProcessStoreValue = 0;
+            vptm.GetVirtualPowerTrainerAsString(postProcess, s);
+        }
+
+        configStr = QString("%1%2").arg(GC_DEV_VIRTUAL).arg(i + 1);
+        appsettings->setValue(configStr, postProcessStoreValue);
+
+        configStr = QString("%1%2").arg(GC_DEV_VIRTUALPOWER).arg(i + 1);
+        appsettings->setValue(configStr, QString(s));
+    }
 }
 
 const QStringList
@@ -181,7 +202,7 @@ const QStringList
 WheelSize::TIRE_SIZES = QStringList() << "--" << "20mm" << "23mm" << "25mm" << "28mm" << "1.00\"" << "1.50\"" << "1.75\"" << "1.90\"" << "1.95\"" << "2.00\"" << "2.10\"" << "2.125\"";
 
                                     // -- 20mm 23mm 25mm 28mm 1.00"  1.50"  1.75"  1.90"  1.95"  2.00"  2.10"  2.125"
-static const float TIRE_DIAMETERS[] = {0, 40,  46,  50,  56,  50.8,  76.2,  88.9,  96.5,  99.1,  101.6, 106.7, 108};
+static const float TIRE_DIAMETERS[] = {0, 40,  46,  50,  56,  50.8f,  76.2f,  88.9f,  96.5f,  99.1f,  101.6f, 106.7f, 108};
 
 int
 WheelSize::calcPerimeter(int rimSizeIndex, int tireSizeIndex)

--- a/src/Train/DeviceConfiguration.h
+++ b/src/Train/DeviceConfiguration.h
@@ -33,14 +33,14 @@ class DeviceConfiguration
     int type;
     QString name,
          portSpec,
-         deviceProfile;        // device specific data
+         deviceProfile;         // device specific data
                                 // used by ANT to store ANTIDs
                                 // available for use by all devices
 
     QString defaultString;      // PHCS for power/heartrate/cadence/speed from this device
-    int  wheelSize;             // set wheel size for each device
-    int  stridelength;          // stride length in cm
-    int  postProcess;           // virtualChannel
+    int wheelSize;              // set wheel size for each device
+    int stridelength;           // stride length in cm
+    int postProcess;
 
     RealtimeController *controller; // can be used to allocate controller for this device
                                     // although a bit odd, it makes synchronising the config

--- a/src/Train/DeviceConfiguration.h
+++ b/src/Train/DeviceConfiguration.h
@@ -40,7 +40,9 @@ class DeviceConfiguration
     QString defaultString;      // PHCS for power/heartrate/cadence/speed from this device
     int wheelSize;              // set wheel size for each device
     int stridelength;           // stride length in cm
+
     int postProcess;
+    QString virtualPowerDefinitionString;
 
     RealtimeController *controller; // can be used to allocate controller for this device
                                     // although a bit odd, it makes synchronising the config

--- a/src/Train/MultiRegressionizer.h
+++ b/src/Train/MultiRegressionizer.h
@@ -28,21 +28,21 @@
 //#define CONFIG_PRINTING
 
 template<typename T> struct XYPair {
-    typedef typename T value_type;
+    typedef T value_type;
 
     T x, y;
 };
 
 template <typename T>
 struct XYGetter {
-    typedef typename T value_type;
+    typedef T value_type;
 
     virtual T X(size_t) const = 0;
     virtual T Y(size_t) const = 0;
 };
 
 template<typename T> struct XYVector : public XYGetter<T>, public std::vector<XYPair<T>> {
-    typedef typename XYPair<T> value_type;
+    typedef struct XYPair<T> value_type;
 
     T X(size_t idx) const { return this->operator[](idx).x; }
     T Y(size_t idx) const { return this->operator[](idx).y; }
@@ -81,7 +81,7 @@ struct T_Matrix
 // Generic Polynomial Based on Vector.
 template <typename T>
 struct T_Polynomial : public std::vector<T> {
-    typedef typename T T_fptype;
+    typedef T T_fptype;
 
     T_fptype Fit(T_fptype v) const {
         static const T_fptype s_zero = 0.;
@@ -139,13 +139,13 @@ class T_PolyRegressionizer : public T_RegressionizerBase<T> {
     // row reduction. By magic the coefficients
     bool ComputeCoefs(
         const T& xy,
-        const int& order)
+        const unsigned& order)
     {
         static const T_fptype s_one = 1.;
 
         if (xy.size() <= 0) return false;
 
-        size_t N = xy.size();
+        int N = (int)xy.size();
         int n = order;
         int np1 = n + 1;
         int np2 = n + 2;
@@ -155,14 +155,14 @@ class T_PolyRegressionizer : public T_RegressionizerBase<T> {
         std::vector<T_fptype> M(tnp1 + N);
 
         // Avoid pow, extra space in array holds accumulated powers of x[j]
-        for (size_t j = 0; j < N; j++) {
+        for (int j = 0; j < N; j++) {
             M[tnp1 + j] = s_one;
         }
 
         M[0] = (T_fptype)(int)N;
         for (int i = 1; i < tnp1; ++i) {
             T_fptype sum = 0;
-            for (size_t j = 0; j < N; j++) {
+            for (int j = 0; j < N; j++) {
                 T_fptype v = M[tnp1 + j] * xy.X(j);
                 M[tnp1 + j] = v;
                 sum += v;
@@ -173,20 +173,20 @@ class T_PolyRegressionizer : public T_RegressionizerBase<T> {
         // Matrix B: populated then row reduced.
         std::vector<std::vector<T_fptype> > B(np1, std::vector<T_fptype>(np2, 0));
 
-        for (size_t i = 0; i <= n; ++i)
-            for (size_t j = 0; j <= n; ++j)
+        for (int i = 0; i <= n; ++i)
+            for (int j = 0; j <= n; ++j)
                 B[i][j] = M[i + j];
 
         std::vector<T_fptype> Y(np1 + N);
 
-        for (size_t j = 0; j < N; j++) {
+        for (int j = 0; j < N; j++) {
             Y[0] += xy[j].y;
             Y[np1 + j] = s_one;
         }
 
         for (int i = 1; i < np1; ++i) {
             T_fptype sum = 0;
-            for (size_t j = 0; j < N; j++) {
+            for (int j = 0; j < N; j++) {
                 XYPair<T_fptype> t = xy[j];
                 T_fptype v = Y[np1 + j] * t.x;
                 Y[np1 + j] = v;
@@ -245,8 +245,8 @@ public:
 
         // Build integer poly regression. Use whichever is best.
         // Iterate over orders, find first order that has great fit
-        for (size_t i = 0; i <= maxOrder; i++) {
-            order = (int)i;
+        for (unsigned i = 0; i <= maxOrder; i++) {
+            order = i;
 
             // If fit cannot be found then fail.
             if (!ComputeCoefs(xy, order)) {
@@ -307,7 +307,6 @@ template <typename T> class T_FractionalPolyRegressionizer : public T_Regression
         static const T_fptype s_minusOne = -1.;
         static const T_fptype s_minusTwo = -2.;
         static const T_fptype s_half = 0.5;
-        static const T_fptype s_pointOne = 0.1;
 
         if (xy.size() == 0) {
             T_fptype  ret = -1;

--- a/src/Train/MultiRegressionizer.h
+++ b/src/Train/MultiRegressionizer.h
@@ -1,0 +1,1005 @@
+/*
+ * Copyright (c) 2020 Eric Christoffersen (impolexg@outlook.com)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef _GC_MultiRegressionizer_h
+#define  _GC_MultiRegressionizer_h
+
+#include <vector>
+#include <algorithm>
+#include <array>
+#include "PolynomialRegression.h"
+
+template<typename T> struct XYPair {
+    typedef typename T value_type;
+
+    T x, y;
+};
+
+template <typename T>
+struct XYGetter {
+    typedef typename T value_type;
+
+    virtual T X(size_t) const = 0;
+    virtual T Y(size_t) const = 0;
+};
+
+template<typename T> struct XYVector : public XYGetter<T>, public std::vector<XYPair<T>> {
+    typedef typename XYPair<T> value_type;
+
+    T X(size_t idx) const { return this->operator[](idx).x; }
+    T Y(size_t idx) const { return this->operator[](idx).y; }
+};
+
+template <typename T_fptype>
+struct T_Matrix
+{
+    std::vector<std::vector<T_fptype> > data;
+
+    // Use [] to index into matrix row
+    std::vector<T_fptype>& operator[](size_t i) { return data[i]; }
+
+    // Declaring the length of the matrix, not including results if matrix is augmented.
+    size_t N;
+
+    T_Matrix(size_t dimensions, std::vector<std::vector<T_fptype> >& temp)
+    {
+        // switching the passed value of dimensions from the user to N, so it can be used throughout the struct
+        N = dimensions;
+        data = temp;
+    }
+
+    void print(void) {
+        for (size_t i = 0; i < data.size(); i++) {
+            for (size_t j = 0; j < data[i].size(); j++) {
+                std::cout << data[i][j] << "\t";
+            }
+            std::cout << std::endl;
+        }
+    }
+};
+
+// Generic Polynomial Based on Vector.
+template <typename T>
+struct T_Polynomial : public std::vector<T> {
+    typedef typename T T_fptype;
+
+    T_fptype Fit(T_fptype v) const {
+        static const T_fptype s_zero = 0.;
+        static const T_fptype s_one = 1.;
+        T_fptype ret = s_zero;
+        T_fptype vpow = s_one;
+        for (auto f : *this) {
+            if (!IsZero2(f, s_one))
+                ret += f * vpow;
+            vpow *= v;
+        }
+        return ret;
+    }
+
+    T_fptype Slope(T_fptype v) const {
+        static const T_fptype s_zero = 0.;
+        static const T_fptype s_one = 1.;
+        T_fptype ret = s_zero;
+        T_fptype vpow = s_one;
+        T_fptype count = s_one;
+        for (size_t i = 1; i < this->size(); i++, count = count + 1) {
+            if (!IsZero2((*this)[i], s_one)) {
+                ret += (*this)[i] * vpow * count;
+            }
+            vpow *= v;
+        }
+        return ret;
+    }
+};
+
+template <typename T>
+class T_RegressionizerBase {
+    typedef typename T::value_type::value_type T_fptype;
+public:
+    virtual T_fptype Slope(T_fptype) const = 0;
+    virtual T_fptype Fit(T_fptype)   const = 0;
+    virtual T_fptype StdDev()        const = 0;
+    virtual T_fptype Order()         const = 0;
+    virtual bool     Valid()         const = 0;
+    virtual void     PrintConfig()   const = 0;
+    virtual PolyFit<T_fptype>* AsPolyFit() const = 0;
+};
+
+template <typename T>
+class T_PolyRegressionizer : public T_RegressionizerBase<T> {
+    typedef typename T::value_type::value_type T_fptype;
+
+    T_Polynomial<T_fptype> coefs;
+    T_fptype stddev;
+    T_fptype epsilon;
+    unsigned maxOrder;
+    unsigned order;
+
+    // Populate matrix for polynomial least square fit, then solve via
+    // row reduction. By magic the coefficients
+    bool ComputeCoefs(
+        const T& xy,
+        const int& order)
+    {
+        static const T_fptype s_one = 1.;
+
+        if (xy.size() <= 0) return false;
+
+        size_t N = xy.size();
+        int n = order;
+        int np1 = n + 1;
+        int np2 = n + 2;
+        int tnp1 = 2 * n + 1;
+        T_fptype tmp;
+
+        std::vector<T_fptype> M(tnp1 + N);
+
+        // Avoid pow, extra space in array holds accumulated powers of x[j]
+        for (size_t j = 0; j < N; j++) {
+            M[tnp1 + j] = s_one;
+        }
+
+        M[0] = (T_fptype)(int)N;
+        for (int i = 1; i < tnp1; ++i) {
+            T_fptype sum = 0;
+            for (size_t j = 0; j < N; j++) {
+                T_fptype v = M[tnp1 + j] * xy.X(j);
+                M[tnp1 + j] = v;
+                sum += v;
+            }
+            M[i] = sum;
+        }
+
+        // Matrix B: populated then row reduced.
+        std::vector<std::vector<T_fptype> > B(np1, std::vector<T_fptype>(np2, 0));
+
+        for (size_t i = 0; i <= n; ++i)
+            for (size_t j = 0; j <= n; ++j)
+                B[i][j] = M[i + j];
+
+        std::vector<T_fptype> Y(np1 + N);
+
+        for (size_t j = 0; j < N; j++) {
+            Y[0] += xy[j].y;
+            Y[np1 + j] = s_one;
+        }
+
+        for (int i = 1; i < np1; ++i) {
+            T_fptype sum = 0;
+            for (size_t j = 0; j < N; j++) {
+                XYPair<T_fptype> t = xy[j];
+                T_fptype v = Y[np1 + j] * t.x;
+                Y[np1 + j] = v;
+                sum += v * t.y;
+            }
+            Y[i] = sum;
+        }
+
+        for (int i = 0; i <= n; ++i)
+            B[i][np1] = Y[i];
+
+        n += 1;
+        int nm1 = n - 1;
+
+        // Pivot
+        for (int i = 0; i < n; ++i)
+            for (int k = i + 1; k < n; ++k)
+                if (B[i][i] < B[k][i])
+                    for (int j = 0; j <= n; ++j) {
+                        tmp = B[i][j];
+                        B[i][j] = B[k][j];
+                        B[k][j] = tmp;
+                    }
+
+        // row reduction
+        for (int i = 0; i < nm1; ++i)
+            for (int k = i + 1; k < n; ++k) {
+                T_fptype t = B[k][i] / B[i][i];
+                for (int j = 0; j <= n; ++j)
+                    B[k][j] -= t * B[i][j];
+            }
+
+        // back sub onto result vector.
+        coefs.clear();
+        coefs.resize(np1);
+
+        for (int i = nm1; i >= 0; --i) {
+            coefs[i] = B[i][n];
+            for (int j = 0; j < n; ++j)
+                if (j != i)
+                    coefs[i] -= B[i][j] * coefs[j];
+
+            coefs[i] /= B[i][i];
+        }
+
+        coefs.clear();
+        for (size_t i = 0; i < a.size(); i++)
+            coefs.push_back(a[i]);
+
+        return true;
+    }
+
+public:
+
+    bool Build(const T& xy, double e) {
+        static const T_fptype s_zero = 0.;
+        static const T_fptype s_minusOne = -1.;
+
+        epsilon = e;
+
+        // Build integer poly regression. Use whichever is best.
+        // Iterate over orders, find first order that has great fit
+        for (size_t i = 0; i <= maxOrder; i++) {
+            order = (int)i;
+
+            // If fit cannot be found then fail.
+            if (!ComputeCoefs(xy, order)) {
+                stddev = s_minusOne;
+                break;
+            }
+
+            // Compute StdDev
+            T_fptype sumSquares = s_zero;
+            for (auto i : xy) {
+                T_fptype delta = i.y - Fit(i.x);
+                sumSquares += delta * delta;
+            }
+            T_fptype N = (unsigned)xy.size();
+            stddev = sqrt(sumSquares / N);
+
+            // Try higher and higher order until fit is accurate 'enough'.
+            if (stddev < epsilon)
+                break;
+        }
+
+        return Valid();
+    }
+
+    T_PolyRegressionizer(T_fptype e = 0.1, unsigned mo = 3) : maxOrder(mo), order(0), stddev(0.), epsilon(e) {}
+
+    virtual T_fptype Fit(T_fptype kph)   const { return coefs.Fit(kph); }
+    virtual T_fptype Slope(T_fptype kph) const { return coefs.Slope(kph); }
+    virtual T_fptype StdDev()            const { return stddev; }
+    virtual T_fptype Order()             const { return (T_fptype)(int)coefs.size(); }
+    virtual bool     Valid()             const { static const T_fptype s_zero = 0.; return stddev >= s_zero; }
+    virtual void     PrintConfig()       const {
+        std::cout << "Poly Regression Curve, order<" << coefs.size() << ">, stddev: " << StdDev() << std::endl;
+    }
+    virtual PolyFit<T_fptype>* AsPolyFit() const {
+        return PolyFitGenerator::GetPolyFit(coefs);
+    }
+};
+
+template <typename T> class T_FractionalPolyRegressionizer : public T_RegressionizerBase<T> {
+
+    typedef typename T::value_type::value_type T_fptype;
+
+    T_fptype m_X, m_Y, m_Z, m_stddev, m_epsilon;
+    unsigned maxOrder;
+
+    // Finds a fit X, Y, Z for:
+    //
+    // w = v ^ X * Y + Z
+    //
+    // Returns stddev if success, else returns negative value.
+    // Fit will fail if any negative x.
+    T_fptype ComputeCoefs(const T& xy) {
+        static const T_fptype s_zero = 0.;
+        static const T_fptype s_one = 1.;
+        static const T_fptype s_minusOne = -1.;
+        static const T_fptype s_minusTwo = -2.;
+        static const T_fptype s_half = 0.5;
+        static const T_fptype s_pointOne = 0.1;
+
+        if (xy.size() == 0) {
+            T_fptype  ret = -1;
+            return ret;
+        }
+
+        std::vector<T_fptype> y;
+        for (auto v : xy) {
+            if (v.x < s_zero) {
+                return s_minusOne;
+            }
+            y.push_back(v.y);
+        }
+
+        T_fptype sumSquares = s_minusOne;
+
+        // bias all y by first element - that is Z.
+        m_Z = y[0];
+
+        size_t e = y.size() - 1;
+
+        if (m_Z != s_zero) for (auto &i : y) i -= m_Z;
+
+        // Start with X = 1., a line from first to last point.
+        m_X = s_one;
+
+        T_fptype delta = s_half;
+
+        std::vector<T_fptype> results(e+1);
+
+        bool firstLoop = true;
+
+        do {
+            T_fptype xv = xy.X(e);
+            T_fptype yv = y[e];
+            if (xv == 0.) m_Y = s_one;
+            else if (yv == 0.) m_Y = s_one;
+            else m_Y = yv / pow(xv, m_X);
+
+            T_fptype newSumSquares = 0;
+            for (size_t i = 0; i <= e; i++) {
+                T_fptype xv = xy.X(i);
+                T_fptype yv = xy.Y(i);
+                if (xv == s_zero) results[i] = s_zero;
+                else results[i] = pow(xv, m_X) * m_Y;
+                T_fptype delta = results[i] - yv;
+                newSumSquares += (delta * delta);
+            }
+
+            // Its good if sum of squares decreases.
+            bool good = firstLoop || newSumSquares < sumSquares;
+            sumSquares = newSumSquares;
+
+            if (!good)
+                delta /= s_minusTwo;
+
+            // Stop when step gets real small.
+            if (fabs(delta) < m_epsilon)
+                break;
+
+            m_X += delta;
+
+            if (fabs(m_X) > (int)maxOrder)
+                break;
+
+            firstLoop = false;
+        } while (true);
+
+        T_fptype N = (unsigned)xy.size();
+        T_fptype variance = sumSquares / N;
+        T_fptype stddev = sqrt(variance);
+
+        return stddev;
+    }
+
+public:
+
+    T_FractionalPolyRegressionizer(T_fptype e = 0.000001, unsigned mo = 3) {
+        static const T_fptype s_zero = 0.;
+        static const T_fptype s_minusOne = -1.;
+        maxOrder = mo; m_X = s_zero; m_Y = s_zero; m_Z = s_zero; m_stddev = s_minusOne; m_epsilon = e;
+    }
+    
+    bool Build(const XYVector<T_fptype>& xy, double epsilon) {
+        m_stddev = ComputeCoefs(xy);
+        return Valid();
+    }
+
+    virtual T_fptype Fit(T_fptype kph)   const { static const T_fptype s_zero = 0.; return (kph < s_zero) ? s_zero : (pow(kph, m_X) * m_Y + m_Z); }
+    virtual T_fptype Slope(T_fptype kph) const { static const T_fptype s_zero = 0.; return (kph < s_zero) ? s_zero : (kph * pow(kph, m_X - 1)); }
+    virtual T_fptype StdDev()            const { return m_stddev; }
+    virtual T_fptype Order()             const { return m_X; }
+    virtual bool     Valid()             const { static const T_fptype s_zero = 0.; return StdDev() >= s_zero; }
+    virtual void     PrintConfig()       const {
+        std::cout << "Fractional Poly Regression Curve, x^" << m_X << "*" << m_Y << "+" << m_Z << ", stddev: " << StdDev() << std::endl;
+    }
+    virtual PolyFit<T_fptype>* AsPolyFit() const {
+        return FitGenerator::GetFractionalPolynomialFitter({ m_X, m_Y, m_Z });
+    }
+};
+
+// Regression Fit using Rational Polynomial.
+// Clearest explanation I found was this:
+// https://math.stackexchange.com/questions/924482/least-squares-regression-matrix-for-rational-functions
+// Uses gaussian elimination to solve.
+template <typename T>
+class T_RationalPolyRegressionizer : public T_RegressionizerBase<T> {
+    typedef typename T::value_type::value_type T_fptype;
+
+    T_Polynomial<T_fptype> m_num, m_den;
+
+    T_fptype stddev;
+    T_fptype epsilon;
+
+    unsigned maxOrder;
+
+    static T_fptype T_pow(T_fptype x, int iPow) {
+        static const T_fptype s_one = 1.;
+        if (iPow == 0)
+            return s_one;
+
+        T_fptype p = T_fptype(x);
+        T_fptype pr = p;
+        for (T_fptype ip = 1; ip < iPow; ip = ip + 1)
+            pr = pr * p;
+
+        return pr;
+    }
+
+    static T_fptype T_fabs(T_fptype t) {
+        static const T_fptype s_zero = 0.;
+        return (t < s_zero) ? -(t) : (t);
+    }
+
+    static void T_GaussElimination(T_Matrix<T_fptype>& M, std::vector<T_fptype>& XVec) {
+        static const T_fptype s_zero = 0.;
+
+        size_t n = M.data.size();
+        XVec.clear();
+        XVec.resize(n);
+
+        for (size_t i = 0; i < n; i++) {
+            // Search for maximum in this column
+            T_fptype maxelement = T_fabs(M[i][i]);
+            size_t maxRow = i;
+            for (size_t k = i + 1; k < n; k++) {
+                T_fptype pos = T_fabs(M[k][i]);
+                if (pos > maxelement) {
+                    maxelement = pos;
+                    maxRow = k;
+                }
+            }
+            // Swap maximum row with current row (column by column)
+            if (maxRow != i) {
+                for (size_t k = i; k < n + 1; k++) {
+                    T_fptype tmp = M[maxRow][k];
+                    M[maxRow][k] = M[i][k];
+                    M[i][k] = tmp;
+                }
+            }
+            // Make all rows below this one 0 in current column
+            for (size_t k = i + 1; k < n; k++) {
+                T_fptype c = M[k][i] / M[i][i];
+                for (size_t j = i; j < n + 1; j++) {
+                    if (i == j) {
+                        M[k][j] = s_zero;
+                    }
+                    else {
+                        M[k][j] = M[k][j] - (c * M[i][j]);
+                    }
+                }
+            }
+        }
+
+        for (int i = (int)(n - 1); i >= 0; i--) {
+            if (M[i][i] != T_fptype(0)) {
+                XVec[i] = M[i][n] / M[i][i];
+                for (int k = (int)(i - 1); k >= 0; k--) {
+                    M[k][n] = M[k][n] - (M[k][i] * XVec[i]);
+                }
+            }
+        }
+    }
+
+    // Build augmented matrix for computing best fit rational polynomial
+    bool BuildRationalPolynomialMatrix(std::vector<std::vector<T_fptype> >& X, std::vector<T_fptype>& x, std::vector<T_fptype>& y, size_t orderN, size_t orderM) {
+
+        static const T_fptype s_zero = 0.;
+
+        orderM = std::min<size_t>(orderM, x.size() + 1);
+        orderN = std::min<size_t>(orderN, x.size() + 1);
+
+        size_t dim = orderN + orderM + 1;
+
+        X.resize(dim);
+        for (auto& i : X) {
+            i.resize(dim + 1); // '+ 1': make room for results column
+        }
+
+        // Top left square matrix srows: n+1, scol: n+1
+
+        // Sum(j) x(j)^(srow + scol)
+
+        // Compute values above diagonal
+        for (size_t i = 0; i <= orderN; i++) {         // i = row
+            for (size_t j = i; j <= orderN; j++) {     // j = column
+                T_fptype v = s_zero;
+                for (auto xn : x)
+                    v += T_pow(T_fptype(xn), (int)(i + j));
+
+                X[i][j] = v;
+            }
+        }
+
+        // Copy upper diagonal values to below diagonal
+        for (size_t i = 1; i <= orderN; i++) {
+            for (size_t j = 0; j < i; j++) {
+                X[i][j] = X[j][i];
+            }
+        }
+
+        // Bottom left rows, srows: m, scol: n + 1
+
+        // Sum(j) y(j) * x(j)^(srow + scol + 1)
+
+        for (size_t i = 0; i < orderM; i++) {         // i = sub row
+            for (size_t j = 0; j < orderN + 1; j++) { // j = sub column
+
+                size_t aI = i + orderN + 1;  // target matrix row idx
+                size_t aJ = j;               // target matrix col idx
+
+                // If possible copy duplicate from previous row.
+                if (i > 0 && j < orderN) {
+                    X[aI][aJ] = X[aI - 1][aJ + 1];
+                } else {
+                    T_fptype iPow = (int)(i + j + 1);
+
+                    T_fptype v = s_zero;
+                    for (size_t n = 0; n < x.size(); n++) {
+                        v += T_fptype(y[n]) * T_pow(T_fptype(x[n]), (int)(i + j + 1));
+                    }
+
+                    X[aI][aJ] = v;
+                }
+            }
+        }
+
+        // Right Hand Columns row: n+1, col: m
+
+        // - sum(j) y(j) * x(j)^(srow + scol + 1)
+
+        for (size_t i = 0; i < orderN + 1; i++) {    // i = sub row
+            for (size_t j = 0; j < orderM; j++) {    // j = sub col
+
+                size_t aI = i;                       // target matrix row idx
+                size_t aJ = j + orderN + 1;          // target matrix col idx
+
+                // If possible copy duplicate from previous column.
+                if (j > 0 && i < orderN) {
+                    X[aI][aJ] = X[aI + 1][aJ - 1];
+                } else {
+                    int iPow = (int)(i + j + 1);
+                    T_fptype v = s_zero;
+                    for (size_t n = 0; n < x.size(); n++) {
+                        v += T_fptype(y[n]) * T_pow(T_fptype(x[n]), (int)(i + j + 1));
+                    }
+
+                    v = -v;
+
+                    X[aI][aJ] = v;
+                }
+            }
+        }
+
+        // Bottom right square, srow: m, scol: m
+
+        // sum(j) y(j)^2 * x(j)^(srow + scol + 2)
+
+        for (size_t i = 0; i < orderM; i++) {
+            for (size_t j = 0; j < orderM; j++) {
+
+                size_t aI = i + orderN + 1;
+                size_t aJ = j + orderN + 1;
+
+                if (i > 0 && j < i) {
+                    X[aI][aJ] = X[aI - 1][aJ + 1];
+                } else {
+                    int iPow = (int)(i + j + 2);
+                    T_fptype v = s_zero;
+                    for (size_t n = 0; n < x.size(); n++) {
+                        v += T_pow(T_fptype(y[n]), 2) * T_pow(T_fptype(x[n]), (int)(i + j + 2));
+                    }
+
+                    v = -v;
+
+                    X[aI][aJ] = v;
+                }
+            }
+        }
+
+        // Populate result coef column:
+
+        // Top part of column vector
+        for (size_t i = 0; i < orderN + 1; i++) {
+            T_fptype sum = s_zero;
+            for (size_t j = 0; j < y.size(); j++) {
+                sum += y[j] * T_pow(x[j], (int)i);
+            }
+            X[i][dim] = sum;
+        }
+        // Bottom part of column vector
+        for (size_t i = 0; i < orderM; i++) {
+            T_fptype sum = s_zero;
+            for (size_t j = 0; j < y.size(); j++) {
+                sum += T_pow(y[j], 2) * T_pow(x[j], (int)(i + 1));
+            }
+            X[i + orderN + 1][dim] = sum;
+        }
+
+        return true;
+    }
+
+public:
+
+    T_RationalPolyRegressionizer(T_fptype e = 0.1, unsigned mo = 3) : maxOrder(mo), stddev(-1.), epsilon(e) {}
+
+    // Build computes poly fit for data, then divides data by poly fitted values, then finds poly fit for those residuals.
+    bool Build(const T& xy, double e) {
+        epsilon = e;
+
+        static const T_fptype s_zero = 0.;
+        static const T_fptype s_minusOne = -1.;
+
+        T_fptype bestStdDev = s_minusOne;
+        T_Polynomial<T_fptype> bestNum, bestDen;
+
+        std::vector<T_fptype> x, y;
+        for (size_t i = 0; i < xy.size(); i++) {
+            x.push_back(xy.X(i));
+            y.push_back(xy.Y(i));
+        }
+
+        // Search for best fit poly within order.
+        for (int m = 0; m <= (int)maxOrder; m++) {
+            for (int n = 0; n <= (int)maxOrder; n++) {
+                m_num.clear();
+                m_den.clear();
+
+                std::vector<std::vector<T_fptype>> X;
+
+                BuildRationalPolynomialMatrix(X, x, y, n, m);
+
+                std::vector<T_fptype> adr;
+                T_Matrix<T_fptype> TM(X.size(), X);
+
+                T_GaussElimination(TM, adr);
+
+                m_den.push_back(1.);
+                for (size_t i = 0; i < adr.size(); i++) {
+                    if (i <= n) m_num.push_back(adr[i]);
+                    else m_den.push_back(adr[i]);
+                }
+
+                T_fptype sumSquares = s_zero;
+                for (auto i : xy) {
+                    T_fptype delta = i.y - Fit(i.x);
+                    sumSquares += delta * delta;
+                }
+                T_fptype N = (unsigned)xy.size();
+                T_fptype variance = sumSquares / N;
+                stddev = sqrt(variance);
+
+                // Now to determine 'best'.
+                // If both are already below epsilon then take the one with lower order.
+                bool isNewBest = false;
+                if (bestStdDev < 0) isNewBest = true;
+                else if (stddev < bestStdDev) {
+                    if (bestStdDev > epsilon)
+                        isNewBest = true;
+                    else {
+                        size_t bestMax = std::max(bestNum.size(), bestDen.size());
+                        size_t curMax = std::max(m_num.size(), m_den.size());
+                        if (curMax < bestMax)
+                            isNewBest = true;
+                        if (curMax == bestMax) {
+                            size_t bestSum = bestNum.size() + bestDen.size();
+                            size_t curSum = m_num.size() + m_den.size();
+                            if (curSum < bestSum)
+                                isNewBest = true;
+                        }
+                    }
+                }
+
+                if (isNewBest) {
+                    bestStdDev = stddev;
+                    bestNum = m_num;
+                    bestDen = m_den;
+                }
+
+            }  // numerator order iteration
+        } // denominator order iteration
+
+        m_num = bestNum;
+        m_den = bestDen;
+        stddev = bestStdDev;
+
+        return Valid();
+    }
+
+    virtual T_fptype Fit(T_fptype kph) const {
+        T_fptype n = m_num.Fit(kph);
+        T_fptype d = m_den.Fit(kph);
+        T_fptype v = n / d;
+        return v;
+    }
+
+    virtual T_fptype Slope(T_fptype v) const {
+        T_fptype N = m_num.Fit(v);
+        T_fptype D = m_den.Fit(v);
+
+        T_fptype dNdV = m_num.Slope(v);
+        T_fptype dDdV = m_den.Slope(v);
+
+        return ((dNdV * D) - (N * dDdV)) / (D * D);
+    }
+
+    virtual T_fptype StdDev()      const { return stddev; }
+    virtual T_fptype Order()       const { return (T_fptype)std::max<int>((int)m_num.size(), (int)m_den.size()); }
+    virtual bool     Valid()       const { static const T_fptype s_zero = 0.; return stddev >= s_zero; }
+    virtual void     PrintConfig() const {
+        std::cout << "Rational Poly Regression Curve, order<" << m_num.size() << "," << m_den.size() << ">, stddev: " << StdDev() << std::endl;
+    }
+
+    virtual PolyFit<T_fptype>* AsPolyFit() const {
+        // Create denominator vector without leading 1.
+        std::vector<T_fptype> den;
+        for (size_t i = 1; i < m_den.size(); i++) {
+            den.push_back(m_den[i]);
+        }
+        return PolyFitGenerator::GetRationalPolyFit(m_num, den, 1.);
+    }
+};
+
+template <typename T>
+class T_MultiRegressionizer {
+
+    typedef typename T::value_type::value_type T_fptype;
+
+    T                                         m_xy;
+    mutable T_PolyRegressionizer<T>           m_pr;
+    mutable T_FractionalPolyRegressionizer<T> m_fpr;
+    mutable T_RationalPolyRegressionizer<T>   m_rpr;
+
+    const mutable T_RegressionizerBase<T>*    m_best;
+    mutable bool                              m_isFinalized;
+
+    const double                              m_epsilon;
+
+    const T_RegressionizerBase<T>* CompareAndReturnBest(const T_RegressionizerBase<T>* a, const T_RegressionizerBase<T>* b) const {
+
+        // Prefer a choice that exists.
+        int c = (a && a->Valid()) + (2 * (b && b->Valid()));
+        switch (c) {
+        case 0: return NULL;
+        case 1: return a;
+        case 2: return b;
+        }
+
+        // Prefer a choice that has stddev below epsilon
+        int v = (a->StdDev() <= m_epsilon) + (2 * (b->StdDev() <= m_epsilon));
+        switch (v) {
+        case 0: return (a->StdDev() <= b->StdDev()) ? a : b;
+        case 1: return a;
+        case 2: return b;
+        }
+
+        // Both valid and stddev less than epsilon, choose model with lower order
+        return (a->Order() <= b->Order()) ? a : b;
+    }
+
+    bool Build() const {
+        if (!m_isFinalized) {
+            m_fpr.Build(m_xy, m_epsilon);
+            m_pr.Build(m_xy,  m_epsilon);
+            m_rpr.Build(m_xy, m_epsilon);
+
+            // Select best fit
+            m_best = CompareAndReturnBest(&m_fpr, &m_pr);
+            m_best = CompareAndReturnBest(m_best, &m_rpr);
+
+            m_isFinalized = (m_best != NULL);
+        }
+
+        return m_isFinalized;
+    }
+
+public:
+
+    typedef T value_type;
+
+    T_MultiRegressionizer(double e = 0.1, unsigned mo = 3) : 
+        m_pr(e, mo), m_fpr(e, mo), m_rpr(e, mo), m_best(NULL), m_isFinalized(false), m_epsilon(e) {}
+
+    void Set(const T& p)            { m_isFinalized = false; m_xy = p; }
+    void Push(XYPair<T_fptype> val) { m_isFinalized = false; m_xy.push_back(val); }
+    void Clear()                    { m_isFinalized = false; m_xy.clear(); }
+
+    T_fptype Fit(T_fptype kph) const {
+        static const T_fptype s_zero = 0.;
+
+        T_fptype ret = s_zero;
+
+        if (Build())
+            ret = m_best->Fit(kph);
+
+        return ret;
+    }
+
+    T_fptype Slope(T_fptype kph) const {
+        static const T_fptype s_zero = 0.;
+
+        T_fptype ret = s_zero;
+
+        if (Build())
+            ret = m_best->Slope(kph);
+
+        return ret;
+    }
+
+    T_fptype XYToYDYDT(T_MultiRegressionizer<T>& ydydt) const {
+        for (auto i : m_xy)
+            ydydt.Push({ i.y, Slope(i.x) });
+
+        return StdDev();
+    }
+
+    T_fptype StdDev() const {
+        T_fptype ret = -1.;
+
+        if (!Build()) return ret;
+
+        return m_best->StdDev();
+    }
+
+    T_fptype Order() const {
+        if (!Build()) return -1;
+        return m_best->Order();
+    }
+
+    void PrintConfig() {
+        if (!Build()) std::cout << "Failed!" << std::endl;
+        else m_best->PrintConfig();
+    }
+
+    void Print() {
+        if (!Build()) std::cout << "Print() failed." << std::endl;
+        else {
+            for (int i = 0; i < m_xy.size(); i++) {
+                std::cout << m_xy.X(i) << "\t\t" << m_xy.Y(i) << std::endl;
+            }
+        }
+    }
+
+    bool Valid() {
+        return Build();
+    }
+
+    PolyFit<T_fptype>* AsPolyFit() {
+        if (!Valid()) return NULL;
+
+        return m_best->AsPolyFit();
+    }
+};
+
+// Gather data from spindown array (type C) into reversed array of xy pairs. Time
+// is reset to start at 0. This yields xy pairs where speed increases, the slope
+// of the speed increase is the deceleration applied by the trainer at that speed.
+template <typename T_fptype, typename C, typename T>
+void T_SpindownArrayToTimeKph(const C* p, unsigned count, T& xy) {
+
+    T_fptype time0 = p[0].time;
+    T_fptype time = p[count - 1].time;
+    T_fptype totalTime = time - time0;
+    for (int i = count - 1; i >= 0; i--) {
+        time = p[i].time;
+        T_fptype speed = p[i].speed;
+        xy.Push({ totalTime - (time - time0), speed });
+    }
+}
+
+// Accumulate spindown data into provided xy pair vector.
+//
+// Fit original time/speed samples to polynomial 'speedFit'.
+// Compute new curve 'accFit', the derivative of 'speedFit'.
+// 'accFit' is the curve of speed to user deceleration.
+// Those pairs are datapoints without context and can be combined with data
+// from other spindowns to create a multiple-spindown fit. (See: SpindownToPolyFit)
+// Points are accumulated onto 'resultsXY' which is the list of pairs of <speed, deceleration>.
+template <typename T_fptype, typename C, typename T>
+T_fptype T_SpeedTimeToAccKph_Accumulate(const C* p, unsigned count, T& resultsXY, unsigned maxOrder = 3, double fitepsilon = 10.) {
+
+    // Max order only applies to initial fit to raw user data. After we have a fit
+    // theres not much point ignoring the fit's stddevs.
+    T_MultiRegressionizer<XYVector<T_fptype>> speedFit(fitepsilon, maxOrder);
+    T_SpindownArrayToTimeKph<T_fptype, C>(p, count, speedFit);
+
+    // Fitting acceleration into a speed power curve. Since this is a fit of a
+    // fitted function we should expect a near perfect fit for its slope and with
+    // a lesser order.
+    T_MultiRegressionizer<XYVector<T_fptype>> accFit(0.1, maxOrder);
+
+    // Converts slope graph of speedfit into a new polynomial of change in
+    // speed with respect to speed. This is decel per speed. The stddev
+    // returned here is how well speedFit was able to model the original data.
+    T_fptype stddev = speedFit.XYToYDYDT(accFit);
+
+    // Now resample original speeds against accFit to produce speed/acc pairs, then
+    // push those pairs onto result array.
+
+    // Use the speeds from incoming points since they are the least interpolated.
+    for (size_t i = 0; i < count; i++) {
+        resultsXY.push_back({ p[i].speed, accFit.Fit(p[i].speed) });
+    }
+
+    return stddev;
+}
+
+// Class to fit multiple spindowns into a single speed/deceleration curve.
+template <typename C, typename T>
+class SpindownToPolyFit {
+
+    typedef typename T::value_type::value_type T_fptype;
+
+    T_MultiRegressionizer<T> m_multifit;
+    T m_resultsXY;
+
+    unsigned m_maxOrder;
+
+    bool m_built;
+
+    bool Build(void) {
+        if (!m_built) {
+            // sort accumulated speed/acceleration results
+            std::sort(m_resultsXY.begin(), m_resultsXY.end(),
+                [](const XYPair<T_fptype>& n1, const XYPair<T_fptype>& n2)->bool {
+                return n1.x < n2.x;
+            });
+
+            // Clear and re-fit speed/acceleration results.
+            m_multifit.Clear();
+            for (auto i : m_resultsXY) {
+                m_multifit.Push(i);
+            }
+
+            m_built = true;
+        }
+
+        return m_built;
+    }
+
+public:
+
+    // Epsilon is the stddev goal for fitting spindown data. Fitter will go up to maxOrder
+    // to achieve the goal. Higher order functions are unstable and do wacky things, so
+    // often its better to tolerate a looser data fit by lowering desired stddev than to
+    // raise the maxOrder.
+    SpindownToPolyFit(double epsilon, unsigned maxOrder) : m_maxOrder(maxOrder), m_multifit(epsilon, maxOrder), m_built(false) {}
+
+    // Process spindown graph into speed/deceleration datapoints and accumulate.
+    T_fptype Push(const C* p, unsigned count) {
+        m_built = false;
+        return T_SpeedTimeToAccKph_Accumulate<T_fptype, C, T> (p, count, m_resultsXY, m_maxOrder);
+    }
+
+    T_fptype StdDev() const {
+        static const T_fptype s_zero = 0.;
+        if (!Build()) return s_zero;
+        return m_multifit->StdDev();
+    }
+
+    // Fit speed against current determined speed/power graph.
+    T_fptype Fit(T_fptype v) {
+        // Return zero on failure?
+        static const T_fptype s_zero = 0.;
+        if (!Build()) return s_zero;
+
+        return m_multifit.Fit(v);
+    }
+
+    // Convert current speed/power graph to polyfit for use outside this class.
+    // Caller must call delete upon it when finished.
+    PolyFit<T_fptype>* AsPolyFit() {
+        if (!Build()) return NULL;
+        
+        return m_multifit->AsPolyFit();
+    }
+};
+#endif // _GC_MultiRegressionizer_h

--- a/src/Train/MultiRegressionizer.h
+++ b/src/Train/MultiRegressionizer.h
@@ -700,10 +700,12 @@ public:
                 static const T_fptype s_hundo = 100.;
                 T_fptype rangeY = (maxY - minY);
                 T_fptype delta = (maxX - minX) / s_hundo;
+                T_fptype tripleRangeY = rangeY + rangeY + rangeY;
+                T_fptype upperLimitY = maxY + (tripleRangeY);
+                T_fptype lowerLimitY = minY - (tripleRangeY);
                 for (T_fptype i = minX; i < (maxX + maxX); i+= delta) {
                     T_fptype fitVal = Fit(i);
-                    if (fitVal > (maxY + rangeY) ||
-                        fitVal < (minY - rangeY)) {
+                    if (fitVal > upperLimitY || fitVal < lowerLimitY) {
                         fail = true;
                         break;
                     }
@@ -1048,8 +1050,5 @@ public:
         return m_multifit.AsPolyFit();
     }
 };
-
-#pragma optimize("", on)
-
 
 #endif // _GC_MultiRegressionizer_h

--- a/src/Train/MultiRegressionizer.h
+++ b/src/Train/MultiRegressionizer.h
@@ -22,6 +22,7 @@
 #include <vector>
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include "BlinnSolver.h"
 #include "PolynomialRegression.h"
 

--- a/src/Train/PolynomialRegression.cpp
+++ b/src/Train/PolynomialRegression.cpp
@@ -47,7 +47,7 @@ void T_AppendVirtualPowerDescriptionString(T_String &s, const char* tla, size_t 
 
 template <typename T, typename T_inittype>
 struct FractionalPolynomialFitter : public T {
-    typename typedef T::value_type T_fptype;
+    typedef typename T::value_type T_fptype;
 
     std::array<T_fptype, 3> arr;
     T_fptype scale;
@@ -75,7 +75,7 @@ struct FractionalPolynomialFitter : public T {
 
 template <size_t T_size, size_t T_num, typename T, typename T_inittype>
 struct RationalFitter : public T {
-    typename typedef T::value_type T_fptype;
+    typedef typename T::value_type T_fptype;
 
     std::array<T_fptype, T_size> arr;
     T_fptype scale;

--- a/src/Train/PolynomialRegression.cpp
+++ b/src/Train/PolynomialRegression.cpp
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2020 Eric Christoffersen (impolexg@outlook.com)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <array>
+#include "PolynomialRegression.h"
+#include "MultiRegressionizer.h"
+
+template <typename T, typename T_inittype>
+struct FractionalPolynomialFitter : public T {
+    typename typedef T::value_type T_fptype;
+
+    std::array<T_fptype, 3> arr;
+    T_fptype scale;
+
+    static T* Make(const T_inittype& v, typename const T_inittype::value_type& scale) {
+        return new FractionalPolynomialFitter(v, scale);
+    }
+
+    FractionalPolynomialFitter(const T_inittype& n, typename const T_inittype::value_type& s) : arr(), scale(s) {
+        for (size_t i = 0; i < n.size(); i++) arr[i] = n[i];
+    }
+
+    T_fptype Fit(T_fptype v) {
+        // Scale v, for example mph -> kph
+        v = v * scale;
+
+        // v^X * Y + Z
+        return (pow(v, arr[0]) * arr[1]) + arr[2];
+    }
+};
+
+template <size_t T_size, size_t T_num, typename T, typename T_inittype>
+struct RationalFitter : public T {
+    typename typedef T::value_type T_fptype;
+
+    std::array<T_fptype, T_size> arr;
+    T_fptype scale;
+
+    static T* Make(const T_inittype& v, const T_inittype& v2, typename const T_inittype::value_type& scale) {
+        return new RationalFitter(v, v2, scale);
+    }
+
+    RationalFitter(const T_inittype& n, const T_inittype& d, typename const T_inittype::value_type& s) : arr(), scale(s) {
+        // Populate numerator coefficients.
+        for (size_t i = 0; i < T_num; i++) arr[i] = n[i];
+
+        // Denominator may have no coefficients (implicit 1.)
+        size_t i = T_num;
+        while (i < T_size) {
+            arr[i] = d[i - T_num];
+            i++;
+        }
+    }
+
+    // Compute Fit.
+    // Because fitter has templated size the compiler is able to fully unroll the fit
+    // calculation. This function also serves all polynomial evaluation since denominator
+    // has implicit 1 which allows zero sized denominator evaluation to be optimized away.
+    T_fptype Fit(T_fptype v) {
+
+        // Scale v, for example mph -> kph
+        v = v * scale;
+
+        // Determine numerator value.
+        T_fptype n = 0.;
+        T_fptype p = 1.; // power starts with x^0 (== 1)
+        for (size_t i = 0; i < T_num; i++) {
+            n += (arr[i] * p);
+            p *= v;
+        }
+
+        // If no denominator coeficients then implicit divide 1. Done-ski.
+        if (T_size == T_num) return n;
+
+        // Determine denominator value.
+
+        // This implementation of rational polynomials has an implicit 1 for denominator
+        // coefficient. It is impossible to not have a 1 for first coeficient. The first
+        // coefficient for denominator of rational polynomial is for x^1.
+        T_fptype d = 1.; // d starts at 1
+
+        // This compile time check avoids compiler warning about unused value.
+        if (T_num < T_size) {
+            p = v;           // loop starts with p = x^1
+            size_t i = T_num;
+            while (i < T_size) {
+                d += (arr[i] * p);
+                p *= v;
+                i++;
+            }
+        }
+
+        T_fptype r = n / d;
+
+        return r;
+    }
+};
+
+template <size_t T_maxSize, size_t T_maxDen, typename T, typename T_inittype, size_t T_valueNumber>
+struct RationalFitterGenerator {
+    static void setMaker(std::array<T * (*)(const T_inittype&, const T_inittype&, typename const T_inittype::value_type&), T_maxSize>& p) {
+        static const size_t s_num = (T_valueNumber % T_maxDen) + 1;
+        static const size_t s_den = T_valueNumber / T_maxDen;
+        p[T_valueNumber] = RationalFitter<s_num + s_den, s_num, T, T_inittype>::Make;
+        RationalFitterGenerator<T_maxSize, T_maxDen, T, T_inittype, T_valueNumber + 1>::setMaker(p);
+    }
+};
+
+template <size_t T_maxSize, size_t T_maxDen, typename T, typename T_inittype>
+struct RationalFitterGenerator<T_maxSize, T_maxDen, T, T_inittype, T_maxSize> {
+    static void setMaker(std::array<T * (*)(const T_inittype&, const T_inittype&, typename const T_inittype::value_type&), T_maxSize>& p) { p; }
+};
+
+template <size_t T_maxNum, size_t T_maxDen, typename T, typename T_inittype>
+struct T_PolyFitGenerator {
+
+    // Value number from <numeratorCount, denominatorCount> to a unique combination of the two,
+    // for example:
+    //
+    // num,den max both 6...
+    //
+    // 1,0 = 0
+    // 2,0 = 1
+    // 6,0 = 5
+    // 1,1 = 6*1 + 0 == 6
+    // 1,2 = 6*2 + 1 == 13
+    // 6,5 = 6*5 + 5 == 35
+    // 6,6 = 6*6 + 5 == 41
+    //
+    // The implicit 1 is there so the linear system to solve for rational polynomial least squares doesnt need to worry about divide by zero.
+
+    std::array<T * (*)(const T_inittype&, const T_inittype&, typename const T_inittype::value_type&), T_maxNum * (T_maxDen + 1)> arr;
+
+    T_PolyFitGenerator() : arr() {
+        RationalFitterGenerator<T_maxNum * (T_maxDen + 1), T_maxDen, T, T_inittype, 0>::setMaker(arr);
+    }
+
+    // Generate Rational Polynomial Fitter
+    T* GetRationalPolyFit(const T_inittype& n, const T_inittype& d, typename const T_inittype::value_type& scale = 1.) const {
+        return arr[(n.size() - 1) + (T_maxDen * (d.size()))](n, d, scale);
+    }
+
+    // Generate Polynomial Fitter
+    T* GetPolyFit(const T_inittype& n, typename const T_inittype::value_type& scale = 1.) const {
+        static const T_inittype z;
+        return arr[n.size() - 1](n, z, scale);
+    }
+
+    // Generate Fractional Polynomial Fitter (v^X*Y)+Z
+    T* GetFractionalPolyFit(const T_inittype& v, typename const T_inittype::value_type& scale = 1.) const {
+        return FractionalPolynomialFitter<T, T_inittype>::Make(v, scale);
+    }
+};
+
+// File static global. Compiler optimizes it so array of maker methods can live entirely in image memory -
+// populated by the loader.
+static const T_PolyFitGenerator<6, 6, PolyFit<double>, std::vector<double>> s_PolyFitGenerator;
+
+// Factory accessed via static methods to avoid exposing templates into tender world...
+
+PolyFit<double>* PolyFitGenerator::GetRationalPolyFit  (const std::vector<double>& numeratorCoefs, const std::vector<double>& denominatorCoefs, const double &scale) {
+    return s_PolyFitGenerator.GetRationalPolyFit(numeratorCoefs, denominatorCoefs, scale);
+}
+
+PolyFit<double>* PolyFitGenerator::GetPolyFit          (const std::vector<double>& coefs, const double& scale) {
+    return s_PolyFitGenerator.GetPolyFit(coefs, scale);
+}
+
+PolyFit<double>* PolyFitGenerator::GetFractionalPolyFit(const std::vector<double>& coefs, const double& scale) {
+    return s_PolyFitGenerator.GetFractionalPolyFit(coefs, scale);
+}

--- a/src/Train/PolynomialRegression.cpp
+++ b/src/Train/PolynomialRegression.cpp
@@ -36,7 +36,7 @@ struct FractionalPolynomialFitter : public T {
         for (size_t i = 0; i < n.size(); i++) arr[i] = n[i];
     }
 
-    T_fptype Fit(T_fptype v) {
+    T_fptype Fit(T_fptype v) const {
         // Scale v, for example mph -> kph
         v = v * scale;
 
@@ -72,7 +72,7 @@ struct RationalFitter : public T {
     // Because fitter has templated size the compiler is able to fully unroll the fit
     // calculation. This function also serves all polynomial evaluation since denominator
     // has implicit 1 which allows zero sized denominator evaluation to be optimized away.
-    T_fptype Fit(T_fptype v) {
+    T_fptype Fit(T_fptype v) const {
 
         // Scale v, for example mph -> kph
         v = v * scale;
@@ -170,7 +170,7 @@ struct T_PolyFitGenerator {
 
 // File static global. Compiler optimizes it so array of maker methods can live entirely in image memory -
 // populated by the loader.
-static const T_PolyFitGenerator<6, 6, PolyFit<double>, std::vector<double>> s_PolyFitGenerator;
+static const T_PolyFitGenerator<7, 7, PolyFit<double>, std::vector<double>> s_PolyFitGenerator;
 
 // Factory accessed via static methods to avoid exposing templates into tender world...
 
@@ -228,14 +228,14 @@ void PolynomialRegressionTest(void) {
     // For convenience push references to above static data into arrays.
     std::vector<const SpindownData*> msdata;
     std::vector<size_t> msdatasize;
-
+    
     msdata.push_back(Kinetic0); msdatasize.push_back(sizeof(Kinetic0) / sizeof(Kinetic0[0]));
     msdata.push_back(Kinetic1); msdatasize.push_back(sizeof(Kinetic1) / sizeof(Kinetic0[1]));
 
     // Spindown fitter: desired fit epsilon is 1kph, max order for match is 6.
     // 6 is almost certainly too high but this is for test so why not.
     SpindownToPolyFit < SpindownData, XYVector<double>> ms_stp(1, 6);
-
+    
     // Array to hold fit variance (computed when each array is pushed.)
     std::vector<double> ms_variances;
 

--- a/src/Train/PolynomialRegression.cpp
+++ b/src/Train/PolynomialRegression.cpp
@@ -36,9 +36,9 @@ void T_AppendVirtualPowerDescriptionString(T_String &s, const char* tla, size_t 
     // tla,arrSize,numSize|coefs,...|scale
 
     accum << tla << ", " << arrSize << "," << numSize << "|";
-    for (int i = 0; i <= (arrSize - 1); i++) {
+    for (int i = 0; i <= (int)(arrSize - 1); i++) {
         accum << arr[i];
-        if (i != (arrSize - 1)) accum << ",";
+        if (i != (int)(arrSize - 1)) accum << ",";
     }
     accum << "|" << scale;
 
@@ -52,11 +52,11 @@ struct FractionalPolynomialFitter : public T {
     std::array<T_fptype, 3> arr;
     T_fptype scale;
 
-    static T* Make(const T_inittype& v, typename const T_inittype::value_type& scale) {
+    static T* Make(const T_inittype& v, const typename T_inittype::value_type& scale) {
         return new FractionalPolynomialFitter(v, scale);
     }
 
-    FractionalPolynomialFitter(const T_inittype& n, typename const T_inittype::value_type& s) : arr(), scale(s) {
+    FractionalPolynomialFitter(const T_inittype& n, const typename T_inittype::value_type& s) : arr(), scale(s) {
         for (size_t i = 0; i < n.size(); i++) arr[i] = n[i];
     }
 
@@ -80,11 +80,11 @@ struct RationalFitter : public T {
     std::array<T_fptype, T_size> arr;
     T_fptype scale;
 
-    static T* Make(const T_inittype& v, const T_inittype& v2, typename const T_inittype::value_type& scale) {
+    static T* Make(const T_inittype& v, const T_inittype& v2, const typename T_inittype::value_type& scale) {
         return new RationalFitter(v, v2, scale);
     }
 
-    RationalFitter(const T_inittype& n, const T_inittype& d, typename const T_inittype::value_type& s) : arr(), scale(s) {
+    RationalFitter(const T_inittype& n, const T_inittype& d, const typename T_inittype::value_type& s) : arr(), scale(s) {
         // Populate numerator coefficients.
         for (size_t i = 0; i < T_num; i++) arr[i] = n[i];
 
@@ -146,7 +146,7 @@ struct RationalFitter : public T {
 
 template <size_t T_maxSize, size_t T_maxDen, typename T, typename T_inittype, size_t T_valueNumber>
 struct RationalFitterGenerator {
-    static void setMaker(std::array<T * (*)(const T_inittype&, const T_inittype&, typename const T_inittype::value_type&), T_maxSize>& p) {
+    static void setMaker(std::array<T * (*)(const T_inittype&, const T_inittype&, const typename T_inittype::value_type&), T_maxSize>& p) {
         static const size_t s_num = (T_valueNumber % T_maxDen) + 1;
         static const size_t s_den = T_valueNumber / T_maxDen;
         p[T_valueNumber] = RationalFitter<s_num + s_den, s_num, T, T_inittype>::Make;
@@ -156,7 +156,7 @@ struct RationalFitterGenerator {
 
 template <size_t T_maxSize, size_t T_maxDen, typename T, typename T_inittype>
 struct RationalFitterGenerator<T_maxSize, T_maxDen, T, T_inittype, T_maxSize> {
-    static void setMaker(std::array<T * (*)(const T_inittype&, const T_inittype&, typename const T_inittype::value_type&), T_maxSize>& p) { p; }
+    static void setMaker(std::array<T * (*)(const T_inittype&, const T_inittype&, const typename T_inittype::value_type&), T_maxSize>& p) { p; }
 };
 
 template <size_t T_maxNum, size_t T_maxDen, typename T, typename T_inittype>
@@ -177,25 +177,25 @@ struct T_PolyFitGenerator {
     //
     // The implicit 1 is there so the linear system to solve for rational polynomial least squares doesnt need to worry about divide by zero.
 
-    std::array<T * (*)(const T_inittype&, const T_inittype&, typename const T_inittype::value_type&), T_maxNum * (T_maxDen + 1)> arr;
+    std::array<T * (*)(const T_inittype&, const T_inittype&, const typename T_inittype::value_type&), T_maxNum * (T_maxDen + 1)> arr;
 
     T_PolyFitGenerator() : arr() {
         RationalFitterGenerator<T_maxNum * (T_maxDen + 1), T_maxDen, T, T_inittype, 0>::setMaker(arr);
     }
 
     // Generate Rational Polynomial Fitter
-    T* GetRationalPolyFit(const T_inittype& n, const T_inittype& d, typename const T_inittype::value_type& scale = 1.) const {
+    T* GetRationalPolyFit(const T_inittype& n, const T_inittype& d, const typename T_inittype::value_type& scale = 1.) const {
         return arr[(n.size() - 1) + (T_maxDen * (d.size()))](n, d, scale);
     }
 
     // Generate Polynomial Fitter
-    T* GetPolyFit(const T_inittype& n, typename const T_inittype::value_type& scale = 1.) const {
+    T* GetPolyFit(const T_inittype& n, const typename T_inittype::value_type& scale = 1.) const {
         static const T_inittype z;
         return arr[n.size() - 1](n, z, scale);
     }
 
     // Generate Fractional Polynomial Fitter (v^X*Y)+Z
-    T* GetFractionalPolyFit(const T_inittype& v, typename const T_inittype::value_type& scale = 1.) const {
+    T* GetFractionalPolyFit(const T_inittype& v, const typename T_inittype::value_type& scale = 1.) const {
         return FractionalPolynomialFitter<T, T_inittype>::Make(v, scale);
     }
 };

--- a/src/Train/PolynomialRegression.cpp
+++ b/src/Train/PolynomialRegression.cpp
@@ -18,8 +18,32 @@
 
 #include <array>
 #include <iostream>
+#include <string>
+#include <sstream>
+
 #include "PolynomialRegression.h"
 #include "MultiRegressionizer.h"
+
+// Utility to emit polynomial as string. This layout is tied to the parsing in
+// realtimecontroller.cpp:void VirtualPowerTrainerManager::GetVirtualPowerTrainerAsString(int idx, QString& s)
+
+template <typename T_String, typename T_fptype>
+void T_AppendVirtualPowerDescriptionString(T_String &s, const char* tla, size_t arrSize, size_t numSize, const T_fptype *arr, T_fptype scale) {
+
+    std::ostringstream accum;
+    accum.precision(12);
+
+    // tla,arrSize,numSize|coefs,...|scale
+
+    accum << tla << ", " << arrSize << "," << numSize << "|";
+    for (int i = 0; i <= (arrSize - 1); i++) {
+        accum << arr[i];
+        if (i != (arrSize - 1)) accum << ",";
+    }
+    accum << "|" << scale;
+
+    s.append(accum.str());
+}
 
 template <typename T, typename T_inittype>
 struct FractionalPolynomialFitter : public T {
@@ -42,6 +66,10 @@ struct FractionalPolynomialFitter : public T {
 
         // v^X * Y + Z
         return (pow(v, arr[0]) * arr[1]) + arr[2];
+    }
+
+    void append(std::string& s) const {
+        T_AppendVirtualPowerDescriptionString(s, "FPR", 3, 0, &(arr[0]), scale);
     }
 };
 
@@ -110,6 +138,10 @@ struct RationalFitter : public T {
 
         return r;
     }
+
+    void append(std::string& s) const {
+        T_AppendVirtualPowerDescriptionString(s, "RPR", T_size, T_num, &(arr[0]), scale);
+    }
 };
 
 template <size_t T_maxSize, size_t T_maxDen, typename T, typename T_inittype, size_t T_valueNumber>
@@ -133,7 +165,7 @@ struct T_PolyFitGenerator {
     // Value number from <numeratorCount, denominatorCount> to a unique combination of the two,
     // for example:
     //
-    // num,den max both 6...
+    // if num,den max both 6...
     //
     // 1,0 = 0
     // 2,0 = 1

--- a/src/Train/PolynomialRegression.h
+++ b/src/Train/PolynomialRegression.h
@@ -25,6 +25,7 @@ template <typename T_fptype>
 struct PolyFit {
     typedef T_fptype value_type;
     virtual value_type Fit(value_type v) const = 0;
+    virtual void append(std::string& s) const = 0;
 };
 
 struct PolyFitGenerator {

--- a/src/Train/PolynomialRegression.h
+++ b/src/Train/PolynomialRegression.h
@@ -24,7 +24,7 @@
 template <typename T_fptype>
 struct PolyFit {
     typedef T_fptype value_type;
-    virtual value_type Fit(value_type v) = 0;
+    virtual value_type Fit(value_type v) const = 0;
 };
 
 struct PolyFitGenerator {

--- a/src/Train/PolynomialRegression.h
+++ b/src/Train/PolynomialRegression.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2020 Eric Christoffersen (impolexg@outlook.com)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef _GC_PolynomialRegression_h
+#define  _GC_PolynomialRegression_h
+
+#include <vector>
+
+template <typename T_fptype>
+struct PolyFit {
+    typedef T_fptype value_type;
+    virtual value_type Fit(value_type v) = 0;
+};
+
+struct PolyFitGenerator {
+    // Following methods return heap allocated objects. delete when finished with them.
+    static PolyFit<double>* GetPolyFit          (const std::vector<double>& coefs, const double& scale = 1.);
+    static PolyFit<double>* GetRationalPolyFit  (const std::vector<double>& numeratorCoefs, const std::vector<double>& denominatorCoefs, const double &scale = 1.);
+    static PolyFit<double>* GetFractionalPolyFit(const std::vector<double>& coefs, const double& scale = 1.);
+};
+#endif

--- a/src/Train/RealtimeController.cpp
+++ b/src/Train/RealtimeController.cpp
@@ -69,402 +69,409 @@ void RealtimeController::processRealtimeData(RealtimeData &rtData)
     }
 }
 
-const VirtualPowerTrainer s_VirtualPowerTrainerArray[] =
-{
-    {
-        "None",
-        PolyFitGenerator::GetPolyFit({ 0, 0, 0, 0 }, MILES_PER_KM),
-        false
-    },
-    {
-        "Power - Kurt Kinetic - Cyclone",
-        // using the algorithm from http://www.kurtkinetic.com/powercurve.php
-        PolyFitGenerator::GetPolyFit({ 0, 6.481090, 0, 0.020106 }, MILES_PER_KM),
-        false
-    },
-    {
-        "Power - Kurt Kinetic - Road Machine",
-        // using the algorithm from http://www.kurtkinetic.com/powercurve.php
-        PolyFitGenerator::GetPolyFit({ 0, 5.244820, 0, 0.019168 }, MILES_PER_KM),
-        false,
-    },
-    {
-        "Power - Cyclops Fluid 2",
-        // using the algorithm from:
-        // http://thebikegeek.blogspot.com/2009/12/while-we-wait-for-better-and-better.html
-        PolyFitGenerator::GetPolyFit({ 0, 8.9788, 0.0137, 0.0115 }, MILES_PER_KM),
-        false,
-    },
-    {
-        "Power - BT-ATS - BT Advanced Training System",
-        // using the algorithm from Steven Sansonetti of BT:
+// Wrap static array in function to ensure it is init on use, which is after PolyFitGenerator
+// who is static init at load time.
+const VirtualPowerTrainer * const PredefinedVirtualPowerTrainerArray(size_t &size) {
 
-        //  This is a 3rd order polynomial, where P = av3 + bv2 + cv + d
-        //  where:
-        //        v is expressed in revs/second
-        PolyFitGenerator::GetPolyFit({ 0.0,5.92125507E-01,-4.61311774E-02,2.90390167E-01 }, 1. / 60.),
-        true // use wheel rpm
-    },
-    {
-        "Power - Lemond Revolution",
-        // Tom Anhalt spent a lot of time working this all out
-        // for the data / analysis see: http://wattagetraining.com/forum/viewtopic.php?f=2&t=335
-        PolyFitGenerator::GetPolyFit({ 0, 4.25, 0, 0.21 }, 15. / 18.),
-        false
-    },
-    {
-        "Power - 1UP USA",
-        // Power curve provided by extraction from SportsTracks plugin
-        PolyFitGenerator::GetPolyFit({ 25, 2.65, 0.42, 0.058 }, MILES_PER_KM),
-        false
-    },
-    // MINOURA - Has many gears
-    {
-        "Power - MINOURA V100 on H",
-        // 7 = V100 on H: y = -0.0036x^3 + 0.2815x^2 + 3.4978x - 9.7857 
-        PolyFitGenerator::GetPolyFit({ -9.7857, 3.4978, 0.2815, -0.0036 }),
-        false
-    },
-    {
-        "Power - MINOURA V100 on 5",
-        // 8 = V100 on 5: y = -0.0023x^3 + 0.2067x^2 + 3.8906x - 11.214
-        PolyFitGenerator::GetPolyFit({ -11.214, 3.8906, 0.2067, -0.0023 }),
-        false
-    },
-    {
-        "Power - MINOURA V100 on 4",
-        // 9 = V100 on 4: y = -0.00173x^3 + 0.1825x^2 + 3.4036x - 10 
-        PolyFitGenerator::GetPolyFit({ -10, 3.4036, 0.1824, -0.00173 }),
-        false
-    },
-    {
-        "Power - MINOURA V100 on 3",
-        // 10 = V100 on 3: y = -0.0011x^3 + 0.1433x^2 + 2.8808x - 8.1429 
-        PolyFitGenerator::GetPolyFit({ -8.1429, 2.8808, 0.1433, -0.0011 }),
-        false,
-    },
-    {
-        "Power - MINOURA V100 on 2",
-        // 11 = V100 on 2: y = -0.0007x^3 + 0.1348x^2 + 1.581x - 3.3571 
-        PolyFitGenerator::GetPolyFit({ -3.3571, 1.581, 0.1348, -0.0007 }),
-        false
-    },
-    {
-        "Power - MINOURA V100 on 1",
-        // 12 = V100 on 1: y = 0.0004x^3 + 0.057x^2 + 1.7797x - 5.0714 
-        PolyFitGenerator::GetPolyFit({ -5.0714, 1.7797, 0.057, 0.0004 }),
-        false
-    },
-    {
-        "Power - MINOURA V100 on L",
-        // 13 = V100 on L: y = 0.0557x^2 + 1.231x - 3.7143 
-        PolyFitGenerator::GetPolyFit({ -3.7143, 1.231, 0.557 }),
-        false
-    },
-    {
-        "Power - MINOURA V270/v130 on H",
-        PolyFitGenerator::GetPolyFit({ -0.628959276017,  0.538329905388 , 0.782320032908 ,-0.0237725215961 ,0.000338955162485 ,-1.84615384615e-06 }),
-        false
-    },
-    {
-        "Power - MINOURA V270/v130 on 5",
-        PolyFitGenerator::GetPolyFit({ -0.472850678733, 1.16395173454 , 0.587825311943 ,-0.0153105032223 ,0.000193281228575 ,-9.35143288085e-07 }),
-        false
-    },
-    {
-        "Power - MINOURA V270/v130 on 4",
-        PolyFitGenerator::GetPolyFit({ -0.364253393665, 1.10649184149, 0.52033045386 ,-0.0117029686, 0.000114219114219 , -3.34841628959e-07 }),
-        false
-    },
-    {
-        "Power - MINOURA V270/v130 on 3",
-        PolyFitGenerator::GetPolyFit({ -0.386877828054 ,1.00085150144 , 0.439146098999, -0.00805837789661 , 3.96681749623e-05, 2.32277526395e-07 }),
-        false
-    },
-    {
-        "Power - MINOURA V270/v130 on 2",
-        PolyFitGenerator::GetPolyFit({ -0.00678733031682, 0.278777594954, 0.434414507062 , -0.0103757370081, 0.000123625394214 , -5.58069381599e-07 }),
-        false
-    },
-    {
-        "Power - MINOURA V270/v130 on 1",
-        PolyFitGenerator::GetPolyFit({ -0.056561085973, 0.704304812834, 0.237884615385 , -0.00251391745509 , -1.7235705471e-05, 3.74057315234e-07 }),
-        false
-    },
-    {
-        "Power - MINOURA V270/v130 on L",
-        PolyFitGenerator::GetPolyFit({ -0.0859728506788, 0.642516796929, 0.122555189908 , -6.92787604552e-05, -3.38406691348e-05, 3.46907993967e-07 }),
-        false
-    },
-    {
-        "Power - SARIS POWERBEAM PRO",
-        // 21 = 0.0008x^3 + 0.145x^2 + 2.5299x + 14.641 where x = speed in kph
-        PolyFitGenerator::GetPolyFit({ 14.641, 2.5299, 0.145, 0.0008 }),
-        false
-    },
-    {
-        "Power - TACX SATORI SETTING 2",
-        PolyFitGenerator::GetPolyFit({ -19.5, 3.9 }),
-        false
-    },
-    {
-        "Power - TACX SATORI SETTING 4",
-        PolyFitGenerator::GetPolyFit({ -52.3, 6.66 }),
-        false,
-    },
-    {
-        "Power - TACX SATORI SETTING 6",
-        PolyFitGenerator::GetPolyFit({ -43.65, 9.43 }),
-        false
-    },
-    {   "Power - TACX SATORI SETTING 8",
-        PolyFitGenerator::GetPolyFit({ -51.15, 13.73 }),
-        false
-    },
-    {
-        "Power - TACX SATORI SETTING 10",
-        PolyFitGenerator::GetPolyFit({ -76.0, 17.7 }),
-        false
-    },
-    {
-        "Power - TACX FLOW SETTING 0",
-        PolyFitGenerator::GetPolyFit({ -47.27, 7.75 }),
-        false
-    },
-    {
-        "Power - TACX FLOW SETTING 2",
-        PolyFitGenerator::GetPolyFit({ -66.69, 9.51 }),
-        false
-    },
-    { "Power - TACX FLOW SETTING 4",
-        PolyFitGenerator::GetPolyFit({ -71.59, 11.03 }),
-        false
-    },
-    {
-        "Power - TACX FLOW SETTING 6",
-        PolyFitGenerator::GetPolyFit({ -95.05, 12.81 }),
-        false
-    },
-    {
-        "Power - TACX FLOW SETTING 8",
-        PolyFitGenerator::GetPolyFit({ -102.43, 14.37 }),
-        false
-    },
-    {
-        "Power - TACX BLUE TWIST SETTING 1",
-        PolyFitGenerator::GetPolyFit({ -24, 3.2 }),
-        false
-    },
-    {
-        "Power - TACX BLUE TWIST SETTING 3",
-        PolyFitGenerator::GetPolyFit({ -46.5, 6.525 }),
-        false
-    },
-    {
-        "Power - TACX BLUE TWIST SETTING 5",
-        PolyFitGenerator::GetPolyFit({ -66.5, 9.775 }),
-        false
-    },
-    {
-        "Power - TACX BLUE TWIST SETTING 7",
-        PolyFitGenerator::GetPolyFit({ -89.5, 13.075 }),
-        false
-    },
-    {
-        "Power - TACX BLUE MOTION SETTING 2",
-        PolyFitGenerator::GetPolyFit({ -36.5, 5.225 }),
-        false
-    },
-    {
-        "Power - TACX BLUE MOTION SETTING 4",
-        PolyFitGenerator::GetPolyFit({ -53.0, 8.25 }),
-        false
-    },
-    {
-        "Power - TACX BLUE MOTION SETTING 6",
-        PolyFitGenerator::GetPolyFit({ -74.0, 11.45 }),
-        false
-    },
-    {
-        "Power - TACX BLUE MOTION SETTING 8",
-        PolyFitGenerator::GetPolyFit({ -89, 14.45 }),
-        false
-    },
-    {
-        "Power - TACX BLUE MOTION SETTING 10",
-        PolyFitGenerator::GetPolyFit({ -110.5, 17.575 }),
-        false
-    },
-    {
-        "Power - ELITE SUPERCRONO POWER MAG LEVEL 1",
-        // Power curve provided by extraction from SportsTracks plugin
-        PolyFitGenerator::GetPolyFit({ -1.16783216783223, 3.62446277061515, 0.17689196198325 , -0.000803192769148186 }, MILES_PER_KM),
-        false
-    },
-    {
-        "Power - ELITE SUPERCRONO POWER MAG LEVEL 2",
-        // Power curve provided by extraction from SportsTracks plugin
-        PolyFitGenerator::GetPolyFit({ -0.363636363636395, 3.54843470904764, 0.442531768374482 ,-0.00590735326986424 }, MILES_PER_KM),
-        false
-    },
-    {
-        "Power - ELITE SUPERCRONO POWER MAG LEVEL 3",
-        // Power curve provided by extraction from SportsTracks plugin
-        PolyFitGenerator::GetPolyFit({ -1.48951048951047, 5.08762781732785, 0.614352424962992 , -0.00917194323478923 }, MILES_PER_KM),
-        false
-    },
-    {
-        "Power - ELITE SUPERCRONO POWER MAG LEVEL 4",
-        // Power curve provided by extraction from SportsTracks plugin
-        PolyFitGenerator::GetPolyFit({ -1.7342657342657, 5.16903286351279, 0.880112976720764 ,-0.0150015681721553 }, MILES_PER_KM),
-        false
-    },
-    {
-        "Power - ELITE SUPERCRONO POWER MAG LEVEL 5",
-        // Power curve provided by extraction from SportsTracks plugin
-        PolyFitGenerator::GetPolyFit({ -3.18881118881126,6.23730215622854,1.0207209560583 ,-0.0172621671756449 }, MILES_PER_KM),
-        false
-    },
-    {
-        "Power - ELITE SUPERCRONO POWER MAG LEVEL 6",
-        // Power curve provided by extraction from SportsTracks plugin
-        PolyFitGenerator::GetPolyFit({ -4.18881118881114, 7.47138264900755, 1.15505017633569, -0.0195227661791347 }, MILES_PER_KM),
-        false
-    },
-    {
-        "Power - ELITE SUPERCRONO POWER MAG LEVEL 7",
-        // Power curve provided by extraction from SportsTracks plugin
-        PolyFitGenerator::GetPolyFit({ -5.11888111888112, 8.74972948026508, 1.2917943039439 , -0.0222497351776137 }, MILES_PER_KM),
-        false
-    },
-    {
-        "Power - ELITE SUPERCRONO POWER MAG LEVEL 8",
-        // Power curve provided by extraction from SportsTracks plugin
-        PolyFitGenerator::GetPolyFit({ -6.48951048951042, 10.2050166192824, 1.42902141301828 ,-0.0255078477814972 }, MILES_PER_KM),
-        false
-    },
-    {
-        "Power - ELITE TURBO MUIN 2013",
-        // Power curve fit from data collected by Ray Maker at dcrainmaker.com
-        PolyFitGenerator::GetPolyFit({ 0, 2.30615942, -0.28395558, 0.02099661 }),
-        false
-    },
-    {
-        "Power - ELITE QUBO POWER FLUID",
-        // Power curve fit from powercurvesensor
-        //     f(x) = 4.31746 * x -2.59259e-002 * x^2 +  9.41799e-003 * x^3
-        PolyFitGenerator::GetPolyFit({ 0, 4.31746, -2.59259e-002 , 9.41799e-003 }),
-        false
-    },
-    {
-        "Power - CYCLOPS MAGNETO PRO (ROAD)",
-        //     Watts = 6.0f + (-0.93 * speed) + (0.275 * speed^2) + (-0.00175 * speed^3)
-        PolyFitGenerator::GetPolyFit({ 0, -0.93, 0.275, -0.00175 }),
-        false
-    },
-    {
-        "Power - ELITE ARION MAG LEVEL 0",
-        PolyFitGenerator::GetFractionalPolyFit({ 3.335794377, 1.217110021, 0. }),
-        false
-    },
-    {
-        "Power - ELITE ARION MAG LEVEL 1",
-        PolyFitGenerator::GetFractionalPolyFit({ 1.206592577, 4.362485081, 0. }),
-        false
-    },
-    {
-        "Power - ELITE ARION MAG LEVEL 2",
-        PolyFitGenerator::GetFractionalPolyFit({ 1.206984321, 6.374459698, 0. }),
-        false
-    },
-    {
-        "Power - Blackburn Tech Fluid",
-        PolyFitGenerator::GetPolyFit({ 6.758241758241894, -1.9995004995004955, 0.24165834165834146 }),
-        false
-    },
-    {
-        "Power - TACX SIRIUS LEVEL 1",
-        PolyFitGenerator::GetPolyFit({ -20.64808196, 3.23874687 }),
-        false
-    },
-    {
-        "Power - TACX SIRIUS LEVEL 2",
-        PolyFitGenerator::GetPolyFit({ -27.25589246, 4.30606133 }),
-        false
-    },
-    {
-        "Power - TACX SIRIUS LEVEL 3",
-        PolyFitGenerator::GetPolyFit({ -36.57159131, 5.44879778 }),
-        false
-    },
-    {
-        "Power - TACX SIRIUS LEVEL 4",
-        PolyFitGenerator::GetPolyFit({ -40.48616615, 6.48525956 }),
-        false
-    },
-    {
-        "Power - TACX SIRIUS LEVEL 5",
-        PolyFitGenerator::GetPolyFit({ -48.35481582, 7.60643338 }),
-        false
-    },
-    {
-        "Power - TACX SIRIUS LEVEL 6",
-        PolyFitGenerator::GetPolyFit({ -58.57819586, 8.73140257 }),
-        false
-    },
-    {
-        "Power - TACX SIRIUS LEVEL 7",
-        PolyFitGenerator::GetPolyFit({ -59.61416463, 9.73079724 }),
-        false
-    },
-    {
-        "Power - TACX SIRIUS LEVEL 8",
-        PolyFitGenerator::GetPolyFit({ -73.08258491, 10.94228338 }),
-        false
-    },
-    {
-        "Power - TACX SIRIUS LEVEL 9",
-        PolyFitGenerator::GetPolyFit({ -77.88781457, 11.99373782 }),
-        false
-    },
-    {
-        "Power - TACX SIRIUS LEVEL 10",
-        PolyFitGenerator::GetPolyFit({ -85.38477516, 13.09580164 }),
-        false
-    },
-    {
-        "Power - ELITE CRONO FLUID ELASTOGEL",
-        PolyFitGenerator::GetPolyFit({ 0, 2.4508084253648112, -0.0005622440886940634 ,0.0031006831781331848 }),
-        false
-    },
-    {
-        "Power - ELITE TURBO MUIN 2015",
-        PolyFitGenerator::GetPolyFit({ 0, 3.01523235942763813175,  -0.12045521113635432750 , 0.01739165560254292102 }),
-        false
-    },
-    {
-        "Power - CycleOps JetFluid Pro",
-        PolyFitGenerator::GetPolyFit({ 0, 0.94874757375670469046 , 0.11615123681031937322 , 0.00400691905019748630 }),
-        false
-    },
-    {
-        "Power - Elite Crono Mag elastogel",
-        PolyFitGenerator::GetPolyFit({ 0, 7.34759700400455518172, -0.00278841177590215417, 0.00052233430180969281 }),
-        false
-    },
-    {
-        "Power - Tacx Magnetic T1820 (4/7)",
-        PolyFitGenerator::GetPolyFit({ 0, 6.77999074563685972005, -0.00148787143661883094, 0.00085058630585658189 }),
-        false
-    },
-    {
-        "Power - Tacx Magnetic T1820 (7/7)",
-        PolyFitGenerator::GetPolyFit({ 0, 9.80556623734881995572, -0.00668894865103764724,  0.00125560535410925628 }),
-        false
-    }
-};
+    static const VirtualPowerTrainer s_PredefinedVirtualPowerTrainerArray[] =
+    {
+        {
+            "None",
+            PolyFitGenerator::GetPolyFit({ 0, 0, 0, 0 }, MILES_PER_KM),
+            false
+        },
+        {
+            "Power - Kurt Kinetic - Cyclone",
+            // using the algorithm from http://www.kurtkinetic.com/powercurve.php
+            PolyFitGenerator::GetPolyFit({ 0, 6.481090, 0, 0.020106 }, MILES_PER_KM),
+            false
+        },
+        {
+            "Power - Kurt Kinetic - Road Machine",
+            // using the algorithm from http://www.kurtkinetic.com/powercurve.php
+            PolyFitGenerator::GetPolyFit({ 0, 5.244820, 0, 0.019168 }, MILES_PER_KM),
+            false,
+        },
+        {
+            "Power - Cyclops Fluid 2",
+            // using the algorithm from:
+            // http://thebikegeek.blogspot.com/2009/12/while-we-wait-for-better-and-better.html
+            PolyFitGenerator::GetPolyFit({ 0, 8.9788, 0.0137, 0.0115 }, MILES_PER_KM),
+            false,
+        },
+        {
+            "Power - BT-ATS - BT Advanced Training System",
+            // using the algorithm from Steven Sansonetti of BT:
 
-const int s_VirtualPowerTrainerArraySize = (int)(sizeof(s_VirtualPowerTrainerArray) / sizeof(s_VirtualPowerTrainerArray[0]));
+            //  This is a 3rd order polynomial, where P = av3 + bv2 + cv + d
+            //  where:
+            //        v is expressed in revs/second
+            PolyFitGenerator::GetPolyFit({ 0.0,5.92125507E-01,-4.61311774E-02,2.90390167E-01 }, 1. / 60.),
+            true // use wheel rpm
+        },
+        {
+            "Power - Lemond Revolution",
+            // Tom Anhalt spent a lot of time working this all out
+            // for the data / analysis see: http://wattagetraining.com/forum/viewtopic.php?f=2&t=335
+            PolyFitGenerator::GetPolyFit({ 0, 4.25, 0, 0.21 }, 15. / 18.),
+            false
+        },
+        {
+            "Power - 1UP USA",
+            // Power curve provided by extraction from SportsTracks plugin
+            PolyFitGenerator::GetPolyFit({ 25, 2.65, 0.42, 0.058 }, MILES_PER_KM),
+            false
+        },
+        // MINOURA - Has many gears
+        {
+            "Power - MINOURA V100 on H",
+            // 7 = V100 on H: y = -0.0036x^3 + 0.2815x^2 + 3.4978x - 9.7857 
+            PolyFitGenerator::GetPolyFit({ -9.7857, 3.4978, 0.2815, -0.0036 }),
+            false
+        },
+        {
+            "Power - MINOURA V100 on 5",
+            // 8 = V100 on 5: y = -0.0023x^3 + 0.2067x^2 + 3.8906x - 11.214
+            PolyFitGenerator::GetPolyFit({ -11.214, 3.8906, 0.2067, -0.0023 }),
+            false
+        },
+        {
+            "Power - MINOURA V100 on 4",
+            // 9 = V100 on 4: y = -0.00173x^3 + 0.1825x^2 + 3.4036x - 10 
+            PolyFitGenerator::GetPolyFit({ -10, 3.4036, 0.1824, -0.00173 }),
+            false
+        },
+        {
+            "Power - MINOURA V100 on 3",
+            // 10 = V100 on 3: y = -0.0011x^3 + 0.1433x^2 + 2.8808x - 8.1429 
+            PolyFitGenerator::GetPolyFit({ -8.1429, 2.8808, 0.1433, -0.0011 }),
+            false,
+        },
+        {
+            "Power - MINOURA V100 on 2",
+            // 11 = V100 on 2: y = -0.0007x^3 + 0.1348x^2 + 1.581x - 3.3571 
+            PolyFitGenerator::GetPolyFit({ -3.3571, 1.581, 0.1348, -0.0007 }),
+            false
+        },
+        {
+            "Power - MINOURA V100 on 1",
+            // 12 = V100 on 1: y = 0.0004x^3 + 0.057x^2 + 1.7797x - 5.0714 
+            PolyFitGenerator::GetPolyFit({ -5.0714, 1.7797, 0.057, 0.0004 }),
+            false
+        },
+        {
+            "Power - MINOURA V100 on L",
+            // 13 = V100 on L: y = 0.0557x^2 + 1.231x - 3.7143 
+            PolyFitGenerator::GetPolyFit({ -3.7143, 1.231, 0.557 }),
+            false
+        },
+        {
+            "Power - MINOURA V270/v130 on H",
+            PolyFitGenerator::GetPolyFit({ -0.628959276017,  0.538329905388 , 0.782320032908 ,-0.0237725215961 ,0.000338955162485 ,-1.84615384615e-06 }),
+            false
+        },
+        {
+            "Power - MINOURA V270/v130 on 5",
+            PolyFitGenerator::GetPolyFit({ -0.472850678733, 1.16395173454 , 0.587825311943 ,-0.0153105032223 ,0.000193281228575 ,-9.35143288085e-07 }),
+            false
+        },
+        {
+            "Power - MINOURA V270/v130 on 4",
+            PolyFitGenerator::GetPolyFit({ -0.364253393665, 1.10649184149, 0.52033045386 ,-0.0117029686, 0.000114219114219 , -3.34841628959e-07 }),
+            false
+        },
+        {
+            "Power - MINOURA V270/v130 on 3",
+            PolyFitGenerator::GetPolyFit({ -0.386877828054 ,1.00085150144 , 0.439146098999, -0.00805837789661 , 3.96681749623e-05, 2.32277526395e-07 }),
+            false
+        },
+        {
+            "Power - MINOURA V270/v130 on 2",
+            PolyFitGenerator::GetPolyFit({ -0.00678733031682, 0.278777594954, 0.434414507062 , -0.0103757370081, 0.000123625394214 , -5.58069381599e-07 }),
+            false
+        },
+        {
+            "Power - MINOURA V270/v130 on 1",
+            PolyFitGenerator::GetPolyFit({ -0.056561085973, 0.704304812834, 0.237884615385 , -0.00251391745509 , -1.7235705471e-05, 3.74057315234e-07 }),
+            false
+        },
+        {
+            "Power - MINOURA V270/v130 on L",
+            PolyFitGenerator::GetPolyFit({ -0.0859728506788, 0.642516796929, 0.122555189908 , -6.92787604552e-05, -3.38406691348e-05, 3.46907993967e-07 }),
+            false
+        },
+        {
+            "Power - SARIS POWERBEAM PRO",
+            // 21 = 0.0008x^3 + 0.145x^2 + 2.5299x + 14.641 where x = speed in kph
+            PolyFitGenerator::GetPolyFit({ 14.641, 2.5299, 0.145, 0.0008 }),
+            false
+        },
+        {
+            "Power - TACX SATORI SETTING 2",
+            PolyFitGenerator::GetPolyFit({ -19.5, 3.9 }),
+            false
+        },
+        {
+            "Power - TACX SATORI SETTING 4",
+            PolyFitGenerator::GetPolyFit({ -52.3, 6.66 }),
+            false,
+        },
+        {
+            "Power - TACX SATORI SETTING 6",
+            PolyFitGenerator::GetPolyFit({ -43.65, 9.43 }),
+            false
+        },
+        {   "Power - TACX SATORI SETTING 8",
+            PolyFitGenerator::GetPolyFit({ -51.15, 13.73 }),
+            false
+        },
+        {
+            "Power - TACX SATORI SETTING 10",
+            PolyFitGenerator::GetPolyFit({ -76.0, 17.7 }),
+            false
+        },
+        {
+            "Power - TACX FLOW SETTING 0",
+            PolyFitGenerator::GetPolyFit({ -47.27, 7.75 }),
+            false
+        },
+        {
+            "Power - TACX FLOW SETTING 2",
+            PolyFitGenerator::GetPolyFit({ -66.69, 9.51 }),
+            false
+        },
+        { "Power - TACX FLOW SETTING 4",
+            PolyFitGenerator::GetPolyFit({ -71.59, 11.03 }),
+            false
+        },
+        {
+            "Power - TACX FLOW SETTING 6",
+            PolyFitGenerator::GetPolyFit({ -95.05, 12.81 }),
+            false
+        },
+        {
+            "Power - TACX FLOW SETTING 8",
+            PolyFitGenerator::GetPolyFit({ -102.43, 14.37 }),
+            false
+        },
+        {
+            "Power - TACX BLUE TWIST SETTING 1",
+            PolyFitGenerator::GetPolyFit({ -24, 3.2 }),
+            false
+        },
+        {
+            "Power - TACX BLUE TWIST SETTING 3",
+            PolyFitGenerator::GetPolyFit({ -46.5, 6.525 }),
+            false
+        },
+        {
+            "Power - TACX BLUE TWIST SETTING 5",
+            PolyFitGenerator::GetPolyFit({ -66.5, 9.775 }),
+            false
+        },
+        {
+            "Power - TACX BLUE TWIST SETTING 7",
+            PolyFitGenerator::GetPolyFit({ -89.5, 13.075 }),
+            false
+        },
+        {
+            "Power - TACX BLUE MOTION SETTING 2",
+            PolyFitGenerator::GetPolyFit({ -36.5, 5.225 }),
+            false
+        },
+        {
+            "Power - TACX BLUE MOTION SETTING 4",
+            PolyFitGenerator::GetPolyFit({ -53.0, 8.25 }),
+            false
+        },
+        {
+            "Power - TACX BLUE MOTION SETTING 6",
+            PolyFitGenerator::GetPolyFit({ -74.0, 11.45 }),
+            false
+        },
+        {
+            "Power - TACX BLUE MOTION SETTING 8",
+            PolyFitGenerator::GetPolyFit({ -89, 14.45 }),
+            false
+        },
+        {
+            "Power - TACX BLUE MOTION SETTING 10",
+            PolyFitGenerator::GetPolyFit({ -110.5, 17.575 }),
+            false
+        },
+        {
+            "Power - ELITE SUPERCRONO POWER MAG LEVEL 1",
+            // Power curve provided by extraction from SportsTracks plugin
+            PolyFitGenerator::GetPolyFit({ -1.16783216783223, 3.62446277061515, 0.17689196198325 , -0.000803192769148186 }, MILES_PER_KM),
+            false
+        },
+        {
+            "Power - ELITE SUPERCRONO POWER MAG LEVEL 2",
+            // Power curve provided by extraction from SportsTracks plugin
+            PolyFitGenerator::GetPolyFit({ -0.363636363636395, 3.54843470904764, 0.442531768374482 ,-0.00590735326986424 }, MILES_PER_KM),
+            false
+        },
+        {
+            "Power - ELITE SUPERCRONO POWER MAG LEVEL 3",
+            // Power curve provided by extraction from SportsTracks plugin
+            PolyFitGenerator::GetPolyFit({ -1.48951048951047, 5.08762781732785, 0.614352424962992 , -0.00917194323478923 }, MILES_PER_KM),
+            false
+        },
+        {
+            "Power - ELITE SUPERCRONO POWER MAG LEVEL 4",
+            // Power curve provided by extraction from SportsTracks plugin
+            PolyFitGenerator::GetPolyFit({ -1.7342657342657, 5.16903286351279, 0.880112976720764 ,-0.0150015681721553 }, MILES_PER_KM),
+            false
+        },
+        {
+            "Power - ELITE SUPERCRONO POWER MAG LEVEL 5",
+            // Power curve provided by extraction from SportsTracks plugin
+            PolyFitGenerator::GetPolyFit({ -3.18881118881126,6.23730215622854,1.0207209560583 ,-0.0172621671756449 }, MILES_PER_KM),
+            false
+        },
+        {
+            "Power - ELITE SUPERCRONO POWER MAG LEVEL 6",
+            // Power curve provided by extraction from SportsTracks plugin
+            PolyFitGenerator::GetPolyFit({ -4.18881118881114, 7.47138264900755, 1.15505017633569, -0.0195227661791347 }, MILES_PER_KM),
+            false
+        },
+        {
+            "Power - ELITE SUPERCRONO POWER MAG LEVEL 7",
+            // Power curve provided by extraction from SportsTracks plugin
+            PolyFitGenerator::GetPolyFit({ -5.11888111888112, 8.74972948026508, 1.2917943039439 , -0.0222497351776137 }, MILES_PER_KM),
+            false
+        },
+        {
+            "Power - ELITE SUPERCRONO POWER MAG LEVEL 8",
+            // Power curve provided by extraction from SportsTracks plugin
+            PolyFitGenerator::GetPolyFit({ -6.48951048951042, 10.2050166192824, 1.42902141301828 ,-0.0255078477814972 }, MILES_PER_KM),
+            false
+        },
+        {
+            "Power - ELITE TURBO MUIN 2013",
+            // Power curve fit from data collected by Ray Maker at dcrainmaker.com
+            PolyFitGenerator::GetPolyFit({ 0, 2.30615942, -0.28395558, 0.02099661 }),
+            false
+        },
+        {
+            "Power - ELITE QUBO POWER FLUID",
+            // Power curve fit from powercurvesensor
+            //     f(x) = 4.31746 * x -2.59259e-002 * x^2 +  9.41799e-003 * x^3
+            PolyFitGenerator::GetPolyFit({ 0, 4.31746, -2.59259e-002 , 9.41799e-003 }),
+            false
+        },
+        {
+            "Power - CYCLOPS MAGNETO PRO (ROAD)",
+            //     Watts = 6.0f + (-0.93 * speed) + (0.275 * speed^2) + (-0.00175 * speed^3)
+            PolyFitGenerator::GetPolyFit({ 0, -0.93, 0.275, -0.00175 }),
+            false
+        },
+        {
+            "Power - ELITE ARION MAG LEVEL 0",
+            PolyFitGenerator::GetFractionalPolyFit({ 3.335794377, 1.217110021, 0. }),
+            false
+        },
+        {
+            "Power - ELITE ARION MAG LEVEL 1",
+            PolyFitGenerator::GetFractionalPolyFit({ 1.206592577, 4.362485081, 0. }),
+            false
+        },
+        {
+            "Power - ELITE ARION MAG LEVEL 2",
+            PolyFitGenerator::GetFractionalPolyFit({ 1.206984321, 6.374459698, 0. }),
+            false
+        },
+        {
+            "Power - Blackburn Tech Fluid",
+            PolyFitGenerator::GetPolyFit({ 6.758241758241894, -1.9995004995004955, 0.24165834165834146 }),
+            false
+        },
+        {
+            "Power - TACX SIRIUS LEVEL 1",
+            PolyFitGenerator::GetPolyFit({ -20.64808196, 3.23874687 }),
+            false
+        },
+        {
+            "Power - TACX SIRIUS LEVEL 2",
+            PolyFitGenerator::GetPolyFit({ -27.25589246, 4.30606133 }),
+            false
+        },
+        {
+            "Power - TACX SIRIUS LEVEL 3",
+            PolyFitGenerator::GetPolyFit({ -36.57159131, 5.44879778 }),
+            false
+        },
+        {
+            "Power - TACX SIRIUS LEVEL 4",
+            PolyFitGenerator::GetPolyFit({ -40.48616615, 6.48525956 }),
+            false
+        },
+        {
+            "Power - TACX SIRIUS LEVEL 5",
+            PolyFitGenerator::GetPolyFit({ -48.35481582, 7.60643338 }),
+            false
+        },
+        {
+            "Power - TACX SIRIUS LEVEL 6",
+            PolyFitGenerator::GetPolyFit({ -58.57819586, 8.73140257 }),
+            false
+        },
+        {
+            "Power - TACX SIRIUS LEVEL 7",
+            PolyFitGenerator::GetPolyFit({ -59.61416463, 9.73079724 }),
+            false
+        },
+        {
+            "Power - TACX SIRIUS LEVEL 8",
+            PolyFitGenerator::GetPolyFit({ -73.08258491, 10.94228338 }),
+            false
+        },
+        {
+            "Power - TACX SIRIUS LEVEL 9",
+            PolyFitGenerator::GetPolyFit({ -77.88781457, 11.99373782 }),
+            false
+        },
+        {
+            "Power - TACX SIRIUS LEVEL 10",
+            PolyFitGenerator::GetPolyFit({ -85.38477516, 13.09580164 }),
+            false
+        },
+        {
+            "Power - ELITE CRONO FLUID ELASTOGEL",
+            PolyFitGenerator::GetPolyFit({ 0, 2.4508084253648112, -0.0005622440886940634 ,0.0031006831781331848 }),
+            false
+        },
+        {
+            "Power - ELITE TURBO MUIN 2015",
+            PolyFitGenerator::GetPolyFit({ 0, 3.01523235942763813175,  -0.12045521113635432750 , 0.01739165560254292102 }),
+            false
+        },
+        {
+            "Power - CycleOps JetFluid Pro",
+            PolyFitGenerator::GetPolyFit({ 0, 0.94874757375670469046 , 0.11615123681031937322 , 0.00400691905019748630 }),
+            false
+        },
+        {
+            "Power - Elite Crono Mag elastogel",
+            PolyFitGenerator::GetPolyFit({ 0, 7.34759700400455518172, -0.00278841177590215417, 0.00052233430180969281 }),
+            false
+        },
+        {
+            "Power - Tacx Magnetic T1820 (4/7)",
+            PolyFitGenerator::GetPolyFit({ 0, 6.77999074563685972005, -0.00148787143661883094, 0.00085058630585658189 }),
+            false
+        },
+        {
+            "Power - Tacx Magnetic T1820 (7/7)",
+            PolyFitGenerator::GetPolyFit({ 0, 9.80556623734881995572, -0.00668894865103764724,  0.00125560535410925628 }),
+            false
+        }
+    };
+
+    size = (int)(sizeof(s_PredefinedVirtualPowerTrainerArray) / sizeof(s_PredefinedVirtualPowerTrainerArray[0]));
+
+    return s_PredefinedVirtualPowerTrainerArray;
+}
 
 // Virtual Power Trainer Manager
 
@@ -625,14 +632,18 @@ VirtualPowerTrainerManager::~VirtualPowerTrainerManager() {
 }
 
 int RealtimeController::GetPredefinedVirtualPowerTrainerCount() {
-    return s_VirtualPowerTrainerArraySize;
+    size_t size;
+    PredefinedVirtualPowerTrainerArray(size);
+    return (int)size;
 }
 
 const VirtualPowerTrainer* RealtimeController::GetPredefinedVirtualPowerTrainer(int id) {
-    if (id < 0 || id >= GetPredefinedVirtualPowerTrainerCount()) 
+    size_t size;
+    const VirtualPowerTrainer * const p = PredefinedVirtualPowerTrainerArray(size);
+    if (id < 0 || id >= size)
         return NULL;
 
-    return &s_VirtualPowerTrainerArray[id];
+    return &(p[id]);
 }
 
 void

--- a/src/Train/RealtimeController.cpp
+++ b/src/Train/RealtimeController.cpp
@@ -64,443 +64,478 @@ void RealtimeController::processRealtimeData(RealtimeData &rtData)
     }
 }
 
-void RealtimeController::SetupPolyFitFromPostprocessId(int postProcess)
+const VirtualPowerTrainer s_VirtualPowerTrainerArray[] =
 {
-    if (iFitId == postProcess) return;
+    {
+        "None",
+        PolyFitGenerator::GetPolyFit({ 0, 0, 0, 0 }, MILES_PER_KM),
+        false
+    },
+    {
+        "Power - Kurt Kinetic - Cyclone",
+        // using the algorithm from http://www.kurtkinetic.com/powercurve.php
+        PolyFitGenerator::GetPolyFit({ 0, 6.481090, 0, 0.020106 }, MILES_PER_KM),
+        false
+    },
+    {
+        "Power - Kurt Kinetic - Road Machine",
+        // using the algorithm from http://www.kurtkinetic.com/powercurve.php
+        PolyFitGenerator::GetPolyFit({ 0, 5.244820, 0, 0.019168 }, MILES_PER_KM),
+        false,
+    },
+    {
+        "Power - Cyclops Fluid 2",
+        // using the algorithm from:
+        // http://thebikegeek.blogspot.com/2009/12/while-we-wait-for-better-and-better.html
+        PolyFitGenerator::GetPolyFit({ 0, 8.9788, 0.0137, 0.0115 }, MILES_PER_KM),
+        false,
+    },
+    {
+        "Power - BT-ATS - BT Advanced Training System",
+        // using the algorithm from Steven Sansonetti of BT:
 
+        //  This is a 3rd order polynomial, where P = av3 + bv2 + cv + d
+        //  where:
+        //        v is expressed in revs/second
+        PolyFitGenerator::GetPolyFit({ 0.0,5.92125507E-01,-4.61311774E-02,2.90390167E-01 }, 1. / 60.),
+        true // use wheel rpm
+    },
+    {
+        "Power - Lemond Revolution",
+        // Tom Anhalt spent a lot of time working this all out
+        // for the data / analysis see: http://wattagetraining.com/forum/viewtopic.php?f=2&t=335
+        PolyFitGenerator::GetPolyFit({ 0, 4.25, 0, 0.21 }, 15. / 18.),
+        false
+    },
+    {
+        "Power - 1UP USA",
+        // Power curve provided by extraction from SportsTracks plugin
+        PolyFitGenerator::GetPolyFit({ 25, 2.65, 0.42, 0.058 }, MILES_PER_KM),
+        false
+    },
+    // MINOURA - Has many gears
+    {
+        "Power - MINOURA V100 on H",
+        // 7 = V100 on H: y = -0.0036x^3 + 0.2815x^2 + 3.4978x - 9.7857 
+        PolyFitGenerator::GetPolyFit({ -9.7857, 3.4978, 0.2815, -0.0036 }),
+        false
+    },
+    {
+        "Power - MINOURA V100 on 5",
+        // 8 = V100 on 5: y = -0.0023x^3 + 0.2067x^2 + 3.8906x - 11.214
+        PolyFitGenerator::GetPolyFit({ -11.214, 3.8906, 0.2067, -0.0023 }),
+        false
+    },
+    {
+        "Power - MINOURA V100 on 4",
+        // 9 = V100 on 4: y = -0.00173x^3 + 0.1825x^2 + 3.4036x - 10 
+        PolyFitGenerator::GetPolyFit({ -10, 3.4036, 0.1824, -0.00173 }),
+        false
+    },
+    {
+        "Power - MINOURA V100 on 3",
+        // 10 = V100 on 3: y = -0.0011x^3 + 0.1433x^2 + 2.8808x - 8.1429 
+        PolyFitGenerator::GetPolyFit({ -8.1429, 2.8808, 0.1433, -0.0011 }),
+        false,
+    },
+    {
+        "Power - MINOURA V100 on 2",
+        // 11 = V100 on 2: y = -0.0007x^3 + 0.1348x^2 + 1.581x - 3.3571 
+        PolyFitGenerator::GetPolyFit({ -3.3571, 1.581, 0.1348, -0.0007 }),
+        false
+    },
+    {
+        "Power - MINOURA V100 on 1",
+        // 12 = V100 on 1: y = 0.0004x^3 + 0.057x^2 + 1.7797x - 5.0714 
+        PolyFitGenerator::GetPolyFit({ -5.0714, 1.7797, 0.057, 0.0004 }),
+        false
+    },
+    {
+        "Power - MINOURA V100 on L",
+        // 13 = V100 on L: y = 0.0557x^2 + 1.231x - 3.7143 
+        PolyFitGenerator::GetPolyFit({ -3.7143, 1.231, 0.557 }),
+        false
+    },
+    {
+        "Power - MINOURA V270/v130 on H",
+        PolyFitGenerator::GetPolyFit({ -0.628959276017,  0.538329905388 , 0.782320032908 ,-0.0237725215961 ,0.000338955162485 ,-1.84615384615e-06 }),
+        false
+    },
+    {
+        "Power - MINOURA V270/v130 on 5",
+        PolyFitGenerator::GetPolyFit({ -0.472850678733, 1.16395173454 , 0.587825311943 ,-0.0153105032223 ,0.000193281228575 ,-9.35143288085e-07 }),
+        false
+    },
+    {
+        "Power - MINOURA V270/v130 on 4",
+        PolyFitGenerator::GetPolyFit({ -0.364253393665, 1.10649184149, 0.52033045386 ,-0.0117029686, 0.000114219114219 , -3.34841628959e-07 }),
+        false
+    },
+    {
+        "Power - MINOURA V270/v130 on 3",
+        PolyFitGenerator::GetPolyFit({ -0.386877828054 ,1.00085150144 , 0.439146098999, -0.00805837789661 , 3.96681749623e-05, 2.32277526395e-07 }),
+        false
+    },
+    {
+        "Power - MINOURA V270/v130 on 2",
+        PolyFitGenerator::GetPolyFit({ -0.00678733031682, 0.278777594954, 0.434414507062 , -0.0103757370081, 0.000123625394214 , -5.58069381599e-07 }),
+        false
+    },
+    {
+        "Power - MINOURA V270/v130 on 1",
+        PolyFitGenerator::GetPolyFit({ -0.056561085973, 0.704304812834, 0.237884615385 , -0.00251391745509 , -1.7235705471e-05, 3.74057315234e-07 }),
+        false
+    },
+    {
+        "Power - MINOURA V270/v130 on L",
+        PolyFitGenerator::GetPolyFit({ -0.0859728506788, 0.642516796929, 0.122555189908 , -6.92787604552e-05, -3.38406691348e-05, 3.46907993967e-07 }),
+        false
+    },
+    {
+        "Power - SARIS POWERBEAM PRO",
+        // 21 = 0.0008x^3 + 0.145x^2 + 2.5299x + 14.641 where x = speed in kph
+        PolyFitGenerator::GetPolyFit({ 14.641, 2.5299, 0.145, 0.0008 }),
+        false
+    },
+    {
+        "Power - TACX SATORI SETTING 2",
+        PolyFitGenerator::GetPolyFit({ -19.5, 3.9 }),
+        false
+    },
+    {
+        "Power - TACX SATORI SETTING 4",
+        PolyFitGenerator::GetPolyFit({ -52.3, 6.66 }),
+        false,
+    },
+    {
+        "Power - TACX SATORI SETTING 6",
+        PolyFitGenerator::GetPolyFit({ -43.65, 9.43 }),
+        false
+    },
+    {   "Power - TACX SATORI SETTING 8",
+        PolyFitGenerator::GetPolyFit({ -51.15, 13.73 }),
+        false
+    },
+    {
+        "Power - TACX SATORI SETTING 10",
+        PolyFitGenerator::GetPolyFit({ -76.0, 17.7 }),
+        false
+    },
+    {
+        "Power - TACX FLOW SETTING 0",
+        PolyFitGenerator::GetPolyFit({ -47.27, 7.75 }),
+        false
+    },
+    {
+        "Power - TACX FLOW SETTING 2",
+        PolyFitGenerator::GetPolyFit({ -66.69, 9.51 }),
+        false
+    },
+    { "Power - TACX FLOW SETTING 4",
+        PolyFitGenerator::GetPolyFit({ -71.59, 11.03 }),
+        false
+    },
+    {
+        "Power - TACX FLOW SETTING 6",
+        PolyFitGenerator::GetPolyFit({ -95.05, 12.81 }),
+        false
+    },
+    {
+        "Power - TACX FLOW SETTING 8",
+        PolyFitGenerator::GetPolyFit({ -102.43, 14.37 }),
+        false
+    },
+    {
+        "Power - TACX BLUE TWIST SETTING 1",
+        PolyFitGenerator::GetPolyFit({ -24, 3.2 }),
+        false
+    },
+    {
+        "Power - TACX BLUE TWIST SETTING 3",
+        PolyFitGenerator::GetPolyFit({ -46.5, 6.525 }),
+        false
+    },
+    {
+        "Power - TACX BLUE TWIST SETTING 5",
+        PolyFitGenerator::GetPolyFit({ -66.5, 9.775 }),
+        false
+    },
+    {
+        "Power - TACX BLUE TWIST SETTING 7",
+        PolyFitGenerator::GetPolyFit({ -89.5, 13.075 }),
+        false
+    },
+    {
+        "Power - TACX BLUE MOTION SETTING 2",
+        PolyFitGenerator::GetPolyFit({ -36.5, 5.225 }),
+        false
+    },
+    {
+        "Power - TACX BLUE MOTION SETTING 4",
+        PolyFitGenerator::GetPolyFit({ -53.0, 8.25 }),
+        false
+    },
+    {
+        "Power - TACX BLUE MOTION SETTING 6",
+        PolyFitGenerator::GetPolyFit({ -74.0, 11.45 }),
+        false
+    },
+    {
+        "Power - TACX BLUE MOTION SETTING 8",
+        PolyFitGenerator::GetPolyFit({ -89, 14.45 }),
+        false
+    },
+    {
+        "Power - TACX BLUE MOTION SETTING 10",
+        PolyFitGenerator::GetPolyFit({ -110.5, 17.575 }),
+        false
+    },
+    {
+        "Power - ELITE SUPERCRONO POWER MAG LEVEL 1",
+        // Power curve provided by extraction from SportsTracks plugin
+        PolyFitGenerator::GetPolyFit({ -1.16783216783223, 3.62446277061515, 0.17689196198325 , -0.000803192769148186 }, MILES_PER_KM),
+        false
+    },
+    {
+        "Power - ELITE SUPERCRONO POWER MAG LEVEL 2",
+        // Power curve provided by extraction from SportsTracks plugin
+        PolyFitGenerator::GetPolyFit({ -0.363636363636395, 3.54843470904764, 0.442531768374482 ,-0.00590735326986424 }, MILES_PER_KM),
+        false
+    },
+    {
+        "Power - ELITE SUPERCRONO POWER MAG LEVEL 3",
+        // Power curve provided by extraction from SportsTracks plugin
+        PolyFitGenerator::GetPolyFit({ -1.48951048951047, 5.08762781732785, 0.614352424962992 , -0.00917194323478923 }, MILES_PER_KM),
+        false
+    },
+    {
+        "Power - ELITE SUPERCRONO POWER MAG LEVEL 4",
+        // Power curve provided by extraction from SportsTracks plugin
+        PolyFitGenerator::GetPolyFit({ -1.7342657342657, 5.16903286351279, 0.880112976720764 ,-0.0150015681721553 }, MILES_PER_KM),
+        false
+    },
+    {
+        "Power - ELITE SUPERCRONO POWER MAG LEVEL 5",
+        // Power curve provided by extraction from SportsTracks plugin
+        PolyFitGenerator::GetPolyFit({ -3.18881118881126,6.23730215622854,1.0207209560583 ,-0.0172621671756449 }, MILES_PER_KM),
+        false
+    },
+    {
+        "Power - ELITE SUPERCRONO POWER MAG LEVEL 6",
+        // Power curve provided by extraction from SportsTracks plugin
+        PolyFitGenerator::GetPolyFit({ -4.18881118881114, 7.47138264900755, 1.15505017633569, -0.0195227661791347 }, MILES_PER_KM),
+        false
+    },
+    {
+        "Power - ELITE SUPERCRONO POWER MAG LEVEL 7",
+        // Power curve provided by extraction from SportsTracks plugin
+        PolyFitGenerator::GetPolyFit({ -5.11888111888112, 8.74972948026508, 1.2917943039439 , -0.0222497351776137 }, MILES_PER_KM),
+        false
+    },
+    {
+        "Power - ELITE SUPERCRONO POWER MAG LEVEL 8",
+        // Power curve provided by extraction from SportsTracks plugin
+        PolyFitGenerator::GetPolyFit({ -6.48951048951042, 10.2050166192824, 1.42902141301828 ,-0.0255078477814972 }, MILES_PER_KM),
+        false
+    },
+    {
+        "Power - ELITE TURBO MUIN 2013",
+        // Power curve fit from data collected by Ray Maker at dcrainmaker.com
+        PolyFitGenerator::GetPolyFit({ 0, 2.30615942, -0.28395558, 0.02099661 }),
+        false
+    },
+    {
+        "Power - ELITE QUBO POWER FLUID",
+        // Power curve fit from powercurvesensor
+        //     f(x) = 4.31746 * x -2.59259e-002 * x^2 +  9.41799e-003 * x^3
+        PolyFitGenerator::GetPolyFit({ 0, 4.31746, -2.59259e-002 , 9.41799e-003 }),
+        false
+    },
+    {
+        "Power - CYCLOPS MAGNETO PRO (ROAD)",
+        //     Watts = 6.0f + (-0.93 * speed) + (0.275 * speed^2) + (-0.00175 * speed^3)
+        PolyFitGenerator::GetPolyFit({ 0, -0.93, 0.275, -0.00175 }),
+        false
+    },
+    {
+        "Power - ELITE ARION MAG LEVEL 0",
+        PolyFitGenerator::GetFractionalPolyFit({ 3.335794377, 1.217110021, 0. }),
+        false
+    },
+    {
+        "Power - ELITE ARION MAG LEVEL 1",
+        PolyFitGenerator::GetFractionalPolyFit({ 1.206592577, 4.362485081, 0. }),
+        false
+    },
+    {
+        "Power - ELITE ARION MAG LEVEL 2",
+        PolyFitGenerator::GetFractionalPolyFit({ 1.206984321, 6.374459698, 0. }),
+        false
+    },
+    {
+        "Power - Blackburn Tech Fluid",
+        PolyFitGenerator::GetPolyFit({ 6.758241758241894, -1.9995004995004955, 0.24165834165834146 }),
+        false
+    },
+    {
+        "Power - TACX SIRIUS LEVEL 1",
+        PolyFitGenerator::GetPolyFit({ -20.64808196, 3.23874687 }),
+        false
+    },
+    {
+        "Power - TACX SIRIUS LEVEL 2",
+        PolyFitGenerator::GetPolyFit({ -27.25589246, 4.30606133 }),
+        false
+    },
+    {
+        "Power - TACX SIRIUS LEVEL 3",
+        PolyFitGenerator::GetPolyFit({ -36.57159131, 5.44879778 }),
+        false
+    },
+    {
+        "Power - TACX SIRIUS LEVEL 4",
+        PolyFitGenerator::GetPolyFit({ -40.48616615, 6.48525956 }),
+        false
+    },
+    {
+        "Power - TACX SIRIUS LEVEL 5",
+        PolyFitGenerator::GetPolyFit({ -48.35481582, 7.60643338 }),
+        false
+    },
+    {
+        "Power - TACX SIRIUS LEVEL 6",
+        PolyFitGenerator::GetPolyFit({ -58.57819586, 8.73140257 }),
+        false
+    },
+    {
+        "Power - TACX SIRIUS LEVEL 7",
+        PolyFitGenerator::GetPolyFit({ -59.61416463, 9.73079724 }),
+        false
+    },
+    {
+        "Power - TACX SIRIUS LEVEL 8",
+        PolyFitGenerator::GetPolyFit({ -73.08258491, 10.94228338 }),
+        false
+    },
+    {
+        "Power - TACX SIRIUS LEVEL 9",
+        PolyFitGenerator::GetPolyFit({ -77.88781457, 11.99373782 }),
+        false
+    },
+    {
+        "Power - TACX SIRIUS LEVEL 10",
+        PolyFitGenerator::GetPolyFit({ -85.38477516, 13.09580164 }),
+        false
+    },
+    {
+        "Power - ELITE CRONO FLUID ELASTOGEL",
+        PolyFitGenerator::GetPolyFit({ 0, 2.4508084253648112, -0.0005622440886940634 ,0.0031006831781331848 }),
+        false
+    },
+    {
+        "Power - ELITE TURBO MUIN 2015",
+        PolyFitGenerator::GetPolyFit({ 0, 3.01523235942763813175,  -0.12045521113635432750 , 0.01739165560254292102 }),
+        false
+    },
+    {
+        "Power - CycleOps JetFluid Pro",
+        PolyFitGenerator::GetPolyFit({ 0, 0.94874757375670469046 , 0.11615123681031937322 , 0.00400691905019748630 }),
+        false
+    },
+    {
+        "Power - Elite Crono Mag elastogel",
+        PolyFitGenerator::GetPolyFit({ 0, 7.34759700400455518172, -0.00278841177590215417, 0.00052233430180969281 }),
+        false
+    },
+    {
+        "Power - Tacx Magnetic T1820 (4/7)",
+        PolyFitGenerator::GetPolyFit({ 0, 6.77999074563685972005, -0.00148787143661883094, 0.00085058630585658189 }),
+        false
+    },
+    {
+        "Power - Tacx Magnetic T1820 (7/7)",
+        PolyFitGenerator::GetPolyFit({ 0, 9.80556623734881995572, -0.00668894865103764724,  0.00125560535410925628 }),
+        false
+    }
+};
+
+const size_t s_VirtualPowerTrainerArraySize = sizeof(s_VirtualPowerTrainerArray) / sizeof(s_VirtualPowerTrainerArray[0]);
+
+// Virtual Power Trainer Manager
+
+size_t VirtualPowerTrainerManager::GetPredefinedVirtualPowerTrainerCount() const {
+    return RealtimeController::GetPredefinedVirtualPowerTrainerCount();
+}
+
+size_t VirtualPowerTrainerManager::GetCustomVirtualPowerTrainerCount() const {
+    return customVirtualPowerTrainers.size();
+}
+
+const VirtualPowerTrainer* VirtualPowerTrainerManager::GetCustomVirtualPowerTrainer(int id) const {
+    if (id < 0 || id > GetCustomVirtualPowerTrainerCount())
+        return NULL;
+
+    return customVirtualPowerTrainers[id];
+}
+
+size_t VirtualPowerTrainerManager::GetVirtualPowerTrainerCount() const {
+    return
+        GetPredefinedVirtualPowerTrainerCount() +
+        GetCustomVirtualPowerTrainerCount();
+}
+
+const VirtualPowerTrainer* VirtualPowerTrainerManager::GetVirtualPowerTrainer(int id) const {
+    if (id < 0 || id > GetVirtualPowerTrainerCount())
+        return NULL;
+
+    int predefinedCount = (int)RealtimeController::GetPredefinedVirtualPowerTrainerCount();
+    if (id < predefinedCount)
+        return RealtimeController::GetPredefinedVirtualPowerTrainer(id);
+
+    return GetCustomVirtualPowerTrainer(id - predefinedCount);
+}
+
+size_t VirtualPowerTrainerManager::PushCustomVirtualPowerTrainer(const VirtualPowerTrainer* vpt) {
+    customVirtualPowerTrainers.push_back(vpt);
+    return customVirtualPowerTrainers.size();
+}
+
+VirtualPowerTrainerManager::~VirtualPowerTrainerManager() {
+    for (auto& i : customVirtualPowerTrainers) {
+        delete i->m_pName; // custom trainer name string is allocated on create but owned and freed by manager.
+        delete i;
+    }
+    customVirtualPowerTrainers.clear();
+}
+
+size_t RealtimeController::GetPredefinedVirtualPowerTrainerCount() {
+    return s_VirtualPowerTrainerArraySize;
+}
+
+const VirtualPowerTrainer* RealtimeController::GetPredefinedVirtualPowerTrainer(int id) {
+    if (id < 0 || id >= GetPredefinedVirtualPowerTrainerCount()) {
+        return NULL;
+    }
+
+    return &s_VirtualPowerTrainerArray[id];
+}
+
+bool RealtimeController::SetupPolyFitFromPostprocessId(int postProcess)
+{
     // Clear and reconstruct new fit state.
-    delete polyFit;
-
     polyFit = NULL;
     iFitId = 0;
     fUseWheelRpm = false;
 
-    PolyFit<double>* pf = NULL;
+    if (postProcess < 0 || postProcess >= virtualPowerTrainerManager.GetVirtualPowerTrainerCount()) return false;
 
-    // setup the algorithm or lookup tables
-    // for the device postprocessing type
-    switch (postProcess) {
-    case 0: // nothing!
-        break;
-    case 1: // Kurt Kinetic - Cyclone
-            // using the algorithm from http://www.kurtkinetic.com/powercurve.php
-        pf = PolyFitGenerator::GetPolyFit({ 0, 6.481090, 0, 0.020106 }, MILES_PER_KM);
-        //double mph = rtData.getSpeed() * MILES_PER_KM;
-        //rtData.setWatts((6.481090) * mph + (0.020106) * (mph*mph*mph));
-        break;
-    case 2: // Kurt Kinetic - Road Machine
-            // using the algorithm from http://www.kurtkinetic.com/powercurve.php
-        pf = PolyFitGenerator::GetPolyFit({ 0, 5.244820, 0, 0.019168 }, MILES_PER_KM);
-        //double mph = rtData.getSpeed() * MILES_PER_KM;
-        //rtData.setWatts((5.244820) * mph + (0.019168) * (mph*mph*mph));
-        break;
-    case 3: // Cyclops Fluid 2
-            // using the algorithm from:
-            // http://thebikegeek.blogspot.com/2009/12/while-we-wait-for-better-and-better.html
-        pf = PolyFitGenerator::GetPolyFit({ 0, 8.9788, 0.0137, 0.0115 }, MILES_PER_KM);
-        //double mph = rtData.getSpeed() * MILES_PER_KM;
-        //rtData.setWatts((0.0115*(mph*mph*mph)) - ((0.0137)*(mph*mph)) + ((8.9788)*(mph)));
-        break;
-    case 4: // BT-ATS - BT Advanced Training System
-            // using the algorithm from Steven Sansonetti of BT:
-        {
-            //  This is a 3rd order polynomial, where P = av3 + bv2 + cv + d
-            //  where:
-            //        v is expressed in revs/second
-            fUseWheelRpm = true;
-            pf = PolyFitGenerator::GetPolyFit({ 0.0,5.92125507E-01,-4.61311774E-02,2.90390167E-01 }, 1. / 60.);
-            //double a = 2.90390167E-01;  // ( 0.290390167)
-            //double b = -4.61311774E-02; // ( -0.0461311774)
-            //double c = 5.92125507E-01;  // (0.592125507)
-            //double d = 0.0;
-            //double v = rtData.getWheelRpm() / 60.0;
-            //rtData.setWatts(a*v*v*v + b*v*v +c*v + d);
-        }
-        break;
-    case 5: // Lemond Revolution
-            // Tom Anhalt spent a lot of time working this all out
-            // for the data / analysis see: http://wattagetraining.com/forum/viewtopic.php?f=2&t=335
-        pf = PolyFitGenerator::GetPolyFit({ 0, 4.25, 0, 0.21 }, 15. / 18.);
-        //double V = rtData.getSpeed() * 0.277777778;
-        //rtData.setWatts((0.21*pow(V,3))+(4.25*V));
-        break;
-    case 6: // 1UP USA
-            // Power curve provided by extraction from SportsTracks plugin
-        pf = PolyFitGenerator::GetPolyFit({ 25, 2.65, 0.42, 0.058 }, MILES_PER_KM);
-        //double V = rtData.getSpeed() * MILES_PER_KM;
-        //rtData.setWatts(25.00 + (2.65f*V) - (0.42f*pow(V,2)) + (0.058f*pow(V,3)));
-        break;
-        // MINOURA - Has many gears
-    case 7: //MINOURA V100 on H
-            // 7 = V100 on H: y = -0.0036x^3 + 0.2815x^2 + 3.4978x - 9.7857 
-        pf = PolyFitGenerator::GetPolyFit({ -9.7857, 3.4978, 0.2815, -0.0036 });
-        //rtData.setWatts(-0.0036*pow(V, 3) + 0.2815*pow(V,2) + (3.4978*V) - 9.7857);
-        break;
-    case 8: //MINOURA V100 on 5
-            // 8 = V100 on 5: y = -0.0023x^3 + 0.2067x^2 + 3.8906x - 11.214
-        pf = PolyFitGenerator::GetPolyFit({ -11.214, 3.8906, 0.2067, -0.0023 });
-        //rtData.setWatts(-0.0023*pow(V, 3) + 0.2067*pow(V,2) + (3.8906*V) - 11.214);
-        break;
-    case 9: //MINOURA V100 on 4
-            // 9 = V100 on 4: y = -0.00173x^3 + 0.1825x^2 + 3.4036x - 10 
-        pf = PolyFitGenerator::GetPolyFit({ -10, 3.4036, 0.1824, -0.00173 });
-        //rtData.setWatts(-0.00173*pow(V, 3) + 0.1825*pow(V,2) + (3.4036*V) - 10.00);
-        break;
-    case 10: //MINOURA V100 on 3
-            // 10 = V100 on 3: y = -0.0011x^3 + 0.1433x^2 + 2.8808x - 8.1429 
-        pf = PolyFitGenerator::GetPolyFit({ -8.1429, 2.8808, 0.1433, -0.0011 });
-        //rtData.setWatts(-0.0011*pow(V, 3) + 0.1433*pow(V,2) + (2.8808*V) - 8.1429);
-        break;
-    case 11: //MINOURA V100 on 2
-            // 11 = V100 on 2: y = -0.0007x^3 + 0.1348x^2 + 1.581x - 3.3571 
-        pf = PolyFitGenerator::GetPolyFit({ -3.3571, 1.581, 0.1348, -0.0007 });
-        //rtData.setWatts(-0.0007*pow(V, 3) + 0.1348*pow(V,2) + (1.581*V) - 3.3571);
-        break;
-    case 12: //MINOURA V100 on 1
-            // 12 = V100 on 1: y = 0.0004x^3 + 0.057x^2 + 1.7797x - 5.0714 
-        pf = PolyFitGenerator::GetPolyFit({ -5.0714, 1.7797, 0.057, 0.0004 });
-        //rtData.setWatts(0.0004*pow(V, 3) + 0.057*pow(V,2) + (1.7797*V) - 5.0714);
-        break;
-    case 13: //MINOURA V100 on L
-            // 13 = V100 on L: y = 0.0557x^2 + 1.231x - 3.7143 
-        pf = PolyFitGenerator::GetPolyFit({ -3.7143, 1.231, 0.557 });
-        //rtData.setWatts(0.0557*pow(V, 2) + (1.231*V) - 3.7143);
-        break;
-    case 14: //MINOURA V270/v130 on H
-        pf = PolyFitGenerator::GetPolyFit({ -0.628959276017,  0.538329905388 , 0.782320032908 ,-0.0237725215961 ,0.000338955162485 ,-1.84615384615e-06 });
-        //rtData.setWatts(-1.84615384615e-06*pow(V, 5) + 0.000338955162485*pow(V, 4) + -0.0237725215961*pow(V, 3) + 0.782320032908*pow(V, 2) + 0.538329905388*V + -0.628959276017);
-        break;
-    case 15: //MINOURA V270/v130 on 5
-        pf = PolyFitGenerator::GetPolyFit({ -0.472850678733, 1.16395173454 , 0.587825311943 ,-0.0153105032223 ,0.000193281228575 ,-9.35143288085e-07 });
-        //rtData.setWatts(-9.35143288085e-07*pow(V, 5) + 0.000193281228575*pow(V, 4) + -0.0153105032223*pow(V, 3) + 0.587825311943*pow(V, 2) + 1.16395173454*V + -0.472850678733);
-        break;
-    case 16: //MINOURA V270/v130 on 4
-        pf = PolyFitGenerator::GetPolyFit({ -0.364253393665, 1.10649184149, 0.52033045386 ,-0.0117029686, 0.000114219114219 , -3.34841628959e-07 });
-        //rtData.setWatts(-3.34841628959e-07*pow(V, 5) + 0.000114219114219*pow(V, 4) + -0.0117029686*pow(V, 3) + 0.52033045386*pow(V, 2) + 1.10649184149*V + -0.364253393665);
-        break;
-    case 17: //MINOURA V270/v130 on 3
-        pf = PolyFitGenerator::GetPolyFit({ -0.386877828054 ,1.00085150144 , 0.439146098999, -0.00805837789661 , 3.96681749623e-05, 2.32277526395e-07 });
-        //rtData.setWatts(2.32277526395e-07*pow(V, 5) + 3.96681749623e-05*pow(V, 4) + -0.00805837789661*pow(V, 3) + 0.439146098999*pow(V, 2) + 1.00085150144*V + -0.386877828054);
-        break;
-    case 18: //MINOURA V270/v130 on 2
-        pf = PolyFitGenerator::GetPolyFit({ -0.00678733031682, 0.278777594954, 0.434414507062 , -0.0103757370081, 0.000123625394214 , -5.58069381599e-07 });
-        //rtData.setWatts(-5.58069381599e-07*pow(V, 5) + 0.000123625394214*pow(V, 4) + -0.0103757370081*pow(V, 3) + 0.434414507062*pow(V, 2) + 0.278777594954*V + -0.00678733031682);
-        break;
-    case 19: //MINOURA V270/v130 on 1
-        pf = PolyFitGenerator::GetPolyFit({ -0.056561085973, 0.704304812834, 0.237884615385 , -0.00251391745509 , -1.7235705471e-05, 3.74057315234e-07 });
-        //rtData.setWatts(3.74057315234e-07*pow(V, 5) + -1.7235705471e-05*pow(V, 4) + -0.00251391745509*pow(V, 3) + 0.237884615385*pow(V, 2) + 0.704304812834*V + -0.056561085973);
-        break;
-    case 20: //MINOURA V270/v130 on L
-        pf = PolyFitGenerator::GetPolyFit({ -0.0859728506788, 0.642516796929, 0.122555189908 , -6.92787604552e-05, -3.38406691348e-05, 3.46907993967e-07 });
-        //rtData.setWatts(3.46907993967e-07*pow(V, 5) + -3.38406691348e-05*pow(V, 4) + -6.92787604552e-05*pow(V, 3) + 0.122555189908*pow(V, 2) + 0.642516796929*V + -0.0859728506788);
-        break;
-    case 21: //SARIS POWERBEAM PRO
-            // 21 = 0.0008x^3 + 0.145x^2 + 2.5299x + 14.641 where x = speed in kph
-        pf = PolyFitGenerator::GetPolyFit({ 14.641, 2.5299, 0.145, 0.0008 });
-        //rtData.setWatts(0.0008*pow(V, 3) + 0.145*pow(V, 2) + (2.5299*V) + 14.641);
-        break;
-    case 22: //  TACX SATORI SETTING 2
-        pf = PolyFitGenerator::GetPolyFit({ -19.5, 3.9 });
-        //double slope = 3.9;
-        //double intercept = -19.5;
-        //rtData.setWatts((slope * V) + intercept);
-        break;
-    case 23: //  TACX SATORI SETTING 4
-        pf = PolyFitGenerator::GetPolyFit({ -52.3, 6.66 });
-        //double slope = 6.66;
-        //double intercept = -52.3;
-        //rtData.setWatts((slope * V) + intercept);
-        break;
-    case 24: //  TACX SATORI SETTING 6
-        pf = PolyFitGenerator::GetPolyFit({ -43.65, 9.43 });
-        //double slope = 9.43;
-        //double intercept = -43.65;
-        //rtData.setWatts((slope * V) + intercept);
-        break;
-    case 25: //  TACX SATORI SETTING 8
-        pf = PolyFitGenerator::GetPolyFit({ -51.15, 13.73 });
-        //double slope = 13.73;
-        //double intercept = -51.15;
-        //rtData.setWatts((slope * V) + intercept);
-        break;
-    case 26: //  TACX SATORI SETTING 10
-        pf = PolyFitGenerator::GetPolyFit({ -76.0, 17.7 });
-        //double slope = 17.7;
-        //double intercept = -76.0;
-        //rtData.setWatts((slope * V) + intercept);
-        break;
-    case 27: //  TACX FLOW SETTING 0
-        pf = PolyFitGenerator::GetPolyFit({ -47.27, 7.75 });
-        //double slope = 7.75;
-        //double intercept = -47.27;
-        //rtData.setWatts((slope * V) + intercept);
-        break;
-    case 28: //  TACX FLOW SETTING 2
-        pf = PolyFitGenerator::GetPolyFit({ -66.69, 9.51 });
-        //double slope = 9.51;
-        //double intercept = -66.69;
-        //rtData.setWatts((slope * V) + intercept);
-        break;
-    case 29: //  TACX FLOW SETTING 4
-        pf = PolyFitGenerator::GetPolyFit({ -71.59, 11.03 });
-        //double slope = 11.03;
-        //double intercept = -71.59;
-        //rtData.setWatts((slope * V) + intercept);
-        break;
-    case 30: //  TACX FLOW SETTING 6
-        pf = PolyFitGenerator::GetPolyFit({ -95.05, 12.81 });
-        //double slope = 12.81;
-        //double intercept = -95.05;
-        //rtData.setWatts((slope * V) + intercept);
-        break;
-    case 31: //  TACX FLOW SETTING 8
-        pf = PolyFitGenerator::GetPolyFit({ -102.43, 14.37 });
-        //double slope = 14.37;
-        //double intercept = -102.43;
-        //rtData.setWatts((slope * V) + intercept);
-        break;
-    case 32: //  TACX BLUE TWIST SETTING 1
-        pf = PolyFitGenerator::GetPolyFit({ -24, 3.2 });
-        //double V = rtData.getSpeed();
-        //double slope = 3.2;
-        //double intercept = -24.0;
-        //rtData.setWatts((slope * V) + intercept);
-        break;
-    case 33: //  TACX BLUE TWIST SETTING 3
-        pf = PolyFitGenerator::GetPolyFit({ -46.5, 6.525 });
-        //double V = rtData.getSpeed();
-        //double slope = 6.525;
-        //double intercept = -46.5;
-        //rtData.setWatts((slope * V) + intercept);
-        break;
-    case 34: //  TACX BLUE TWIST SETTING 5
-        pf = PolyFitGenerator::GetPolyFit({ -66.5, 9.775 });
-        //double V = rtData.getSpeed();
-        //double slope = 9.775;
-        //double intercept = -66.5;
-        //rtData.setWatts((slope * V) + intercept);
-        break;
-    case 35: //  TACX BLUE TWIST SETTING 7
-        pf = PolyFitGenerator::GetPolyFit({ -89.5, 13.075 });
-        //double V = rtData.getSpeed();
-        //double slope = 13.075;
-        //double intercept = -89.5;
-        //rtData.setWatts((slope * V) + intercept);
-        break;
-    case 36: //  TACX BLUE MOTION SETTING 2
-        pf = PolyFitGenerator::GetPolyFit({ -36.5, 5.225 });
-        //double V = rtData.getSpeed();
-        //double slope = 5.225;
-        //double intercept = -36.5;
-        //rtData.setWatts((slope * V) + intercept);
-        break;
-    case 37: //  TACX BLUE MOTION SETTING 4
-        pf = PolyFitGenerator::GetPolyFit({ -53.0, 8.25 });
-        //double V = rtData.getSpeed();
-        //double slope = 8.25;
-        //double intercept = -53.0;
-        //rtData.setWatts((slope * V) + intercept);
-        break;
-    case 38: //  TACX BLUE MOTION SETTING 6
-        pf = PolyFitGenerator::GetPolyFit({ -74.0, 11.45 });
-        //double V = rtData.getSpeed();
-        //double slope = 11.45;
-        //double intercept = -74.0;
-        //rtData.setWatts((slope * V) + intercept);
-        break;
-    case 39: //  TACX BLUE MOTION SETTING 8
-        pf = PolyFitGenerator::GetPolyFit({ -89, 14.45 });
-        //double V = rtData.getSpeed();
-        //double slope = 14.45;
-        //double intercept = -89.0;
-        //rtData.setWatts((slope * V) + intercept);
-        break;
-    case 40: //  TACX BLUE MOTION SETTING 10
-        pf = PolyFitGenerator::GetPolyFit({ -110.5, 17.575 });
-        //double V = rtData.getSpeed();
-        //double slope = 17.575;
-        //double intercept = -110.5;
-        //rtData.setWatts((slope * V) + intercept);
-        break;
-    case 41: // ELITE SUPERCRONO POWER MAG LEVEL 1
-        // Power curve provided by extraction from SportsTracks plugin
-        pf = PolyFitGenerator::GetPolyFit({ -1.16783216783223, 3.62446277061515, 0.17689196198325 , -0.000803192769148186 }, MILES_PER_KM);
-        //double V = rtData.getSpeed() * MILES_PER_KM;
-        //rtData.setWatts(-0.000803192769148186*pow(V, 3) + 0.17689196198325*pow(V,2) + (3.62446277061515*V) - 1.16783216783223);
-        break;
-    case 42: // ELITE SUPERCRONO POWER MAG LEVEL 2
-        // Power curve provided by extraction from SportsTracks plugin
-        pf = PolyFitGenerator::GetPolyFit({ -0.363636363636395, 3.54843470904764, 0.442531768374482 ,-0.00590735326986424 }, MILES_PER_KM);
-        //double V = rtData.getSpeed() * MILES_PER_KM;
-        //rtData.setWatts(-0.00590735326986424*pow(V, 3) + 0.442531768374482*pow(V,2) + (3.54843470904764*V) - 0.363636363636395);
-        break;
-    case 43: // ELITE SUPERCRONO POWER MAG LEVEL 3
-        // Power curve provided by extraction from SportsTracks plugin
-        pf = PolyFitGenerator::GetPolyFit({ -1.48951048951047, 5.08762781732785, 0.614352424962992 , -0.00917194323478923 }, MILES_PER_KM);
-        //double V = rtData.getSpeed() * MILES_PER_KM;
-        //rtData.setWatts(pf->Fit(V));
-        //rtData.setWatts(-0.00917194323478923*pow(V, 3) + 0.614352424962992*pow(V,2) + (5.08762781732785*V) - 1.48951048951047);
-        break;
-    case 44: // ELITE SUPERCRONO POWER MAG LEVEL 4
-        // Power curve provided by extraction from SportsTracks plugin
-        pf = PolyFitGenerator::GetPolyFit({ -1.7342657342657, 5.16903286351279, 0.880112976720764 ,-0.0150015681721553 }, MILES_PER_KM);
-        //double V = rtData.getSpeed() * MILES_PER_KM;
-        //rtData.setWatts(pf->Fit(V));
-        //rtData.setWatts(-0.0150015681721553*pow(V, 3) + 0.880112976720764*pow(V,2) + (5.16903286351279*V) - 1.7342657342657);
-        break;
-    case 45: // ELITE SUPERCRONO POWER MAG LEVEL 5
-        // Power curve provided by extraction from SportsTracks plugin
-        pf = PolyFitGenerator::GetPolyFit({ -3.18881118881126,6.23730215622854,1.0207209560583 ,-0.0172621671756449 }, MILES_PER_KM);
-        //double V = rtData.getSpeed() * MILES_PER_KM;
-        //rtData.setWatts(-0.0172621671756449*pow(V, 3) + 1.0207209560583*pow(V,2) + (6.23730215622854*V) - 3.18881118881126);
-        break;
-    case 46: // ELITE SUPERCRONO POWER MAG LEVEL 6
-        // Power curve provided by extraction from SportsTracks plugin
-        pf = PolyFitGenerator::GetPolyFit({ -4.18881118881114, 7.47138264900755, 1.15505017633569, -0.0195227661791347 }, MILES_PER_KM);
-        //double V = rtData.getSpeed() * MILES_PER_KM;
-        //rtData.setWatts(-0.0195227661791347*pow(V, 3) + 1.15505017633569*pow(V,2) + (7.47138264900755*V) - 4.18881118881114);
-        break;
-    case 47: // ELITE SUPERCRONO POWER MAG LEVEL 7
-        // Power curve provided by extraction from SportsTracks plugin
-        pf = PolyFitGenerator::GetPolyFit({ -5.11888111888112, 8.74972948026508, 1.2917943039439 , -0.0222497351776137 }, MILES_PER_KM);
-        //double V = rtData.getSpeed() * MILES_PER_KM;
-        //rtData.setWatts(-0.0222497351776137*pow(V, 3) + 1.2917943039439*pow(V,2) + (8.74972948026508*V) - 5.11888111888112);
-        break;
-    case 48: // ELITE SUPERCRONO POWER MAG LEVEL 8
-        // Power curve provided by extraction from SportsTracks plugin
-        pf = PolyFitGenerator::GetPolyFit({ -6.48951048951042, 10.2050166192824, 1.42902141301828 ,-0.0255078477814972 }, MILES_PER_KM);
-        //double V = rtData.getSpeed() * MILES_PER_KM;
-        //rtData.setWatts(-0.0255078477814972*pow(V, 3) + 1.42902141301828*pow(V,2) + (10.2050166192824*V) - 6.48951048951042);
-        break;
-    case 49: //ELITE TURBO MUIN 2013
-        // Power curve fit from data collected by Ray Maker at dcrainmaker.com
-        pf = PolyFitGenerator::GetPolyFit({ 0, 2.30615942, -0.28395558, 0.02099661 });
-        //double V = rtData.getSpeed();
-        //rtData.setWatts(2.30615942 * V -0.28395558 * pow(V,2) + 0.02099661 * pow(V,3));
-        break;
-    case 50: // ELITE QUBO POWER FLUID
-        // Power curve fit from powercurvesensor
-        //     f(x) = 4.31746 * x -2.59259e-002 * x^2 +  9.41799e-003 * x^3
-        pf = PolyFitGenerator::GetPolyFit({ 0, 4.31746, -2.59259e-002 , 9.41799e-003 });
-        //double V = rtData.getSpeed();
-        //rtData.setWatts(4.31746 * V - 2.59259e-002 * pow(V, 2) + 9.41799e-003 * pow(V, 3));
-        break;
-    case 51: // CYCLOPS MAGNETO PRO (ROAD)
-        //     Watts = 6.0f + (-0.93 * speed) + (0.275 * speed^2) + (-0.00175 * speed^3)
-        pf = PolyFitGenerator::GetPolyFit({ 0, -0.93, 0.275, -0.00175 });
-        //double V = rtData.getSpeed();
-        //rtData.setWatts(6.0f + (-0.93f * V) + (0.275f * pow(V, 2)) + (-0.00175f * pow(V, 3)));
-        break;
-    case 52: // ELITE ARION MAG LEVEL 0
-        pf = PolyFitGenerator::GetFractionalPolyFit({ 3.335794377, 1.217110021, 0. });
-        //double v = rtData.getSpeed();
-        //rtData.setWatts(pow(v, 1.217110021) * 3.335794377);
-        break;
-    case 53: // ELITE ARION MAG LEVEL 1
-        pf = PolyFitGenerator::GetFractionalPolyFit({ 1.206592577, 4.362485081, 0. });
-        //double v = rtData.getSpeed();
-        //rtData.setWatts(pow(v, 1.206592577) * 4.362485081);
-        break;
-    case 54: // ELITE ARION MAG LEVEL 2
-        pf = PolyFitGenerator::GetFractionalPolyFit({ 1.206984321, 6.374459698, 0. });
-        //double v = rtData.getSpeed();
-        //rtData.setWatts(pow(v, 1.206984321) * 6.374459698);
-        break;
-    case 55: // Blackburn Tech Fluid
-        pf = PolyFitGenerator::GetPolyFit({ 6.758241758241894, -1.9995004995004955, 0.24165834165834146 });
-        //double v = rtData.getSpeed();
-        //rtData.setWatts(6.758241758241894 - 1.9995004995004955 * v + 0.24165834165834146 * pow(v, 2));
-        break;
-    case 56: // TACX SIRIUS LEVEL 1
-        pf = PolyFitGenerator::GetPolyFit({ -20.64808196, 3.23874687 });
-        //double v = rtData.getSpeed();
-        //rtData.setWatts(3.23874687 * v - 20.64808196);
-        break;
-    case 57: // TACX SIRIUS LEVEL 2
-        pf = PolyFitGenerator::GetPolyFit({ -27.25589246, 4.30606133 });
-        //double v = rtData.getSpeed();
-        //rtData.setWatts(4.30606133 * v - 27.25589246);
-        break;
-    case 58: // TACX SIRIUS LEVEL 3
-        pf = PolyFitGenerator::GetPolyFit({ -36.57159131, 5.44879778 });
-        //double v = rtData.getSpeed();
-        //rtData.setWatts(5.44879778 * v - 36.57159131);
-        break;
-    case 59: // TACX SIRIUS LEVEL 4
-        pf = PolyFitGenerator::GetPolyFit({ -40.48616615, 6.48525956 });
-        //double v = rtData.getSpeed();
-        //rtData.setWatts(6.48525956 * v - 40.48616615);
-        break;
-    case 60: // TACX SIRIUS LEVEL 5
-        pf = PolyFitGenerator::GetPolyFit({ -48.35481582, 7.60643338 });
-        //double v = rtData.getSpeed();
-        //rtData.setWatts(7.60643338 * v - 48.35481582);
-        break;
-    case 61: // TACX SIRIUS LEVEL 6
-        pf = PolyFitGenerator::GetPolyFit({ -58.57819586, 8.73140257 });
-        //double v = rtData.getSpeed();
-        //rtData.setWatts(8.73140257 * v - 58.57819586);
-        break;
-    case 62: // TACX SIRIUS LEVEL 7
-        pf = PolyFitGenerator::GetPolyFit({ -59.61416463, 9.73079724 });
-        //double v = rtData.getSpeed();
-        //rtData.setWatts(9.73079724 * v - 59.61416463);
-        break;
-    case 63: // TACX SIRIUS LEVEL 8
-        pf = PolyFitGenerator::GetPolyFit({ -73.08258491, 10.94228338 });
-        //double v = rtData.getSpeed();
-        //rtData.setWatts(10.94228338 * v - 73.08258491);
-        break;
-    case 64: // TACX SIRIUS LEVEL 9
-        pf = PolyFitGenerator::GetPolyFit({ -77.88781457, 11.99373782 });
-        //double v = rtData.getSpeed();
-        //rtData.setWatts(11.99373782 * v - 77.88781457);
-        break;
-    case 65: // TACX SIRIUS LEVEL 10
-        pf = PolyFitGenerator::GetPolyFit({ -85.38477516, 13.09580164 });
-        //double v = rtData.getSpeed();
-        //rtData.setWatts(13.09580164 * v - 85.38477516);
-        break;
-    case 66: // ELITE CRONO FLUID ELASTOGEL
-        pf = PolyFitGenerator::GetPolyFit({ 0, 2.4508084253648112, -0.0005622440886940634 ,0.0031006831781331848 });
-        //double v = rtData.getSpeed();
-        //rtData.setWatts(2.4508084253648112 * v - 0.0005622440886940634 * pow(v, 2) + 0.0031006831781331848 * pow(v, 3));
-        break;
-    case 67: // ELITE TURBO MUIN 2015
-        pf = PolyFitGenerator::GetPolyFit({ 0, 3.01523235942763813175,  -0.12045521113635432750 , 0.01739165560254292102 });
-        //double V = rtData.getSpeed();
-        //rtData.setWatts(3.01523235942763813175 * V - 0.12045521113635432750 * pow(V,2) + 0.01739165560254292102 * pow(V,3));
-        break;
-    case 68: // CycleOps JetFluid Pro
-        pf = PolyFitGenerator::GetPolyFit({ 0, 0.94874757375670469046 , 0.11615123681031937322 , 0.00400691905019748630 });
-        //double V = rtData.getSpeed();
-        //rtData.setWatts(0.94874757375670469046 * V + 0.11615123681031937322 * pow(V,2) + 0.00400691905019748630 * pow(V,3));
-        break;
-    case 69: // Elite Crono Mag elastogel
-        pf = PolyFitGenerator::GetPolyFit({ 0, 7.34759700400455518172, -0.00278841177590215417, 0.00052233430180969281 });
-        //double V = rtData.getSpeed();
-        //rtData.setWatts(7.34759700400455518172 * V - 0.00278841177590215417 * pow(V,2) + 0.00052233430180969281 * pow(V,3));
-        break;
-    case 70: // Tacx Magnetic T1820 (4/7)
-        pf = PolyFitGenerator::GetPolyFit({ 0, 6.77999074563685972005, -0.00148787143661883094, 0.00085058630585658189 });
-        //double V = rtData.getSpeed();
-        //rtData.setWatts(6.77999074563685972005 * V - 0.00148787143661883094 * pow(V,2) + 0.00085058630585658189 * pow(V,3));
-        break;
-    case 71: // Tacx Magnetic T1820 (7/7)
-        pf = PolyFitGenerator::GetPolyFit({ 0, 9.80556623734881995572, -0.00668894865103764724,  0.00125560535410925628 });
-        //double V = rtData.getSpeed();
-        //rtData.setWatts(9.80556623734881995572 * V - 0.00668894865103764724 * pow(V,2) + 0.00125560535410925628 * pow(V,3));
-        break;
-    default: // unknown - do nothing
-        break;
-    }
+    const VirtualPowerTrainer* pTrainer = virtualPowerTrainerManager.GetVirtualPowerTrainer(postProcess);
+    polyFit = pTrainer->m_pf;
+    fUseWheelRpm = pTrainer->m_fUseWheelRpm;
+    iFitId = postProcess;
 
-    polyFit = pf;
-    if (polyFit) {
-        iFitId = postProcess;
-    }
+    return polyFit != NULL;
 }
-
 
 // for future devices, we may need to setup algorithmic tables etc
 void

--- a/src/Train/RealtimeController.cpp
+++ b/src/Train/RealtimeController.cpp
@@ -23,7 +23,7 @@
 
 // Abstract base class for Realtime device controllers
 
-RealtimeController::RealtimeController(TrainSidebar *parent, DeviceConfiguration *dc) : parent(parent), dc(dc)
+RealtimeController::RealtimeController(TrainSidebar *parent, DeviceConfiguration *dc) : parent(parent), dc(dc), polyFit(NULL), iFitId(0), fUseWheelRpm(false)
 {
     if (dc != NULL)
     {
@@ -50,586 +50,457 @@ bool RealtimeController::doesLoad() { return false; }
 void RealtimeController::getRealtimeData(RealtimeData &) { }
 void RealtimeController::pushRealtimeData(RealtimeData &) { } // update realtime data with current values
 
-void
-RealtimeController::processRealtimeData(RealtimeData &rtData)
+void RealtimeController::processRealtimeData(RealtimeData &rtData)
 {
     if (!dc) return; // no config
 
-    // setup the algorithm or lookup tables
-    // for the device postprocessing type
-    switch(dc->postProcess) {
-    case 0 : // nothing!
-        break;
-    case 1 : // Kurt Kinetic - Cyclone
-        {
-        double mph = rtData.getSpeed() * MILES_PER_KM;
-        // using the algorithm from http://www.kurtkinetic.com/powercurve.php
-        rtData.setWatts((6.481090) * mph + (0.020106) * (mph*mph*mph));
-        }
-        break;
-    case 2 : // Kurt Kinetic - Road Machine
-        {
-        double mph = rtData.getSpeed() * MILES_PER_KM;
-        // using the algorithm from http://www.kurtkinetic.com/powercurve.php
-        rtData.setWatts((5.244820) * mph + (0.019168) * (mph*mph*mph));
-        }
-        break;
-    case 3 : // Cyclops Fluid 2
-        {
-        double mph = rtData.getSpeed() * MILES_PER_KM;
-        // using the algorithm from:
-        // http://thebikegeek.blogspot.com/2009/12/while-we-wait-for-better-and-better.html
-        rtData.setWatts((0.0115*(mph*mph*mph)) - ((0.0137)*(mph*mph)) + ((8.9788)*(mph)));
-        }
-        break;
-    case 4 : // BT-ATS - BT Advanced Training System
-        {
-        //        v is expressed in revs/second
-        double v = rtData.getWheelRpm()/60.0;
-        // using the algorithm from Steven Sansonetti of BT:
-        //  This is a 3rd order polynomial, where P = av3 + bv2 + cv + d
-        //  where:
-                double a =       2.90390167E-01; // ( 0.290390167)
-                double b =     - 4.61311774E-02; // ( -0.0461311774)
-                double c =       5.92125507E-01; // (0.592125507)
-                double d =       0.0;
-        rtData.setWatts(a*v*v*v + b*v*v +c*v + d);
-        }
-        break;
+    // Lazy init. Perhaps not needed?
+    if (dc->postProcess != iFitId)
+        processSetup();
 
-    case 5 : // Lemond Revolution
-        {
-        double V = rtData.getSpeed() * 0.277777778;
-        // Tom Anhalt spent a lot of time working this all out
-        // for the data / analysis see: http://wattagetraining.com/forum/viewtopic.php?f=2&t=335
-        rtData.setWatts((0.21*pow(V,3))+(4.25*V));
-        }
-        break;
-
-    case 6 : // 1UP USA
-        {
-        double V = rtData.getSpeed() * MILES_PER_KM;
-        // Power curve provided by extraction from SportsTracks plugin
-        rtData.setWatts(25.00 + (2.65f*V) - (0.42f*pow(V,2)) + (0.058f*pow(V,3)));
-        }
-        break;
-
-    // MINOURA - Has many gears
-    case 7 : //MINOURA V100 on H
-        {
-        double V = rtData.getSpeed();
-        // 7 = V100 on H: y = -0.0036x^3 + 0.2815x^2 + 3.4978x - 9.7857 
-        rtData.setWatts(-0.0036*pow(V, 3) + 0.2815*pow(V,2) + (3.4978*V) - 9.7857);
-        }
-        break;
-
-    case 8 : //MINOURA V100 on 5
-        {
-        double V = rtData.getSpeed();
-        // 8 = V100 on 5: y = -0.0023x^3 + 0.2067x^2 + 3.8906x - 11.214 
-        rtData.setWatts(-0.0023*pow(V, 3) + 0.2067*pow(V,2) + (3.8906*V) - 11.214);
-        }
-        break;
-
-    case 9 : //MINOURA V100 on 4
-        {
-        double V = rtData.getSpeed();
-        // 9 = V100 on 4: y = -0.00173x^3 + 0.1825x^2 + 3.4036x - 10 
-        rtData.setWatts(-0.00173*pow(V, 3) + 0.1825*pow(V,2) + (3.4036*V) - 10.00);
-        }
-        break;
-
-    case 10 : //MINOURA V100 on 3
-        {
-        double V = rtData.getSpeed();
-        // 10 = V100 on 3: y = -0.0011x^3 + 0.1433x^2 + 2.8808x - 8.1429 
-        rtData.setWatts(-0.0011*pow(V, 3) + 0.1433*pow(V,2) + (2.8808*V) - 8.1429);
-        }
-        break;
-
-    case 11 : //MINOURA V100 on 2
-        {
-        double V = rtData.getSpeed();
-        // 11 = V100 on 2: y = -0.0007x^3 + 0.1348x^2 + 1.581x - 3.3571 
-        rtData.setWatts(-0.0007*pow(V, 3) + 0.1348*pow(V,2) + (1.581*V) - 3.3571);
-        }
-        break;
-
-    case 12 : //MINOURA V100 on 1
-        {
-        double V = rtData.getSpeed();
-        // 12 = V100 on 1: y = 0.0004x^3 + 0.057x^2 + 1.7797x - 5.0714 
-        rtData.setWatts(0.0004*pow(V, 3) + 0.057*pow(V,2) + (1.7797*V) - 5.0714);
-        }
-        break;
-
-    case 13 : //MINOURA V100 on L
-        {
-        double V = rtData.getSpeed();
-        // 13 = V100 on L: y = 0.0557x^2 + 1.231x - 3.7143 
-        rtData.setWatts(0.0557*pow(V, 2) + (1.231*V) - 3.7143);
-        }
-        break;
-
-    case 14 : //MINOURA V270/v130 on H
-        {
-        double V = rtData.getSpeed();
-        rtData.setWatts(-1.84615384615e-06*pow(V, 5) + 0.000338955162485*pow(V, 4) + -0.0237725215961*pow(V, 3) + 0.782320032908*pow(V, 2) + 0.538329905388*V + -0.628959276017);
-        }
-        break;
-
-    case 15 : //MINOURA V270/v130 on 5
-        {
-        double V = rtData.getSpeed();
-        rtData.setWatts(-9.35143288085e-07*pow(V, 5) + 0.000193281228575*pow(V, 4) + -0.0153105032223*pow(V, 3) + 0.587825311943*pow(V, 2) + 1.16395173454*V + -0.472850678733);
-        }
-        break;
-
-    case 16 : //MINOURA V270/v130 on 4
-        {
-        double V = rtData.getSpeed();
-        rtData.setWatts(-3.34841628959e-07*pow(V, 5) + 0.000114219114219*pow(V, 4) + -0.0117029686*pow(V, 3) + 0.52033045386*pow(V, 2) + 1.10649184149*V + -0.364253393665);
-        }
-        break;
-
-    case 17 : //MINOURA V270/v130 on 3
-        {
-        double V = rtData.getSpeed();
-        rtData.setWatts(2.32277526395e-07*pow(V, 5) + 3.96681749623e-05*pow(V, 4) + -0.00805837789661*pow(V, 3) + 0.439146098999*pow(V, 2) + 1.00085150144*V + -0.386877828054);
-        }
-        break;
-
-    case 18 : //MINOURA V270/v130 on 2
-        {
-        double V = rtData.getSpeed();
-        rtData.setWatts(-5.58069381599e-07*pow(V, 5) + 0.000123625394214*pow(V, 4) + -0.0103757370081*pow(V, 3) + 0.434414507062*pow(V, 2) + 0.278777594954*V + -0.00678733031682);
-        }
-        break;
-
-    case 19 : //MINOURA V270/v130 on 1
-        {
-        double V = rtData.getSpeed();
-        rtData.setWatts(3.74057315234e-07*pow(V, 5) + -1.7235705471e-05*pow(V, 4) + -0.00251391745509*pow(V, 3) + 0.237884615385*pow(V, 2) + 0.704304812834*V + -0.056561085973);
-        }
-        break;
-
-    case 20 : //MINOURA V270/v130 on L
-        {
-        double V = rtData.getSpeed();
-        rtData.setWatts(3.46907993967e-07*pow(V, 5) + -3.38406691348e-05*pow(V, 4) + -6.92787604552e-05*pow(V, 3) + 0.122555189908*pow(V, 2) + 0.642516796929*V + -0.0859728506788);
-        }
-        break;
-
-    case 21 : //SARIS POWERBEAM PRO
-        {
-        double V = rtData.getSpeed();
-        // 21 = 0.0008x^3 + 0.145x^2 + 2.5299x + 14.641 where x = speed in kph
-        rtData.setWatts(0.0008*pow(V, 3) + 0.145*pow(V, 2) + (2.5299*V) + 14.641);
-        }
-        break;
-
-    case 22 : //  TACX SATORI SETTING 2
-        {
-        double V = rtData.getSpeed();
-        double slope = 3.9;
-        double intercept = -19.5;
-        rtData.setWatts((slope * V) + intercept);
-        }
-        break;
-
-    case 23 : //  TACX SATORI SETTING 4
-        {
-        double V = rtData.getSpeed();
-        double slope = 6.66;
-        double intercept = -52.3;
-        rtData.setWatts((slope * V) + intercept);
-        }
-        break;
-
-    case 24 : //  TACX SATORI SETTING 6
-        {
-        double V = rtData.getSpeed();
-        double slope = 9.43;
-        double intercept = -43.65;
-        rtData.setWatts((slope * V) + intercept);
-        }
-        break;
-
-    case 25 : //  TACX SATORI SETTING 8
-        {
-        double V = rtData.getSpeed();
-        double slope = 13.73;
-        double intercept = -51.15;
-        rtData.setWatts((slope * V) + intercept);
-        }
-        break;
-
-    case 26 : //  TACX SATORI SETTING 10
-        {
-        double V = rtData.getSpeed();
-        double slope = 17.7;
-        double intercept = -76.0;
-        rtData.setWatts((slope * V) + intercept);
-        }
-        break;
-
-    case 27 : //  TACX FLOW SETTING 0
-        {
-        double V = rtData.getSpeed();
-        double slope = 7.75;
-        double intercept = -47.27;
-        rtData.setWatts((slope * V) + intercept);
-        }
-        break;
-
-    case 28 : //  TACX FLOW SETTING 2
-        {
-        double V = rtData.getSpeed();
-        double slope = 9.51;
-        double intercept = -66.69;
-        rtData.setWatts((slope * V) + intercept);
-        }
-        break;
-
-    case 29 : //  TACX FLOW SETTING 4
-        {
-        double V = rtData.getSpeed();
-        double slope = 11.03;
-        double intercept = -71.59;
-        rtData.setWatts((slope * V) + intercept);
-        }
-        break;
-
-    case 30 : //  TACX FLOW SETTING 6
-        {
-        double V = rtData.getSpeed();
-        double slope = 12.81;
-        double intercept = -95.05;
-        rtData.setWatts((slope * V) + intercept);
-        }
-        break;
-
-    case 31 : //  TACX FLOW SETTING 8
-        {
-        double V = rtData.getSpeed();
-        double slope = 14.37;
-        double intercept = -102.43;
-        rtData.setWatts((slope * V) + intercept);
-        }
-        break;
-        
-    case 32 : //  TACX BLUE TWIST SETTING 1
-        {
-        double V = rtData.getSpeed();
-        double slope = 3.2;
-        double intercept = -24.0;
-        rtData.setWatts((slope * V) + intercept);
-        }
-        break;
-
-    case 33 : //  TACX BLUE TWIST SETTING 3
-        {
-        double V = rtData.getSpeed();
-        double slope = 6.525;
-        double intercept = -46.5;
-        rtData.setWatts((slope * V) + intercept);
-        }
-        break;
-
-    case 34 : //  TACX BLUE TWIST SETTING 5
-        {
-        double V = rtData.getSpeed();
-        double slope = 9.775;
-        double intercept = -66.5;
-        rtData.setWatts((slope * V) + intercept);
-        }
-        break;
-
-    case 35 : //  TACX BLUE TWIST SETTING 7
-        {
-        double V = rtData.getSpeed();
-        double slope = 13.075;
-        double intercept = -89.5;
-        rtData.setWatts((slope * V) + intercept);
-        }
-        break;
-        
-    case 36 : //  TACX BLUE MOTION SETTING 2
-        {
-        double V = rtData.getSpeed();
-        double slope = 5.225;
-        double intercept = -36.5;
-        rtData.setWatts((slope * V) + intercept);
-        }
-        break;
-    
-    case 37 : //  TACX BLUE MOTION SETTING 4
-        {
-        double V = rtData.getSpeed();
-        double slope = 8.25;
-        double intercept = -53.0;
-        rtData.setWatts((slope * V) + intercept);
-        }
-        break;
-
-    case 38 : //  TACX BLUE MOTION SETTING 6
-        {
-        double V = rtData.getSpeed();
-        double slope = 11.45;
-        double intercept = -74.0;
-        rtData.setWatts((slope * V) + intercept);
-        }
-        break;
-
-    case 39 : //  TACX BLUE MOTION SETTING 8
-        {
-        double V = rtData.getSpeed();
-        double slope = 14.45;
-        double intercept = -89.0;
-        rtData.setWatts((slope * V) + intercept);
-        }
-        break;
-
-    case 40 : //  TACX BLUE MOTION SETTING 10
-        {
-        double V = rtData.getSpeed();
-        double slope = 17.575;
-        double intercept = -110.5;
-        rtData.setWatts((slope * V) + intercept);
-        }
-        break;
-
-    case 41 : // ELITE SUPERCRONO POWER MAG LEVEL 1
-        {
-        double V = rtData.getSpeed() * MILES_PER_KM;
-        // Power curve provided by extraction from SportsTracks plugin
-        rtData.setWatts(-0.000803192769148186*pow(V, 3) + 0.17689196198325*pow(V,2) + (3.62446277061515*V) - 1.16783216783223);
-        }
-        break;
-
-    case 42 : // ELITE SUPERCRONO POWER MAG LEVEL 2
-        {
-        double V = rtData.getSpeed() * MILES_PER_KM;
-        // Power curve provided by extraction from SportsTracks plugin
-        rtData.setWatts(-0.00590735326986424*pow(V, 3) + 0.442531768374482*pow(V,2) + (3.54843470904764*V) - 0.363636363636395);
-        }
-        break;
-
-    case 43 : // ELITE SUPERCRONO POWER MAG LEVEL 3
-        {
-        double V = rtData.getSpeed() * MILES_PER_KM;
-        // Power curve provided by extraction from SportsTracks plugin
-        rtData.setWatts(-0.00917194323478923*pow(V, 3) + 0.614352424962992*pow(V,2) + (5.08762781732785*V) - 1.48951048951047);
-        }
-        break;
-
-    case 44 : // ELITE SUPERCRONO POWER MAG LEVEL 4
-        {
-        double V = rtData.getSpeed() * MILES_PER_KM;
-        // Power curve provided by extraction from SportsTracks plugin
-        rtData.setWatts(-0.0150015681721553*pow(V, 3) + 0.880112976720764*pow(V,2) + (5.16903286351279*V) - 1.7342657342657);
-        }
-        break;
-
-    case 45 : // ELITE SUPERCRONO POWER MAG LEVEL 5
-        {
-        double V = rtData.getSpeed() * MILES_PER_KM;
-        // Power curve provided by extraction from SportsTracks plugin
-        rtData.setWatts(-0.0172621671756449*pow(V, 3) + 1.0207209560583*pow(V,2) + (6.23730215622854*V) - 3.18881118881126);
-        }
-        break;
-
-    case 46 : // ELITE SUPERCRONO POWER MAG LEVEL 6
-        {
-        double V = rtData.getSpeed() * MILES_PER_KM;
-        // Power curve provided by extraction from SportsTracks plugin
-        rtData.setWatts(-0.0195227661791347*pow(V, 3) + 1.15505017633569*pow(V,2) + (7.47138264900755*V) - 4.18881118881114);
-        }
-        break;
-
-    case 47 : // ELITE SUPERCRONO POWER MAG LEVEL 7
-        {
-        double V = rtData.getSpeed() * MILES_PER_KM;
-        // Power curve provided by extraction from SportsTracks plugin
-        rtData.setWatts(-0.0222497351776137*pow(V, 3) + 1.2917943039439*pow(V,2) + (8.74972948026508*V) - 5.11888111888112);
-        }
-        break;
-
-    case 48 : // ELITE SUPERCRONO POWER MAG LEVEL 8
-        {
-        double V = rtData.getSpeed() * MILES_PER_KM;
-        // Power curve provided by extraction from SportsTracks plugin
-        rtData.setWatts(-0.0255078477814972*pow(V, 3) + 1.42902141301828*pow(V,2) + (10.2050166192824*V) - 6.48951048951042);
-        }
-        break;
-
-    case 49: //ELITE TURBO MUIN 2013
-        {
-        double V = rtData.getSpeed();
-        // Power curve fit from data collected by Ray Maker at dcrainmaker.com
-        rtData.setWatts(2.30615942 * V -0.28395558 * pow(V,2) + 0.02099661 * pow(V,3));
-        }
-        break;
-    case 50: // ELITE QUBO POWER FLUID
-        {
-        double V = rtData.getSpeed();
-        // Power curve fit from powercurvesensor
-        //     f(x) = 4.31746 * x -2.59259e-002 * x^2 +  9.41799e-003 * x^3
-        rtData.setWatts(4.31746 * V - 2.59259e-002 * pow(V, 2) + 9.41799e-003 * pow(V, 3));
-        }
-        break;
-    case 51: // CYCLOPS MAGNETO PRO (ROAD)
-        {
-        double V = rtData.getSpeed();
-        //     Watts = 6.0f + (-0.93 * speed) + (0.275 * speed^2) + (-0.00175 * speed^3)
-        rtData.setWatts(6.0f + (-0.93f * V) + (0.275f * pow(V, 2)) + (-0.00175f * pow(V, 3)));
-        }
-        break;
-
-    case 52: // ELITE ARION MAG LEVEL 0
-        {
-        double v = rtData.getSpeed();
-        rtData.setWatts(pow(v, 1.217110021) * 3.335794377);
-        }
-        break;
-
-    case 53: // ELITE ARION MAG LEVEL 1
-        {
-        double v = rtData.getSpeed();
-        rtData.setWatts(pow(v, 1.206592577) * 4.362485081);
-        }
-        break;
-
-    case 54: // ELITE ARION MAG LEVEL 2
-        {
-        double v = rtData.getSpeed();
-        rtData.setWatts(pow(v, 1.206984321) * 6.374459698);
-        }
-        break;
-
-    case 55: // Blackburn Tech Fluid
-        {
-        double v = rtData.getSpeed();
-        rtData.setWatts(6.758241758241894 - 1.9995004995004955 * v + 0.24165834165834146 * pow(v, 2));
-        }
-        break;
-
-    case 56: // TACX SIRIUS LEVEL 1
-        {
-        double v = rtData.getSpeed();
-        rtData.setWatts(3.23874687 * v - 20.64808196);
-        }
-        break;
-
-    case 57: // TACX SIRIUS LEVEL 2
-        {
-        double v = rtData.getSpeed();
-        rtData.setWatts(4.30606133 * v - 27.25589246);
-        }
-        break;
-
-    case 58: // TACX SIRIUS LEVEL 3
-        {
-        double v = rtData.getSpeed();
-        rtData.setWatts(5.44879778 * v - 36.57159131);
-        }
-        break;
-
-    case 59: // TACX SIRIUS LEVEL 4
-        {
-        double v = rtData.getSpeed();
-        rtData.setWatts(6.48525956 * v - 40.48616615);
-        }
-        break;
-
-    case 60: // TACX SIRIUS LEVEL 5
-        {
-        double v = rtData.getSpeed();
-        rtData.setWatts(7.60643338 * v - 48.35481582);
-        }
-        break;
-
-    case 61: // TACX SIRIUS LEVEL 6
-        {
-        double v = rtData.getSpeed();
-        rtData.setWatts(8.73140257 * v - 58.57819586);
-        }
-        break;
-
-    case 62: // TACX SIRIUS LEVEL 7
-        {
-        double v = rtData.getSpeed();
-        rtData.setWatts(9.73079724 * v - 59.61416463);
-        }
-        break;
-
-    case 63: // TACX SIRIUS LEVEL 8
-        {
-        double v = rtData.getSpeed();
-        rtData.setWatts(10.94228338 * v - 73.08258491);
-        }
-        break;
-
-    case 64: // TACX SIRIUS LEVEL 9
-        {
-        double v = rtData.getSpeed();
-        rtData.setWatts(11.99373782 * v - 77.88781457);
-        }
-        break;
-
-    case 65: // TACX SIRIUS LEVEL 10
-        {
-        double v = rtData.getSpeed();
-        rtData.setWatts(13.09580164 * v - 85.38477516);
-        }
-        break;
-
-    case 66: // ELITE CRONO FLUID ELASTOGEL
-        {
-        double v = rtData.getSpeed();
-        rtData.setWatts(2.4508084253648112 * v - 0.0005622440886940634 * pow(v, 2) + 0.0031006831781331848 * pow(v, 3));
-        }
-        break;
-
-    case 67: // ELITE TURBO MUIN 2015
-        {
-        double V = rtData.getSpeed();
-        rtData.setWatts(3.01523235942763813175 * V - 0.12045521113635432750 * pow(V,2) + 0.01739165560254292102 * pow(V,3));
-        }
-        break;
-
-    case 68: // CycleOps JetFluid Pro
-        {
-        double V = rtData.getSpeed();
-        rtData.setWatts(0.94874757375670469046 * V + 0.11615123681031937322 * pow(V,2) + 0.00400691905019748630 * pow(V,3));
-        }
-        break;
-
-    case 69: // Elite Crono Mag elastogel
-        {
-        double V = rtData.getSpeed();
-        rtData.setWatts(7.34759700400455518172 * V - 0.00278841177590215417 * pow(V,2) + 0.00052233430180969281 * pow(V,3));
-        }
-        break;
-
-    case 70: // Tacx Magnetic T1820 (4/7)
-        {
-        double V = rtData.getSpeed();
-        rtData.setWatts(6.77999074563685972005 * V - 0.00148787143661883094 * pow(V,2) + 0.00085058630585658189 * pow(V,3));
-        }
-        break;
-
-    case 71: // Tacx Magnetic T1820 (7/7)
-        {
-        double V = rtData.getSpeed();
-        rtData.setWatts(9.80556623734881995572 * V - 0.00668894865103764724 * pow(V,2) + 0.00125560535410925628 * pow(V,3));
-        }
-        break;
-
-    default : // unknown - do nothing
-        break;
+    if (polyFit) {
+        double v = (fUseWheelRpm) ? rtData.getWheelRpm() : rtData.getSpeed();
+        rtData.setWatts(polyFit->Fit(v));
     }
 }
+
+void RealtimeController::SetupPolyFitFromPostprocessId(int postProcess)
+{
+    if (iFitId == postProcess) return;
+
+    // Clear and reconstruct new fit state.
+    delete polyFit;
+
+    polyFit = NULL;
+    iFitId = 0;
+    fUseWheelRpm = false;
+
+    PolyFit<double>* pf = NULL;
+
+    // setup the algorithm or lookup tables
+    // for the device postprocessing type
+    switch (postProcess) {
+    case 0: // nothing!
+        break;
+    case 1: // Kurt Kinetic - Cyclone
+            // using the algorithm from http://www.kurtkinetic.com/powercurve.php
+        pf = PolyFitGenerator::GetPolyFit({ 0, 6.481090, 0, 0.020106 }, MILES_PER_KM);
+        //double mph = rtData.getSpeed() * MILES_PER_KM;
+        //rtData.setWatts((6.481090) * mph + (0.020106) * (mph*mph*mph));
+        break;
+    case 2: // Kurt Kinetic - Road Machine
+            // using the algorithm from http://www.kurtkinetic.com/powercurve.php
+        pf = PolyFitGenerator::GetPolyFit({ 0, 5.244820, 0, 0.019168 }, MILES_PER_KM);
+        //double mph = rtData.getSpeed() * MILES_PER_KM;
+        //rtData.setWatts((5.244820) * mph + (0.019168) * (mph*mph*mph));
+        break;
+    case 3: // Cyclops Fluid 2
+            // using the algorithm from:
+            // http://thebikegeek.blogspot.com/2009/12/while-we-wait-for-better-and-better.html
+        pf = PolyFitGenerator::GetPolyFit({ 0, 8.9788, 0.0137, 0.0115 }, MILES_PER_KM);
+        //double mph = rtData.getSpeed() * MILES_PER_KM;
+        //rtData.setWatts((0.0115*(mph*mph*mph)) - ((0.0137)*(mph*mph)) + ((8.9788)*(mph)));
+        break;
+    case 4: // BT-ATS - BT Advanced Training System
+            // using the algorithm from Steven Sansonetti of BT:
+        {
+            //  This is a 3rd order polynomial, where P = av3 + bv2 + cv + d
+            //  where:
+            //        v is expressed in revs/second
+            fUseWheelRpm = true;
+            pf = PolyFitGenerator::GetPolyFit({ 0.0,5.92125507E-01,-4.61311774E-02,2.90390167E-01 }, 1. / 60.);
+            //double a = 2.90390167E-01;  // ( 0.290390167)
+            //double b = -4.61311774E-02; // ( -0.0461311774)
+            //double c = 5.92125507E-01;  // (0.592125507)
+            //double d = 0.0;
+            //double v = rtData.getWheelRpm() / 60.0;
+            //rtData.setWatts(a*v*v*v + b*v*v +c*v + d);
+        }
+        break;
+    case 5: // Lemond Revolution
+            // Tom Anhalt spent a lot of time working this all out
+            // for the data / analysis see: http://wattagetraining.com/forum/viewtopic.php?f=2&t=335
+        pf = PolyFitGenerator::GetPolyFit({ 0, 4.25, 0, 0.21 }, 15. / 18.);
+        //double V = rtData.getSpeed() * 0.277777778;
+        //rtData.setWatts((0.21*pow(V,3))+(4.25*V));
+        break;
+    case 6: // 1UP USA
+            // Power curve provided by extraction from SportsTracks plugin
+        pf = PolyFitGenerator::GetPolyFit({ 25, 2.65, 0.42, 0.058 }, MILES_PER_KM);
+        //double V = rtData.getSpeed() * MILES_PER_KM;
+        //rtData.setWatts(25.00 + (2.65f*V) - (0.42f*pow(V,2)) + (0.058f*pow(V,3)));
+        break;
+        // MINOURA - Has many gears
+    case 7: //MINOURA V100 on H
+            // 7 = V100 on H: y = -0.0036x^3 + 0.2815x^2 + 3.4978x - 9.7857 
+        pf = PolyFitGenerator::GetPolyFit({ -9.7857, 3.4978, 0.2815, -0.0036 });
+        //rtData.setWatts(-0.0036*pow(V, 3) + 0.2815*pow(V,2) + (3.4978*V) - 9.7857);
+        break;
+    case 8: //MINOURA V100 on 5
+            // 8 = V100 on 5: y = -0.0023x^3 + 0.2067x^2 + 3.8906x - 11.214
+        pf = PolyFitGenerator::GetPolyFit({ -11.214, 3.8906, 0.2067, -0.0023 });
+        //rtData.setWatts(-0.0023*pow(V, 3) + 0.2067*pow(V,2) + (3.8906*V) - 11.214);
+        break;
+    case 9: //MINOURA V100 on 4
+            // 9 = V100 on 4: y = -0.00173x^3 + 0.1825x^2 + 3.4036x - 10 
+        pf = PolyFitGenerator::GetPolyFit({ -10, 3.4036, 0.1824, -0.00173 });
+        //rtData.setWatts(-0.00173*pow(V, 3) + 0.1825*pow(V,2) + (3.4036*V) - 10.00);
+        break;
+    case 10: //MINOURA V100 on 3
+            // 10 = V100 on 3: y = -0.0011x^3 + 0.1433x^2 + 2.8808x - 8.1429 
+        pf = PolyFitGenerator::GetPolyFit({ -8.1429, 2.8808, 0.1433, -0.0011 });
+        //rtData.setWatts(-0.0011*pow(V, 3) + 0.1433*pow(V,2) + (2.8808*V) - 8.1429);
+        break;
+    case 11: //MINOURA V100 on 2
+            // 11 = V100 on 2: y = -0.0007x^3 + 0.1348x^2 + 1.581x - 3.3571 
+        pf = PolyFitGenerator::GetPolyFit({ -3.3571, 1.581, 0.1348, -0.0007 });
+        //rtData.setWatts(-0.0007*pow(V, 3) + 0.1348*pow(V,2) + (1.581*V) - 3.3571);
+        break;
+    case 12: //MINOURA V100 on 1
+            // 12 = V100 on 1: y = 0.0004x^3 + 0.057x^2 + 1.7797x - 5.0714 
+        pf = PolyFitGenerator::GetPolyFit({ -5.0714, 1.7797, 0.057, 0.0004 });
+        //rtData.setWatts(0.0004*pow(V, 3) + 0.057*pow(V,2) + (1.7797*V) - 5.0714);
+        break;
+    case 13: //MINOURA V100 on L
+            // 13 = V100 on L: y = 0.0557x^2 + 1.231x - 3.7143 
+        pf = PolyFitGenerator::GetPolyFit({ -3.7143, 1.231, 0.557 });
+        //rtData.setWatts(0.0557*pow(V, 2) + (1.231*V) - 3.7143);
+        break;
+    case 14: //MINOURA V270/v130 on H
+        pf = PolyFitGenerator::GetPolyFit({ -0.628959276017,  0.538329905388 , 0.782320032908 ,-0.0237725215961 ,0.000338955162485 ,-1.84615384615e-06 });
+        //rtData.setWatts(-1.84615384615e-06*pow(V, 5) + 0.000338955162485*pow(V, 4) + -0.0237725215961*pow(V, 3) + 0.782320032908*pow(V, 2) + 0.538329905388*V + -0.628959276017);
+        break;
+    case 15: //MINOURA V270/v130 on 5
+        pf = PolyFitGenerator::GetPolyFit({ -0.472850678733, 1.16395173454 , 0.587825311943 ,-0.0153105032223 ,0.000193281228575 ,-9.35143288085e-07 });
+        //rtData.setWatts(-9.35143288085e-07*pow(V, 5) + 0.000193281228575*pow(V, 4) + -0.0153105032223*pow(V, 3) + 0.587825311943*pow(V, 2) + 1.16395173454*V + -0.472850678733);
+        break;
+    case 16: //MINOURA V270/v130 on 4
+        pf = PolyFitGenerator::GetPolyFit({ -0.364253393665, 1.10649184149, 0.52033045386 ,-0.0117029686, 0.000114219114219 , -3.34841628959e-07 });
+        //rtData.setWatts(-3.34841628959e-07*pow(V, 5) + 0.000114219114219*pow(V, 4) + -0.0117029686*pow(V, 3) + 0.52033045386*pow(V, 2) + 1.10649184149*V + -0.364253393665);
+        break;
+    case 17: //MINOURA V270/v130 on 3
+        pf = PolyFitGenerator::GetPolyFit({ -0.386877828054 ,1.00085150144 , 0.439146098999, -0.00805837789661 , 3.96681749623e-05, 2.32277526395e-07 });
+        //rtData.setWatts(2.32277526395e-07*pow(V, 5) + 3.96681749623e-05*pow(V, 4) + -0.00805837789661*pow(V, 3) + 0.439146098999*pow(V, 2) + 1.00085150144*V + -0.386877828054);
+        break;
+    case 18: //MINOURA V270/v130 on 2
+        pf = PolyFitGenerator::GetPolyFit({ -0.00678733031682, 0.278777594954, 0.434414507062 , -0.0103757370081, 0.000123625394214 , -5.58069381599e-07 });
+        //rtData.setWatts(-5.58069381599e-07*pow(V, 5) + 0.000123625394214*pow(V, 4) + -0.0103757370081*pow(V, 3) + 0.434414507062*pow(V, 2) + 0.278777594954*V + -0.00678733031682);
+        break;
+    case 19: //MINOURA V270/v130 on 1
+        pf = PolyFitGenerator::GetPolyFit({ -0.056561085973, 0.704304812834, 0.237884615385 , -0.00251391745509 , -1.7235705471e-05, 3.74057315234e-07 });
+        //rtData.setWatts(3.74057315234e-07*pow(V, 5) + -1.7235705471e-05*pow(V, 4) + -0.00251391745509*pow(V, 3) + 0.237884615385*pow(V, 2) + 0.704304812834*V + -0.056561085973);
+        break;
+    case 20: //MINOURA V270/v130 on L
+        pf = PolyFitGenerator::GetPolyFit({ -0.0859728506788, 0.642516796929, 0.122555189908 , -6.92787604552e-05, -3.38406691348e-05, 3.46907993967e-07 });
+        //rtData.setWatts(3.46907993967e-07*pow(V, 5) + -3.38406691348e-05*pow(V, 4) + -6.92787604552e-05*pow(V, 3) + 0.122555189908*pow(V, 2) + 0.642516796929*V + -0.0859728506788);
+        break;
+    case 21: //SARIS POWERBEAM PRO
+            // 21 = 0.0008x^3 + 0.145x^2 + 2.5299x + 14.641 where x = speed in kph
+        pf = PolyFitGenerator::GetPolyFit({ 14.641, 2.5299, 0.145, 0.0008 });
+        //rtData.setWatts(0.0008*pow(V, 3) + 0.145*pow(V, 2) + (2.5299*V) + 14.641);
+        break;
+    case 22: //  TACX SATORI SETTING 2
+        pf = PolyFitGenerator::GetPolyFit({ -19.5, 3.9 });
+        //double slope = 3.9;
+        //double intercept = -19.5;
+        //rtData.setWatts((slope * V) + intercept);
+        break;
+    case 23: //  TACX SATORI SETTING 4
+        pf = PolyFitGenerator::GetPolyFit({ -52.3, 6.66 });
+        //double slope = 6.66;
+        //double intercept = -52.3;
+        //rtData.setWatts((slope * V) + intercept);
+        break;
+    case 24: //  TACX SATORI SETTING 6
+        pf = PolyFitGenerator::GetPolyFit({ -43.65, 9.43 });
+        //double slope = 9.43;
+        //double intercept = -43.65;
+        //rtData.setWatts((slope * V) + intercept);
+        break;
+    case 25: //  TACX SATORI SETTING 8
+        pf = PolyFitGenerator::GetPolyFit({ -51.15, 13.73 });
+        //double slope = 13.73;
+        //double intercept = -51.15;
+        //rtData.setWatts((slope * V) + intercept);
+        break;
+    case 26: //  TACX SATORI SETTING 10
+        pf = PolyFitGenerator::GetPolyFit({ -76.0, 17.7 });
+        //double slope = 17.7;
+        //double intercept = -76.0;
+        //rtData.setWatts((slope * V) + intercept);
+        break;
+    case 27: //  TACX FLOW SETTING 0
+        pf = PolyFitGenerator::GetPolyFit({ -47.27, 7.75 });
+        //double slope = 7.75;
+        //double intercept = -47.27;
+        //rtData.setWatts((slope * V) + intercept);
+        break;
+    case 28: //  TACX FLOW SETTING 2
+        pf = PolyFitGenerator::GetPolyFit({ -66.69, 9.51 });
+        //double slope = 9.51;
+        //double intercept = -66.69;
+        //rtData.setWatts((slope * V) + intercept);
+        break;
+    case 29: //  TACX FLOW SETTING 4
+        pf = PolyFitGenerator::GetPolyFit({ -71.59, 11.03 });
+        //double slope = 11.03;
+        //double intercept = -71.59;
+        //rtData.setWatts((slope * V) + intercept);
+        break;
+    case 30: //  TACX FLOW SETTING 6
+        pf = PolyFitGenerator::GetPolyFit({ -95.05, 12.81 });
+        //double slope = 12.81;
+        //double intercept = -95.05;
+        //rtData.setWatts((slope * V) + intercept);
+        break;
+    case 31: //  TACX FLOW SETTING 8
+        pf = PolyFitGenerator::GetPolyFit({ -102.43, 14.37 });
+        //double slope = 14.37;
+        //double intercept = -102.43;
+        //rtData.setWatts((slope * V) + intercept);
+        break;
+    case 32: //  TACX BLUE TWIST SETTING 1
+        pf = PolyFitGenerator::GetPolyFit({ -24, 3.2 });
+        //double V = rtData.getSpeed();
+        //double slope = 3.2;
+        //double intercept = -24.0;
+        //rtData.setWatts((slope * V) + intercept);
+        break;
+    case 33: //  TACX BLUE TWIST SETTING 3
+        pf = PolyFitGenerator::GetPolyFit({ -46.5, 6.525 });
+        //double V = rtData.getSpeed();
+        //double slope = 6.525;
+        //double intercept = -46.5;
+        //rtData.setWatts((slope * V) + intercept);
+        break;
+    case 34: //  TACX BLUE TWIST SETTING 5
+        pf = PolyFitGenerator::GetPolyFit({ -66.5, 9.775 });
+        //double V = rtData.getSpeed();
+        //double slope = 9.775;
+        //double intercept = -66.5;
+        //rtData.setWatts((slope * V) + intercept);
+        break;
+    case 35: //  TACX BLUE TWIST SETTING 7
+        pf = PolyFitGenerator::GetPolyFit({ -89.5, 13.075 });
+        //double V = rtData.getSpeed();
+        //double slope = 13.075;
+        //double intercept = -89.5;
+        //rtData.setWatts((slope * V) + intercept);
+        break;
+    case 36: //  TACX BLUE MOTION SETTING 2
+        pf = PolyFitGenerator::GetPolyFit({ -36.5, 5.225 });
+        //double V = rtData.getSpeed();
+        //double slope = 5.225;
+        //double intercept = -36.5;
+        //rtData.setWatts((slope * V) + intercept);
+        break;
+    case 37: //  TACX BLUE MOTION SETTING 4
+        pf = PolyFitGenerator::GetPolyFit({ -53.0, 8.25 });
+        //double V = rtData.getSpeed();
+        //double slope = 8.25;
+        //double intercept = -53.0;
+        //rtData.setWatts((slope * V) + intercept);
+        break;
+    case 38: //  TACX BLUE MOTION SETTING 6
+        pf = PolyFitGenerator::GetPolyFit({ -74.0, 11.45 });
+        //double V = rtData.getSpeed();
+        //double slope = 11.45;
+        //double intercept = -74.0;
+        //rtData.setWatts((slope * V) + intercept);
+        break;
+    case 39: //  TACX BLUE MOTION SETTING 8
+        pf = PolyFitGenerator::GetPolyFit({ -89, 14.45 });
+        //double V = rtData.getSpeed();
+        //double slope = 14.45;
+        //double intercept = -89.0;
+        //rtData.setWatts((slope * V) + intercept);
+        break;
+    case 40: //  TACX BLUE MOTION SETTING 10
+        pf = PolyFitGenerator::GetPolyFit({ -110.5, 17.575 });
+        //double V = rtData.getSpeed();
+        //double slope = 17.575;
+        //double intercept = -110.5;
+        //rtData.setWatts((slope * V) + intercept);
+        break;
+    case 41: // ELITE SUPERCRONO POWER MAG LEVEL 1
+        // Power curve provided by extraction from SportsTracks plugin
+        pf = PolyFitGenerator::GetPolyFit({ -1.16783216783223, 3.62446277061515, 0.17689196198325 , -0.000803192769148186 }, MILES_PER_KM);
+        //double V = rtData.getSpeed() * MILES_PER_KM;
+        //rtData.setWatts(-0.000803192769148186*pow(V, 3) + 0.17689196198325*pow(V,2) + (3.62446277061515*V) - 1.16783216783223);
+        break;
+    case 42: // ELITE SUPERCRONO POWER MAG LEVEL 2
+        // Power curve provided by extraction from SportsTracks plugin
+        pf = PolyFitGenerator::GetPolyFit({ -0.363636363636395, 3.54843470904764, 0.442531768374482 ,-0.00590735326986424 }, MILES_PER_KM);
+        //double V = rtData.getSpeed() * MILES_PER_KM;
+        //rtData.setWatts(-0.00590735326986424*pow(V, 3) + 0.442531768374482*pow(V,2) + (3.54843470904764*V) - 0.363636363636395);
+        break;
+    case 43: // ELITE SUPERCRONO POWER MAG LEVEL 3
+        // Power curve provided by extraction from SportsTracks plugin
+        pf = PolyFitGenerator::GetPolyFit({ -1.48951048951047, 5.08762781732785, 0.614352424962992 , -0.00917194323478923 }, MILES_PER_KM);
+        //double V = rtData.getSpeed() * MILES_PER_KM;
+        //rtData.setWatts(pf->Fit(V));
+        //rtData.setWatts(-0.00917194323478923*pow(V, 3) + 0.614352424962992*pow(V,2) + (5.08762781732785*V) - 1.48951048951047);
+        break;
+    case 44: // ELITE SUPERCRONO POWER MAG LEVEL 4
+        // Power curve provided by extraction from SportsTracks plugin
+        pf = PolyFitGenerator::GetPolyFit({ -1.7342657342657, 5.16903286351279, 0.880112976720764 ,-0.0150015681721553 }, MILES_PER_KM);
+        //double V = rtData.getSpeed() * MILES_PER_KM;
+        //rtData.setWatts(pf->Fit(V));
+        //rtData.setWatts(-0.0150015681721553*pow(V, 3) + 0.880112976720764*pow(V,2) + (5.16903286351279*V) - 1.7342657342657);
+        break;
+    case 45: // ELITE SUPERCRONO POWER MAG LEVEL 5
+        // Power curve provided by extraction from SportsTracks plugin
+        pf = PolyFitGenerator::GetPolyFit({ -3.18881118881126,6.23730215622854,1.0207209560583 ,-0.0172621671756449 }, MILES_PER_KM);
+        //double V = rtData.getSpeed() * MILES_PER_KM;
+        //rtData.setWatts(-0.0172621671756449*pow(V, 3) + 1.0207209560583*pow(V,2) + (6.23730215622854*V) - 3.18881118881126);
+        break;
+    case 46: // ELITE SUPERCRONO POWER MAG LEVEL 6
+        // Power curve provided by extraction from SportsTracks plugin
+        pf = PolyFitGenerator::GetPolyFit({ -4.18881118881114, 7.47138264900755, 1.15505017633569, -0.0195227661791347 }, MILES_PER_KM);
+        //double V = rtData.getSpeed() * MILES_PER_KM;
+        //rtData.setWatts(-0.0195227661791347*pow(V, 3) + 1.15505017633569*pow(V,2) + (7.47138264900755*V) - 4.18881118881114);
+        break;
+    case 47: // ELITE SUPERCRONO POWER MAG LEVEL 7
+        // Power curve provided by extraction from SportsTracks plugin
+        pf = PolyFitGenerator::GetPolyFit({ -5.11888111888112, 8.74972948026508, 1.2917943039439 , -0.0222497351776137 }, MILES_PER_KM);
+        //double V = rtData.getSpeed() * MILES_PER_KM;
+        //rtData.setWatts(-0.0222497351776137*pow(V, 3) + 1.2917943039439*pow(V,2) + (8.74972948026508*V) - 5.11888111888112);
+        break;
+    case 48: // ELITE SUPERCRONO POWER MAG LEVEL 8
+        // Power curve provided by extraction from SportsTracks plugin
+        pf = PolyFitGenerator::GetPolyFit({ -6.48951048951042, 10.2050166192824, 1.42902141301828 ,-0.0255078477814972 }, MILES_PER_KM);
+        //double V = rtData.getSpeed() * MILES_PER_KM;
+        //rtData.setWatts(-0.0255078477814972*pow(V, 3) + 1.42902141301828*pow(V,2) + (10.2050166192824*V) - 6.48951048951042);
+        break;
+    case 49: //ELITE TURBO MUIN 2013
+        // Power curve fit from data collected by Ray Maker at dcrainmaker.com
+        pf = PolyFitGenerator::GetPolyFit({ 0, 2.30615942, -0.28395558, 0.02099661 });
+        //double V = rtData.getSpeed();
+        //rtData.setWatts(2.30615942 * V -0.28395558 * pow(V,2) + 0.02099661 * pow(V,3));
+        break;
+    case 50: // ELITE QUBO POWER FLUID
+        // Power curve fit from powercurvesensor
+        //     f(x) = 4.31746 * x -2.59259e-002 * x^2 +  9.41799e-003 * x^3
+        pf = PolyFitGenerator::GetPolyFit({ 0, 4.31746, -2.59259e-002 , 9.41799e-003 });
+        //double V = rtData.getSpeed();
+        //rtData.setWatts(4.31746 * V - 2.59259e-002 * pow(V, 2) + 9.41799e-003 * pow(V, 3));
+        break;
+    case 51: // CYCLOPS MAGNETO PRO (ROAD)
+        //     Watts = 6.0f + (-0.93 * speed) + (0.275 * speed^2) + (-0.00175 * speed^3)
+        pf = PolyFitGenerator::GetPolyFit({ 0, -0.93, 0.275, -0.00175 });
+        //double V = rtData.getSpeed();
+        //rtData.setWatts(6.0f + (-0.93f * V) + (0.275f * pow(V, 2)) + (-0.00175f * pow(V, 3)));
+        break;
+    case 52: // ELITE ARION MAG LEVEL 0
+        pf = PolyFitGenerator::GetFractionalPolyFit({ 3.335794377, 1.217110021, 0. });
+        //double v = rtData.getSpeed();
+        //rtData.setWatts(pow(v, 1.217110021) * 3.335794377);
+        break;
+    case 53: // ELITE ARION MAG LEVEL 1
+        pf = PolyFitGenerator::GetFractionalPolyFit({ 1.206592577, 4.362485081, 0. });
+        //double v = rtData.getSpeed();
+        //rtData.setWatts(pow(v, 1.206592577) * 4.362485081);
+        break;
+    case 54: // ELITE ARION MAG LEVEL 2
+        pf = PolyFitGenerator::GetFractionalPolyFit({ 1.206984321, 6.374459698, 0. });
+        //double v = rtData.getSpeed();
+        //rtData.setWatts(pow(v, 1.206984321) * 6.374459698);
+        break;
+    case 55: // Blackburn Tech Fluid
+        pf = PolyFitGenerator::GetPolyFit({ 6.758241758241894, -1.9995004995004955, 0.24165834165834146 });
+        //double v = rtData.getSpeed();
+        //rtData.setWatts(6.758241758241894 - 1.9995004995004955 * v + 0.24165834165834146 * pow(v, 2));
+        break;
+    case 56: // TACX SIRIUS LEVEL 1
+        pf = PolyFitGenerator::GetPolyFit({ -20.64808196, 3.23874687 });
+        //double v = rtData.getSpeed();
+        //rtData.setWatts(3.23874687 * v - 20.64808196);
+        break;
+    case 57: // TACX SIRIUS LEVEL 2
+        pf = PolyFitGenerator::GetPolyFit({ -27.25589246, 4.30606133 });
+        //double v = rtData.getSpeed();
+        //rtData.setWatts(4.30606133 * v - 27.25589246);
+        break;
+    case 58: // TACX SIRIUS LEVEL 3
+        pf = PolyFitGenerator::GetPolyFit({ -36.57159131, 5.44879778 });
+        //double v = rtData.getSpeed();
+        //rtData.setWatts(5.44879778 * v - 36.57159131);
+        break;
+    case 59: // TACX SIRIUS LEVEL 4
+        pf = PolyFitGenerator::GetPolyFit({ -40.48616615, 6.48525956 });
+        //double v = rtData.getSpeed();
+        //rtData.setWatts(6.48525956 * v - 40.48616615);
+        break;
+    case 60: // TACX SIRIUS LEVEL 5
+        pf = PolyFitGenerator::GetPolyFit({ -48.35481582, 7.60643338 });
+        //double v = rtData.getSpeed();
+        //rtData.setWatts(7.60643338 * v - 48.35481582);
+        break;
+    case 61: // TACX SIRIUS LEVEL 6
+        pf = PolyFitGenerator::GetPolyFit({ -58.57819586, 8.73140257 });
+        //double v = rtData.getSpeed();
+        //rtData.setWatts(8.73140257 * v - 58.57819586);
+        break;
+    case 62: // TACX SIRIUS LEVEL 7
+        pf = PolyFitGenerator::GetPolyFit({ -59.61416463, 9.73079724 });
+        //double v = rtData.getSpeed();
+        //rtData.setWatts(9.73079724 * v - 59.61416463);
+        break;
+    case 63: // TACX SIRIUS LEVEL 8
+        pf = PolyFitGenerator::GetPolyFit({ -73.08258491, 10.94228338 });
+        //double v = rtData.getSpeed();
+        //rtData.setWatts(10.94228338 * v - 73.08258491);
+        break;
+    case 64: // TACX SIRIUS LEVEL 9
+        pf = PolyFitGenerator::GetPolyFit({ -77.88781457, 11.99373782 });
+        //double v = rtData.getSpeed();
+        //rtData.setWatts(11.99373782 * v - 77.88781457);
+        break;
+    case 65: // TACX SIRIUS LEVEL 10
+        pf = PolyFitGenerator::GetPolyFit({ -85.38477516, 13.09580164 });
+        //double v = rtData.getSpeed();
+        //rtData.setWatts(13.09580164 * v - 85.38477516);
+        break;
+    case 66: // ELITE CRONO FLUID ELASTOGEL
+        pf = PolyFitGenerator::GetPolyFit({ 0, 2.4508084253648112, -0.0005622440886940634 ,0.0031006831781331848 });
+        //double v = rtData.getSpeed();
+        //rtData.setWatts(2.4508084253648112 * v - 0.0005622440886940634 * pow(v, 2) + 0.0031006831781331848 * pow(v, 3));
+        break;
+    case 67: // ELITE TURBO MUIN 2015
+        pf = PolyFitGenerator::GetPolyFit({ 0, 3.01523235942763813175,  -0.12045521113635432750 , 0.01739165560254292102 });
+        //double V = rtData.getSpeed();
+        //rtData.setWatts(3.01523235942763813175 * V - 0.12045521113635432750 * pow(V,2) + 0.01739165560254292102 * pow(V,3));
+        break;
+    case 68: // CycleOps JetFluid Pro
+        pf = PolyFitGenerator::GetPolyFit({ 0, 0.94874757375670469046 , 0.11615123681031937322 , 0.00400691905019748630 });
+        //double V = rtData.getSpeed();
+        //rtData.setWatts(0.94874757375670469046 * V + 0.11615123681031937322 * pow(V,2) + 0.00400691905019748630 * pow(V,3));
+        break;
+    case 69: // Elite Crono Mag elastogel
+        pf = PolyFitGenerator::GetPolyFit({ 0, 7.34759700400455518172, -0.00278841177590215417, 0.00052233430180969281 });
+        //double V = rtData.getSpeed();
+        //rtData.setWatts(7.34759700400455518172 * V - 0.00278841177590215417 * pow(V,2) + 0.00052233430180969281 * pow(V,3));
+        break;
+    case 70: // Tacx Magnetic T1820 (4/7)
+        pf = PolyFitGenerator::GetPolyFit({ 0, 6.77999074563685972005, -0.00148787143661883094, 0.00085058630585658189 });
+        //double V = rtData.getSpeed();
+        //rtData.setWatts(6.77999074563685972005 * V - 0.00148787143661883094 * pow(V,2) + 0.00085058630585658189 * pow(V,3));
+        break;
+    case 71: // Tacx Magnetic T1820 (7/7)
+        pf = PolyFitGenerator::GetPolyFit({ 0, 9.80556623734881995572, -0.00668894865103764724,  0.00125560535410925628 });
+        //double V = rtData.getSpeed();
+        //rtData.setWatts(9.80556623734881995572 * V - 0.00668894865103764724 * pow(V,2) + 0.00125560535410925628 * pow(V,3));
+        break;
+    default: // unknown - do nothing
+        break;
+    }
+
+    polyFit = pf;
+    if (polyFit) {
+        iFitId = postProcess;
+    }
+}
+
 
 // for future devices, we may need to setup algorithmic tables etc
 void
@@ -637,21 +508,7 @@ RealtimeController::processSetup()
 {
     if (!dc) return; // no config
 
-    // setup the algorithm or lookup tables
-    // for the device postProcessing type
-    switch(dc->postProcess) {
-    case 0 : // nothing!
-        break;
-    case 1 : // TODO Kurt Kinetic - use an algorithm...
-    case 2 : // TODO Kurt Kinetic - use an algorithm...
-        break;
-    case 3 : // TODO Cyclops Fluid 2 - use an algorithm
-        break;
-    case 4 : // TODO BT-ATS - BT Advanced Training System - use an algorithm
-        break;
-    default : // unknown - do nothing
-        break;
-    }
+    SetupPolyFitFromPostprocessId(dc->postProcess);
 }
 
 void

--- a/src/Train/RealtimeController.h
+++ b/src/Train/RealtimeController.h
@@ -26,6 +26,8 @@
 #define _GC_RealtimeController_h 1
 #include "GoldenCheetah.h"
 
+#include "PolynomialRegression.h"
+
 #define DEVICE_ERROR 1
 #define DEVICE_OK 0
 
@@ -37,7 +39,7 @@ public:
     TrainSidebar *parent;                     // for push devices
 
     RealtimeController (TrainSidebar *parent, DeviceConfiguration *dc = 0);
-    virtual ~RealtimeController() {}
+    virtual ~RealtimeController() { delete polyFit; }
 
     virtual int start();
     virtual int restart();                              // restart after paused
@@ -85,6 +87,12 @@ private:
     DeviceConfiguration *dc;
     DeviceConfiguration devConf;
     QTime lastCalTimestamp;
+
+    PolyFit<double>* polyFit; // Speed to power fit.
+    int iFitId;                 // For lazy re-init, record id of current fit.
+    bool fUseWheelRpm;          // If power is derived from wheelrpm instead of speed.
+
+    void SetupPolyFitFromPostprocessId(int postProcess);
 };
 
 #endif // _GC_RealtimeController_h

--- a/src/Train/RealtimeController.h
+++ b/src/Train/RealtimeController.h
@@ -27,6 +27,8 @@
 
 #include "GoldenCheetah.h"
 
+#include <string>
+
 #define DEVICE_ERROR 1
 #define DEVICE_OK 0
 
@@ -34,10 +36,12 @@ struct VirtualPowerTrainer {
     const char*            m_pName;
     const PolyFit<double>* m_pf;
     bool                   m_fUseWheelRpm;
+
+    void to_string(std::string& s) const;
 };
 
 extern const VirtualPowerTrainer s_VirtualPowerTrainerArray[];
-extern const size_t              s_VirtualPowerTrainerArraySize;
+extern const int                 s_VirtualPowerTrainerArraySize;
 
 class VirtualPowerTrainerManager {
     // Custom are dynamic and managed by class instance.
@@ -45,13 +49,18 @@ class VirtualPowerTrainerManager {
 
     const VirtualPowerTrainer* GetCustomVirtualPowerTrainer(int id) const;
 
+    int  GetPredefinedVirtualPowerTrainerCount() const;
+    int  GetCustomVirtualPowerTrainerCount() const;
+
 public:
-    size_t GetPredefinedVirtualPowerTrainerCount() const;
-    size_t GetCustomVirtualPowerTrainerCount() const;
-    size_t GetVirtualPowerTrainerCount() const;
+    static bool IsPredefinedVirtualPowerTrainerIndex(int id);
+    int  GetVirtualPowerTrainerCount() const;
     const VirtualPowerTrainer* GetVirtualPowerTrainer(int idx) const;
 
-    size_t PushCustomVirtualPowerTrainer(const VirtualPowerTrainer* vpt);
+    int  PushCustomVirtualPowerTrainer(const VirtualPowerTrainer* vpt);
+
+    void GetVirtualPowerTrainerAsString(int idx, QString& string);
+    int  PushCustomVirtualPowerTrainer(const QString& string);
 
     ~VirtualPowerTrainerManager();
 };
@@ -115,15 +124,12 @@ private:
 
     const PolyFit<double>* polyFit; // Speed to power fit.
     bool fUseWheelRpm;              // If power is derived from wheelrpm instead of speed.
-    int iFitId;                     // For lazy re-init, record id of current fit.
-
-    // Virtual Power Trainer Curve Management
 
 public:
     VirtualPowerTrainerManager virtualPowerTrainerManager;
 
     // Predefined are static so not part of instance.
-    static size_t GetPredefinedVirtualPowerTrainerCount();
+    static int GetPredefinedVirtualPowerTrainerCount();
     static const VirtualPowerTrainer* GetPredefinedVirtualPowerTrainer(int id);
 
     bool SetupPolyFitFromPostprocessId(int postProcess);

--- a/src/src.pro
+++ b/src/src.pro
@@ -778,7 +778,8 @@ HEADERS += Train/AddDeviceWizard.h Train/CalibrationData.h Train/ComputrainerCon
            Train/DeviceTypes.h Train/DialWindow.h Train/ErgDBDownloadDialog.h Train/ErgDB.h Train/ErgFile.h Train/ErgFilePlot.h \
            Train/Library.h Train/LibraryParser.h Train/MeterWidget.h Train/NullController.h Train/RealtimeController.h \
            Train/RealtimeData.h Train/RealtimePlot.h Train/RealtimePlotWindow.h Train/RemoteControl.h Train/SpinScanPlot.h \
-           Train/SpinScanPlotWindow.h Train/SpinScanPolarPlot.h Train/GarminServiceHelper.h Train/PhysicsUtility.h Train/BicycleSim.h
+           Train/SpinScanPlotWindow.h Train/SpinScanPolarPlot.h Train/GarminServiceHelper.h Train/PhysicsUtility.h Train/BicycleSim.h \
+           Train/PolynomialRegression.h Train/MultiRegressionizer.h
 
 greaterThan(QT_MAJOR_VERSION, 4) {
     HEADERS += Train/TodaysPlanWorkoutDownload.h
@@ -879,7 +880,8 @@ SOURCES += Train/AddDeviceWizard.cpp Train/CalibrationData.cpp Train/Computraine
            Train/DeviceTypes.cpp Train/DialWindow.cpp Train/ErgDB.cpp Train/ErgDBDownloadDialog.cpp Train/ErgFile.cpp Train/ErgFilePlot.cpp \
            Train/Library.cpp Train/LibraryParser.cpp Train/MeterWidget.cpp Train/NullController.cpp Train/RealtimeController.cpp \
            Train/RealtimeData.cpp Train/RealtimePlot.cpp Train/RealtimePlotWindow.cpp Train/RemoteControl.cpp Train/SpinScanPlot.cpp \
-           Train/SpinScanPlotWindow.cpp Train/SpinScanPolarPlot.cpp Train/GarminServiceHelper.cpp Train/PhysicsUtility.cpp Train/BicycleSim.cpp
+           Train/SpinScanPlotWindow.cpp Train/SpinScanPolarPlot.cpp Train/GarminServiceHelper.cpp Train/PhysicsUtility.cpp Train/BicycleSim.cpp \
+           Train/PolynomialRegression.cpp
 
 greaterThan(QT_MAJOR_VERSION, 4) {
     SOURCES  += Train/TodaysPlanWorkoutDownload.cpp


### PR DESCRIPTION
This is part 1 of issue 3408.

Implements all the math needed for custom power curve feature, then ports all current virtual curves in realtimetrainer to use new polyfit object.

Subsequent checkins will add ui to allow custom functions to be defined and used.

Added test function to pull in and compile the templates (not called.)
