### PR TITLE
Add support for the Wahoo Kickr (Core) through BlueTooth LE

### DIFF
--- a/src/Train/BT40Controller.cpp
+++ b/src/Train/BT40Controller.cpp
@@ -27,7 +27,7 @@ BT40Controller::BT40Controller(TrainSidebar *parent, DeviceConfiguration *dc) : 
     discoveryAgent = new QBluetoothDeviceDiscoveryAgent();
     localDc = dc;
     if (localDc) wheelSize = localDc->wheelSize;
-    else wheelSize = 2100;
+    else wheelSize = 2100.0;
 
     connect(discoveryAgent, SIGNAL(deviceDiscovered(const QBluetoothDeviceInfo&)),
 	    this, SLOT(addDevice(const QBluetoothDeviceInfo&)));
@@ -163,7 +163,7 @@ BT40Controller::deviceScanError(QBluetoothDeviceDiscoveryAgent::Error error)
 void
 BT40Controller::setWheelRpm(double wrpm) {
     telemetry.setWheelRpm(wrpm);
-    telemetry.setSpeed(wrpm * wheelSize / 1000 * 60 / 1000);
+    telemetry.setSpeed(wrpm * wheelSize / 1000.0 * 60.0 / 1000.0);
 }
 
 void BT40Controller::setLoad(double l)

--- a/src/Train/BT40Controller.cpp
+++ b/src/Train/BT40Controller.cpp
@@ -149,6 +149,7 @@ BT40Controller::addDevice(const QBluetoothDeviceInfo &info)
 void
 BT40Controller::scanFinished()
 {
+    emit setNotification(tr("Bluetooth scan finished"), 2);
     qDebug() << "BT scan finished";
 }
 

--- a/src/Train/BT40Controller.cpp
+++ b/src/Train/BT40Controller.cpp
@@ -26,6 +26,9 @@ BT40Controller::BT40Controller(TrainSidebar *parent, DeviceConfiguration *dc) : 
     localDevice = new QBluetoothLocalDevice(this);
     discoveryAgent = new QBluetoothDeviceDiscoveryAgent();
     localDc = dc;
+    if (localDc) wheelSize = localDc->wheelSize;
+    else wheelSize = 2100;
+
     connect(discoveryAgent, SIGNAL(deviceDiscovered(const QBluetoothDeviceInfo&)),
 	    this, SLOT(addDevice(const QBluetoothDeviceInfo&)));
     connect(discoveryAgent, SIGNAL(error(QBluetoothDeviceDiscoveryAgent::Error)),
@@ -138,6 +141,7 @@ BT40Controller::addDevice(const QBluetoothDeviceInfo &info)
         devices.append(dev);
         dev->connectDevice();
         connect(dev, &BT40Device::setNotification, this, &BT40Controller::setNotification);
+        dev->setWheelCircumference(wheelSize);
     }
 }
 
@@ -159,14 +163,62 @@ BT40Controller::deviceScanError(QBluetoothDeviceDiscoveryAgent::Error error)
 void
 BT40Controller::setWheelRpm(double wrpm) {
     telemetry.setWheelRpm(wrpm);
-    int wheel;
-    if (localDc) wheel = localDc->wheelSize;
-    else wheel = 2100;
-    telemetry.setSpeed(wrpm * wheel / 1000 * 60 / 1000);
+    telemetry.setSpeed(wrpm * wheelSize / 1000 * 60 / 1000);
 }
 
