### PR TITLE
BT40: add support for Tacx's ANT over BLE to set gradient

### DIFF
--- a/src/Train/BT40Controller.cpp
+++ b/src/Train/BT40Controller.cpp
@@ -164,3 +164,9 @@ BT40Controller::setWheelRpm(double wrpm) {
     else wheel = 2100;
     telemetry.setSpeed(wrpm * wheel / 1000 * 60 / 1000);
 }
+
+void BT40Controller::setGradient(double grad) {
+  for (auto* dev: devices) {
+    dev->setGradient(grad);
+  }
+}

--- a/src/Train/BT40Controller.h
+++ b/src/Train/BT40Controller.h
@@ -46,6 +46,8 @@ public:
     bool discover(QString name);
     void setDevice(QString);
 
+    void setGradient(double) override;
+
     // telemetry push pull
     bool doesPush(), doesPull(), doesLoad();
     void getRealtimeData(RealtimeData &rtData);

--- a/src/Train/BT40Device.h
+++ b/src/Train/BT40Device.h
@@ -40,6 +40,8 @@ public:
     static QMap<QBluetoothUuid, btle_sensor_type_t> supportedServices;
     QBluetoothDeviceInfo deviceInfo() const;
 
+    void setGradient(double Gradient);
+
 private slots:
     void deviceConnected();
     void deviceDisconnected();
@@ -65,6 +67,11 @@ private:
     quint16 prevCrankRevs;
     quint16 prevWheelTime;
     quint32 prevWheelRevs;
+
+    // Tacx ANT over UART specific service
+    QLowEnergyCharacteristic m_charTacxUART;
+    QLowEnergyService* m_servTacxUART = nullptr;
+
     bool connected;
     void getCadence(QDataStream& ds);
     void getWheelRpm(QDataStream& ds);


### PR DESCRIPTION
This is based on https://github.com/abellono/tacx-ios-bluetooth-example/

This has only been tested so far with a Tacx Flow Smart T2240. I don't have access to a device with "rolling resistance", so I can't really test it.