### PR TITLE
Add VO2 and Ventilation graphs to WorkoutWidget and add settings

### DIFF
--- a/src/FileIO/RideFile.h
+++ b/src/FileIO/RideFile.h
@@ -212,7 +212,7 @@ class RideFile : public QObject // QObject to emit signals
                           aPower, wprime, aTISS, anTISS, smo2, thb, 
                           rvert, rcad, rcontact, gear, o2hb, hhb,
                           lpco, rpco, lppb, rppb, lppe, rppe, lpppb, rpppb, lpppe, rpppe,
-                          wbal, tcore, clength, aPowerKg, index,
+                          wbal, tcore, clength, aPowerKg, index, vo2, ventilation,
                           none }; // none must ALWAYS be last
         typedef enum seriestype SeriesType;
 

--- a/src/FileIO/RideFile.h
+++ b/src/FileIO/RideFile.h
@@ -212,7 +212,7 @@ class RideFile : public QObject // QObject to emit signals
                           aPower, wprime, aTISS, anTISS, smo2, thb, 
                           rvert, rcad, rcontact, gear, o2hb, hhb,
                           lpco, rpco, lppb, rppb, lppe, rppe, lpppb, rpppb, lpppe, rpppe,
-                          wbal, tcore, clength, aPowerKg, index, vo2, ventilation,
+                          wbal, tcore, clength, aPowerKg, index,
                           none }; // none must ALWAYS be last
         typedef enum seriestype SeriesType;
 

--- a/src/Gui/Colors.cpp
+++ b/src/Gui/Colors.cpp
@@ -229,6 +229,12 @@ void GCColor::setupColors()
 #endif
         { tr("Overview Background"), "COVERVIEWBACKGROUND", QColor(0,0,0) },
         { tr("Overview Card Background"), "CCARDBACKGROUND", QColor(52,52,52) },
+        { tr("VO2"), "CVO2", Qt::magenta },
+        { tr("Ventilation"), "CVENTILATION", Qt::cyan },
+        { tr("VCO2"), "CVCO2", Qt::green },
+        { tr("Tidal Volume"), "CTIDALVOLUME", Qt::yellow },
+        { tr("Respiratory Frequency"), "CRESPFREQUENCY", Qt::yellow },
+        { tr("FeO2"), "CFEO2", Qt::yellow },
         { "", "", QColor(0,0,0) },
     };
 

--- a/src/Gui/Colors.h
+++ b/src/Gui/Colors.h
@@ -162,7 +162,7 @@ class ColorEngine : public QObject
 #define GColor(x) GCColor::getColor(x)
 
 // Define how many cconfigurable metric colors are available
-#define CNUMOFCFGCOLORS       98
+#define CNUMOFCFGCOLORS       104
 
 #define CPLOTBACKGROUND       0
 #define CRIDEPLOTBACKGROUND   1
@@ -262,4 +262,10 @@ class ColorEngine : public QObject
 #define CCHROME               95
 #define COVERVIEWBACKGROUND   96
 #define CCARDBACKGROUND       97
+#define CVO2                  98
+#define CVENTILATION          99
+#define CVCO2                 100
+#define CTIDALVOLUME          101
+#define CRESPFREQUENCY        102
+#define CFEO2                 103
 #endif

--- a/src/Train/DialWindow.cpp
+++ b/src/Train/DialWindow.cpp
@@ -589,16 +589,33 @@ void DialWindow::seriesChanged()
     case RealtimeData::VI:
     case RealtimeData::SkibaVI:
     case RealtimeData::Slope:
-    case RealtimeData::Rf:
-    case RealtimeData::RMV:
-    case RealtimeData::VO2:
-    case RealtimeData::VCO2:
-    case RealtimeData::RER:
-    case RealtimeData::TidalVolume:
     case RealtimeData::FeO2:
+        foreground = GColor(CFEO2);
+        break;
+    case RealtimeData::RER:
     case RealtimeData::None:
             foreground = GColor(CDIAL);
             break;
+
+    case RealtimeData::Rf:
+        foreground = GColor(CRESPFREQUENCY);
+        break;
+
+    case RealtimeData::RMV:
+        foreground = GColor(CVENTILATION);
+        break;
+
+    case RealtimeData::VO2:
+        foreground = GColor(CVO2);
+        break;
+
+    case RealtimeData::VCO2:
+        foreground = GColor(CVCO2);
+        break;
+
+    case RealtimeData::TidalVolume:
+        foreground = GColor(CTIDALVOLUME);
+        break;
 
     case RealtimeData::Load:
             foreground = GColor(CLOAD);

--- a/src/Train/RealtimeData.cpp
+++ b/src/Train/RealtimeData.cpp
@@ -639,7 +639,7 @@ QString RealtimeData::seriesName(DataSeries series)
     case Rf: return tr("Respiratory Frequency");
         break;
 