-void BT40Controller::setGradient(double grad) {
+void BT40Controller::setLoad(double l)
+{
   for (auto* dev: devices) {
-    dev->setGradient(grad);
+    dev->setLoad(l);
   }
 }
+
+void BT40Controller::setGradient(double g) {
+  for (auto* dev: devices) {
+    dev->setGradient(g);
+  }
+}
+
+void BT40Controller::setMode(int m)
+{
+  for (auto* dev: devices) {
+    dev->setMode(m);
+  }
+}
+
+void BT40Controller::setWindSpeed(double s)
+{
+  for (auto* dev: devices) {
+    dev->setWindSpeed(s);
+  }
+}
+
+void BT40Controller::setWeight(double w)
+{
+  for (auto* dev: devices) {
+    dev->setWeight(w);
+  }
+}
+
+void BT40Controller::setRollingResistance(double rr)
+{
+  for (auto* dev: devices) {
+    dev->setRollingResistance(rr);
+  }
+}
+
+void BT40Controller::setWindResistance(double wr)
+{
+  for (auto* dev: devices) {
+    dev->setWindResistance(wr);
+  }
+}
+
+void BT40Controller::setWheelCircumference(double wc)
+{
+  wheelSize = wc;
+  for (auto* dev: devices) {
+    dev->setWheelCircumference(wc);
+  }
+}
+

--- a/src/Train/BT40Controller.h
+++ b/src/Train/BT40Controller.h
@@ -46,7 +46,14 @@ public:
     bool discover(QString name);
     void setDevice(QString);
 
-    void setGradient(double) override;
+    void setLoad(double);
+    void setGradient(double);
+    void setMode(int);
+    void setWindSpeed(double);
+    void setWeight(double);
+    void setRollingResistance(double);
+    void setWindResistance(double);
+    void setWheelCircumference(double);
 
     // telemetry push pull
     bool doesPush(), doesPull(), doesLoad();
@@ -96,6 +103,7 @@ private:
     RealtimeData telemetry;
     QList<BT40Device*> devices;
     DeviceConfiguration* localDc;
+    double wheelSize;
 };
 
 #endif // _GC_BT40Controller_h

--- a/src/Train/BT40Device.cpp
+++ b/src/Train/BT40Device.cpp
@@ -35,6 +35,9 @@
 #define BLE_TACX_UART_UUID "{6e40fec1-b5a3-f393-e0a9-e50e24dcca9e}"
 #define BLE_TACX_UART_CHAR_WRITE "{6E40FEC3-B5A3-F393-E0A9-E50E24DCCA9E}"
 
+// Wahoo specific extension to the Cycling Power service
+#define WAHOO_BRAKE_CONTROL_UUID "{A026E005-0A7D-4AB3-97FA-F1500F9FEB8B}"
+
 QMap<QBluetoothUuid, btle_sensor_type_t> BT40Device::supportedServices = {
     { QBluetoothUuid(QBluetoothUuid::HeartRate), { "Heartrate", ":images/IconHR.png" }},
     { QBluetoothUuid(QBluetoothUuid::CyclingPower), { "Power", ":images/IconPower.png" }},
@@ -59,6 +62,17 @@ BT40Device::BT40Device(QObject *parent, QBluetoothDeviceInfo devinfo) : parent(p
     prevCrankTime = 0;
     prevCrankRevs = 0;
     prevCrankStaleness = -1; // indicates prev crank data values aren't measured values
+
+    loadType = Load_None;
+    load = 0;
+    gradient = 0;
+    prevGradient = -100;
+    mode = RT_MODE_SLOPE;
+    windSpeed = 0;
+    weight = 80;
+    rollingResistance = 0.0033;
+    windResistance = 0.6;
+    wheelSize = 2100;
 }
 
 BT40Device::~BT40Device()
@@ -121,6 +135,9 @@ BT40Device::deviceDisconnected()
         }
     }
 
