### PR TITLE
Remove Conditional Compilation for Qt < 5.9

### DIFF
--- a/INSTALL-LINUX
+++ b/INSTALL-LINUX
@@ -1,3 +1,11 @@
+Update Note: to build GoldenCheetah v3.6 we are using the APT Package
+Manager to install dependencies, including Qt 5.14.2, on Travis CI Ubuntu
+Xenial build environment.
+You can check the travis/linux folder for the complete and updated build scripts,
+the minimum Qt version known to work is 5.9 with Qt WebEngine and Qt Charts.
+
+Ale Martinez - May, 2020
+
                                  +++++++++++++++++++++++
                                  LINUX BUILD WALKTHROUGH
                                  +++++++++++++++++++++++

--- a/INSTALL-MAC
+++ b/INSTALL-MAC
@@ -1,3 +1,11 @@
+Update Note: to build GoldenCheetah v3.6 we are using the Homebrew Package
+Manager to install dependencies, including Qt 5.14.2, on Travis CI macOS High
+Sierra build environment.
+You can check the travis/osx folder for the complete and updated build scripts,
+the minimum Qt version known to work is 5.9 with Qt WebEngine and Qt Charts.
+
+Ale Martinez - May, 2020
+
                                  +++++++++++++++++++++++
                                 MAC OSX BUILD WALKTHROUGH
                                  +++++++++++++++++++++++

--- a/INSTALL-WIN32
+++ b/INSTALL-WIN32
@@ -1,4 +1,10 @@
+Update Note: to build GoldenCheetah v3.6 we are using Microsoft Visual C++ 2017,
+included in Microsoft Visual Studio 2019, with Qt 5.14.2 on AppVeyor continuous
+integration platform.
+You can check the appveyor.yml for the complete and updated build script,
+the minimum Qt version known to work is 5.9 with Qt WebEngine and Qt Charts.
 
+Ale Martinez - May, 2020
                                  +++++++++++++++++++++++
                                  WIN32 BUILD WALKTHROUGH
                                  +++++++++++++++++++++++
@@ -6,6 +12,7 @@
                                      Joern Rischmueller
 
                                        February 2017
+
 
 This instruction will guide  you through a standard build of GoldenCheetah (without external
 dependencies or API based services included).
@@ -199,9 +206,3 @@ to contribute is to provide a pull-request.
 
 Cheers.
 Joern
- 
-
-
-
-
-

--- a/src/Charts/AllPlot.h
+++ b/src/Charts/AllPlot.h
@@ -86,11 +86,7 @@ class CurveColors : public QObject
             // BUG in QMacStyle and painting of spanSlider
             // so we use a plain style to avoid it, but only
             // on a MAC, since win and linux are fine
-#if QT_VERSION > 0x5000
             QStyle *style = QStyleFactory::create("fusion");
-#else
-            QStyle *style = QStyleFactory::create("Cleanlooks");
-#endif
             slider->setStyle(style);
 #endif
             slider->hide();

--- a/src/Charts/AllPlotWindow.cpp
+++ b/src/Charts/AllPlotWindow.cpp
@@ -650,11 +650,7 @@ AllPlotWindow::AllPlotWindow(Context *context) :
     // BUG in QMacStyle and painting of spanSlider
     // so we use a plain style to avoid it, but only
     // on a MAC, since win and linux are fine
-#if QT_VERSION > 0x5000
     QStyle *style = QStyleFactory::create("fusion");
-#else
-    QStyle *style = QStyleFactory::create("Cleanlooks");
-#endif
     spanSlider->setStyle(style);
     scrollLeft->setStyle(style);
     scrollRight->setStyle(style);

--- a/src/Charts/DiaryWindow.cpp
+++ b/src/Charts/DiaryWindow.cpp
@@ -72,13 +72,8 @@ DiaryWindow::DiaryWindow(Context *context) :
     monthlyView = new QTableView(this);
     monthlyView->setItemDelegate(new GcCalendarDelegate);
     monthlyView->setModel(calendarModel);
-#if QT_VERSION > 0x050000
     monthlyView->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
     monthlyView->verticalHeader()->setSectionResizeMode(QHeaderView::Stretch);
-#else
-    monthlyView->horizontalHeader()->setResizeMode(QHeaderView::Stretch);
-    monthlyView->verticalHeader()->setResizeMode(QHeaderView::Stretch);
-#endif
     monthlyView->verticalHeader()->hide();
     monthlyView->viewport()->installEventFilter(this);
     monthlyView->setGridStyle(Qt::DotLine);

--- a/src/Charts/GoldenCheetah.cpp
+++ b/src/Charts/GoldenCheetah.cpp
@@ -452,11 +452,7 @@ GcWindow::mouseMoveEvent(QMouseEvent *e)
 
     default:
     case Move :
-#if QT_VERSION < 0x040700
-        setCursor(Qt::ClosedHandCursor);
-#else
         setCursor(Qt::DragMoveCursor);
-#endif
         emit moving(this);
         break;
 
@@ -895,11 +891,7 @@ void GcChartWindow:: saveImage()
 
         QPixmap picture;
         menuButton->hide();
-#if QT_VERSION > 0x050000
         picture = grab(rect());
-#else
-        picture = QPixmap::grabWidget (this);
-#endif
         picture.save(fileName);
 
     }

