### PR TITLE
Add control to Video Player to select among several Meter Widget layouts

### DIFF
--- a/src/Core/Context.h
+++ b/src/Core/Context.h
@@ -97,6 +97,7 @@ class Context : public QObject
         DateRange dr_;
         ErgFile *workout; // the currently selected workout file
         VideoSyncFile *videosync; // the currently selected videosync file
+        QString videoFilename;
         long now; // point in time during train session
         SpecialFields specialFields;
 
@@ -155,7 +156,7 @@ class Context : public QObject
         void notifyVideoSyncFileSelected(VideoSyncFile *x) { videosync=x; videoSyncFileSelected(x); }
         ErgFile *currentErgFile() { return workout; }
         VideoSyncFile *currentVideoSyncFile() { return videosync; }
-        void notifyMediaSelected( QString x) { mediaSelected(x); }
+        void notifyMediaSelected( QString x) { videoFilename = x; mediaSelected(x); }
         void notifySelectVideo(QString x) { selectMedia(x); }
         void notifySelectWorkout(QString x) { selectWorkout(x); }
         void notifySelectVideoSync(QString x) { selectVideoSync(x); }

--- a/src/Resources/xml/video-layout.xml
+++ b/src/Resources/xml/video-layout.xml
@@ -1,4 +1,5 @@
-<layout name="preset_1">
+<layouts>
+<layout name="Graphical Meters">
    <meter name="Speedometer" container="Video" source="Speed" type="NeedleMeter">
        <RelativeSize Width="15.0" Height="15.0" />
        <RelativePosition X="12.0" Y="77.0" />
@@ -83,13 +84,85 @@
        <MainColor R="255" G="0" B="0" A="180" />
        <Text>load</Text>
    </meter>
-	<!-- START  Changes for elevation widget -->
-	<meter name="elevation" container="Video" source="Elevation" type="Elevation">
-		<RelativeSize Width="40.0" Height="15.0" />
-		<RelativePosition X="20.0" Y="92.0" />
-		<BackgroundColor R="200" G="200" B="200" A="125" />
-		<OutlineColor R="255" G="255" B="255" A="250" />
-        <MainColor R="255" G="0" B="0" A="250" />
-    </meter>
-	<!-- END Changes for elevation widget -->
+   <meter name="elevation" container="Video" source="Elevation" type="Elevation">
+       <RelativeSize Width="40.0" Height="15.0" />
+       <RelativePosition X="20.0" Y="92.0" />
+       <BackgroundColor R="200" G="200" B="200" A="125" />
+       <OutlineColor R="255" G="255" B="255" A="250" />
+       <MainColor R="255" G="0" B="0" A="250" />
+   </meter>
 </layout>
+
+<layout name="Text Meters">
+   <meter name="MeterPanel" container="Video" source="None" type="Text" Background="true">
+       <RelativeSize Width="15.0" Height="50.0" />
+       <RelativePosition X="10.0" Y="25.0" />
+       <MainColor R="250" G="250" B="250" A="200" />
+       <MainFont Name="Consolas" Size="64" />
+       <AltFont Name="Consolas" Size="64" />
+       <BackgroundColor R="50" G="50" B="50" A="100" />
+       <Text></Text>
+   </meter>
+   <meter name="Slope" container="MeterPanel" source="Load" type="Text" alignment="AlignLeft" textWidth="5">
+       <RelativeSize Width="100.0" Height="10.0" />
+       <RelativePosition X="50.0" Y="8.0" />
+       <MainColor R="250" G="250" B="250" A="200" />
+       <MainFont Name="Consolas" Size="64" />
+       <AltFont Name="Consolas" Size="64" />
+   </meter>
+   <meter name="Speed" container="MeterPanel" source="Speed" type="Text" alignment="AlignLeft" textWidth="5">
+       <RelativeSize Width="100.0" Height="10.0" />
+       <RelativePosition X="50.0" Y="20.0" />
+       <MainColor R="250" G="250" B="250" A="200" />
+       <MainFont Name="Consolas" Size="64" />
+       <AltFont Name="Consolas" Size="64" />
+   </meter>
+   <meter name="Distance" container="MeterPanel" source="Distance" type="Text" alignment="AlignLeft" textWidth="5">
+       <RelativeSize Width="100.0" Height="10.0" />
+       <RelativePosition X="50.0" Y="32.0" />
+       <MainColor R="250" G="250" B="250" A="200" />
+       <MainFont Name="Consolas" Size="64" />
+       <AltFont Name="Consolas" Size="64" />
+   </meter>
+   <meter name="Wattmeter" container="MeterPanel" source="Watt" type="Text" alignment="AlignLeft" textWidth="5">
+       <RelativeSize Width="100.0" Height="10.0" />
+       <RelativePosition X="50.0" Y="44.0" />
+       <MainColor R="250" G="250" B="250" A="200" />
+       <MainFont Name="Consolas" Size="64" />
+       <AltFont Name="Consolas" Size="64" />
+       <AltText> Watts</AltText>
+   </meter>
+   <meter name="Altitude" container="MeterPanel" source="Altitude" type="Text" alignment="AlignLeft" textWidth="5">
+       <RelativeSize Width="100.0" Height="10.0" />
+       <RelativePosition X="50.0" Y="56.0" />
+       <MainColor R="250" G="250" B="250" A="200" />
+       <MainFont Name="Consolas" Size="64" />
+       <AltFont Name="Consolas" Size="64" />
+   </meter>
+   <meter name="Cadencemeter" container="MeterPanel" source="Cadence" type="Text" alignment="AlignLeft" textWidth="5">
+       <RelativeSize Width="100.0" Height="10.0" />
+       <RelativePosition X="50.0" Y="68.0" />
+       <MainColor R="250" G="250" B="250" A="200" />
+       <MainFont Name="Consolas" Size="64" />
+       <AltFont Name="Consolas" Size="64" />
+       <AltText> RPM</AltText>
+   </meter>
+   <meter name="Elapsed" container="MeterPanel" source="Time" type="Text">
+       <RelativeSize Width="100.0" Height="10.0" />
+       <RelativePosition X="50.0" Y="80.0" />
+       <MainColor R="250" G="250" B="250" A="200" />
+       <MainFont Name="Consolas" Size="64" />
+       <AltFont Name="Consolas" Size="64" />
+   </meter>
+   <meter name="elevation" container="Video" source="Elevation" type="Elevation">
+       <RelativeSize Width="40.0" Height="15.0" />
+       <RelativePosition X="20.0" Y="92.0" />
+       <BackgroundColor R="200" G="200" B="200" A="125" />
+       <OutlineColor R="255" G="255" B="255" A="250" />
+       <MainColor R="255" G="0" B="0" A="250" />
+   </meter>
+</layout>
+
+<layout name="No Meters">
+</layout>
+</layouts>