+    // Stop sending load setting commands
+    loadType = Load_None;
+
     // Try to reconnect if the connection was lost inadvertently
     if (connected) {
         this->connectDevice();
@@ -152,6 +169,7 @@ BT40Device::serviceScanDone()
         connect(service, SIGNAL(stateChanged(QLowEnergyService::ServiceState)), this, SLOT(serviceStateChanged(QLowEnergyService::ServiceState)));
         connect(service, SIGNAL(characteristicChanged(QLowEnergyCharacteristic,QByteArray)), this, SLOT(updateValue(QLowEnergyCharacteristic,QByteArray)));
         connect(service, SIGNAL(descriptorWritten(QLowEnergyDescriptor,QByteArray)), this, SLOT(confirmedDescriptorWrite(QLowEnergyDescriptor,QByteArray)));
+        connect(service, SIGNAL(characteristicWritten(QLowEnergyCharacteristic,QByteArray)), this, SLOT(confirmedCharacteristicWrite(QLowEnergyCharacteristic,QByteArray)));
         connect(service, SIGNAL(error(QLowEnergyService::ServiceError)), this, SLOT(serviceError(QLowEnergyService::ServiceError)));
 
         if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::CyclingPower)) {
@@ -204,6 +222,8 @@ BT40Device::serviceStateChanged(QLowEnergyService::ServiceState s)
 
                     characteristics.append(service->characteristic(
                     QBluetoothUuid(QBluetoothUuid::CyclingPowerMeasurement)));
+                    characteristics.append(service->characteristic(
+                                QBluetoothUuid(QString(WAHOO_BRAKE_CONTROL_UUID))));
 
                 } else if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::CyclingSpeedAndCadence)) {
 
@@ -227,17 +247,45 @@ BT40Device::serviceStateChanged(QLowEnergyService::ServiceState s)
                         vmProWidget->onReconnected(service);
                     }
                 } else if (service->serviceUuid() == QBluetoothUuid(QString(BLE_TACX_UART_UUID))) {
-                  m_charTacxUART = service->characteristic(QBluetoothUuid(QString(BLE_TACX_UART_CHAR_WRITE)));
-                  m_servTacxUART = service;
+
+                    characteristics.append(service->characteristic(
+                                QBluetoothUuid(QString(BLE_TACX_UART_CHAR_WRITE))));
+
                 }
 
                 foreach(QLowEnergyCharacteristic characteristic, characteristics)
                 {
                     if (characteristic.isValid()) {
-                        qDebug() << "Starting notification for char with UUID: " << characteristic.uuid().toString();
-                        const QLowEnergyDescriptor notificationDesc = characteristic.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration);
-                        if (notificationDesc.isValid()) {
-                            service->writeDescriptor(notificationDesc, QByteArray::fromHex("0100"));
+                        if(characteristic.uuid() == QBluetoothUuid(QString(BLE_TACX_UART_CHAR_WRITE))) {
+                            loadService = service;
+                            loadCharacteristic = characteristic;
+                            loadType = Tacx_UART;
+
+                        } else if(characteristic.uuid() == QBluetoothUuid(QString(WAHOO_BRAKE_CONTROL_UUID))) {
+                            qDebug() << "Starting indication for char with UUID: " << characteristic.uuid().toString();
+                            const QLowEnergyDescriptor notificationDesc = characteristic.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration);
+                            if (notificationDesc.isValid()) {
+                                service->writeDescriptor(notificationDesc, QByteArray::fromHex("0200"));
+                                loadService = service;
+                                loadCharacteristic = characteristic;
+                                loadType = Wahoo_Kickr;
+                                commandQueue.clear();
+                                commandRetry = 0;
+                                // The BTLE device scan can take tens of seconds.
+                                // Meanwhile GC thinks that the device is connected and sends parameters.
+                                // The parameters were stored and are now sent. 
+                                setWheelCircumference(wheelSize);
+                                setRiderCharacteristics(weight, rollingResistance, windResistance);
+                                setWindSpeed(windSpeed);
+                                setGradient(gradient);
+                            }
+
+                        } else {
+                            qDebug() << "Starting notification for char with UUID: " << characteristic.uuid().toString();
+                            const QLowEnergyDescriptor notificationDesc = characteristic.descriptor(QBluetoothUuid::ClientCharacteristicConfiguration);
+                            if (notificationDesc.isValid()) {
+                                service->writeDescriptor(notificationDesc, QByteArray::fromHex("0100"));
+                            }
                         }
                     }
                 }
@@ -391,6 +439,13 @@ BT40Device::serviceError(QLowEnergyService::ServiceError e)
         }
         break;
 
+    case QLowEnergyService::CharacteristicWriteError:
+        {    
+            qWarning() << "Failed to write BTLE characteristic" << "for device" << m_currentDevice.name() << " " << m_currentDevice.deviceUuid();
+            if(loadType == Wahoo_Kickr) commandWriteFailed();
+        }
+        break;
+
     default:
         {
             qWarning() << "BTLE service error" << e << "for device" << m_currentDevice.name() << " " << m_currentDevice.deviceUuid();;
@@ -406,6 +461,13 @@ BT40Device::confirmedDescriptorWrite(const QLowEnergyDescriptor &d, const QByteA
         qWarning() << "disabled BTLE notifications" << "for device" << m_currentDevice.name() << " " << m_currentDevice.deviceUuid();;
         this->disconnectDevice();
     }
+}
+
+void
+BT40Device::confirmedCharacteristicWrite(const QLowEnergyCharacteristic &c, const QByteArray &value)
+{
+    qDebug() << "BTLE wrote to " << m_currentDevice.name() << " " << c.uuid() << value.toHex(':');
+    if(loadType == Wahoo_Kickr) commandWritten();
 }
 
 void
