### PR TITLE
Propagate Weight and other simulation parameters to training devices

### DIFF
--- a/src/Train/BT40Controller.cpp
+++ b/src/Train/BT40Controller.cpp
@@ -26,8 +26,14 @@ BT40Controller::BT40Controller(TrainSidebar *parent, DeviceConfiguration *dc) : 
     localDevice = new QBluetoothLocalDevice(this);
     discoveryAgent = new QBluetoothDeviceDiscoveryAgent();
     localDc = dc;
-    if (localDc) wheelSize = localDc->wheelSize;
-    else wheelSize = 2100.0;
+    load = 0;
+    gradient = 0;
+    mode = RT_MODE_SLOPE;
+    windSpeed = 0;
+    weight = 80;
+    rollingResistance = 0.0033;
+    windResistance = 0.6;
+    wheelSize = 2100;
 
     connect(discoveryAgent, SIGNAL(deviceDiscovered(const QBluetoothDeviceInfo&)),
 	    this, SLOT(addDevice(const QBluetoothDeviceInfo&)));
@@ -76,8 +82,10 @@ int
 BT40Controller::stop()
 {
     foreach (BT40Device* const &device, devices) {
-	device->disconnectDevice();
+        device->disconnectDevice();
+        delete device;
     }
+    devices.clear();
     return 0;
 }
 
@@ -139,9 +147,22 @@ BT40Controller::addDevice(const QBluetoothDeviceInfo &info)
 
         BT40Device* dev = new BT40Device(this, info);
         devices.append(dev);
+
+        // When start() is called, it initiates the device scan and returns immediately.
+        // Then, commands like setWeight() may come before any device is discovered.
+        // In that case, the weight is stored but is sent to an empty list of devices.
+        // However, when devices are added, the stored parameters are sent.
+        dev->setWheelCircumference(wheelSize);
+        dev->setRollingResistance(rollingResistance);
+        dev->setWindResistance(windResistance);
+        dev->setWeight(weight);
+        dev->setWindSpeed(windSpeed);
+        dev->setMode(mode);
+        if (mode == RT_MODE_ERGO) dev->setLoad(load);
+        else dev->setGradient(gradient);
+
         dev->connectDevice();
         connect(dev, &BT40Device::setNotification, this, &BT40Controller::setNotification);
-        dev->setWheelCircumference(wheelSize);
     }
 }
 
