### PR TITLE
Elevation and grade gidgets

### DIFF
--- a/src/Resources/xml/video-layout.xml
+++ b/src/Resources/xml/video-layout.xml
@@ -84,12 +84,6 @@
        <Text>load</Text>
    </meter>
 	<!-- START  Changes for elevation widget -->
-    <meter name="duration" container="Video" source="Duration" type="Text">
-        <RelativeSize Width="15.0" Height="5.0" />
-        <RelativePosition X="18.0" Y="0.0" />
-	    <MainColor R="255" G="255" B="255" A="255" />
-        <BackgroundColor R="255" G="255" B="255" A="0" />		
-	</meter>
 	<meter name="elevation" container="Video" source="Elevation" type="Elevation">
 		<RelativeSize Width="40.0" Height="15.0" />
 		<RelativePosition X="20.0" Y="92.0" />

--- a/src/Resources/xml/video-layout.xml
+++ b/src/Resources/xml/video-layout.xml
@@ -90,19 +90,6 @@
 	    <MainColor R="255" G="255" B="255" A="255" />
         <BackgroundColor R="255" G="255" B="255" A="0" />		
 	</meter>
-    <meter name="distance" container="Video" source="Distance" type="Text">
-        <RelativeSize Width="10.0" Height="5.0" />
-        <RelativePosition X="18.0" Y="7.0" />
-	    <MainColor R="255" G="255" B="255" A="255" />
-        <BackgroundColor R="255" G="255" B="255" A="0" />	
-	</meter>
-<!-- Included in elevation for now
-    <meter name="gradient" container="Video" source="Gradient" type="Text">
-        <RelativeSize Width="10.0" Height="5.0" />
-        <RelativePosition X="15.0" Y="13.0" />
-		<BackgroundColor R="200" G="200" B="200" A="125" />
-	</meter>
--->
 	<meter name="elevation" container="Video" source="Elevation" type="Elevation">
 		<RelativeSize Width="40.0" Height="15.0" />
 		<RelativePosition X="20.0" Y="92.0" />

--- a/src/Resources/xml/video-layout.xml
+++ b/src/Resources/xml/video-layout.xml
@@ -83,4 +83,32 @@
        <MainColor R="255" G="0" B="0" A="180" />
        <Text>load</Text>
    </meter>
+	<!-- START  Changes for elevation widget -->
+    <meter name="duration" container="Video" source="Duration" type="Text">
+        <RelativeSize Width="15.0" Height="5.0" />
+        <RelativePosition X="18.0" Y="0.0" />
+	    <MainColor R="255" G="255" B="255" A="255" />
+        <BackgroundColor R="255" G="255" B="255" A="0" />		
+	</meter>
+    <meter name="distance" container="Video" source="Distance" type="Text">
+        <RelativeSize Width="10.0" Height="5.0" />
+        <RelativePosition X="18.0" Y="7.0" />
+	    <MainColor R="255" G="255" B="255" A="255" />
+        <BackgroundColor R="255" G="255" B="255" A="0" />	
+	</meter>
+<!-- Included in elevation for now
+    <meter name="gradient" container="Video" source="Gradient" type="Text">
+        <RelativeSize Width="10.0" Height="5.0" />
+        <RelativePosition X="15.0" Y="13.0" />
+		<BackgroundColor R="200" G="200" B="200" A="125" />
+	</meter>
+-->
+	<meter name="elevation" container="Video" source="Elevation" type="Elevation">
+		<RelativeSize Width="40.0" Height="15.0" />
+		<RelativePosition X="20.0" Y="92.0" />
+		<BackgroundColor R="200" G="200" B="200" A="125" />
+		<OutlineColor R="255" G="255" B="255" A="250" />
+        <MainColor R="255" G="0" B="0" A="250" />
+    </meter>
+	<!-- END Changes for elevation widget -->
 </layout>

--- a/src/Train/MeterWidget.cpp
+++ b/src/Train/MeterWidget.cpp
@@ -43,6 +43,7 @@ MeterWidget::MeterWidget(QString Name, QWidget *parent, QString Source) : QWidge
     m_Angle = 180.0;
     m_SubRange = 10;
     boundingRectVisibility = false;