-    case RMV: return tr("Respiratory Minute Volume");
+    case RMV: return tr("Ventilation");
         break;
 
     case VO2: return tr("VO2");

--- a/src/Train/WorkoutWidget.cpp
+++ b/src/Train/WorkoutWidget.cpp
@@ -96,6 +96,8 @@ WorkoutWidget::WorkoutWidget(WorkoutWindow *parent, Context *context) :
     cadenceMax = 200; // make it line up between power and hr
     hrMax = 220;
     speedMax = 50;
+    vo2Max = 5000;
+    ventilationMax = 130;
 
     onDrag = onCreate = onRect = atRect = QPointF(-1,-1);
     qwkactive = false;
@@ -150,14 +152,18 @@ WorkoutWidget::start()
     speed.clear();
     cadence.clear();
     sampleTimes.clear();
+    vo2.clear();
+    ventilation.clear();
 
     // and resampling data
-    count = wbalSum = wattsSum = hrSum = speedSum = cadenceSum =0;
+    count = wbalSum = wattsSum = hrSum = speedSum = cadenceSum = vo2Sum = ventilationSum = 0;
 
     // set initial
     cadenceMax = 200;
     hrMax = 220;
     speedMax = 50;
+    vo2Max = 5000;
+    ventilationMax = 130;
 
     // replot
     update();
@@ -187,6 +193,8 @@ WorkoutWidget::telemetryUpdate(RealtimeData rt)
     hrSum += rt.getHr();
     cadenceSum += rt.getCadence();
     speedSum += rt.getSpeed();
+    vo2Sum += rt.getVO2();
+    ventilationSum += rt.getRMV();
 
     count++;
 
@@ -202,15 +210,21 @@ WorkoutWidget::telemetryUpdate(RealtimeData rt)
         speed << s;
         int c = cadenceSum / 5.0f;
         cadence << c;
+        int v = vo2Sum / 5.0f;
+        vo2 << v;
+        int ve = ventilationSum / 5.0f;
+        ventilation << ve;
         sampleTimes << context->getNow();
 
         // clear for next time
-        count = wbalSum = wattsSum = hrSum = speedSum = cadenceSum =0;
+        count = wbalSum = wattsSum = hrSum = speedSum = cadenceSum = vo2Sum = ventilationSum = 0;
 
         // do we need to increase maxes?
         if (c > cadenceMax) cadenceMax=c;
         if (s > speedMax) speedMax=s;
         if (h > hrMax) hrMax=h;
+        if (v > vo2Max) vo2Max=v;
+        if (ve > ventilationMax) ventilationMax=ve;
 
         // Do we need to increase plot x-axis max? (add 15 min at a time)
         if (cadence.size() > maxVX_) setMaxVX(maxVX_ + 900);
@@ -2484,6 +2498,20 @@ WorkoutWidget::transform(double seconds, double watts, RideFile::SeriesType s)
         }
         break;
 
+    case RideFile::vo2:
+        {
+        // ratio of pixels to plot units
+        yratio = double(c.height()) / double(vo2Max);
+        }
+        break;
+
+    case RideFile::ventilation:
+        {
+        // ratio of pixels to plot units
+        yratio = double(c.height()) / double(ventilationMax);
+        }
+        break;
+
     }
     return QPoint(c.x() - (minVX() * xratio) + (seconds * xratio), c.bottomLeft().y() - (watts * yratio));
 }
@@ -2937,4 +2965,82 @@ WorkoutWidget::paste()
 
     // update the display
     update();
+}
+
+bool
+WorkoutWidget::shouldPlotHr()
+{
+    return parent->shouldPlotHr();
+}
+
+bool
+WorkoutWidget::shouldPlotPwr()
+{
+    return parent->shouldPlotPwr();
+}
+
+bool
+WorkoutWidget::shouldPlotCadence()
+{
+    return parent->shouldPlotCadence();
+}
+
+bool
+WorkoutWidget::shouldPlotWbal()
+{
+    return parent->shouldPlotWbal();
+}
+
+bool
+WorkoutWidget::shouldPlotVo2()
+{
+    return parent->shouldPlotVo2();
+}
+
+bool
+WorkoutWidget::shouldPlotVentilation()
+{
+    return parent->shouldPlotVentilation();
+}
+
+bool
+WorkoutWidget::shouldPlotSpeed()
+{
+    return parent->shouldPlotSpeed();
+}
+
+int
+WorkoutWidget::hrPlotAvgLength()
+{
+    return parent->hrPlotAvgLength();
+}
+
+int
+WorkoutWidget::pwrPlotAvgLength()
+{
+    return parent->pwrPlotAvgLength();
+}
+
+int
+WorkoutWidget::cadencePlotAvgLength()
+{
+    return parent->cadencePlotAvgLength();
+}
+
+int
+WorkoutWidget::vo2PlotAvgLength()
+{
+    return parent->vo2PlotAvgLength();
+}
+
+int
+WorkoutWidget::ventilationPlotAvgLength()
+{
+    return parent->ventilationPlotAvgLength();
+}
+
+int
+WorkoutWidget::speedPlotAvgLength()
+{
+    return parent->speedPlotAvgLength();
 }