--- a/src/Train/VideoLayoutParser.h
+++ b/src/Train/VideoLayoutParser.h
@@ -32,21 +32,25 @@
 class VideoLayoutParser : public QXmlDefaultHandler
 {
 public:
-    VideoLayoutParser(QList<MeterWidget*>* metersWidget, QWidget* VideoContainer);
+    VideoLayoutParser(QList<MeterWidget*>* metersWidget, QList<QString>* layoutNames, QWidget* VideoContainer);
 
     bool startElement( const QString&, const QString&, const QString&, const QXmlAttributes& );
     bool endElement( const QString&, const QString&, const QString& );
 
     bool characters( const QString& );
     void SetDefaultValues();
+    int  layoutPositionSelected;
 
 private:
     QList<MeterWidget*>* metersWidget;
+    QList<QString>* layoutNames;
     QWidget*    VideoContainer;
 
     QString     buffer;
 
     int         nonameindex;
+    int         layoutPosition;
+    bool        skipLayout;
 
     QString     source;
     QString     meterName;

--- a/src/Train/VideoWindow.h
+++ b/src/Train/VideoWindow.h
@@ -143,14 +143,19 @@ class VideoWindow : public GcChartWindow
     Q_OBJECT
     G_OBJECT
 
+    // which layout to use
+    Q_PROPERTY(int videoLayout READ videoLayout WRITE setVideoLayout USER true)
 
     public:
 
         VideoWindow(Context *);
         ~VideoWindow();
+        int videoLayout() const { return layoutSelector->currentIndex(); }
+
 
     public slots:
 
+        void layoutChanged();
         void startPlayback();
         void stopPlayback();
         void pausePlayback();
@@ -162,6 +167,7 @@ class VideoWindow : public GcChartWindow
     protected:
 
         void resizeEvent(QResizeEvent *);
+        void setVideoLayout(int x) { layoutSelector->setCurrentIndex(x); }
 
         // current data
         int curPosition;
@@ -175,6 +181,11 @@ class VideoWindow : public GcChartWindow
 
         QList<MeterWidget*> m_metersWidget;
         QPoint prevPosition;
+
+    private:
+        QList<QString> layoutNames;
+        void readVideoLayout(int x);
+        void showMeters();
 
 #ifdef GC_VIDEO_VLC
 
@@ -193,6 +204,7 @@ class VideoWindow : public GcChartWindow
 #endif
 
         QWidget *container;
+        QComboBox *layoutSelector;
 
         bool init; // we initialised ok ?
 };


### PR DESCRIPTION
The video layout file is extended to contain possibly several named layouts. The file is read to list the layouts and offer a selection in the Video Player chart settings menu. The file is then read again to
instantiate the selected layout.

This was a suggestion of Alejandro Martinez. Interestingly, you can edit the settings and change the layout of the Video Viewer even while the training session is underway. You can add a video viewer as well while the training session is running. Your video layout choice is saved in your training layout. A video-layout.xml resource file is provided with 3 different layouts if you want to test it (move elsewhere your current ~/.goldencheetah/User/config/video-layout.xml and the new file will automatically be provided as default the next time you use a video viewer). The provided "Text Widget" layout does not look too good currently but should be nice with the Meter Widget enhancements pull request that I proposed a few days ago.