### PR TITLE
MeterWidgets must move / hide when main window is moved / minimized

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -981,7 +981,6 @@ void
 MainWindow::moveEvent(QMoveEvent*)
 {
     appsettings->setValue(GC_SETTINGS_MAIN_GEOM, saveGeometry());
-    emit mainWindowMoved();
 }
 
 void

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -981,6 +981,7 @@ void
 MainWindow::moveEvent(QMoveEvent*)
 {
     appsettings->setValue(GC_SETTINGS_MAIN_GEOM, saveGeometry());
+    emit mainWindowMoved();
 }
 
 void
@@ -1035,6 +1036,17 @@ MainWindow::closeEvent(QCloseEvent* event)
     }
     appsettings->setValue(GC_SETTINGS_MAIN_GEOM, saveGeometry());
     appsettings->setValue(GC_SETTINGS_MAIN_STATE, saveState());
+}
+
+void
+MainWindow::changeEvent(QEvent *event)
+{
+    if(event->type() != QEvent::WindowStateChange) return;
+
+    // Some overlay Widgets (Meter) are top level windows 
+    // and need to follow the MainWindow state
+    Qt::WindowStates states = windowState();
+    emit mainWindowStateChanged(states &  Qt::WindowMinimized, isVisible());
 }
 
 MainWindow::~MainWindow()

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -95,7 +95,6 @@ class MainWindow : public QMainWindow
         Tab *athleteTab() { return currentTab; }
 
     signals:
-        void mainWindowMoved();
         void mainWindowStateChanged(bool minimized, bool visible);
 
     protected:

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -94,6 +94,10 @@ class MainWindow : public QMainWindow
         // currently selected tab
         Tab *athleteTab() { return currentTab; }
 
+    signals:
+        void mainWindowMoved();
+        void mainWindowStateChanged(bool minimized, bool visible);
+
     protected:
 
         // used by ChooseCyclistDialog to see which athletes
@@ -104,6 +108,7 @@ class MainWindow : public QMainWindow
         virtual void resizeEvent(QResizeEvent*);
         virtual void moveEvent(QMoveEvent*);
         virtual void closeEvent(QCloseEvent*);
+        virtual void changeEvent(QEvent *);
         virtual void dragEnterEvent(QDragEnterEvent *);
         virtual void dropEvent(QDropEvent *);
 

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -163,6 +163,8 @@ VideoWindow::VideoWindow(Context *context)  :
         connect(context, SIGNAL(seek(long)), this, SLOT(seekPlayback(long)));
         connect(context, SIGNAL(unpause()), this, SLOT(resumePlayback()));
         connect(context, SIGNAL(mediaSelected(QString)), this, SLOT(mediaSelected(QString)));
+        connect(this->window(), SIGNAL(mainWindowMoved()), this, SLOT(mainWindowMoved()));
+        connect(this->window(), SIGNAL(mainWindowStateChanged(bool, bool)), this, SLOT(mainWindowStateChanged(bool, bool)));
     }
 }
 
@@ -201,6 +203,17 @@ void VideoWindow::resizeEvent(QResizeEvent * )
 {
     foreach(MeterWidget* p_meterWidget , m_metersWidget)
         p_meterWidget->AdjustSizePos();
+}
+
+void VideoWindow::mainWindowMoved()
+{
+    if(isVisible()) foreach(MeterWidget* p, m_metersWidget) p->AdjustSizePos();
+}
+
+void VideoWindow::mainWindowStateChanged(bool minimized, bool visible)
+{
+    if(minimized) foreach(MeterWidget* p, m_metersWidget) p->hide();
+    else if(visible && isVisible()) foreach(MeterWidget* p, m_metersWidget) p->show();
 }
 
 void VideoWindow::startPlayback()

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -163,7 +163,6 @@ VideoWindow::VideoWindow(Context *context)  :
         connect(context, SIGNAL(seek(long)), this, SLOT(seekPlayback(long)));
         connect(context, SIGNAL(unpause()), this, SLOT(resumePlayback()));
         connect(context, SIGNAL(mediaSelected(QString)), this, SLOT(mediaSelected(QString)));
-        connect(this->window(), SIGNAL(mainWindowMoved()), this, SLOT(mainWindowMoved()));
         connect(this->window(), SIGNAL(mainWindowStateChanged(bool, bool)), this, SLOT(mainWindowStateChanged(bool, bool)));
     }
 }
@@ -203,11 +202,7 @@ void VideoWindow::resizeEvent(QResizeEvent * )
 {
     foreach(MeterWidget* p_meterWidget , m_metersWidget)
         p_meterWidget->AdjustSizePos();
-}
-
-void VideoWindow::mainWindowMoved()
-{
-    if(isVisible()) foreach(MeterWidget* p, m_metersWidget) p->AdjustSizePos();
+    prevPosition = mapToGlobal(pos());
 }
 
 void VideoWindow::mainWindowStateChanged(bool minimized, bool visible)
@@ -259,6 +254,7 @@ void VideoWindow::startPlayback()
         p_meterWidget->raise();
         p_meterWidget->show();
     }
+    prevPosition = mapToGlobal(pos());
 }
 
 void VideoWindow::stopPlayback()
@@ -428,6 +424,10 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
             }
         }
     }
+
+    // The Meter Widgets need to follow the Video Window when it moves
+    // (main window moves, scrolling...), we check the position at every update
+    if(mapToGlobal(pos()) != prevPosition) resizeEvent(NULL);
 
     foreach(MeterWidget* p_meterWidget , m_metersWidget)
         p_meterWidget->update();

--- a/src/Train/VideoWindow.h
+++ b/src/Train/VideoWindow.h
@@ -176,6 +176,8 @@ class VideoWindow : public GcChartWindow
         void telemetryUpdate(RealtimeData rtd);
         void seekPlayback(long ms);
         void mediaSelected(QString filename);
+        void mainWindowMoved();
+        void mainWindowStateChanged(bool minimized, bool visible);
 
     protected:
 

--- a/src/Train/VideoWindow.h
+++ b/src/Train/VideoWindow.h
@@ -176,7 +176,6 @@ class VideoWindow : public GcChartWindow
         void telemetryUpdate(RealtimeData rtd);
         void seekPlayback(long ms);
         void mediaSelected(QString filename);
-        void mainWindowMoved();
         void mainWindowStateChanged(bool minimized, bool visible);
 
     protected:
@@ -194,6 +193,7 @@ class VideoWindow : public GcChartWindow
         bool m_MediaChanged;
 
         QList<MeterWidget*> m_metersWidget;
+        QPoint prevPosition;
 
 #ifdef GC_VIDEO_VLC
 


### PR DESCRIPTION
Currently, when you move the main window, the MeterWidgets do not follow
and become out of place. Similarly, when the main window is minimized on
Linux, the MeterWidgets stay on the desktop. Signals are added to the
main window for those 2 conditions. The VideoWindow connects to those
signals and adjusts the MeterWidgets accordingly.