--- a/src/Train/WorkoutWidget.cpp
+++ b/src/Train/WorkoutWidget.cpp
@@ -23,7 +23,6 @@
 
 #include "WPrime.h"
 #include "ErgFile.h"
-#include "RideFile.h"
 #include "RideFileCache.h"
 #include "RealtimeData.h"
 
@@ -2459,7 +2458,7 @@ WorkoutWidget::logX(double t)
 
 // transform from plot to painter co-ordinate
 QPoint
-WorkoutWidget::transform(double seconds, double watts, RideFile::SeriesType s)
+WorkoutWidget::transform(double seconds, double watts, WwSeriesType s)
 {
     // from plot coords to painter coords on the canvas
     QRectF c = canvas();
@@ -2470,42 +2469,42 @@ WorkoutWidget::transform(double seconds, double watts, RideFile::SeriesType s)
     switch (s) {
 
     default:
-    case RideFile::watts:
+    case POWER:
         {
         // ratio of pixels to plot units
         yratio = double(c.height()) / (maxY()-minY());
         }
         break;
 
-    case RideFile::hr:
+    case HEARTRATE:
         {
         // ratio of pixels to plot units
         yratio = double(c.height()) / double(hrMax);
         }
         break;
 
-    case RideFile::cad:
+    case CADENCE:
         {
         // ratio of pixels to plot units
         yratio = double(c.height()) / double(cadenceMax);
         }
         break;
 
-    case RideFile::kph:
+    case SPEED:
         {
         // ratio of pixels to plot units
         yratio = double(c.height()) / double(speedMax);
         }
         break;
 
-    case RideFile::vo2:
+    case VO2:
         {
         // ratio of pixels to plot units
         yratio = double(c.height()) / double(vo2Max);
         }
         break;
 
-    case RideFile::ventilation:
+    case VENTILATION:
         {
         // ratio of pixels to plot units
         yratio = double(c.height()) / double(ventilationMax);

--- a/src/Train/WorkoutWidget.h
+++ b/src/Train/WorkoutWidget.h
@@ -135,6 +135,9 @@ class WorkoutWidget : public QWidget
         QList<int> hr; // 1s samples [bpm]
         QList<double> speed; // 1s samples [km/h]
         QList<int> cadence; // 1s samples [rpm]
+        QList<int> vo2; // 1s samples [ml/min]
+        QList<int> ventilation; // 1s samples [l/min]
+        QList<double> hrAvg, pwrAvg, cadenceAvg, vo2Avg, ventilationAvg, speedAvg; // averages
 
         // interaction state;
         // none - initial state
@@ -294,6 +297,22 @@ class WorkoutWidget : public QWidget
         // hate this function !
         bool setBlockCursor();
 
+        // settings getters
+        bool shouldPlotHr();
+        bool shouldPlotPwr();
+        bool shouldPlotCadence();
+        bool shouldPlotWbal();
+        bool shouldPlotVo2();
+        bool shouldPlotVentilation();
+        bool shouldPlotSpeed();
+
+        int hrPlotAvgLength();
+        int pwrPlotAvgLength();
+        int cadencePlotAvgLength();
+        int vo2PlotAvgLength();
+        int ventilationPlotAvgLength();
+        int speedPlotAvgLength();
+
     protected:
 
         // interacting with points
@@ -384,6 +403,8 @@ class WorkoutWidget : public QWidget
         int cadenceMax;
         int hrMax;
         double speedMax;
+        int vo2Max;
+        int ventilationMax;
 
         // resampling when recording
         double wbalSum;
@@ -391,6 +412,8 @@ class WorkoutWidget : public QWidget
         double cadenceSum;
         double speedSum;
         double hrSum;
+        double vo2Sum;
+        double ventilationSum;
         int count;
 };
 

--- a/src/Train/WorkoutWidget.h
+++ b/src/Train/WorkoutWidget.h
@@ -25,7 +25,6 @@
 
 #include "WPrime.h"
 
-#include "RideFile.h"
 #include "Settings.h"
 #include "Units.h"
 #include "Colors.h"
@@ -147,6 +146,9 @@ class WorkoutWidget : public QWidget
         // create - clicked to create
         enum { none, create, drag, dragblock, rect } state;
 
+        enum wwseriestype { CADENCE, HEARTRATE, POWER, SPEED, WBAL, VO2, VENTILATION };
+        typedef enum wwseriestype WwSeriesType;
+
         // adding items and points
         void addItem(WorkoutWidgetItem*x) { children_.append(x); }
         void addPoint(WWPoint*x) { points_.append(x); }
@@ -196,7 +198,7 @@ class WorkoutWidget : public QWidget
         }
 
         // transform from plot to painter co-ordinate
-        QPoint transform(double x, double y, RideFile::SeriesType s=RideFile::watts);
+        QPoint transform(double x, double y, WwSeriesType s=POWER);
 
         // for log(x) scale
         int logX(double t);

--- a/src/Train/WorkoutWidgetItems.cpp
+++ b/src/Train/WorkoutWidgetItems.cpp
@@ -371,60 +371,91 @@ WWTelemetry::paint(QPainter *painter)
     if (!workoutWidget()->recording()) return;
 
     // Draw POWER
-    paintSampleList(painter, GColor(CPOWER), workoutWidget()->watts, RideFile::watts);
+    if (workoutWidget()->shouldPlotPwr())
+    {
+        updateAvg(workoutWidget()->watts, workoutWidget()->pwrAvg, workoutWidget()->vo2PlotAvgLength());
+        paintSampleList(painter, GColor(CPOWER), workoutWidget()->pwrAvg, RideFile::watts);
+    }
+
     // Draw HR
-    paintSampleList(painter, GColor(CHEARTRATE), workoutWidget()->hr, RideFile::hr);
+    if (workoutWidget()->shouldPlotHr())
+    {
+        updateAvg(workoutWidget()->hr, workoutWidget()->hrAvg, workoutWidget()->hrPlotAvgLength());
+        paintSampleList(painter, GColor(CHEARTRATE), workoutWidget()->hrAvg, RideFile::hr);
+    }
     // Draw Speed
-    paintSampleList(painter, GColor(CSPEED), workoutWidget()->speed, RideFile::kph);
+    if (workoutWidget()->shouldPlotSpeed())
+    {
+        updateAvg(workoutWidget()->speed, workoutWidget()->speedAvg, workoutWidget()->speedPlotAvgLength());
+        paintSampleList(painter, GColor(CSPEED), workoutWidget()->speedAvg, RideFile::kph);
+    }
     // Draw Cadence
-    paintSampleList(painter, GColor(CCADENCE), workoutWidget()->cadence, RideFile::cad);
+    if (workoutWidget()->shouldPlotCadence())
+    {
+        updateAvg(workoutWidget()->cadence, workoutWidget()->cadenceAvg, workoutWidget()->cadencePlotAvgLength());
+        paintSampleList(painter, GColor(CCADENCE), workoutWidget()->cadenceAvg, RideFile::cad);
+    }
+    // Draw VO2
+    if (workoutWidget()->shouldPlotVo2())
+    {
+        updateAvg(workoutWidget()->vo2, workoutWidget()->vo2Avg, workoutWidget()->vo2PlotAvgLength());
+        paintSampleList(painter, GColor(CVO2), workoutWidget()->vo2Avg, RideFile::vo2);
+    }
+    // Draw Ventilation
+    if (workoutWidget()->shouldPlotVentilation())
+    {
+        updateAvg(workoutWidget()->ventilation, workoutWidget()->ventilationAvg, workoutWidget()->ventilationPlotAvgLength());
+        paintSampleList(painter, GColor(CVENTILATION), workoutWidget()->ventilationAvg, RideFile::ventilation);
+    }
 
     //
     // W'bal last, if not zones return
     //
+    if (workoutWidget()->shouldPlotWbal())
+    {
+        // lets get the zones, CP and PMAX, if none we're done
+        int rnum = -1;
 
-    // lets get the zones, CP and PMAX, if none we're done
-    int rnum = -1;
+        // CP etc are not available so draw nothing
+        if (context->athlete->zones(false) == NULL ||
+           (rnum = context->athlete->zones(false)->whichRange(QDate::currentDate())) == -1) return;
 
-    // CP etc are not available so draw nothing
-    if (context->athlete->zones(false) == NULL || 
-       (rnum = context->athlete->zones(false)->whichRange(QDate::currentDate())) == -1) return;
+        // lets get the zones, CP and PMAX
+        int WPRIME = context->athlete->zones(false)->getWprime(rnum);
 
-    // lets get the zones, CP and PMAX
-    int WPRIME = context->athlete->zones(false)->getWprime(rnum);
+        // full color
+        QColor color = GColor(CWBAL);
+        QPen wlinePen(color);
+        wlinePen.setWidth(1 *dpiXFactor);
+        painter->setPen(wlinePen);
 
-    // full color
-    QColor color = GColor(CWBAL);
-    QPen wlinePen(color);
-    wlinePen.setWidth(1 *dpiXFactor);
-    painter->setPen(wlinePen);
+        // top left origin
+        QPointF tl = workoutWidget()->canvas().topLeft();
 
-    // top left origin
-    QPointF tl = workoutWidget()->canvas().topLeft();
+        // pixels per WPRIME value
+        double ratio = workoutWidget()->canvas().height() / WPRIME;
 
-    // pixels per WPRIME value
-    double ratio = workoutWidget()->canvas().height() / WPRIME;
+        // join the dots
+        QPointF last = QPointF(tl.x(),tl.y());
 
-    // join the dots
-    QPointF last = QPointF(tl.x(),tl.y());
+        // run through the wpBal values...
+        int index = 0;
+        foreach(int b, workoutWidget()->wbal) {
+            // this dot...
+            if (b < 0) b=0;
 
-    // run through the wpBal values...
-    int index = 0;
-    foreach(int b, workoutWidget()->wbal) {
-        // this dot...
-        if (b < 0) b=0;
+            // x and y pixel location
+            double now = workoutWidget()->sampleTimes.at(index) / 1000.0f;
+            double px = workoutWidget()->transform(now, 0).x();
+            double py = tl.y() + ((WPRIME-b) * ratio);
 
-        // x and y pixel location
-        double now = workoutWidget()->sampleTimes.at(index) / 1000.0f;
-        double px = workoutWidget()->transform(now, 0).x();
-        double py = tl.y() + ((WPRIME-b) * ratio);
+            QPointF dot(px,py);
+            painter->drawLine(last, dot);
+            last = dot;
 
-        QPointF dot(px,py);
-        painter->drawLine(last, dot);
-        last = dot;
-
-        // next sample
-        index++;
+            // next sample
+            index++;
+        }
     }
 }
 

--- a/src/Train/WorkoutWidgetItems.cpp
+++ b/src/Train/WorkoutWidgetItems.cpp
@@ -374,38 +374,38 @@ WWTelemetry::paint(QPainter *painter)
     if (workoutWidget()->shouldPlotPwr())
     {
         updateAvg(workoutWidget()->watts, workoutWidget()->pwrAvg, workoutWidget()->vo2PlotAvgLength());
-        paintSampleList(painter, GColor(CPOWER), workoutWidget()->pwrAvg, RideFile::watts);
+        paintSampleList(painter, GColor(CPOWER), workoutWidget()->pwrAvg, WorkoutWidget::POWER);
     }
 
     // Draw HR
     if (workoutWidget()->shouldPlotHr())
     {
         updateAvg(workoutWidget()->hr, workoutWidget()->hrAvg, workoutWidget()->hrPlotAvgLength());
-        paintSampleList(painter, GColor(CHEARTRATE), workoutWidget()->hrAvg, RideFile::hr);
+        paintSampleList(painter, GColor(CHEARTRATE), workoutWidget()->hrAvg, WorkoutWidget::HEARTRATE);
     }
     // Draw Speed
     if (workoutWidget()->shouldPlotSpeed())
     {
         updateAvg(workoutWidget()->speed, workoutWidget()->speedAvg, workoutWidget()->speedPlotAvgLength());
-        paintSampleList(painter, GColor(CSPEED), workoutWidget()->speedAvg, RideFile::kph);
+        paintSampleList(painter, GColor(CSPEED), workoutWidget()->speedAvg, WorkoutWidget::SPEED);
     }
     // Draw Cadence
     if (workoutWidget()->shouldPlotCadence())
     {
         updateAvg(workoutWidget()->cadence, workoutWidget()->cadenceAvg, workoutWidget()->cadencePlotAvgLength());
-        paintSampleList(painter, GColor(CCADENCE), workoutWidget()->cadenceAvg, RideFile::cad);
+        paintSampleList(painter, GColor(CCADENCE), workoutWidget()->cadenceAvg, WorkoutWidget::CADENCE);
     }
     // Draw VO2
     if (workoutWidget()->shouldPlotVo2())
     {
         updateAvg(workoutWidget()->vo2, workoutWidget()->vo2Avg, workoutWidget()->vo2PlotAvgLength());
-        paintSampleList(painter, GColor(CVO2), workoutWidget()->vo2Avg, RideFile::vo2);
+        paintSampleList(painter, GColor(CVO2), workoutWidget()->vo2Avg, WorkoutWidget::VO2);
     }
     // Draw Ventilation
     if (workoutWidget()->shouldPlotVentilation())
     {
         updateAvg(workoutWidget()->ventilation, workoutWidget()->ventilationAvg, workoutWidget()->ventilationPlotAvgLength());
-        paintSampleList(painter, GColor(CVENTILATION), workoutWidget()->ventilationAvg, RideFile::ventilation);
+        paintSampleList(painter, GColor(CVENTILATION), workoutWidget()->ventilationAvg, WorkoutWidget::VENTILATION);
     }
 
     //

--- a/src/Train/WorkoutWidgetItems.h
+++ b/src/Train/WorkoutWidgetItems.h
@@ -198,6 +198,24 @@ class WWTelemetry : public WorkoutWidgetItem {
         Context *context;
 
         template<typename T>
+        void updateAvg(const QList<T> &source, QList<double> &avg, int number)
+        {
+            // Calc moving average
+            if (source.count() > avg.count())
+            {
+                for (int j=avg.count(); j<source.count(); j++)
+                {
+                    double temp = 0;
+                    for (int i=0; i< qMin(number, j); i++)
+                    {
+                        temp += source.at(j-i);
+                    }
+                    avg.append(temp/qMin(number, j));
+                }
+            }
+        }
+
+        template<typename T>
         void paintSampleList(QPainter* painter, const QColor& color, const QList<T>& list,
                              const RideFile::SeriesType& seriesType)
         {

--- a/src/Train/WorkoutWidgetItems.h
+++ b/src/Train/WorkoutWidgetItems.h
@@ -217,7 +217,7 @@ class WWTelemetry : public WorkoutWidgetItem {
 
         template<typename T>
         void paintSampleList(QPainter* painter, const QColor& color, const QList<T>& list,
-                             const RideFile::SeriesType& seriesType)
+                             const WorkoutWidget::WwSeriesType& seriesType)
         {
             QPen linePen(color);
             linePen.setWidth(1);

--- a/src/Train/WorkoutWindow.cpp
+++ b/src/Train/WorkoutWindow.cpp
@@ -24,12 +24,110 @@
 static int MINTOOLHEIGHT = 350; // smaller than this, lose the toolbar
 
 WorkoutWindow::WorkoutWindow(Context *context) :
-    GcChartWindow(context), draw(true), context(context), active(false), recording(false)
+    GcChartWindow(context), draw(true), context(context), active(false), recording(false),
+    plotHr(true),
+    plotPwr(true),
+    plotCadence(true),
+    plotWbal(true),
+    plotVo2(true),
+    plotVentilation(true),
+    plotSpeed(true),
+    plotHrAvg(1),
+    plotPwrAvg(1),
+    plotCadenceAvg(1),
+    plotVo2Avg(1),
+    plotVentilationAvg(1),
+    plotSpeedAvg(1)
 {
     setContentsMargins(0,0,0,0);
     setProperty("color", GColor(CTRAINPLOTBACKGROUND));
 
-    setControls(NULL);
+    //
+    // Chart settings
+    //
+
+    QWidget *settingsWidget = new QWidget(this);
+    settingsWidget->setContentsMargins(0,0,0,0);
+
+    QGridLayout *gridLayout = new QGridLayout(settingsWidget);
+
+
+    plotHrCB = new QCheckBox();
+    plotPwrCB = new QCheckBox();
+    plotCadenceCB = new QCheckBox();
+    plotWbalCB = new QCheckBox();
+    plotVo2CB = new QCheckBox();
+    plotVentilationCB = new QCheckBox();
+    plotSpeedCB = new QCheckBox();
+
+    plotHrSB = new QSpinBox(); plotHrSB->setMinimum(1);
+    plotPwrSB = new QSpinBox(); plotPwrSB->setMinimum(1);
+    plotCadenceSB = new QSpinBox(); plotCadenceSB->setMinimum(1);
+    plotVo2SB = new QSpinBox(); plotVo2SB->setMinimum(1);
+    plotVentilationSB = new QSpinBox(); plotVentilationSB->setMinimum(1);
+    plotSpeedSB = new QSpinBox(); plotSpeedSB->setMinimum(1);
+
+    plotHrCB->setCheckState(plotHr ? Qt::Checked : Qt::Unchecked);
+    plotPwrCB->setCheckState(plotPwr ? Qt::Checked : Qt::Unchecked);
+    plotCadenceCB->setCheckState(plotCadence ? Qt::Checked : Qt::Unchecked);
+    plotWbalCB->setCheckState(plotWbal ? Qt::Checked : Qt::Unchecked);
+    plotVo2CB->setCheckState(plotVo2 ? Qt::Checked : Qt::Unchecked);
+    plotVentilationCB->setCheckState(plotVentilation ? Qt::Checked : Qt::Unchecked);
+    plotSpeedCB->setCheckState(plotSpeed ? Qt::Checked : Qt::Unchecked);
+
+    connect(plotHrCB, SIGNAL(stateChanged(int)), this, SLOT(plotHrChanged(int)));
+    connect(plotPwrCB, SIGNAL(stateChanged(int)), this, SLOT(plotPwrChanged(int)));
+    connect(plotCadenceCB, SIGNAL(stateChanged(int)), this, SLOT(plotCadenceChanged(int)));
+    connect(plotWbalCB, SIGNAL(stateChanged(int)), this, SLOT(plotWbalChanged(int)));
+    connect(plotVo2CB, SIGNAL(stateChanged(int)), this, SLOT(plotVo2Changed(int)));
+    connect(plotVentilationCB, SIGNAL(stateChanged(int)), this, SLOT(plotVentilationChanged(int)));
+    connect(plotSpeedCB, SIGNAL(stateChanged(int)), this, SLOT(plotSpeedChanged(int)));
+
+    connect(plotHrSB, SIGNAL(valueChanged(int)), this, SLOT(plotHrAvgChanged(int)));
+    connect(plotPwrSB, SIGNAL(valueChanged(int)), this, SLOT(plotPwrAvgChanged(int)));
+    connect(plotCadenceSB, SIGNAL(valueChanged(int)), this, SLOT(plotCadenceAvgChanged(int)));
+    connect(plotVo2SB, SIGNAL(valueChanged(int)), this, SLOT(plotVo2AvgChanged(int)));
+    connect(plotVentilationSB, SIGNAL(valueChanged(int)), this, SLOT(plotVentilationAvgChanged(int)));
+    connect(plotSpeedSB, SIGNAL(valueChanged(int)), this, SLOT(plotSpeedAvgChanged(int)));
+
+
+    int row = 0;
+    gridLayout->addWidget(new QLabel(tr("Show Heartrate")),row,0);
+    gridLayout->addWidget(plotHrCB,row,1);
+    gridLayout->addWidget(new QLabel(tr("Seconds to average")),row,2);
+    gridLayout->addWidget(plotHrSB,row++,3);
+
+    gridLayout->addWidget(new QLabel(tr("Show Power")),row,0);
+    gridLayout->addWidget(plotPwrCB,row,1);
+    gridLayout->addWidget(new QLabel(tr("Seconds to average")),row,2);
+    gridLayout->addWidget(plotPwrSB,row++,3);
+
+    gridLayout->addWidget(new QLabel(tr("Show Cadence")),row,0);
+    gridLayout->addWidget(plotCadenceCB,row,1);
+    gridLayout->addWidget(new QLabel(tr("Seconds to average")),row,2);
+    gridLayout->addWidget(plotCadenceSB,row++,3);
+
+    gridLayout->addWidget(new QLabel(tr("Show VO2")),row,0);
+    gridLayout->addWidget(plotVo2CB,row,1);
+    gridLayout->addWidget(new QLabel(tr("Seconds to average")),row,2);
+    gridLayout->addWidget(plotVo2SB,row++,3);
+
+    gridLayout->addWidget(new QLabel(tr("Show Ventilation")),row,0);
+    gridLayout->addWidget(plotVentilationCB,row,1);
+    gridLayout->addWidget(new QLabel(tr("Seconds to average")),row,2);
+    gridLayout->addWidget(plotVentilationSB,row++,3);
+
+    gridLayout->addWidget(new QLabel(tr("Show Speed")),row,0);
+    gridLayout->addWidget(plotSpeedCB,row,1);
+    gridLayout->addWidget(new QLabel(tr("Seconds to average")),row,2);
+    gridLayout->addWidget(plotSpeedSB,row++,3);
+
+    gridLayout->addWidget(new QLabel(tr("Show WBal")),row,0);
+    gridLayout->addWidget(plotWbalCB,row++,1);
+    gridLayout->addItem(new QSpacerItem(1,1,QSizePolicy::Preferred,QSizePolicy::Expanding),row,0);
+
+
+    setControls(settingsWidget);
     ergFile = NULL;
 
     QVBoxLayout *main = new QVBoxLayout;
@@ -536,4 +634,88 @@ WorkoutWindow::stop()
     recording = false;
     if (height() > MINTOOLHEIGHT) toolbar->show();
     workout->stop();
+}
+
+void
+WorkoutWindow::plotHrChanged(int value)
+{
+    plotHr = (value != Qt::Unchecked);
+}
+
+void
+WorkoutWindow::plotPwrChanged(int value)
+{
+    plotPwr = (value != Qt::Unchecked);
+}
+
+void
+WorkoutWindow::plotCadenceChanged(int value)
+{
+    plotCadence = (value != Qt::Unchecked);
+}
+
+void
+WorkoutWindow::plotWbalChanged(int value)
+{
+    plotWbal = (value != Qt::Unchecked);
+}
+
+void
+WorkoutWindow::plotVo2Changed(int value)
+{
+    plotVo2 = (value != Qt::Unchecked);
+}
+
+void
+WorkoutWindow::plotVentilationChanged(int value)
+{
+    plotVentilation = (value != Qt::Unchecked);
+}
+
+void
+WorkoutWindow::plotSpeedChanged(int value)
+{
+    plotSpeed = (value != Qt::Unchecked);
+}
+
+void
+WorkoutWindow::plotHrAvgChanged(int value)
+{
+    plotHrAvg = value;
+    workout->hrAvg.clear();
+}
+
+void
+WorkoutWindow::plotPwrAvgChanged(int value)
+{
+    plotPwrAvg = value;
+    workout->pwrAvg.clear();
+}
+
+void
+WorkoutWindow::plotCadenceAvgChanged(int value)
+{
+    plotCadenceAvg = value;
+    workout->cadenceAvg.clear();
+}
+
+void
+WorkoutWindow::plotVo2AvgChanged(int value)
+{
+    plotVo2Avg = value;
+    workout->vo2Avg.clear();
+}
+
+void
+WorkoutWindow::plotVentilationAvgChanged(int value)
+{
+    plotVentilationAvg = value;
+    workout->ventilationAvg.clear();
+}
+
+void
+WorkoutWindow::plotSpeedAvgChanged(int value)
+{
+    plotSpeedAvg = value;
+    workout->speedAvg.clear();
 }

--- a/src/Train/WorkoutWindow.h
+++ b/src/Train/WorkoutWindow.h
@@ -122,6 +122,37 @@ class WorkoutWindow : public GcChartWindow
         // show hide toolbar if too small
         void resizeEvent(QResizeEvent * event);
 
+        // settings changes
+        void plotHrChanged(int value);
+        void plotPwrChanged(int value);
+        void plotCadenceChanged(int value);
+        void plotWbalChanged(int value);
+        void plotVo2Changed(int value);
+        void plotVentilationChanged(int value);
+        void plotSpeedChanged(int value);
+        void plotHrAvgChanged(int value);
+        void plotPwrAvgChanged(int value);
+        void plotCadenceAvgChanged(int value);
+        void plotVo2AvgChanged(int value);
+        void plotVentilationAvgChanged(int value);
+        void plotSpeedAvgChanged(int value);
+
+        // get settings
+        bool shouldPlotHr() { return plotHr;}
+        bool shouldPlotPwr() { return plotPwr;}
+        bool shouldPlotCadence() { return plotCadence;}
+        bool shouldPlotWbal() { return plotWbal;}
+        bool shouldPlotVo2() { return plotVo2;}
+        bool shouldPlotVentilation() { return plotVentilation;}
+        bool shouldPlotSpeed() { return plotSpeed;}
+
+        int hrPlotAvgLength() { return plotHrAvg; }
+        int pwrPlotAvgLength() { return plotPwrAvg; }
+        int cadencePlotAvgLength() { return plotCadenceAvg; }
+        int vo2PlotAvgLength() { return plotVo2Avg; }
+        int ventilationPlotAvgLength() { return plotVentilationAvg; }
+        int speedPlotAvgLength() { return plotSpeedAvg; }
+
     protected:
         bool eventFilter(QObject *obj, QEvent *event);
 
@@ -132,6 +163,8 @@ class WorkoutWindow : public GcChartWindow
         QToolBar *toolbar;
         WorkoutWidget *workout; // will become editor.
         QScrollBar *scroll;     // for controlling the position
+        QCheckBox *plotHrCB, *plotPwrCB, *plotCadenceCB, *plotWbalCB, *plotVo2CB, *plotVentilationCB, *plotSpeedCB;
+        QSpinBox *plotHrSB, *plotPwrSB, *plotCadenceSB, *plotVo2SB, *plotVentilationSB, *plotSpeedSB;
 
         WWPowerScale *powerscale;
         WWWBalScale *wbalscale;
@@ -149,6 +182,8 @@ class WorkoutWindow : public GcChartWindow
 
         bool active;
         bool recording;
+        bool plotHr, plotPwr, plotCadence, plotWbal, plotVo2, plotVentilation, plotSpeed;
+        int plotHrAvg, plotPwrAvg, plotCadenceAvg, plotVo2Avg, plotVentilationAvg, plotSpeedAvg;
 };
 
 #endif // _GC_WorkoutWindow_h


### PR DESCRIPTION
* When running tests with VO2 measurements, it can be useful to see a
  graph of at least VO2 but also Ventilation to determine when e.g. a
  ramp test results in a plateau and can be considered done.

* Make the color of some VO2 measurements configurable.

* Add chart settings to WorkoutWindow, so that plots can be enabled or
  disabled. Also add the possiblity to do averaging.

* Use the term Ventilation instead of Respiratory Minute Volume