### PR TITLE
Trim TCX files before importing

### DIFF
--- a/src/FileIO/TcxRideFile.cpp
+++ b/src/FileIO/TcxRideFile.cpp
@@ -37,6 +37,12 @@ static int tcxFileReaderRegistered =
 RideFile *TcxFileReader::openRideFile(QFile &file, QStringList &errors, QList<RideFile*>*list) const
 {
     (void) errors;
+
+    if(!file.open(QIODevice::ReadOnly))
+        return NULL;
+    QByteArray tcx = file.readAll();
+    file.close();
+
     RideFile *rideFile = new RideFile();
     rideFile->setRecIntSecs(1.0);
     rideFile->setDeviceType("Garmin");
@@ -44,7 +50,9 @@ RideFile *TcxFileReader::openRideFile(QFile &file, QStringList &errors, QList<Ri
 
     TcxParser handler(rideFile, list);
 
-    QXmlInputSource source (&file);
+    QXmlInputSource source = QXmlInputSource();
+    source.setData(tcx.trimmed());
+
     QXmlSimpleReader reader;
     reader.setContentHandler (&handler);
     reader.parse (source);


### PR DESCRIPTION
TLDR: Allows to import TCX files with leading whitespaces, such as those generated by Strava.

As per XML standard the XML declaration must be the first node in the document, and no white space characters are allowed to appear before it.

Unfortunately some companies do not always respect this rule, amongst them Strava. This makes importing files exported from them difficult. This problem has already been reported in the past in #3149 but it was not addressed. Stumbling upon this problem myself I have tried to fix it.

Except from trimming leading whitespaces this commit has no other intended functional changes. In my tests this holds true.