+    forceSquareRatio = true;
 }
 
 void MeterWidget::SetRelativeSize(float RelativeWidth, float RelativeHeight)
@@ -75,7 +76,13 @@ void MeterWidget::AdjustSizePos()
 
 void MeterWidget::ComputeSize()
 {
-    m_Width = m_Height = (m_container->width() * m_RelativeWidth + m_container->height() * m_RelativeHeight) / 2;
+    if (forceSquareRatio)
+        m_Width = m_Height = (m_container->width() * m_RelativeWidth + m_container->height() * m_RelativeHeight) / 2;
+    else
+    {
+        m_Width = m_container->width() * m_RelativeWidth;
+        m_Height =  m_container->height() * m_RelativeHeight;
+    }
 }
 
 QSize MeterWidget::sizeHint() const
@@ -119,12 +126,7 @@ void MeterWidget::setBoundingRectVisibility(bool show, QColor  boundingRectColor
 
 TextMeterWidget::TextMeterWidget(QString Name, QWidget *parent, QString Source) : MeterWidget(Name, parent, Source)
 {
-}
-
-void TextMeterWidget::ComputeSize()
-{
-    m_Width = m_container->width() * m_RelativeWidth;
-    m_Height =  m_container->height() * m_RelativeHeight;
+    forceSquareRatio = false;
 }
 
 void TextMeterWidget::paintEvent(QPaintEvent* paintevent)

--- a/src/Train/MeterWidget.cpp
+++ b/src/Train/MeterWidget.cpp
@@ -37,7 +37,7 @@ MeterWidget::MeterWidget(QString Name, QWidget *parent, QString Source) : QWidge
     m_OutlineColor = QColor(128,128,128,180);
     m_MainFont = QFont(this->font().family(), 64);
     m_AltFont = QFont(this->font().family(), 48);
-    m_BackgroundColor = QColor(96, 96, 96, 200);
+    m_BackgroundColor = QColor(96, 96, 96, 0);
     m_RangeMin = 0;
     m_RangeMax = 100;
     m_Angle = 180.0;
@@ -134,6 +134,7 @@ void TextMeterWidget::paintEvent(QPaintEvent* paintevent)
     MeterWidget::paintEvent(paintevent);
 
     m_MainBrush = QBrush(m_MainColor);
+    m_BackgroundBrush = QBrush(m_BackgroundColor);
     m_OutlinePen = QPen(m_OutlineColor);
     m_OutlinePen.setWidth(1);
     m_OutlinePen.setStyle(Qt::SolidLine);
@@ -141,6 +142,12 @@ void TextMeterWidget::paintEvent(QPaintEvent* paintevent)
     //painter
     QPainter painter(this);
     painter.setRenderHint(QPainter::Antialiasing);
+
+    //draw background
+    painter.setPen(Qt::NoPen);
+    painter.setBrush(m_BackgroundBrush);
+    if (Text!=QString(""))
+        painter.drawRect (0, 0, m_Width, m_Height);
 
     QPainterPath my_painterPath;
     my_painterPath.addText(QPointF(0,0),m_MainFont,Text);

--- a/src/Train/MeterWidget.cpp
+++ b/src/Train/MeterWidget.cpp
@@ -407,9 +407,9 @@ void ElevationMeterWidget::paintEvent(QPaintEvent* paintevent)
 
     // Display gradient text to the right of the line until the middle, then display to the left of the line
     if (cyclistX < m_Width*0.5) {
-        painter.drawText((double)cyclistX, ((double)m_Height * 0.95), s_grad);
+        painter.drawText((double)cyclistX+5, ((double)m_Height * 0.95), s_grad);
     } else {
-        painter.drawText((double)cyclistX-40, ((double)m_Height * 0.95), s_grad);
+        painter.drawText((double)cyclistX-45, ((double)m_Height * 0.95), s_grad);
     }
     //Debug
     //sGrad = s_grad.toStdString();

--- a/src/Train/MeterWidget.cpp
+++ b/src/Train/MeterWidget.cpp
@@ -333,14 +333,7 @@ void ElevationMeterWidget::paintEvent(QPaintEvent* paintevent)
     QPainter painter(this);
     painter.setRenderHint(QPainter::Antialiasing);
 
-//    at present no more background, maybe it will be restored in a future developpment
-//    //draw background
-//    painter.setPen(Qt::NoPen);
-//    painter.setBrush(m_BackgroundBrush);
-//    painter.drawRect (0, 0, m_Width, m_Height);
-
-    // TODO : do this only once for the same ergfile, make Min/Max and Polygon part of class members
-    //find min/max
+    // Find min/max
     double minX, minY, maxX, maxY, cyclistX=0.0;
     // (based on ErgFilePlot.cpp)
     minX=maxX=context->currentErgFile()->Points[0].x; // meters
@@ -362,21 +355,15 @@ void ElevationMeterWidget::paintEvent(QPaintEvent* paintevent)
     // this->Value should hold the current distance in meters. 
     cyclistX = (this->Value * 1000.0 - minX) * (double)m_Width / (maxX-minX);
 
-    //Test variables
-    //double ptx=0, pty=0, d_pts=0;
-
+    //Get point to create the polygon
     QPolygon polygon;
     polygon << QPoint(0.0, (double)m_Height);
     double x, y, pt=0;
     double nextX = 1;
-    //d_pts = context->currentErgFile()->Points.size();
     for( pt=0; pt < context->currentErgFile()->Points.size(); pt++)
     {
         for ( ; x < nextX && pt < context->currentErgFile()->Points.size(); pt++)
         {
-            //d_pts = context->currentErgFile()->Points.size();
-            //ptx = (context->currentErgFile()->Points[pt].x - minX);
-            //pty = (context->currentErgFile()->Points[pt].y - minY);
             x = (context->currentErgFile()->Points[pt].x - minX) * (double)m_Width / (maxX-minX);
             y = (context->currentErgFile()->Points[pt].y - minY) * (double)m_Height / (maxY-minY);
         }
@@ -411,7 +398,4 @@ void ElevationMeterWidget::paintEvent(QPaintEvent* paintevent)
     } else {
         painter.drawText((double)cyclistX-45, ((double)m_Height * 0.95), s_grad);
     }
-    //Debug
-    //sGrad = s_grad.toStdString();
-    //qDebug("==> cyclistx,gradient,s_grad,sGrad = %f, %f, %s, %s", cyclistX, this->gradientValue, s_grad, sGrad);
 } 