@@ -481,18 +543,213 @@ BT40Device::deviceInfo() const
     return m_currentDevice;
 }
 
-void BT40Device::setGradient(double gradient)
+void
+BT40Device::setLoad(double l)
 {
-  // Only supported for Tacx devices
-  if (!m_servTacxUART || !m_charTacxUART.isValid()) {
-    return;
-  }
-
-  qDebug() << "[+] Tacx: write gradient" << gradient;
-
-  // Based on https://github.com/abellono/tacx-ios-bluetooth-example/blob/master/How-to%20FE-C%20over%20BLE%20v1_0_0.pdf, channel must be 5.
-  const auto Msg = ANTMessage::fecSetTrackResistance(5, gradient, 0);
-  m_servTacxUART->writeCharacteristic(m_charTacxUART,
-    QByteArray{(const char*) &Msg.data[0], Msg.length},
-    QLowEnergyService::WriteWithoutResponse);
+    load = l;
+    if (mode == RT_MODE_ERGO) setLoadErg(load);
+    else if (mode == RT_MODE_SPIN || mode == RT_MODE_SLOPE) setGradient(load);
 }
+
+void BT40Device::setGradient(double g)
+{
+    gradient = g;
+
+    if(loadType == Tacx_UART) {
+        qDebug() << "[+] Tacx: write gradient" << gradient;
+
+        // Based on https://github.com/abellono/tacx-ios-bluetooth-example/blob/master/How-to%20FE-C%20over%20BLE%20v1_0_0.pdf, channel must be 5.
+        const auto Msg = ANTMessage::fecSetTrackResistance(5, gradient, 0);
+        loadService->writeCharacteristic(loadCharacteristic,
+                QByteArray{(const char*) &Msg.data[0], Msg.length},
+                QLowEnergyService::WriteWithoutResponse);
+
+    // Changing gradient is long on some devices, filter duplicates
+    } else if(loadType == Wahoo_Kickr && gradient != prevGradient) {
+        QByteArray command;
+        int value = (gradient / 100.0 + 1.0) * 32768;
+        command.resize(3);
+        command[0] = 0x46;
+        command[1] = (char)value;
+        command[2] = (char)(value >> 8);
+        qDebug() << "BTLE SetGradient " << gradient << " " << loadCharacteristic.uuid() << command.toHex(':');
+        commandSend(command);
+        prevGradient = gradient;
+    }
+}
+
+void
+BT40Device::setMode(int m)
+{
+    mode = m;
+}
+
+void
+BT40Device::setWindSpeed(double s)  // In meters/second
+{
+    windSpeed = s;
+
+    if(loadType == Wahoo_Kickr) {
+        QByteArray command;
+        int value = (int)((windSpeed + 32.768) * 1000.0);
+        value = qMax(0, qMin(value, 65535));
+        command.resize(3);
+        command[0] = 0x47;
+        command[1] = (char)value;
+        command[2] = (char)(value >> 8);
+        qDebug() << "BTLE SetWindSpeed " << windSpeed << " " << loadCharacteristic.uuid() << command.toHex(':');
+        commandSend(command);
+    }
+}
+
+void
+BT40Device::setWeight(double w)
+{
+    weight = w;
+    setRiderCharacteristics(weight, rollingResistance, windResistance);
+}
+
+void
+BT40Device::setRollingResistance(double rr)
+{
+    rollingResistance = rr;
+    setRiderCharacteristics(weight, rollingResistance, windResistance);
+}
+
+void
+BT40Device::setWindResistance(double wr)
+{
+    windResistance = wr;
+    setRiderCharacteristics(weight, rollingResistance, windResistance);
+}
+
+void
+BT40Device::setWheelCircumference(double c) // in millimeters
+{
+    wheelSize = c;
+
+    if(loadType == Wahoo_Kickr) {
+        QByteArray command;
+        int value = (int)(wheelSize * 10.0);
+        command.resize(3);
+        command[0] = 0x48;
+        command[1] = (char)value;
+        command[2] = (char)(value >> 8);
+        qDebug() << "BTLE SetWheelCircumference " << wheelSize << " " << loadCharacteristic.uuid() << command.toHex(':');
+        commandSend(command);
+    }
+}
+
+void
+BT40Device::setLoadErg(double l)  // Load in Watts
+{
+    load = l;
+
+    if(loadType == Wahoo_Kickr) {
+        QByteArray command;
+        command.resize(3);
+        command[0] = 0x42;
+        command[1] = (char)load;
+        command[2] = (char)(((int)load) >> 8);
+        qDebug() << "BTLE SetLoadErg " << load << " " << loadCharacteristic.uuid() << command.toHex(':');
+        commandSend(command);
+    }
+}
+
+void
+BT40Device::setLoadIntensity(double l)  // between 0 and 1
+{
+    load = l;
+
+    if(loadType == Wahoo_Kickr) {
+        QByteArray command;
+        int value = (1.0 - load) * 16383.0;
+        command.resize(3);
+        command[0] = 0x40;
+        command[1] = (char)value;
+        command[2] = (char)(value >> 8);
+        qDebug() << "BTLE SetLoadIntensity " << load << " " << loadCharacteristic.uuid() << command.toHex(':');
+        commandSend(command);
+    }
+}
+
+void
+BT40Device::setLoadLevel(int l)  // From 0 to 9
+{
+    load = l;
+
+    if(loadType == Wahoo_Kickr) {
+        QByteArray command;
+        command.resize(2);
+        command[0] = 0x41;
+        command[1] = (char)load;
+        qDebug() << "BTLE SetLoadLevel " << load << " " << loadCharacteristic.uuid() << command.toHex(':');
+        commandSend(command);
+    }
+}
+
+void
+BT40Device::setRiderCharacteristics(double weight, double rollingResistance, double windResistance)
+{
+    if(loadType == Wahoo_Kickr) {
+        QByteArray command;
+        int valueWeight = (int)(weight * 100.0);
+        int valueCrr = (int)(rollingResistance * 10000.0);
+        int valueCwr = (int)(windResistance * 1000.0);
+        command.resize(7);
+        command[0] = 0x43;
+        command[1] = (char)valueWeight;
+        command[2] = (char)(valueWeight >> 8);
+        command[3] = (char)valueCrr;
+        command[4] = (char)(valueCrr >> 8);
+        command[5] = (char)valueCwr;
+        command[6] = (char)(valueCwr >> 8);
+        qDebug() << "BTLE SetRiderCharacteristic " << weight << " " << rollingResistance << " " << windResistance << " " << loadCharacteristic.uuid() << command.toHex(':');
+        commandSend(command);
+    }
+}
+
+/* On the Wahoo Kickr and possibly many other BT40 devices, writes often fail.
+   It seems that you need the previous command to be completed and the device
+   to be ready for a new command. This queue insures that commands are sent one 
+   after another and even retries a few times upon fail. 
+*/
+
+void
+BT40Device::commandSend(QByteArray &command)
+{
+    if(commandQueue.size() > 20) {
+        qWarning() << "BTLE overflow of load control commands for device " << m_currentDevice.name() << " " << m_currentDevice.deviceUuid();
+        return;
+    }
+    commandQueue.enqueue(command);
+
+    if(commandQueue.size() == 1) commandWrite(command);
+}
+
+void
+BT40Device::commandWrite(QByteArray &command)
+{
+    qDebug() << "BTLE write load command " << loadCharacteristic.uuid() << " " << command.toHex(':');
+    loadService->writeCharacteristic(loadCharacteristic, command);
+}
+
+void
+BT40Device::commandWriteFailed() {
+    commandRetry++;
+    if(commandRetry > 10) {
+        QByteArray command = commandQueue.dequeue();
+        qWarning() << "BTLE load control command "<< command.toHex(':') << " retried " << commandRetry << " times and dropped for device" << m_currentDevice.name() << " " << m_currentDevice.deviceUuid();
+        commandRetry = 0;
+    }
+
+    if(commandQueue.size() > 0) commandWrite(commandQueue.head());
+}
+
+void
+BT40Device::commandWritten() {
+    commandRetry = 0;
+    commandQueue.dequeue();
+    if(commandQueue.size() > 0) commandWrite(commandQueue.head());
+}
+