@@ -169,12 +190,15 @@ BT40Controller::setWheelRpm(double wrpm) {
 
 void BT40Controller::setLoad(double l)
 {
+  load = l;
   for (auto* dev: devices) {
     dev->setLoad(l);
   }
 }
 
-void BT40Controller::setGradient(double g) {
+void BT40Controller::setGradient(double g) 
+{
+  gradient = g;
   for (auto* dev: devices) {
     dev->setGradient(g);
   }
@@ -182,6 +206,7 @@ void BT40Controller::setGradient(double g) {
 
 void BT40Controller::setMode(int m)
 {
+  mode = m;
   for (auto* dev: devices) {
     dev->setMode(m);
   }
@@ -189,6 +214,7 @@ void BT40Controller::setMode(int m)
 
 void BT40Controller::setWindSpeed(double s)
 {
+  windSpeed = s;
   for (auto* dev: devices) {
     dev->setWindSpeed(s);
   }
@@ -196,6 +222,7 @@ void BT40Controller::setWindSpeed(double s)
 
 void BT40Controller::setWeight(double w)
 {
+  weight = w;
   for (auto* dev: devices) {
     dev->setWeight(w);
   }
@@ -203,6 +230,7 @@ void BT40Controller::setWeight(double w)
 
 void BT40Controller::setRollingResistance(double rr)
 {
+  rollingResistance = rr;
   for (auto* dev: devices) {
     dev->setRollingResistance(rr);
   }
@@ -210,6 +238,7 @@ void BT40Controller::setRollingResistance(double rr)
 
 void BT40Controller::setWindResistance(double wr)
 {
+  windResistance = wr;
   for (auto* dev: devices) {
     dev->setWindResistance(wr);
   }

--- a/src/Train/BT40Controller.h
+++ b/src/Train/BT40Controller.h
@@ -103,6 +103,14 @@ private:
     RealtimeData telemetry;
     QList<BT40Device*> devices;
     DeviceConfiguration* localDc;
+
+    double load;
+    double gradient;
+    int mode;
+    double windSpeed;
+    double weight;
+    double rollingResistance;
+    double windResistance;
     double wheelSize;
 };
 

--- a/src/Train/BT40Device.cpp
+++ b/src/Train/BT40Device.cpp
@@ -284,13 +284,16 @@ BT40Device::serviceStateChanged(QLowEnergyService::ServiceState s)
                                 loadType = Wahoo_Kickr;
                                 commandQueue.clear();
                                 commandRetry = 0;
-                                // The BTLE device scan can take tens of seconds.
-                                // Meanwhile GC thinks that the device is connected and sends parameters.
-                                // The parameters were stored and are now sent. 
+
+                                // When connect() is called, it returns immediately,
+                                // while service discovery happens asynchronously.
+                                // Then, commands like setWeight() may come before the service is discovered.
+                                // In that case, the weight is stored and is sent now once the service is found.
                                 setWheelCircumference(wheelSize);
                                 setRiderCharacteristics(weight, rollingResistance, windResistance);
                                 setWindSpeed(windSpeed);
-                                setGradient(gradient);
+                                if (mode == RT_MODE_ERGO) setLoad(load);
+                                else setGradient(gradient);
                             }
 
                         } else {

--- a/src/Train/BicycleSim.h
+++ b/src/Train/BicycleSim.h
@@ -150,6 +150,9 @@ public:
     double MassKG() const;                   // Actual mass of bike and rider.
     double EquivalentMassKG() const;         // Additional mass due to rotational inertia
     double KEMass() const;                   // Total effective kinetic mass
+    double RollingResistance() const { return m_constants.m_crr; }
+    double WindResistance() const { return m_constants.m_Cd * m_constants.m_A; }
+
     const BicycleWheel &FrontWheel() const { return m_frontWheel; }
     const BicycleWheel &RearWheel() const { return m_rearWheel; }
 

--- a/src/Train/FortiusController.cpp
+++ b/src/Train/FortiusController.cpp
@@ -156,3 +156,10 @@ FortiusController::setMode(int mode)
     
     myFortius->setMode(mode);
 }
+
+void
+FortiusController::setWeight(double weight)
+{
+    myFortius->setWeight(weight);
+}
+

--- a/src/Train/FortiusController.h
+++ b/src/Train/FortiusController.h
@@ -52,6 +52,7 @@ public:
     void setLoad(double);
     void setGradient(double);
     void setMode(int);
+    void setWeight(double);
 };
 
 #endif // _GC_FortiusController_h

--- a/src/Train/ImagicController.cpp
+++ b/src/Train/ImagicController.cpp
@@ -217,3 +217,10 @@ ImagicController::setMode(int mode)
 
     myImagic->setMode(mode);
 }
+
+void
+ImagicController::setWeight(double weight)
+{
+    myImagic->setWeight(weight);
+}
+

--- a/src/Train/ImagicController.h
+++ b/src/Train/ImagicController.h
@@ -56,6 +56,7 @@ public:
     void setLoad(double);
     void setGradient(double);
     void setMode(int);
+    void setWeight(double);
 };
 
 

--- a/src/Train/RealtimeController.h
+++ b/src/Train/RealtimeController.h
@@ -61,6 +61,11 @@ public:
     virtual void setLoad(double) { return; }
     virtual void setGradient(double) { return; }
     virtual void setMode(int) { return; }
+    virtual void setWindSpeed(double) { return; }
+    virtual void setWeight(double) { return; }
+    virtual void setRollingResistance(double) { return; }
+    virtual void setWindResistance(double) { return; }
+    virtual void setWheelCircumference(double) { return; }
 
     virtual uint8_t  getCalibrationType() { return CALIBRATION_TYPE_NOT_SUPPORTED; }
     virtual double   getCalibrationTargetSpeed() { return 0; }

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -1517,6 +1517,12 @@ void TrainSidebar::Connect()
     activeDevices = devices();
 
     foreach(int dev, activeDevices) {
+        Devices[dev].controller->setWheelCircumference(Devices[dev].wheelSize);
+        Devices[dev].controller->setRollingResistance(bicycle.RollingResistance());
+        Devices[dev].controller->setWindResistance(bicycle.WindResistance());
+        Devices[dev].controller->setWeight(bicycle.MassKG());
+        Devices[dev].controller->setWindSpeed(0); // Move to loadUpdate when wind simulation is added
+
         Devices[dev].controller->start();
         Devices[dev].controller->resetCalibrationState();
         connect(Devices[dev].controller, &RealtimeController::setNotification, this, &TrainSidebar::setNotification);


### PR DESCRIPTION
The weight has a direct impact on how fast you climb for a given power.
Other parameters like the wind resistance and the rolling resistance do
not change as much but should still be communicated to devices which can
take them into account. All the needed values were already present in
the BicycleSim and DeviceConfiguration modules. It is simply a matter of
communicating those values in the RealtimeController interface, just like
the gradient.

The changes are relatively minor, considering that new data has to pass from TrainSidebar to Controllers to Devices. The BT40Device, Fortius and Imagic are supported. It will be interesting to add support for that in other training devices.