--- a/src/Charts/HomeWindow.cpp
+++ b/src/Charts/HomeWindow.cpp
@@ -1683,9 +1683,7 @@ ImportChartDialog::ImportChartDialog(Context *context, QList<QMap<QString,QStrin
     table->setShowGrid(false);
     table->setSelectionMode(QAbstractItemView::NoSelection);
     table->horizontalHeader()->setStretchLastSection(true);
-#if QT_VERSION > 0x050200
     table->horizontalHeader()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
-#endif
 
     // Populate the list of named searches
     for(int i=0; i<list.count(); i++) {

--- a/src/Charts/LTMPopup.cpp
+++ b/src/Charts/LTMPopup.cpp
@@ -55,11 +55,7 @@ LTMPopup::LTMPopup(Context *context) : QWidget(context->mainWindow), context(con
     // ride list...
     rides = new QTableWidget(this);
 #ifdef Q_OS_LINUX // QT 4.7 bug on Linux, selection-background-color is ignored (no transparency)
-#if QT_VERSION > 0x5000
     QStyle *style = QStyleFactory::create("fusion");
-#else
-    QStyle *style = QStyleFactory::create("Cleanlooks");
-#endif
     rides->setStyle(style);
 #endif
     rides->setFrameStyle(QFrame::NoFrame);

--- a/src/Charts/LTMWindow.cpp
+++ b/src/Charts/LTMWindow.cpp
@@ -111,11 +111,7 @@ LTMWindow::LTMWindow(Context *context) :
     // BUG in QMacStyle and painting of spanSlider
     // so we use a plain style to avoid it, but only
     // on a MAC, since win and linux are fine
-#if QT_VERSION > 0x5000
     QStyle *style = QStyleFactory::create("fusion");
-#else
-    QStyle *style = QStyleFactory::create("Cleanlooks");
-#endif
     spanSlider->setStyle(style);
     scrollLeft->setStyle(style);
     scrollRight->setStyle(style);
@@ -143,10 +139,8 @@ LTMWindow::LTMWindow(Context *context) :
     // the data table
     QFont defaultFont; // mainwindow sets up the defaults.. we need to apply
     dataSummary = new QWebEngineView(this);
-#if QT_VERSION >= 0x050800
     // stop stealing focus!
     dataSummary->settings()->setAttribute(QWebEngineSettings::FocusOnNavigationEnabled, false);
-#endif
     //XXXdataSummary->setEnabled(false); // stop grabbing focus
     if (dpiXFactor > 1) {
     // 80 lines per page on hidpi screens (?)

--- a/src/Charts/LogTimeScaleDraw.cpp
+++ b/src/Charts/LogTimeScaleDraw.cpp
@@ -33,15 +33,9 @@
 #include "qwt_scale_map.h"
 #include "qwt_scale_draw.h"
 
-#if QT_VERSION < 0x040000
-#include <qwmatrix.h>
-#define QwtMatrix QWMatrix
-#define QwtPointArray QPointArray
-#else
 #include <qmatrix.h>
 #define QwtMatrix QMatrix
 #define QwtPointArray QPolygon
-#endif
 
 struct tick_info_t {
     double x;
@@ -102,11 +96,7 @@ LogTimeScaleDraw::drawLabel(QPainter *painter, double value) const
     const QwtMatrix m = labelTransformation( pos, labelSize).toAffine();
 
     painter->save();
-#if QT_VERSION < 0x040000
-    painter->setWorldMatrix(m, true);
-#else
     painter->setMatrix(m, true);
-#endif
 
     lbl.draw (painter, QRect(QPoint(0, 0), labelSize.toSize()) );
     painter->restore();

--- a/src/Charts/PythonChart.cpp
+++ b/src/Charts/PythonChart.cpp
@@ -26,9 +26,7 @@
 
 #include <QtConcurrent>
 
-#if QT_VERSION >= 0x050800
 #include <QWebEngineSettings>
-#endif
 
 // always pull in after all QT headers
 #ifdef slots
@@ -437,10 +435,8 @@ PythonChart::setWeb(bool x)
         canvas->page()->view()->setContentsMargins(0,0,0,0);
         canvas->setZoomFactor(dpiXFactor);
         canvas->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));
-#if QT_VERSION >= 0x050800
         // stop stealing focus!
         canvas->settings()->setAttribute(QWebEngineSettings::FocusOnNavigationEnabled, false);
-#endif
         renderlayout->insertWidget(0, canvas);
     }
 

--- a/src/Charts/RideMapWindow.cpp
+++ b/src/Charts/RideMapWindow.cpp
@@ -121,10 +121,8 @@ RideMapWindow::RideMapWindow(Context *context, int mapType) : GcChartWindow(cont
     setChartLayout(layout);
 
     view = new QWebEngineView(this);
-#if QT_VERSION >= 0x050800
     // stop stealing focus!
     view->settings()->setAttribute(QWebEngineSettings::FocusOnNavigationEnabled, false);
-#endif
     view->setPage(new mapWebPage());
     view->setContentsMargins(0,0,0,0);
     view->page()->view()->setContentsMargins(0,0,0,0);

--- a/src/Charts/RideSummaryWindow.cpp
+++ b/src/Charts/RideSummaryWindow.cpp
@@ -92,10 +92,8 @@ RideSummaryWindow::RideSummaryWindow(Context *context, bool ridesummary) :
     vlayout->setContentsMargins(10,10,10,10);
 
     rideSummary = new QWebEngineView(this);
-#if QT_VERSION >= 0x050800
     // stop stealing focus!
     rideSummary->settings()->setAttribute(QWebEngineSettings::FocusOnNavigationEnabled, false);
-#endif
 
     rideSummary->setContentsMargins(0,0,0,0);
     rideSummary->page()->view()->setContentsMargins(0,0,0,0);

--- a/src/Charts/RideSummaryWindow.h
+++ b/src/Charts/RideSummaryWindow.h
@@ -28,9 +28,7 @@
 #include <QWebEngineSettings>
 
 #include <QFormLayout>
-#if QT_VERSION >= 0x050000
 #include <QtConcurrent>
-#endif
 
 #include <QPointer>
 #include "RideFileCache.h"

--- a/src/Cloud/CalDAV.cpp
+++ b/src/Cloud/CalDAV.cpp
@@ -609,11 +609,7 @@ CalDAV::requestGoogleAccessTokenToExecute() {
 
     // get a valid access token
     QByteArray data;
-#if QT_VERSION > 0x050000
     QUrlQuery params;
-#else
-    QUrl params;
-#endif
     QString urlstr = "https://www.googleapis.com/oauth2/v3/token?";
     params.addQueryItem("client_id", GC_GOOGLE_CALENDAR_CLIENT_ID);
 #ifdef GC_GOOGLE_CALENDAR_CLIENT_SECRET
@@ -622,11 +618,7 @@ CalDAV::requestGoogleAccessTokenToExecute() {
     params.addQueryItem("refresh_token", refresh_token);
     params.addQueryItem("grant_type", "refresh_token");
 
-#if QT_VERSION > 0x050000
     data.append(params.query(QUrl::FullyEncoded));
-#else
-    data=params.encodedQuery();
-#endif
 
     // get a new Access Token (since they are just temporarily valid)
     QUrl url = QUrl(urlstr);

--- a/src/Cloud/OAuthDialog.h
+++ b/src/Cloud/OAuthDialog.h
@@ -29,9 +29,7 @@
 #include <QSslSocket>
 
 // QUrl split into QUrlQuerty in QT5
-#if QT_VERSION > 0x050000
 #include <QUrlQuery>
-#endif
 
 #include <QWebEngineHistory>
 #include <QWebEngineHistoryItem>

--- a/src/Cloud/Strava.cpp
+++ b/src/Cloud/Strava.cpp
@@ -184,11 +184,7 @@ Strava::readdir(QString path, QStringList &errors, QDateTime from, QDateTime to)
     while (offset < resultCount) {
         QString urlstr = "https://www.strava.com/api/v3/athlete/activities?";
 
-#if QT_VERSION > 0x050000
         QUrlQuery params;
-#else
-        QUrl params;
-#endif
 
         // use toMSecsSinceEpoch for compatibility with QT4
         params.addQueryItem("before", QString::number(to.addDays(1).toMSecsSinceEpoch()/1000.0f, 'f', 0));

--- a/src/Cloud/TodaysPlan.cpp
+++ b/src/Cloud/TodaysPlan.cpp
@@ -528,7 +528,6 @@ TodaysPlan::listAthletes()
     // did we get a good response ?
     QByteArray r = reply->readAll();
 
-#if QT_VERSION > 0x050000
     QJsonParseError parseError;
     QJsonDocument document = QJsonDocument::fromJson(r, &parseError);
 
@@ -553,7 +552,6 @@ TodaysPlan::listAthletes()
             }
         }
     }
- #endif
     return returning;
 }
 

--- a/src/Cloud/TrainingsTageBuch.cpp
+++ b/src/Cloud/TrainingsTageBuch.cpp
@@ -88,22 +88,14 @@ TrainingsTageBuch::open(QStringList &errors)
     QString username = getSetting(GC_TTBUSER).toString();
     QString password = getSetting(GC_TTBPASS).toString();
 
-#if QT_VERSION > 0x050000
     QUrlQuery urlquery;
-#else
-    QUrl urlquery( TTB_URL + "/settings/list" );
-#endif
     urlquery.addQueryItem( "view", "xml" );
     urlquery.addQueryItem( "user", username );
     urlquery.addQueryItem( "pass", password );
 
-#if QT_VERSION > 0x050000
     QUrl url (TTB_URL + "/settings/list");
     url.setQuery(urlquery.query());
     QNetworkRequest request = QNetworkRequest(url);
-#else
-    QNetworkRequest request = QNetworkRequest(urlquery);
-#endif
 
     request.setRawHeader( "Accept-Encoding", "identity" );
     request.setRawHeader( "Accept", "application/xml" );
@@ -139,22 +131,14 @@ TrainingsTageBuch::open(QStringList &errors)
 
     // GET SESSION TOKEN
 
-#if QT_VERSION > 0x050000
     urlquery = QUrlQuery();
-#else
-    urlquery = QUrl(TTB_URL + "/login/sso");
-#endif
     urlquery.addQueryItem( "view", "xml" );
     urlquery.addQueryItem( "user", username );
     urlquery.addQueryItem( "pass", password );
 
-#if QT_VERSION > 0x050000
     url = QUrl(TTB_URL + "/login/sso");
     url.setQuery(urlquery.query());
     request = QNetworkRequest(url);
-#else
-    request = QNetworkRequest(urlquery);
-#endif
 
     request.setRawHeader( "Accept-Encoding", "identity" );
     request.setRawHeader( "Accept", "application/xml" );
@@ -227,22 +211,14 @@ TrainingsTageBuch::writeFile(QByteArray &data, QString remotename, RideFile *rid
     filePart.setBody(data);
     body->append(filePart);
 
-#if QT_VERSION > 0x050000
     QUrlQuery urlquery;
-#else
-    QUrl urlquery( TTB_URL + "/file/upload" );
-#endif
     urlquery.addQueryItem( "view", "xml" );
     urlquery.addQueryItem( "sso", sessionId );
 
 
-#if QT_VERSION > 0x050000
     QUrl url (TTB_URL + "/file/upload");
     url.setQuery(urlquery.query());
     QNetworkRequest request = QNetworkRequest(url);
-#else
-    QNetworkRequest request = QNetworkRequest(urlquery);
-#endif
 
     request.setRawHeader( "Accept-Encoding", "identity" );
     request.setRawHeader( "Accept", "application/xml" );

--- a/src/Cloud/TrainingsTageBuch.h
+++ b/src/Cloud/TrainingsTageBuch.h
@@ -32,9 +32,7 @@
 #include <QXmlSimpleReader>
 #include <QXmlDefaultHandler>
 #include <QNetworkReply>
-#if QT_VERSION > 0x050000
 #include <QUrlQuery>
-#endif
 
 class TrainingsTageBuch : public CloudService {
 

--- a/src/Cloud/Velohero.cpp
+++ b/src/Cloud/Velohero.cpp
@@ -87,22 +87,14 @@ Velohero::open(QStringList &errors)
     QString username = getSetting(GC_VELOHEROUSER).toString();
     QString password = getSetting(GC_VELOHEROPASS).toString();
 
-#if QT_VERSION > 0x050000
     QUrlQuery urlquery;
-#else
-    QUrl urlquery( VELOHERO_URL + "/sso" );
-#endif
     urlquery.addQueryItem("view", "xml");
     urlquery.addQueryItem("user", username);
     urlquery.addQueryItem("pass", password);
 
-#if QT_VERSION > 0x050000
     QUrl url (VELOHERO_URL + "/sso");
     url.setQuery(urlquery.query());
     QNetworkRequest request = QNetworkRequest(url);
-#else
-    QNetworkRequest request = QNetworkRequest(urlquery);
-#endif
 
     request.setRawHeader("Accept-Encoding", "identity");
     request.setRawHeader("Accept", "application/xml");
@@ -176,21 +168,13 @@ Velohero::writeFile(QByteArray &data, QString remotename, RideFile *ride)
     filePart.setBody(data);
     body->append(filePart);
 
-#if QT_VERSION > 0x050000
     QUrlQuery urlquery;
-#else
-    QUrl urlquery( VELOHERO_URL + "/upload/file" );
-#endif
     urlquery.addQueryItem( "view", "xml" );
     urlquery.addQueryItem( "sso", sessionId );
 
-#if QT_VERSION > 0x050000
     QUrl url (VELOHERO_URL + "/upload/file");
     url.setQuery(urlquery.query());
     QNetworkRequest request = QNetworkRequest(url);
-#else
-    QNetworkRequest request = QNetworkRequest(urlquery);
-#endif
 
     request.setRawHeader( "Accept-Encoding", "identity" );
     request.setRawHeader( "Accept", "application/xml" );

--- a/src/Cloud/WithingsDownload.cpp
+++ b/src/Cloud/WithingsDownload.cpp
@@ -81,11 +81,7 @@ WithingsDownload::getBodyMeasures(QString &error, QDateTime from, QDateTime to, 
     if(!strNokiaRefreshToken.isEmpty()) {
         printd("OAuth 2.0 API\n");
 
-#if QT_VERSION > 0x050000
         QUrlQuery postData;
-#else
-        QUrl postData;
-#endif
 
         QString refresh_token = appsettings->cvalue(context->athlete->cyclist, GC_NOKIA_REFRESH_TOKEN).toString();
 
@@ -124,11 +120,7 @@ WithingsDownload::getBodyMeasures(QString &error, QDateTime from, QDateTime to, 
                 if (userid != "") appsettings->setCValue(context->athlete->cyclist, GC_WIUSER, userid);
 
 
-            #if QT_VERSION > 0x050000
                 QUrlQuery params;
-            #else
-                QUrl params;
-            #endif
 
                 emit downloadStarted(100);
 

--- a/src/Cloud/Xert.cpp
+++ b/src/Cloud/Xert.cpp
@@ -177,11 +177,7 @@ Xert::readdir(QString path, QStringList &errors, QDateTime from, QDateTime to)
 
     QString urlstr("https://www.xertonline.com/oauth/activity?");
 
-#if QT_VERSION > 0x050000
     QUrlQuery params;
-#else
-    QUrl params;
-#endif
 
     // use toMSecsSinceEpoch for compatibility with QT4
     params.addQueryItem("to", QString::number(to.addDays(1).toMSecsSinceEpoch()/1000.0f, 'f', 0));

--- a/src/Core/RideCache.h
+++ b/src/Core/RideCache.h
@@ -30,11 +30,7 @@
 
 #include <QFuture>
 #include <QFutureWatcher>
-#if QT_VERSION > 0x050000
 # include <QtConcurrent>
-#else
-# include <QtConcurrentRun>
-#endif
 
 class Context;
 class LTMPlot;

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -511,9 +511,5 @@ extern int OperatingSystem;
 #define OSX     3
 #define OPENBSD 4
 
-#if QT_VERSION > 0x050000
 #define OS_STYLE "Fusion"
-#else
-#define OS_STYLE "Plastique"
-#endif
 #endif // _GC_Settings_h

--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -53,9 +53,7 @@
 #include <X11/Xlib.h>
 #endif
 
-#if QT_VERSION > 0x050000
 #include <QStandardPaths>
-#endif
 
 #ifdef GC_WANT_GSL
 #include <gsl/gsl_errno.h>
@@ -116,14 +114,9 @@ void terminate(int code)
 // redirect logging
 //
 #ifdef GC_WANT_HTTP
-#if QT_VERSION > 0x50000
 void myMessageOutput(QtMsgType type, const QMessageLogContext &, const QString &string)
  {
     const char *msg = string.toLocal8Bit().constData();
-#else
-void myMessageOutput(QtMsgType type, const char *msg)
- {
-#endif
      //in this function, you can write the message to any stream!
      switch (type) {
      default: // QtInfoMsg from 5.5 would arrive here
@@ -388,7 +381,6 @@ main(int argc, char *argv[])
     dpiXFactor = 1.0;
     dpiYFactor = 1.0;
 
-#if QT_VERSION_MAJOR >= 5
 #ifndef Q_OS_MAC // not needed on a Mac
 
     // We will set screen ratio factor for sizing when a screen
@@ -433,9 +425,6 @@ main(int argc, char *argv[])
     } else {
        //qDebug()<<"geom:"<<QApplication::desktop()->geometry()<<"no need for hidpi scaling"<<"physcial DPI:"<<QApplication::desktop()->physicalDpiX()<<"logical DPI:"<<QApplication::desktop()->logicalDpiX();
     }
-#endif
-#else
-       //qDebug()<<"geom:"<<QApplication::desktop()->geometry()<<"no hidpi support available";
 #endif
 
     // scale up to user scale factor
@@ -496,12 +485,8 @@ main(int argc, char *argv[])
 #if defined(Q_OS_MACX)
         QString libraryPath="Library/GoldenCheetah";
 #elif defined(Q_OS_WIN)
-#if QT_VERSION > 0x050000 // windows and qt5
         QStringList paths=QStandardPaths::standardLocations(QStandardPaths::DataLocation);
         QString libraryPath = paths.at(0); 
-#else // windows not qt5
-        QString libraryPath=QDesktopServices::storageLocation(QDesktopServices::DataLocation) + "/GoldenCheetah";
-#endif // qt5
 #else // not windows or osx (must be Linux or OpenBSD)
         // Q_OS_LINUX et al
         QString libraryPath=".goldencheetah";
@@ -625,11 +610,7 @@ main(int argc, char *argv[])
             } else {
                 // switch off warnings if in gui mode
 #ifndef GC_WANT_ALLDEBUG
-#if QT_VERSION > 0x50000
                 qInstallMessageHandler(myMessageOutput);
-#else
-                qInstallMsgHandler(myMessageOutput);
-#endif
 #endif
             }
 

--- a/src/FileIO/AthleteBackup.cpp
+++ b/src/FileIO/AthleteBackup.cpp
@@ -19,9 +19,7 @@
 #include <QProgressDialog>
 #include <QMessageBox>
 #include <QFileDialog>
-#if QT_VERSION > 0x050400
 #include <QStorageInfo>
-#endif
 
 #include "Athlete.h"
 #include "AthleteBackup.h"
@@ -133,7 +131,6 @@ AthleteBackup::backup(QString progressText)
        return false;
     }
 
-#if QT_VERSION > 0x050400
     // if if there is enough space available for the backup
     QStorageInfo storage(backupFolder);
     if (storage.isValid() && storage.isReady()) {
@@ -146,13 +143,6 @@ AthleteBackup::backup(QString progressText)
         QMessageBox::warning(NULL, tr("Athlete Backup"), tr("Directory %1 not available. No backup .zip file created for athlete %2.").arg(backupFolder).arg(athlete));
         return false;
     }
-#else
-    QDir checkDir(backupFolder);
-    if (!checkDir.exists()) {
-        QMessageBox::warning(NULL, tr("Athlete Backup"), tr("Directory %1 not available. No backup .zip file created for athlete %2.").arg(backupFolder).arg(athlete));
-        return false;
-    }
-#endif
 
     QChar zero = QLatin1Char('0');
     QString targetFileName = QString( "GC_%1_%2_%3_%4_%5_%6_%7_%8.zip" )

--- a/src/Gui/AnalysisSidebar.cpp
+++ b/src/Gui/AnalysisSidebar.cpp
@@ -261,9 +261,7 @@ AnalysisSidebar::setRide(RideItem*ride)
             add->setData(0, Qt::UserRole+1, QVariant(interval->color));
             add->setData(0, Qt::UserRole+2, QVariant(interval->test));
             add->setFlags(Qt::ItemIsEnabled
-#if QT_VERSION >= 0x50101
                           | Qt::ItemNeverHasChildren
-#endif
                           | Qt::ItemIsSelectable 
                           | Qt::ItemIsDragEnabled 
                           | Qt::ItemIsEditable);

--- a/src/Gui/ComparePane.cpp
+++ b/src/Gui/ComparePane.cpp
@@ -324,7 +324,6 @@ ComparePane::refreshTable()
         table->resizeColumnsToContents(); // set columns to fit
         table->setVisible(true);
 
-#if QT_VERSION > 0x050000 // fix the first two if we can
         for (int i=0; i<list.count(); i++) {
             if (i < 2) {
                 table->horizontalHeader()->setSectionResizeMode(i, QHeaderView::Fixed);
@@ -332,9 +331,6 @@ ComparePane::refreshTable()
                 table->horizontalHeader()->setSectionResizeMode(i, QHeaderView::Interactive);
             }
         }
-#else
-        table->horizontalHeader()->setResizeMode(QHeaderView::Interactive);
-#endif
         table->horizontalHeader()->setStretchLastSection(true);
 
     } else { //SEASONS
@@ -480,7 +476,6 @@ ComparePane::refreshTable()
         table->setVisible(false);
         table->resizeColumnsToContents(); // set columns to fit
         table->setVisible(true);
-#if QT_VERSION > 0x050000 // fix the first two if we can
         for (int i=0; i<list.count(); i++) {
             if (i < 2) {
                 table->horizontalHeader()->setSectionResizeMode(i, QHeaderView::Fixed);
@@ -488,9 +483,6 @@ ComparePane::refreshTable()
                 table->horizontalHeader()->setSectionResizeMode(i, QHeaderView::Interactive);
             }
         }
-#else
-        table->horizontalHeader()->setResizeMode(QHeaderView::Interactive);
-#endif
         table->horizontalHeader()->setStretchLastSection(true);
     }
     // sorting has to be disabled as long as table content is updated

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -71,13 +71,11 @@
 #include "WorkoutWizard.h"
 #include "ErgDBDownloadDialog.h"
 #include "AddDeviceWizard.h"
-#if QT_VERSION > 0x050000
 #include "Dropbox.h"
 #include "GoogleDrive.h"
 #include "KentUniversity.h"
 #include "SixCycle.h"
 #include "OpenData.h"
-#endif
 #include "AddCloudWizard.h"
 #include "LocalFileStore.h"
 #include "CloudService.h"
@@ -264,11 +262,7 @@ MainWindow::MainWindow(const QDir &home)
      *--------------------------------------------------------------------*/
     head = new GcToolBar(this);
 
-#if QT_VERSION > 0x50000
     QStyle *toolStyle = QStyleFactory::create("fusion");
-#else
-    QStyle *toolStyle = QStyleFactory::create("Cleanlooks");
-#endif
     QPalette metal;
     metal.setColor(QPalette::Button, QColor(215,215,215));
 
@@ -500,9 +494,7 @@ MainWindow::MainWindow(const QDir &home)
     optionsMenu->addSeparator();
     optionsMenu->addAction(tr("Create a new workout..."), this, SLOT(showWorkoutWizard()));
     optionsMenu->addAction(tr("Download workouts from ErgDB..."), this, SLOT(downloadErgDB()));
-#if QT_VERSION > 0x050000
     optionsMenu->addAction(tr("Download workouts from Today's Plan..."), this, SLOT(downloadTodaysPlanWorkouts()));
-#endif
     optionsMenu->addAction(tr("Import workouts, videos, videoSyncs..."), this, SLOT(importWorkout()));
     optionsMenu->addAction(tr("Scan disk for workouts, videos, videoSyncs..."), this, SLOT(manageLibrary()));
 
@@ -653,7 +645,7 @@ MainWindow::MainWindow(const QDir &home)
      * Lets ask for telemetry and check for updates
      *--------------------------------------------------------------------*/
 
-#if QT_VERSION > 0x050000 && !defined(OPENDATA_DISABLE)
+#if !defined(OPENDATA_DISABLE)
     OpenData::check(currentTab->context);
 #else
     fprintf(stderr, "OpenData disabled, secret not defined.\n"); fflush(stderr);
@@ -1026,12 +1018,10 @@ MainWindow::closeEvent(QCloseEvent* event)
 
         // save global mainwindow settings
         appsettings->setValue(GC_TABBAR, showhideTabbar->isChecked());
-#if QT_VERSION > 0x050200
         // wait for threads.. max of 10 seconds before just exiting anyway
         for (int i=0; i<10 && QThreadPool::globalInstance()->activeThreadCount(); i++) {
             QThread::sleep(1);
         }
-#endif
     }
     appsettings->setValue(GC_SETTINGS_MAIN_GEOM, saveGeometry());
     appsettings->setValue(GC_SETTINGS_MAIN_STATE, saveState());
@@ -2110,7 +2100,6 @@ MainWindow::downloadErgDB()
  * TodaysPlan Workouts
  *--------------------------------------------------------------------*/
 
-#if QT_VERSION > 0x050000
 void
 MainWindow::downloadTodaysPlanWorkouts()
 {
@@ -2127,7 +2116,6 @@ MainWindow::downloadTodaysPlanWorkouts()
         "Please check your preference settings."));
     }
 }
-#endif
 
 /*----------------------------------------------------------------------
  * Workout/Media Library
@@ -2178,11 +2166,9 @@ MainWindow::uploadCloud(QAction *action)
         QString actionText = QString(action->text()).replace("&", "");
 
         if (actionText == "University of Kent") {
-#if QT_VERSION > 0x50000
             CloudService *db = CloudServiceFactory::instance().newService(action->data().toString(), currentTab->context);
             KentUniversityUploadDialog uploader(this, db, currentTab->context->ride);
             int ret = uploader.exec();
- #endif
         } else {
             CloudService *db = CloudServiceFactory::instance().newService(action->data().toString(), currentTab->context);
             CloudService::upload(this, currentTab->context, db, currentTab->context->ride);

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -201,9 +201,7 @@ class MainWindow : public QMainWindow
         // Training View
         void addDevice();
         void downloadErgDB();
-#if QT_VERSION > 0x050000
         void downloadTodaysPlanWorkouts();
-#endif
         void manageLibrary();
         void showWorkoutWizard();
         void importWorkout();

--- a/src/Gui/MergeActivityWizard.cpp
+++ b/src/Gui/MergeActivityWizard.cpp
@@ -1109,11 +1109,7 @@ MergeAdjust::MergeAdjust(MergeActivityWizard *parent) : QWizardPage(parent), wiz
     // BUG in QMacStyle and painting of spanSlider
     // so we use a plain style to avoid it, but only
     // on a MAC, since win and linux are fine
-#if QT_VERSION > 0x5000
     QStyle *style = QStyleFactory::create("fusion");
-#else
-    QStyle *style = QStyleFactory::create("Cleanlooks");
-#endif
     spanSlider->setStyle(style);
 #endif
 

--- a/src/Gui/Pages.cpp
+++ b/src/Gui/Pages.cpp
@@ -39,10 +39,8 @@
 #include "RideAutoImportConfig.h"
 #include "HelpWhatsThis.h"
 #include "GcUpgrade.h"
-#if QT_VERSION >= 0x050000
 #include "Dropbox.h"
 #include "GoogleDrive.h"
-#endif
 #include "LocalFileStore.h"
 #include "Secrets.h"
 #include "Utils.h"
@@ -201,14 +199,12 @@ GeneralPage::GeneralPage(Context *context) : context(context)
     offset += 1;
 #endif
 
-#if QT_VERSION >= 0x050000
     opendata = new QCheckBox(tr("Share to the OpenData project"), this);
     QString grant = appsettings->cvalue(context->athlete->cyclist, GC_OPENDATA_GRANTED, "X").toString();
     opendata->setChecked(grant == "Y");
     configLayout->addWidget(opendata, 7+offset,1, Qt::AlignLeft);
     if (grant == "X") opendata->hide();
     offset += 1;
-#endif
 
     //
     // Athlete directory (home of athletes)
@@ -343,11 +339,9 @@ GeneralPage::saveClicked()
     appsettings->setValue(GC_PYTHON_HOME, pythonDirectory->text());
 #endif
 
-#if QT_VERSION >= 0x050000
     // update to reflect the state - if hidden user hasn't been asked yet to
     // its neither set or unset !
     if (!opendata->isHidden()) appsettings->setCValue(context->athlete->cyclist, GC_OPENDATA_GRANTED, opendata->isChecked() ? "Y" : "N");
-#endif
 
     // Elevation
     appsettings->setValue(GC_ELEVATION_HYSTERESIS, hystedit->text());

--- a/src/Gui/Pages.h
+++ b/src/Gui/Pages.h
@@ -114,9 +114,7 @@ class GeneralPage : public QWidget
 #ifdef GC_WANT_PYTHON
         QCheckBox *embedPython;
 #endif
-#if QT_VERSION >= 0x050000
         QCheckBox *opendata;
-#endif
         QLineEdit *garminHWMarkedit;
         QLineEdit *hystedit;
         QLineEdit *athleteDirectory;

--- a/src/Gui/RideNavigator.cpp
+++ b/src/Gui/RideNavigator.cpp
@@ -626,7 +626,7 @@ RideNavigator::setColumnWidth(int x, bool resized, int logicalIndex, int oldWidt
 
     active = true;
 
-#if !defined (Q_OS_MAC) || (defined (Q_OS_MAC) && (QT_VERSION < 0x050000)) // on QT5 the scrollbars have no width
+#if !defined (Q_OS_MAC) // on QT5 the scrollbars have no width
     if (tableView->verticalScrollBar()->isVisible())
         x -= tableView->verticalScrollBar()->width()
                 + 0 ; // !! no longer account for content margins of 3,3,3,3 was + 6
@@ -1236,7 +1236,7 @@ void NavigatorCellDelegate::paint(QPainter *painter, const QStyleOptionViewItem 
             painter->drawText(myOption.rect, Qt::AlignLeft | Qt::TextWordWrap, calendarText);
             painter->setPen(isColor);
 
-#if (defined (Q_OS_MAC) && (QT_VERSION >= 0x050000)) // on QT5 the scrollbars have no width
+#if defined (Q_OS_MAC) // on QT5 the scrollbars have no width
             if (!selected && !rideBG && high.x()+12 > rideNavigator->geometry().width() && !isnormal) {
 #else
             if (!selected && !rideBG && high.x()+32 > rideNavigator->geometry().width() && !isnormal) {
@@ -1373,14 +1373,10 @@ RideNavigator::showTreeContextMenuPopup(const QPoint &pos)
 
 RideTreeView::RideTreeView(QWidget *parent) : QTreeView(parent)
 {
-#if (defined WIN32) && (QT_VERSION > 0x050000) && (QT_VERSION < 0x050301) 
-    // don't allow ride drop on Windows with QT5 until 5.3.1 when they fixed the bug
-#else
     setDragDropMode(QAbstractItemView::InternalMove);
     setDragEnabled(true);
     setDragDropOverwriteMode(false);
     setDropIndicatorShown(true);
-#endif
 #ifdef Q_OS_MAC
     setAttribute(Qt::WA_MacShowFocusRect, 0);
 #endif

--- a/src/R/RLibrary.h
+++ b/src/R/RLibrary.h
@@ -21,9 +21,6 @@
 
 // QFunctionPointer typedef introduced in QT5
 #include <QtGlobal>
-#if QT_VERSION < 0x050000
-typedef void *QFunctionPointer;
-#endif
 
 #include <QStringList>
 class QString;

--- a/src/Train/AddDeviceWizard.cpp
+++ b/src/Train/AddDeviceWizard.cpp
@@ -205,13 +205,11 @@ DeviceScanner::quickScan(bool deep) // scan quickly or if true scan forever, as 
 
     // we will need a factory for this soon..
     case DEV_CT : wizard->controller = new ComputrainerController(NULL, NULL); break;
-#if QT_VERSION >= 0x050000
     case DEV_MONARK : wizard->controller = new MonarkController(NULL, NULL); break;
     case DEV_KETTLER : wizard->controller = new KettlerController(NULL, NULL); break;
     case DEV_KETTLER_RACER : wizard->controller = new KettlerRacerController (NULL, NULL); break;
     case DEV_ERGOFIT : wizard->controller = new ErgofitController(NULL, NULL); break;
     case DEV_DAUM : wizard->controller = new DaumController(NULL, NULL); break;
-#endif
 #ifdef GC_HAVE_LIBUSB
     case DEV_FORTIUS : wizard->controller = new FortiusController(NULL, NULL); break;
     case DEV_IMAGIC : wizard->controller = new ImagicController(NULL, NULL); break;

--- a/src/Train/AddDeviceWizard.h
+++ b/src/Train/AddDeviceWizard.h
@@ -32,13 +32,11 @@
 #include "ImagicController.h"
 #endif
 #include "ComputrainerController.h"
-#if QT_VERSION >= 0x050000
 #include "MonarkController.h"
 #include "KettlerController.h"
 #include "KettlerRacerController.h"
 #include "ErgofitController.h"
 #include "DaumController.h"
-#endif
 #include "ANTlocalController.h"
 #include "ANTChannel.h"
 #include "NullController.h"

--- a/src/Train/DeviceTypes.cpp
+++ b/src/Train/DeviceTypes.cpp
@@ -51,7 +51,6 @@ DeviceTypes::DeviceTypes()
         tr("Racermate Computrainer Lab or Pro bike trainer with the handlebar controller "
         "connected via a USB adaptor or directly connected to a local serial port.") ,
         ":images/devices/computrainer.png"                                        },
-#if QT_VERSION >= 0x050000
       { DEV_MONARK,       DEV_SERIAL,  (char *) "Monark LTx/LCx",true,    false,
         tr("Monark USB device ") ,
         ":images/devices/monark_lt2.png"                                        },
@@ -67,7 +66,6 @@ DeviceTypes::DeviceTypes()
       { DEV_DAUM, DEV_SERIAL, (char *)"Daum Cockpit" ,true, false,
         tr("Daum Serial Device ") ,
         ":images/activity.png"},
-#endif
 #ifdef GC_HAVE_LIBUSB
       { DEV_FORTIUS,  DEV_LIBUSB,  (char *) "Tacx Fortius",          true,    false,
         tr("Tacx Fortius bike trainer with the handlebar controller connected "

--- a/src/Train/TrainBottom.cpp
+++ b/src/Train/TrainBottom.cpp
@@ -45,9 +45,7 @@ TrainBottom::TrainBottom(TrainSidebar *trainSidebar, QWidget *parent) :
     m_connectButton->setStyleSheet("background-color: rgba( 255, 255, 255, 0% ); border: 0px;");
     m_connectButton->setAutoRepeat(true);
     m_connectButton->setAutoRepeatDelay(200);
-#if QT_VERSION > 0x050400
     m_connectButton->setShortcut(Qt::Key_MediaPrevious);
-#endif
     toolbuttons->addWidget(m_connectButton);
 
     QIcon rewIcon(":images/oxygen/rewind.png");
@@ -60,9 +58,7 @@ TrainBottom::TrainBottom(TrainSidebar *trainSidebar, QWidget *parent) :
     m_rewindButton->setStyleSheet("background-color: rgba( 255, 255, 255, 0% ); border: 0px;");
     m_rewindButton->setAutoRepeat(true);
     m_rewindButton->setAutoRepeatDelay(200);
-#if QT_VERSION > 0x050400
     m_rewindButton->setShortcut(Qt::Key_MediaPrevious);
-#endif
     toolbuttons->addWidget(m_rewindButton);
 
     QIcon stopIcon(":images/oxygen/stop.png");
@@ -73,9 +69,7 @@ TrainBottom::TrainBottom(TrainSidebar *trainSidebar, QWidget *parent) :
     m_stopButton->setAutoDefault(false);
     m_stopButton->setFlat(true);
     m_stopButton->setStyleSheet("background-color: rgba( 255, 255, 255, 0% ); border: 0px;");
-#if QT_VERSION > 0x050400
     m_stopButton->setShortcut(Qt::Key_MediaStop);
-#endif
     toolbuttons->addWidget(m_stopButton);
 
     QIcon playIcon(":images/oxygen/play.png");
@@ -99,9 +93,7 @@ TrainBottom::TrainBottom(TrainSidebar *trainSidebar, QWidget *parent) :
     m_forwardButton->setStyleSheet("background-color: rgba( 255, 255, 255, 0% ); border: 0px;");
     m_forwardButton->setAutoRepeat(true);
     m_forwardButton->setAutoRepeatDelay(200);
-#if QT_VERSION > 0x050400
     m_forwardButton->setShortcut(Qt::Key_MediaNext);
-#endif
     toolbuttons->addWidget(m_forwardButton);
 
     QIcon lapIcon(":images/oxygen/lap.png");
@@ -112,9 +104,7 @@ TrainBottom::TrainBottom(TrainSidebar *trainSidebar, QWidget *parent) :
     m_lapButton->setAutoDefault(false);
     m_lapButton->setFlat(true);
     m_lapButton->setStyleSheet("background-color: rgba( 255, 255, 255, 0% ); border: 0px;");
-#if QT_VERSION > 0x050400
     m_lapButton->setShortcut(Qt::Key_0);
-#endif
     toolbuttons->addWidget(m_lapButton);
 
     QIcon calIcon(":images/oxygen/cal.png");
@@ -125,9 +115,7 @@ TrainBottom::TrainBottom(TrainSidebar *trainSidebar, QWidget *parent) :
     cal->setAutoDefault(false);
     cal->setFlat(true);
     cal->setStyleSheet("background-color: rgba( 255, 255, 255, 0% ); border: 0px;");
-    #if QT_VERSION > 0x050400
-        cal->setShortcut(Qt::Key_C);
-    #endif
+    cal->setShortcut(Qt::Key_C);
     toolbuttons->addWidget(cal);
 
     QIcon upIcon(":images/oxygen/up.png");
@@ -140,9 +128,7 @@ TrainBottom::TrainBottom(TrainSidebar *trainSidebar, QWidget *parent) :
     loadUp->setAutoRepeat(true);
     loadUp->setAutoRepeatInterval(50);
     loadUp->setStyleSheet("background-color: rgba( 255, 255, 255, 0% ); border: 0px;");
-#if QT_VERSION > 0x050400
     loadUp->setShortcut(Qt::Key_Plus);
-#endif
     toolbuttons->addWidget(loadUp);
 
     QIcon downIcon(":images/oxygen/down.png");
@@ -155,9 +141,7 @@ TrainBottom::TrainBottom(TrainSidebar *trainSidebar, QWidget *parent) :
     loadDown->setAutoRepeat(true);
     loadDown->setAutoRepeatInterval(50);
     loadDown->setStyleSheet("background-color: rgba( 255, 255, 255, 0% ); border: 0px;");
-#if QT_VERSION > 0x050400
     loadDown->setShortcut(Qt::Key_Minus);
-#endif
     toolbuttons->addWidget(loadDown);
 
     intensitySlider = new QSlider(Qt::Vertical, this);

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -42,13 +42,11 @@
 // Three current realtime device types supported are:
 #include "RealtimeController.h"
 #include "ComputrainerController.h"
-#if QT_VERSION >= 0x050000
 #include "MonarkController.h"
 #include "KettlerController.h"
 #include "KettlerRacerController.h"
 #include "ErgofitController.h"
 #include "DaumController.h"
-#endif
 #include "ANTlocalController.h"
 #include "NullController.h"
 #ifdef QT_BLUETOOTH_LIB
@@ -645,7 +643,6 @@ TrainSidebar::configChanged(qint32)
         // to interact with the device
         if (Devices.at(i).type == DEV_CT) {
             Devices[i].controller = new ComputrainerController(this, &Devices[i]);
-#if QT_VERSION >= 0x050000
         } else if (Devices.at(i).type == DEV_MONARK) {
             Devices[i].controller = new MonarkController(this, &Devices[i]);
         } else if (Devices.at(i).type == DEV_KETTLER) {
@@ -656,7 +653,6 @@ TrainSidebar::configChanged(qint32)
             Devices[i].controller = new ErgofitController(this, &Devices[i]);
         } else if (Devices.at(i).type == DEV_DAUM) {
             Devices[i].controller = new DaumController(this, &Devices[i]);
-#endif
 #ifdef GC_HAVE_LIBUSB
         } else if (Devices.at(i).type == DEV_FORTIUS) {
             Devices[i].controller = new FortiusController(this, &Devices[i]);
@@ -1796,10 +1792,6 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
                 if (ergFile) ergTimeRemaining = ergFile->Points.at(ergFile->rightPoint).x - load_msecs;
                 else ergTimeRemaining = 0;
 
-#if defined Q_OS_LINUX && QT_VERSION < 0x050600
-                // Sorry, lap alerts are only enabled for for Qt version 5.6 onwards on Linux
-                // see https://bugreports.qt.io/browse/QTBUG-40823
-#else
                 // alert when approaching end of lap
                 if (lapAudioEnabled && lapAudioThisLap) {
 
@@ -1816,7 +1808,6 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
                         QSound::play(":audio/lap.wav");
                     }
                 }
-#endif
 
                 if(lapTimeRemaining < 0) {
                         if (ergFile) lapTimeRemaining =  ergFile->Duration - load_msecs;

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -44,14 +44,6 @@ VideoWindow::VideoWindow(Context *context)  :
     //
     // USE VLC VIDEOPLAYER
     //
-#ifndef Q_CC_MSVC
-#if QT_VERSION >= 0x050000
-// we no longer warn here since it is a runtime issue, on some Ubuntu platforms
-// the VLC plugin cache is out of date and needs refreshing with the command:
-// $ sudo /usr/lib/vlc/vlc-cache-gen -f /usr/lib/vlc/plugins/
-// #warning "WARNING: Please ensure the VLC QT4 plugin (gui/libqt4_plugin) is NOT available as it will cause GC to crash."
-#endif
-#endif
 
     // config parameters to libvlc
     const char * const vlc_args[] = {
@@ -65,33 +57,18 @@ VideoWindow::VideoWindow(Context *context)  :
                     //"--quiet"
                 };
 
-    /* create an exception handler */
-    //libvlc_exception_init(&exceptions);
-    //vlc_exceptions(&exceptions);
-
     /* Load the VLC engine */
     inst = libvlc_new(sizeof(vlc_args) / sizeof(vlc_args[0]), vlc_args);
-    //vlc_exceptions(&exceptions);
 
     /* Create a new item */
-
     if (inst) { // if vlc doesn't initialise don't even try!
 
         m = NULL;
-        //vlc_exceptions(&exceptions);
 
         /* Create a media player playing environement */
         mp = libvlc_media_player_new (inst);
-        //vlc_exceptions(&exceptions);
 
-        //vlc_exceptions(&exceptions);
-
-#if (defined Q_OS_LINUX) && QT_VERSION <= 0x50000
-        container = new QX11EmbedContainer(this);
-#else
         container = new QWidget(this);
-#endif
-
         layout->addWidget(container);
 
 #if defined(WIN32)
@@ -170,11 +147,6 @@ VideoWindow::VideoWindow(Context *context)  :
 VideoWindow::~VideoWindow()
 {
     if (!init) return; // we didn't initialise properly so all bets are off
-
-#if (defined Q_OS_LINUX) && (QT_VERSION < 0x050000) && (defined GC_VIDEO_VLC)
-    // unembed vlc backend first
-    container->discardClient();
-#endif
 
     stopPlayback();
 
@@ -439,13 +411,6 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
 #ifdef GC_VIDEO_VLC
     if (!m || !context->isRunning || context->isPaused)
         return;
-
-    QList<ErgFilePoint> *ErgFilePoints = NULL;
-    if (context->currentErgFile()) {
-        if (context->currentErgFile()->format == CRS) {
-            ErgFilePoints = &(context->currentErgFile()->Points);
-        }
-    }
 
     // find the curPosition
     if (context->currentVideoSyncFile())

--- a/src/Train/VideoWindow.h
+++ b/src/Train/VideoWindow.h
@@ -40,7 +40,7 @@
 #ifdef Q_OS_MAC
 
 // if we aint chosen one or the other then use quicktime
-#if !defined GC_VIDEO_QUICKTIME && !defined GC_VIDEO_NONE && !defined GC_VIDEO_QT5
+#if !defined GC_VIDEO_QUICKTIME && !defined GC_VIDEO_NONE && !defined GC_VIDEO_QT5 && !defined GC_VIDEO_VLC
 #define GC_VIDEO_QUICKTIME
 #endif
 
@@ -51,12 +51,8 @@
 
 // but qt5 *is* supported, but use at your own risk!
 #if defined GC_VIDEO_QT5
-#if QT_VERSION >= 0x050201
 #warning "QT 5 video is supported experimentally in this version"
-#else
-#error "QT5 video is only supported with QT 5.2.1 or higher"
 #endif
-#endif // GC_VIDEO_QT5
 
 #endif //Q_OS_MAC
 
@@ -73,24 +69,15 @@
 #endif
 #endif
 
-// if we aint chosen one or the other then use VLC QT < 5.2.1 or QT5 >= 5.2.1
+// if we aint chosen one or the other then use QT5
 #if !defined GC_VIDEO_NONE && !defined GC_VIDEO_QT5 && !defined GC_VIDEO_VLC
-#if QT_VERSION < 0x50201
-#define GC_VIDEO_VLC
-#else
 #define GC_VIDEO_QT5
 #endif
-#endif // !defined NONE,QT5,VLC
 
 // now check for stupid settings
 #if defined GC_VIDEO_QUICKTIME
 #error "QuickTime is only supported on Mac OS X"
 #endif
-
-// but qt5 *is* supported, but use at your own risk!
-#if defined GC_VIDEO_QT5 && QT_VERSION < 0x050201
-#error "QT5 video is only supported with QT 5.2.1 or higher"
-#endif // GC_VIDEO_QT5
 
 #endif // Q_OS_LINUX || Q_OS_WIN
 
@@ -130,11 +117,6 @@ extern "C" {
 #include "DeviceTypes.h"
 #include "RealtimeData.h"
 #include "TrainSidebar.h"
-
-// Linux container changed in QT5
-#if (defined Q_OS_LINUX) && (QT_VERSION < 0x050000)
-#include <QX11EmbedContainer>
-#endif
 
 // regardless we always have a media helper
 class MediaHelper
@@ -211,11 +193,7 @@ class VideoWindow : public GcChartWindow
         QMediaPlayer *mp;
 #endif
 
-#if defined(WIN32) || defined (Q_OS_MAC) || (defined(Q_OS_LINUX) && QT_VERSION > 0x050000)
         QWidget *container;
-#elif defined(Q_OS_LINUX)
-        QX11EmbedContainer *container;
-#endif
 
         bool init; // we initialised ok ?
 };

--- a/src/Train/WorkoutWidget.cpp
+++ b/src/Train/WorkoutWidget.cpp
@@ -566,11 +566,7 @@ WorkoutWidget::eventFilter(QObject *obj, QEvent *event)
         // STATE: NONE
         if (state == none) {
             QWheelEvent *w = static_cast<QWheelEvent*>(event);
-#if QT_VERSION >= 0x050000
             updateNeeded = scale(w->angleDelta());
-#else
-            updateNeeded = scale(QPoint(0,w->delta()));
-#endif
             filterNeeded = true;
         }
 

--- a/src/Train/WorkoutWizard.cpp
+++ b/src/Train/WorkoutWizard.cpp
@@ -76,11 +76,7 @@ WorkoutEditorBase::WorkoutEditorBase(QStringList &colms, QWidget *parent) :QFram
 
     table->setColumnCount(colms.count());
     table->setHorizontalHeaderLabels(colms);
-#if QT_VERSION > 0x050000
     table->horizontalHeader()->setSectionResizeMode(QHeaderView::ResizeToContents);
-#else
-    table->horizontalHeader()->setResizeMode(QHeaderView::ResizeToContents);
-#endif
     table->setShowGrid(true);
     table->setAlternatingRowColors(true);
     table->resizeColumnsToContents();

--- a/src/src.pro
+++ b/src/src.pro
@@ -195,7 +195,7 @@ TRANSLATIONS = Resources/translations/gc_fr.ts \
 # need lrelease to generate qm files
 isEmpty(QMAKE_LRELEASE) {
     win32:QMAKE_LRELEASE = $$[QT_INSTALL_BINS]\\lrelease.exe
-    unix:!macx {QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease-qt4 }
+    unix:!macx {QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease }
     else:QMAKE_LRELEASE = $$[QT_INSTALL_BINS]/lrelease
 }
 


### PR DESCRIPTION
This is a clean up to remove conditional compilation for all Qt versions
older than the last known to work: Qt 5.9 with Qt WebEngine and Qt Charts.
Includes an update note to INSTALL documents.