### PR TITLE
Convert size from pixels to points for use in setPointSize

### DIFF
--- a/src/Train/DialWindow.cpp
+++ b/src/Train/DialWindow.cpp
@@ -542,7 +542,7 @@ void DialWindow::resizeEvent(QResizeEvent * )
 
     } else {
         // set point size within reasonable limits for low dpi screens
-        int size = geometry().height()-24;
+        int size = (geometry().height() - 24) * 72 / logicalDpiY();
         if (size <= 0) size = 4;
         if (size >= 64) size = 64;
 


### PR DESCRIPTION
Currently, size is computed from the QWidget geometry height in pixels and then used to set the font size in points. In many cases the result is not that bad because, depending on the screen size and resolution, the pizel size is not that far from one point. We now convert from pixels to inch (DPI) and then from inches to points (72 points/inch). This solves the problem of the text being clipped sometimes or the margin being too large.