### PR TITLE
Teach elevation widget to honor skipping

### DIFF
--- a/src/Train/MeterWidget.cpp
+++ b/src/Train/MeterWidget.cpp
@@ -21,6 +21,7 @@
 #include "MeterWidget.h"
 #include "ErgFile.h"
 #include "Context.h"
+#include "Units.h"
 
 MeterWidget::MeterWidget(QString Name, QWidget *parent, QString Source) : QWidget(parent), m_Name(Name), m_container(parent), m_Source(Source)
 {
@@ -393,32 +394,38 @@ void ElevationMeterWidget::paintEvent(QPaintEvent* paintevent)
     painter.setPen(m_OutlinePen);
     painter.drawLine(cyclistX, 0.0, cyclistX, (double)m_Height-bubbleSize);
 
-    //Cosmetic enhancment: Display grade as #.#% 
-    std::string sGrad;
-    QString s_grad ="";
-    s_grad = ((-1.0 < this->gradientValue && this->gradientValue < 0.0)?QString("-"):QString("")) + QString::number((int) this->gradientValue);
-    s_grad += QString(".") + QString::number(abs((int)(this->gradientValue * 10.0) % 10)) + QString("%");
+    // Display grade as #.#% 
+    QString gradientString = ((-1.0 < this->gradientValue && this->gradientValue < 0.0)?QString("-"):QString("")) + QString::number((int) this->gradientValue) +
+                                QString(".") + QString::number(abs((int)(this->gradientValue * 10.0) % 10)) + QString("%");
 
     // Display gradient text to the right of the line until the middle, then display to the left of the line
-    if (cyclistX < m_Width*0.5) {
-        painter.drawText((double)cyclistX+5, ((double)m_Height * 0.95), s_grad);
-    } else {
-        painter.drawText((double)cyclistX-45, ((double)m_Height * 0.95), s_grad);
-    }
+    double gradientDrawX = cyclistX;
+    double gradientDrawY = m_Height * 0.95;
 
-    //Cosmetic enhancement: Display route distance in meters
+    if (cyclistX < m_Width * 0.5)
+        gradientDrawX += 5.;
+    else
+        gradientDrawX =- 45.;
+
+    painter.drawText(gradientDrawX, gradientDrawY, gradientString);
+
+    // Display route distance in meters (or pistol shots)
     double routeDistanceMeters = this->Value * 1000.;
-    QString s_dist = QString::number((int)routeDistanceMeters) + QString("m");
 
-    double paintX = (double)cyclistX;
-    double paintY = ((double)m_Height * 0.75);
+    QString distanceString;
+    if (context->athlete->useMetricUnits)
+        distanceString = QString::number((int)routeDistanceMeters) + QString("m");
+    else
+        distanceString = QString::number((int)(routeDistanceMeters*FEET_PER_METER)) + QString("ft");
+
+    double distanceDrawX = (double)cyclistX;
+    double distanceDrawY = ((double)m_Height * 0.75);
 
     // Display distance text to the right of the line until the middle, then display to the left of the line
-    if (cyclistX < m_Width * 0.5) {
-        paintX += 5;
-    } else {
-        paintX -= 45;
-    }
+    if (cyclistX < m_Width * 0.5)
+        distanceDrawX += 5;
+    else
+        distanceDrawX -= 45;
 
-    painter.drawText(paintX, paintY, s_dist);
+    painter.drawText(distanceDrawX, distanceDrawY, distanceString);
 }

--- a/src/Train/MeterWidget.cpp
+++ b/src/Train/MeterWidget.cpp
@@ -415,7 +415,7 @@ void ElevationMeterWidget::paintEvent(QPaintEvent* paintevent)
     routeDistance = ((int)(routeDistance * 1000.)) / 1000.;
 
     QString distanceString = QString::number(routeDistance, 'f', 3) +
