### PR TITLE
Meter widget on linux

### DIFF
--- a/src/Train/MeterWidget.cpp
+++ b/src/Train/MeterWidget.cpp
@@ -25,11 +25,16 @@
 MeterWidget::MeterWidget(QString Name, QWidget *parent, QString Source) : QWidget(parent), m_Name(Name), m_container(parent), m_Source(Source)
 {
     setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
-    setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
 
+#ifdef Q_OS_LINUX
+    setWindowFlags(Qt::Window | Qt::FramelessWindowHint | Qt::X11BypassWindowManagerHint);
+    setAttribute(Qt::WA_TranslucentBackground);
+#else
+    setWindowFlags(Qt::Window | Qt::FramelessWindowHint);
     setAttribute(Qt::WA_NoSystemBackground);
     setAttribute(Qt::WA_TranslucentBackground);
     setAttribute(Qt::WA_PaintOnScreen);
+#endif
 
     setAttribute(Qt::WA_TransparentForMouseEvents);
 

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -104,6 +104,7 @@ VideoWindow::VideoWindow(Context *context)  :
 #elif defined(Q_OS_LINUX)
         libvlc_media_player_set_xwindow (mp, container->winId());
 #endif
+#endif
 
 #if defined(WIN32) || defined(Q_OS_LINUX)
         // Video Overlays Initialization: if video config file is not present

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -87,22 +87,19 @@ VideoWindow::VideoWindow(Context *context)  :
         //vlc_exceptions(&exceptions);
 
 
-    /* This is a non working code that show how to hooks into a window,
-     * if we have a window around */
-#ifdef Q_OS_LINUX
-#if QT_VERSION > 0x50000
-        x11Container = new QWidget(this); //XXX PORT TO 5.1 BROKEN CODE XXX
+#if (defined WIN32) || (defined Q_OS_LINUX)
+#if (defined Q_OS_LINUX) && QT_VERSION <= 0x50000
+        container = new QX11EmbedContainer(this);
 #else
-        x11Container = new QX11EmbedContainer(this);
+        container = new QWidget(this); //XXX PORT TO 5.1 BROKEN CODE XXX
 #endif
-        layout->addWidget(x11Container);
-        libvlc_media_player_set_xwindow (mp, x11Container->winId());
-#endif
-
-#ifdef WIN32
-        container = new QWidget(this);
         layout->addWidget(container);
+
+#if (defined Q_OS_LINUX)
+        libvlc_media_player_set_xwindow (mp, container->winId());
+#else
         libvlc_media_player_set_hwnd (mp, (HWND)(container->winId()));
+#endif
 
         // Video Overlays Initialization: if video config file is not present
         // copy a default one to be used as a model by the user.
@@ -173,7 +170,7 @@ VideoWindow::~VideoWindow()
 
 #if (defined Q_OS_LINUX) && (QT_VERSION < 0x050000) && (defined GC_VIDEO_VLC)
     // unembed vlc backend first
-    x11Container->discardClient();
+    container->discardClient();
 #endif
 
     stopPlayback();

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -86,9 +86,6 @@ VideoWindow::VideoWindow(Context *context)  :
 
         //vlc_exceptions(&exceptions);
 
-
-#if defined(WIN32) || defined (Q_OS_MAC) || defined(Q_OS_LINUX)
-
 #if (defined Q_OS_LINUX) && QT_VERSION <= 0x50000
         container = new QX11EmbedContainer(this);
 #else
@@ -103,7 +100,6 @@ VideoWindow::VideoWindow(Context *context)  :
         libvlc_media_player_set_nsobject (mp, (void*)(container->winId()));
 #elif defined(Q_OS_LINUX)
         libvlc_media_player_set_xwindow (mp, container->winId());
-#endif
 #endif
 
 #if defined(WIN32) || defined(Q_OS_LINUX)

--- a/src/Train/VideoWindow.h
+++ b/src/Train/VideoWindow.h
@@ -211,9 +211,9 @@ class VideoWindow : public GcChartWindow
 
 #ifdef Q_OS_LINUX
 #if QT_VERSION > 0x050000
-        QWidget *x11Container;
+        QWidget *container;
 #else
-        QX11EmbedContainer *x11Container;
+        QX11EmbedContainer *container;
 #endif
 #endif
 


### PR DESCRIPTION
Meter Widgets, with a transparent background over the video window, use
little screen estate while providing all the needed information. They
were added for WIN32 first but actually work fine on Linux with minor
flag adjustments.