### PR TITLE
Fix incorrect speed (halved) on BT40

### DIFF
--- a/src/Train/BT40Device.cpp
+++ b/src/Train/BT40Device.cpp
@@ -48,6 +48,7 @@ BT40Device::BT40Device(QObject *parent, QBluetoothDeviceInfo devinfo) : parent(p
     connected = false;
     prevWheelTime = 0;
     prevWheelRevs = 0;
+    prevWheelStaleness = true;
     prevCrankTime = 0;
     prevCrankRevs = 0;
     prevCrankStaleness = -1; // indicates prev crank data values aren't measured values
@@ -451,9 +452,13 @@ BT40Device::getWheelRpm(QDataStream& ds)
     ds >> wheeltime;
 
     double rpm = 0.0;
-    quint16 time = wheeltime - prevWheelTime;
-    quint32 revs = wheelrevs - prevWheelRevs;
-    if (time) rpm = 1024*60*revs / time;
+
+    if(!prevWheelStaleness) {
+        quint16 time = wheeltime - prevWheelTime;
+        quint32 revs = wheelrevs - prevWheelRevs;
+        if (time) rpm = 2048*60*revs / time;
+    }
+    else prevWheelStaleness = false;
 
     prevWheelRevs = wheelrevs;
     prevWheelTime = wheeltime;

--- a/src/Train/BT40Device.h
+++ b/src/Train/BT40Device.h
@@ -63,6 +63,7 @@ private:
     int prevCrankStaleness;
     quint16 prevCrankTime;
     quint16 prevCrankRevs;
+    bool prevWheelStaleness;
     quint16 prevWheelTime;
     quint32 prevWheelRevs;
     bool connected;


### PR DESCRIPTION
Unlike for the cadence value which uses 1/1024 second units, the wheel
revolution value is based on 1/2048 second units [1]. It is easy to
notice the problem when you ride downhill at 25 kph instead of 50kph! In
addition, the speed was initially incorrect because the previous wheel
position value was stale. This would sometimes give the speed of a
rocket for the initial interval and make a jump on the distance of
several km.

[1] Cycling Power Service, Bluetooth Service Specification, Date 2016-05-03, Revision CPS_v1.1, Prepared By Sports and Fitness Working Group, head of page 15.

https://www.bluetooth.org/DocMan/handlers/DownloadDoc.ashx?doc_id=412770