### PR TITLE
ErgFile: fix distance precision issues

### DIFF
--- a/src/Train/ErgFile.cpp
+++ b/src/Train/ErgFile.cpp
@@ -620,7 +620,7 @@ void ErgFile::parseComputrainer(QString p)
 
                 // distance guff
                 add.x = rdist;
-                int distance = absoluteSlope.cap(1).toDouble() * 1000; // convert to meters
+                double distance = absoluteSlope.cap(1).toDouble() * 1000.; // convert to meters
 
                 if (!bIsMetric) distance *= KM_PER_MILE;
                 rdist += distance;
@@ -628,7 +628,7 @@ void ErgFile::parseComputrainer(QString p)
                 // gradient and altitude
                 add.val = absoluteSlope.cap(2).toDouble();
                 add.y = ralt;
-                ralt += distance * add.val / 100; /* paused */
+                ralt += distance * add.val / 100.; /* paused */
 
                 Points.append(add);
                 if (add.y > MaxWatts) MaxWatts=add.y;


### PR DESCRIPTION
When parsing a "distance slope wind" type, a truncate to integers was done after computation to meters. This involved rounding issues that were accumulated, and were quite visible when such a file was used to synchronized with an RLV video (the slope changes happened "too early").