-        ((context->athlete->useMetricUnits) ? QString("km") : QString("mi"));
+        ((context->athlete->useMetricUnits) ? tr("km") : tr("mi"));
 
     double distanceDrawX = (double)cyclistX;
     double distanceDrawY = ((double)m_Height * 0.75);

--- a/src/Train/MeterWidget.cpp
+++ b/src/Train/MeterWidget.cpp
@@ -409,14 +409,13 @@ void ElevationMeterWidget::paintEvent(QPaintEvent* paintevent)
 
     painter.drawText(gradientDrawX, gradientDrawY, gradientString);
 
-    // Display route distance in meters (or pistol shots)
-    double routeDistanceMeters = this->Value * 1000.;
+    double routeDistance = this->Value;
+    if (!context->athlete->useMetricUnits) routeDistance *= MILES_PER_KM;
 
-    QString distanceString;
-    if (context->athlete->useMetricUnits)
-        distanceString = QString::number((int)routeDistanceMeters) + QString("m");
-    else
-        distanceString = QString::number((int)(routeDistanceMeters*FEET_PER_METER)) + QString("ft");
+    routeDistance = ((int)(routeDistance * 1000.)) / 1000.;
+
+    QString distanceString = QString::number(routeDistance, 'f', 3) +
+        ((context->athlete->useMetricUnits) ? QString("km") : QString("mi"));
 
     double distanceDrawX = (double)cyclistX;
     double distanceDrawY = ((double)m_Height * 0.75);

--- a/src/Train/MeterWidget.cpp
+++ b/src/Train/MeterWidget.cpp
@@ -365,7 +365,7 @@ void ElevationMeterWidget::paintEvent(QPaintEvent* paintevent)
     //Get point to create the polygon
     QPolygon polygon;
     polygon << QPoint(0.0, (double)m_Height);
-    double x, y, pt=0;
+    double x = 0., y, pt=0;
     double nextX = 1;
     for( pt=0; pt < context->currentErgFile()->Points.size(); pt++)
     {
@@ -405,4 +405,20 @@ void ElevationMeterWidget::paintEvent(QPaintEvent* paintevent)
     } else {
         painter.drawText((double)cyclistX-45, ((double)m_Height * 0.95), s_grad);
     }
-} 
+
+    //Cosmetic enhancement: Display route distance in meters
+    double routeDistanceMeters = this->Value * 1000.;
+    QString s_dist = QString::number((int)routeDistanceMeters) + QString("m");
+
+    double paintX = (double)cyclistX;
+    double paintY = ((double)m_Height * 0.75);
+
+    // Display distance text to the right of the line until the middle, then display to the left of the line
+    if (cyclistX < m_Width * 0.5) {
+        paintX += 5;
+    } else {
+        paintX -= 45;
+    }
+
+    painter.drawText(paintX, paintY, s_dist);
+}

--- a/src/Train/RealtimeData.cpp
+++ b/src/Train/RealtimeData.cpp
@@ -31,6 +31,7 @@ RealtimeData::RealtimeData()
     lrbalance = rte = lte = lps = rps = 0.0;
     latitude = longitude = altitude = 0.0;
     rf = rmv = vo2 = vco2 = tv = feo2 = 0.0;
+    routeDistance = 0.0;
     trainerStatusAvailable = false;
     trainerReady = true;
     trainerRunning = true;
@@ -114,6 +115,11 @@ void RealtimeData::setErgMsecsRemaining(long x)
 void RealtimeData::setDistance(double x)
 {
     this->distance = x;
+}
+
+void RealtimeData::setRouteDistance(double x)
+{
+    this->routeDistance = x;
 }
 
 void RealtimeData::setLapDistance(double x)
