### PR TITLE
AppVeyor - Don't use parallel build for QWT

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -105,6 +105,9 @@ before_build:
 
 build_script:
 - qmake.exe build.pro -r -spec win32-msvc
+- cd qwt\
+- jom -j1
+- cd ..
 - jom -j4
 
 after_build:


### PR DESCRIPTION
Seems like QWT sometimes fails when using parallel build, so use -j1
when building it to force non-parallel build.