--- a/src/Train/BT40Device.cpp
+++ b/src/Train/BT40Device.cpp
@@ -216,11 +216,15 @@ BT40Device::serviceStateChanged(QLowEnergyService::ServiceState s)
                 QList<QLowEnergyCharacteristic> characteristics;
                 if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::HeartRate)) {
 
+                    emit setNotification(tr("Connected to device / service: ") + m_currentDevice.name() + 
+                                " / HeartRate", 4);
                     characteristics.append(service->characteristic(
                     QBluetoothUuid(QBluetoothUuid::HeartRateMeasurement)));
 
                 } else if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::CyclingPower)) {
 
+                    emit setNotification(tr("Connected to device / service: ") + m_currentDevice.name() + 
+                                " / CyclingPower", 4);
                     characteristics.append(service->characteristic(
                     QBluetoothUuid(QBluetoothUuid::CyclingPowerMeasurement)));
                     characteristics.append(service->characteristic(
@@ -228,10 +232,14 @@ BT40Device::serviceStateChanged(QLowEnergyService::ServiceState s)
 
                 } else if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::CyclingSpeedAndCadence)) {
 
+                    emit setNotification(tr("Connected to device / service: ") + m_currentDevice.name() + 
+                                " / CyclingSpeedAndCadence", 4);
                     characteristics.append(service->characteristic(
                     QBluetoothUuid(QBluetoothUuid::CSCMeasurement)));
                 } else if (service->serviceUuid() == QBluetoothUuid(QString(VO2MASTERPRO_SERVICE_UUID))) {
 
+                    emit setNotification(tr("Connected to device / service: ") + m_currentDevice.name() + 
+                                " / VO2MASTERPRO", 4);
                     characteristics.append(service->characteristic(
                                 QBluetoothUuid(QString(VO2MASTERPRO_VENTILATORY_CHAR_UUID))));
                     characteristics.append(service->characteristic(
@@ -249,6 +257,8 @@ BT40Device::serviceStateChanged(QLowEnergyService::ServiceState s)
                     }
                 } else if (service->serviceUuid() == QBluetoothUuid(QString(BLE_TACX_UART_UUID))) {
 
+                    emit setNotification(tr("Connected to device / service: ") + m_currentDevice.name() + 
+                                " / TACX_UART", 4);
                     characteristics.append(service->characteristic(
                                 QBluetoothUuid(QString(BLE_TACX_UART_CHAR_WRITE))));
 

--- a/src/Train/BT40Device.cpp
+++ b/src/Train/BT40Device.cpp
@@ -123,6 +123,7 @@ BT40Device::deviceDisconnected()
             dynamic_cast<BT40Controller*>(parent)->setBPM(0.0);
         } else if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::CyclingPower)) {
             dynamic_cast<BT40Controller*>(parent)->setWatts(0.0);
+            dynamic_cast<BT40Controller*>(parent)->setWheelRpm(0.0);
         } else if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::CyclingSpeedAndCadence)) {
             dynamic_cast<BT40Controller*>(parent)->setWheelRpm(0.0);
         } else if (service->serviceUuid() == QBluetoothUuid(QString(VO2MASTERPRO_SERVICE_UUID))) {
@@ -494,7 +495,7 @@ BT40Device::getCadence(QDataStream& ds)
 
             const int time = cur_time + (cur_time < prevCrankTime ? 0x10000:0) - prevCrankTime;
             const int revs = cur_revs + (cur_revs < prevCrankRevs ? 0x10000:0) - prevCrankRevs;
-            const double rpm = 1024*60*revs / time;
+            const double rpm = 1024*60*revs / double(time);
             dynamic_cast<BT40Controller*>(parent)->setCadence(rpm);
         }
 
@@ -528,7 +529,7 @@ BT40Device::getWheelRpm(QDataStream& ds)
     if(!prevWheelStaleness) {
         quint16 time = wheeltime - prevWheelTime;
         quint32 revs = wheelrevs - prevWheelRevs;
-        if (time) rpm = 2048*60*revs / time;
+        if (time) rpm = 2048*60*revs / double(time);
     }
     else prevWheelStaleness = false;
 


### PR DESCRIPTION
All the commands to set the different parameters (weight, wheel size, gradient or load, wind speed...) are added to BT40Device and BT40Controller. This way, the load / gradient are set on the Wahoo Kickr as you ride. A separate pull request will add support to actually take advantage of the parameters beyond load and gradient, like the cyclist weight, now available in this and other devices like the Fortius.