@@ -213,6 +219,10 @@ long RealtimeData::getLapMsecs() const
 double RealtimeData::getDistance() const
 {
     return distance;
+}
+double RealtimeData::getRouteDistance() const
+{
+    return routeDistance;
 }
 double RealtimeData::getLapDistance() const
 {
@@ -327,6 +337,9 @@ double RealtimeData::value(DataSeries series) const
         break;
 
     case Distance: return distance;
+        break;
+
+    case RouteDistance: return routeDistance;
         break;
 
     case LapDistance: return lapDistance;
@@ -486,6 +499,7 @@ const QList<RealtimeData::DataSeries> &RealtimeData::listDataSeries()
         seriesList << Latitude;
         seriesList << Longitude;
         seriesList << Altitude;
+        seriesList << RouteDistance;
     }
     return seriesList;
 }
@@ -544,6 +558,9 @@ QString RealtimeData::seriesName(DataSeries series)
         break;
 
     case Distance: return tr("Distance");
+        break;
+
+    case RouteDistance: return tr("RouteDistance");
         break;
 
     case AltWatts: return tr("Alternate Power");

--- a/src/Train/RealtimeData.h
+++ b/src/Train/RealtimeData.h
@@ -46,7 +46,7 @@ public:
                       LeftTorqueEffectiveness, RightTorqueEffectiveness,
                       LeftPedalSmoothness, RightPedalSmoothness, Slope, 
                       LapDistance, LapDistanceRemaining, ErgTimeRemaining,
-                      Latitude, Longitude, Altitude };
+                      Latitude, Longitude, Altitude, RouteDistance };
 
     typedef enum dataseries DataSeries;
 
@@ -75,6 +75,7 @@ public:
     void setLapMsecsRemaining(long);
     void setErgMsecsRemaining(long);
     void setDistance(double);
+    void setRouteDistance(double);
     void setBikeScore(long);
     void setJoules(long);
     void setXPower(long);
@@ -129,6 +130,7 @@ public:
     long getMsecs() const;
     long getLapMsecs() const;
     double getDistance() const;
+    double getRouteDistance() const;
     long getLap() const;
     double getLapDistance() const;
     double getLapDistanceRemaining() const;
@@ -171,6 +173,7 @@ private:
 
     // derived data
     double distance;
+    double routeDistance;
     double lapDistance;
     double lapDistanceRemaining;
     double virtualSpeed;

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -1674,6 +1674,7 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
                 if (dev == kphTelemetry) {
                     rtData.setSpeed(local.getSpeed());
                     rtData.setDistance(local.getDistance());
+                    rtData.setRouteDistance(local.getRouteDistance());
                     rtData.setLapDistance(local.getLapDistance());
                     rtData.setLapDistanceRemaining(local.getLapDistanceRemaining());
                     fReceivedKphTelemetry = true;
@@ -1739,6 +1740,7 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
                 }
 
                 rtData.setDistance(displayDistance);
+                rtData.setRouteDistance(displayWorkoutDistance);
                 rtData.setLapDistance(displayLapDistance);
                 rtData.setLapDistanceRemaining(displayLapDistanceRemaining);
 
@@ -1831,6 +1833,7 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
                 rtData.setErgMsecsRemaining(ergTimeRemaining);
             } else {
                 rtData.setDistance(displayDistance);
+                rtData.setRouteDistance(displayWorkoutDistance);
                 rtData.setLapDistance(displayLapDistance);
                 rtData.setLapDistanceRemaining(displayLapDistanceRemaining);
                 rtData.setMsecs(session_elapsed_msec);

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -322,7 +322,7 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
                 {
                     p_meterWidget->setWindowOpacity(0); // Hide the widget
                 }
-            p_meterWidget->Value = rtd.getDistance();
+            p_meterWidget->Value = rtd.getRouteDistance();
             ElevationMeterWidget* elevationMeterWidget = dynamic_cast<ElevationMeterWidget*>(p_meterWidget);
             if (!elevationMeterWidget)
                 qDebug() << "Error: Elevation keyword used but widget is not elevation type";


### PR DESCRIPTION
Elevation widget was showing progress based on distance, which is workout distance and didn't accout for distance change due to skip forward/skip back.

Add routedistance to realtimedata so elevation widget can access it
elevation using routedistance to show progress
Fix uninit iterator in elevation widget paint
Draw route distance in elevation widget