--- a/src/Train/MeterWidget.cpp
+++ b/src/Train/MeterWidget.cpp
@@ -79,7 +79,9 @@ void MeterWidget::AdjustSizePos()
 void MeterWidget::ComputeSize()
 {
     if (forceSquareRatio)
+    {
         m_Width = m_Height = (m_container->width() * m_RelativeWidth + m_container->height() * m_RelativeHeight) / 2;
+    }
     else
     {
         m_Width = m_container->width() * m_RelativeWidth;

--- a/src/Train/MeterWidget.cpp
+++ b/src/Train/MeterWidget.cpp
@@ -360,24 +360,23 @@ void ElevationMeterWidget::paintEvent(QPaintEvent* paintevent)
     minY -= (maxY-minY) * 0.20f; // add 20% as bottom headroom (slope gradient will be shown there in a bubble)
 
     // this->Value should hold the current distance in meters. 
-     // need to change to context->currentErgFile()-> rtd.getDistance();
     cyclistX = (this->Value * 1000.0 - minX) * (double)m_Width / (maxX-minX);
 
     //Test variables
-    double ptx=0, pty=0, d_pts=0;
+    //double ptx=0, pty=0, d_pts=0;
 
     QPolygon polygon;
     polygon << QPoint(0.0, (double)m_Height);
     double x, y, pt=0;
     double nextX = 1;
-    d_pts = context->currentErgFile()->Points.size();
+    //d_pts = context->currentErgFile()->Points.size();
     for( pt=0; pt < context->currentErgFile()->Points.size(); pt++)
     {
         for ( ; x < nextX && pt < context->currentErgFile()->Points.size(); pt++)
         {
-            d_pts = context->currentErgFile()->Points.size();
-            ptx = (context->currentErgFile()->Points[pt].x - minX);
-            pty = (context->currentErgFile()->Points[pt].y - minY);
+            //d_pts = context->currentErgFile()->Points.size();
+            //ptx = (context->currentErgFile()->Points[pt].x - minX);
+            //pty = (context->currentErgFile()->Points[pt].y - minY);
             x = (context->currentErgFile()->Points[pt].x - minX) * (double)m_Width / (maxX-minX);
             y = (context->currentErgFile()->Points[pt].y - minY) * (double)m_Height / (maxY-minY);
         }

--- a/src/Train/MeterWidget.h
+++ b/src/Train/MeterWidget.h
@@ -59,6 +59,7 @@ class MeterWidget : public QWidget
     float    m_RangeMin, m_RangeMax;
     float    m_Angle;
     int      m_SubRange;
+    bool     forceSquareRatio;
 
     QColor  m_MainColor;
     QColor  m_ScaleColor;
@@ -83,7 +84,6 @@ class TextMeterWidget : public MeterWidget
 {
   public:
     explicit TextMeterWidget(QString name, QWidget *parent = 0, QString Source = QString("None"));
-    virtual void ComputeSize();
     virtual void paintEvent(QPaintEvent* paintevent);
 };
 

--- a/src/Train/MeterWidget.h
+++ b/src/Train/MeterWidget.h
@@ -20,6 +20,7 @@
 #define _MeterWidget_h 1
 
 #include <QWidget>
+#include "Context.h"
 
 class MeterWidget : public QWidget
 {
@@ -109,5 +110,15 @@ class NeedleMeterWidget : public MeterWidget
     virtual void paintEvent(QPaintEvent* paintevent);
 };
 
+class ElevationMeterWidget : public MeterWidget
+{
+  public:
+    explicit ElevationMeterWidget(QString name, QWidget *parent = 0, QString Source = QString("None"), Context *context = NULL);
+    virtual void paintEvent(QPaintEvent* paintevent);
+    float gradientValue;
+    void setContext(Context *context) { this->context = context; }
+  private:
+    Context *context;
+};
 
 #endif // _MeterWidget_h

--- a/src/Train/VideoLayoutParser.cpp
+++ b/src/Train/VideoLayoutParser.cpp
@@ -134,6 +134,10 @@ bool VideoLayoutParser::startElement( const QString&, const QString&,
         {
             meterWidget = new CircularBargraphMeterWidget(meterName, containerWidget, source);
         }
+        else if (meterType == QString("Elevation"))
+        {
+            meterWidget = new ElevationMeterWidget(meterName, containerWidget, source);
+        }
         else
         {
             qDebug() << QObject::tr("Error creating meter");

--- a/src/Train/VideoLayoutParser.cpp
+++ b/src/Train/VideoLayoutParser.cpp
@@ -47,7 +47,7 @@ void VideoLayoutParser::SetDefaultValues()
         meterWidget->m_MainColor = QColor(255,0,0,200);
         meterWidget->m_ScaleColor = QColor(255,255,255,200);
         meterWidget->m_OutlineColor = QColor(100,100,100,200);
-        meterWidget->m_BackgroundColor = QColor(100,100,100,200);
+        meterWidget->m_BackgroundColor = QColor(100,100,100,0);
         meterWidget->m_MainFont = QFont(meterWidget->font().family(), 64);
         meterWidget->m_AltFont = QFont(meterWidget->font().family(), 48);
     }

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -335,7 +335,7 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
         }
         else if (p_meterWidget->Source() == QString("Duration"))
         {
-            // Formated time dureation of ride
+            // Formated time duration of ride
             p_meterWidget->Value = rtd.getMsecs();
             int hours = p_meterWidget->Value / 3600000L;
             int minutes = ((long)p_meterWidget->Value % 3600000L) / 60000L;

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -316,51 +316,26 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
             p_meterWidget->Text = QString::number((int)p_meterWidget->Value);
             p_meterWidget->AltText = QString(".") +QString::number((int)(p_meterWidget->Value * 10.0) - (((int) p_meterWidget->Value) * 10)) + (metric ? tr(" kph") : tr(" mph"));
         }
-        else if (p_meterWidget->Source() == QString("Gradient"))
-        {
-            // Do not show when not in ERG mode (mode=1)
-            if ( rtd.mode == 1)
-                {
-                    p_meterWidget->setWindowOpacity(0); // Hide the widget
-                }
-            // int curLap;
-            double slope = 0.0;
-            if (context && context->currentErgFile() )
-            //     slope = context->currentErgFile()->gradientAt((context->currentVideoSyncFile()->km + context->currentVideoSyncFile()->manualOffset) * 1000.0, curLap);
-                slope = rtd.getSlope();
-            p_meterWidget->Value = slope; 
-            p_meterWidget->Text = ((-1.0 < slope && slope < 0.0)?QString("-"):QString("")) + QString::number((int) p_meterWidget->Value);
-            p_meterWidget->AltText = QString(".") + QString::number(abs((int)(p_meterWidget->Value * 10.0) % 10)) + QString("%");
-        }
         else if (p_meterWidget->Source() == QString("Elevation"))
         {
-            // Do not show when not in ERG mode (mode=1)
-            if ( rtd.mode == 1)
+            // Do not show in ERG mode
+            if (rtd.mode == ERG || rtd.mode == MRC)
                 {
                     p_meterWidget->setWindowOpacity(0); // Hide the widget
                 }
-            if (context && context->currentErgFile())
-                //p_meterWidget->Value = context->currentVideoSyncFile()->km + context->currentVideoSyncFile()->manualOffset;
-                p_meterWidget->Value = rtd.getDistance();
+            p_meterWidget->Value = rtd.getDistance();
             ElevationMeterWidget* elevationMeterWidget = dynamic_cast<ElevationMeterWidget*>(p_meterWidget);
             if (!elevationMeterWidget)
                 qDebug() << "Error: Elevation keyword used but widget is not elevation type";
             else
             {
                 elevationMeterWidget->setContext(context);
-                // TODO : do not use gradient when not in slope simulation mode
-                //int curLap;
-                double slope = 0.0;
-                if (context && context->currentErgFile())
-                    //slope = context->currentErgFile()->gradientAt((context->currentVideoSyncFile()->km + context->currentVideoSyncFile()->manualOffset) * 1000.0, curLap);
-                    slope = rtd.getSlope();
-                elevationMeterWidget->gradientValue = slope; 
+                elevationMeterWidget->gradientValue = rtd.getSlope();
             }
         }
         else if (p_meterWidget->Source() == QString("Duration"))
         {
-            // TODO add fixed size property to TextWidget to avoid small movement of text
-            //     ... to be used when source is speed, duration & distance
+            // Formated time dureation of ride
             p_meterWidget->Value = rtd.getMsecs();
             int hours = p_meterWidget->Value / 3600000L;
             int minutes = ((long)p_meterWidget->Value % 3600000L) / 60000L;
@@ -483,11 +458,11 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
             curPosition = 1; // minimum curPosition is 1 as we will use [curPosition-1]
 
         double CurrentDistance = 0.0;
-        if (context && context->currentVideoSyncFile())
-        {
+        //if (context && context->currentVideoSyncFile())
+        //{
             CurrentDistance = qBound(0.0,  rtd.getDistance() + context->currentVideoSyncFile()->manualOffset, context->currentVideoSyncFile()->Distance);
             context->currentVideoSyncFile()->km = CurrentDistance;
-        }
+        //}
 
         // make sure the current position is less than the new distance
         while ((VideoSyncFiledataPoints[curPosition].km > CurrentDistance) && (curPosition > 1))

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -446,8 +446,7 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
         if (curPosition > VideoSyncFiledataPoints.count() - 1 || curPosition < 1)
             curPosition = 1; // minimum curPosition is 1 as we will use [curPosition-1]
 
-        double CurrentDistance = 0.0;
-        CurrentDistance = qBound(0.0,  rtd.getDistance() + context->currentVideoSyncFile()->manualOffset, context->currentVideoSyncFile()->Distance);
+        double CurrentDistance = qBound(0.0,  rtd.getDistance() + context->currentVideoSyncFile()->manualOffset, context->currentVideoSyncFile()->Distance);
         context->currentVideoSyncFile()->km = CurrentDistance;
 
         // make sure the current position is less than the new distance

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -316,6 +316,38 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
             p_meterWidget->Text = QString::number((int)p_meterWidget->Value);
             p_meterWidget->AltText = QString(".") +QString::number((int)(p_meterWidget->Value * 10.0) - (((int) p_meterWidget->Value) * 10)) + (metric ? tr(" kph") : tr(" mph"));
         }
+        else if (p_meterWidget->Source() == QString("Gradient"))
+        {
+            // TODO : do not show when not in slope simulation mode
+            // int curLap;
+            double slope = 0.0;
+            if (context && context->currentErgFile() )
+            //     slope = context->currentErgFile()->gradientAt((context->currentVideoSyncFile()->km + context->currentVideoSyncFile()->manualOffset) * 1000.0, curLap);
+                slope = rtd.getSlope();
+            p_meterWidget->Value = slope; 
+            p_meterWidget->Text = ((-1.0 < slope && slope < 0.0)?QString("-"):QString("")) + QString::number((int) p_meterWidget->Value);
+            p_meterWidget->AltText = QString(".") + QString::number(abs((int)(p_meterWidget->Value * 10.0) % 10)) + QString("%");
+        }
+        else if (p_meterWidget->Source() == QString("Elevation"))
+        {
+            if (context && context->currentErgFile())
+                //p_meterWidget->Value = context->currentVideoSyncFile()->km + context->currentVideoSyncFile()->manualOffset;
+                p_meterWidget->Value = rtd.getDistance();
+            ElevationMeterWidget* elevationMeterWidget = dynamic_cast<ElevationMeterWidget*>(p_meterWidget);
+            if (!elevationMeterWidget)
+                qDebug() << "Error: Elevation keyword used but widget is not elevation type";
+            else
+            {
+                elevationMeterWidget->setContext(context);
+                // TODO : do not use gradient when not in slope simulation mode
+                //int curLap;
+                double slope = 0.0;
+                if (context && context->currentErgFile())
+                    //slope = context->currentErgFile()->gradientAt((context->currentVideoSyncFile()->km + context->currentVideoSyncFile()->manualOffset) * 1000.0, curLap);
+                    slope = rtd.getSlope();
+                elevationMeterWidget->gradientValue = slope; 
+            }
+        }
         else if (p_meterWidget->Source() == QString("Cadence"))
         {
             p_meterWidget->Value = rtd.getCadence();

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -447,11 +447,8 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
             curPosition = 1; // minimum curPosition is 1 as we will use [curPosition-1]
 
         double CurrentDistance = 0.0;
-        //if (context && context->currentVideoSyncFile())
-        //{
-            CurrentDistance = qBound(0.0,  rtd.getDistance() + context->currentVideoSyncFile()->manualOffset, context->currentVideoSyncFile()->Distance);
-            context->currentVideoSyncFile()->km = CurrentDistance;
-        //}
+        CurrentDistance = qBound(0.0,  rtd.getDistance() + context->currentVideoSyncFile()->manualOffset, context->currentVideoSyncFile()->Distance);
+        context->currentVideoSyncFile()->km = CurrentDistance;
 
         // make sure the current position is less than the new distance
         while ((VideoSyncFiledataPoints[curPosition].km > CurrentDistance) && (curPosition > 1))

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -333,17 +333,6 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
                 elevationMeterWidget->gradientValue = rtd.getSlope();
             }
         }
-        else if (p_meterWidget->Source() == QString("Duration"))
-        {
-            // Formated time duration of ride
-            p_meterWidget->Value = rtd.getMsecs();
-            int hours = p_meterWidget->Value / 3600000L;
-            int minutes = ((long)p_meterWidget->Value % 3600000L) / 60000L;
-            int seconds = ((long)p_meterWidget->Value % 60000L) / 1000L;
-            int dsecs = ((long)p_meterWidget->Value % 1000L) / 100L;
-            p_meterWidget->Text = QString("%1:%2").arg((int)hours,(int)1,(int)10,QLatin1Char('0')).arg((int)minutes,(int)2,(int)10,QLatin1Char('0'));
-            p_meterWidget->AltText = QString(":%1.%2").arg((int)seconds,(int)2,(int)10,QLatin1Char('0')).arg((int)dsecs,(int)1,(int)10,QLatin1Char('0'));
-        }
         else if (p_meterWidget->Source() == QString("Cadence"))
         {
             p_meterWidget->Value = rtd.getCadence();

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -318,7 +318,11 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
         }
         else if (p_meterWidget->Source() == QString("Gradient"))
         {
-            // TODO : do not show when not in slope simulation mode
+            // Do not show when not in ERG mode (mode=1)
+            if ( rtd.mode == 1)
+                {
+                    p_meterWidget->setWindowOpacity(0); // Hide the widget
+                }
             // int curLap;
             double slope = 0.0;
             if (context && context->currentErgFile() )
@@ -330,6 +334,11 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
         }
         else if (p_meterWidget->Source() == QString("Elevation"))
         {
+            // Do not show when not in ERG mode (mode=1)
+            if ( rtd.mode == 1)
+                {
+                    p_meterWidget->setWindowOpacity(0); // Hide the widget
+                }
             if (context && context->currentErgFile())
                 //p_meterWidget->Value = context->currentVideoSyncFile()->km + context->currentVideoSyncFile()->manualOffset;
                 p_meterWidget->Value = rtd.getDistance();
@@ -347,6 +356,18 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
                     slope = rtd.getSlope();
                 elevationMeterWidget->gradientValue = slope; 
             }
+        }
+        else if (p_meterWidget->Source() == QString("Duration"))
+        {
+            // TODO add fixed size property to TextWidget to avoid small movement of text
+            //     ... to be used when source is speed, duration & distance
+            p_meterWidget->Value = rtd.getMsecs();
+            int hours = p_meterWidget->Value / 3600000L;
+            int minutes = ((long)p_meterWidget->Value % 3600000L) / 60000L;
+            int seconds = ((long)p_meterWidget->Value % 60000L) / 1000L;
+            int dsecs = ((long)p_meterWidget->Value % 1000L) / 100L;
+            p_meterWidget->Text = QString("%1:%2").arg((int)hours,(int)1,(int)10,QLatin1Char('0')).arg((int)minutes,(int)2,(int)10,QLatin1Char('0'));
+            p_meterWidget->AltText = QString(":%1.%2").arg((int)seconds,(int)2,(int)10,QLatin1Char('0')).arg((int)dsecs,(int)1,(int)10,QLatin1Char('0'));
         }
         else if (p_meterWidget->Source() == QString("Cadence"))
         {
@@ -461,8 +482,12 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
         if (curPosition > VideoSyncFiledataPoints.count() - 1 || curPosition < 1)
             curPosition = 1; // minimum curPosition is 1 as we will use [curPosition-1]
 
-        double CurrentDistance = qBound(0.0,  rtd.getDistance() + context->currentVideoSyncFile()->manualOffset, context->currentVideoSyncFile()->Distance);
-        context->currentVideoSyncFile()->km = CurrentDistance;
+        double CurrentDistance = 0.0;
+        if (context && context->currentVideoSyncFile())
+        {
+            CurrentDistance = qBound(0.0,  rtd.getDistance() + context->currentVideoSyncFile()->manualOffset, context->currentVideoSyncFile()->Distance);
+            context->currentVideoSyncFile()->km = CurrentDistance;
+        }
 
         // make sure the current position is less than the new distance
         while ((VideoSyncFiledataPoints[curPosition].km > CurrentDistance) && (curPosition > 1))


### PR DESCRIPTION
This is based on the work done by Vianney Voyer about 5 years ago. The original is posted here:  https://github.com/GoldenCheetah/GoldenCheetah/pull/1698 . I've made some modification and removed dependencies on video sync as well as reading the slope from rtd rather than calculating it. I'm attaching a screen shot of the video window. The widget is visible in slope mode.

![Elevation giddget](https://user-images.githubusercontent.com/63119383/80143552-fcae3100-857a-11ea-891d-78ecde44dbdf.PNG)

In my tests seems to work best with the changes posted here: #3380 . Eric's changes allow for tcx files to be used for video sync.