### PR TITLE
Computrainer Button tidy up

### DIFF
--- a/src/Train/ComputrainerController.cpp
+++ b/src/Train/ComputrainerController.cpp
@@ -23,6 +23,8 @@
 ComputrainerController::ComputrainerController(TrainSidebar *parent,  DeviceConfiguration *dc) : RealtimeController(parent, dc)
 {
     myComputrainer = new Computrainer (parent, dc ? dc->portSpec : ""); // we may get NULL passed when configuring
+    f1Depressed = false;
+    f2Depressed = false;
     f3Depressed = false;
 }
 
@@ -131,31 +133,35 @@ ComputrainerController::getRealtimeData(RealtimeData &rtData)
     Load = myComputrainer->getLoad();
     Gradient = myComputrainer->getGradient();
 	// the calls to the parent will determine which mode we are on (ERG/SPIN) and adjust load/slop appropriately
-    if ((Buttons&CT_PLUS) && !(Buttons&CT_F3)) {
-            parent->Higher();
+    if (Buttons&CT_PLUS) {
+        parent->Higher();
     }
-    if ((Buttons&CT_MINUS) && !(Buttons&CT_F3)) {
-            parent->Lower();
+    if (Buttons&CT_MINUS) {
+        parent->Lower();
     }
     rtData.setLoad(Load);
 	rtData.setSlope(Gradient);
 
-#if 0 // F3 now toggles calibration
-    // FFWD/REWIND
-    if ((Buttons&CT_PLUS) && (Buttons&CT_F3)) {
-           parent->FFwd();
+    // Start/Pause
+    if (Buttons&CT_F1) {
+        // We're only interested in the act of pressing the button, not it being held down
+        if (f1Depressed == false) {
+            f1Depressed = true;
+            parent->Start();
+        }
+    } else {
+        f1Depressed = false; // It has been released
     }
-    if ((Buttons&CT_MINUS) && (Buttons&CT_F3)) {
-           parent->Rewind();
-    }
-#endif
 
     // LAP/INTERVAL
-    if (Buttons&CT_F1 && !(Buttons&CT_F3)) {
-        parent->newLap();
-    }
-    if ((Buttons&CT_F1) && (Buttons&CT_F3)) {
-           parent->FFwdLap();
+    if (Buttons&CT_F2) {
+        // We're only interested in the act of pressing the button, not it being held down
+        if (f2Depressed == false) {
+            f2Depressed = true;
+            parent->newLap();
+        }
+    } else {
+        f2Depressed = false; // It has been released
     }
 
     // if Buttons == 0 we just pressed stop!
@@ -163,10 +169,6 @@ ComputrainerController::getRealtimeData(RealtimeData &rtData)
         parent->Stop(0);
     }
 
-    // displaymode
-    if (Buttons&CT_F2) {
-        parent->nextDisplayMode();
-    }
 }
 
 void ComputrainerController::pushRealtimeData(RealtimeData &) { } // update realtime data with current values

--- a/src/Train/ComputrainerController.h
+++ b/src/Train/ComputrainerController.h
@@ -53,6 +53,8 @@ public:
     uint8_t  getCalibrationType() { return CALIBRATION_TYPE_COMPUTRAINER; }
 
 private:
+    bool f1Depressed;
+    bool f2Depressed;
     bool f3Depressed;
 };
 

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -1938,11 +1938,6 @@ void TrainSidebar::steerScroll(int scrollAmount)
         context->notifySteerScroll(scrollAmount);
 }
 
-// can be called from the controller
-void TrainSidebar::nextDisplayMode()
-{
-}
-
 void TrainSidebar::warnnoConfig()
 {
     QMessageBox::warning(this, tr("No Devices Configured"), tr("Please configure a device in Preferences."));

--- a/src/Train/TrainSidebar.h
+++ b/src/Train/TrainSidebar.h
@@ -113,7 +113,6 @@ class TrainSidebar : public GcWindow
         // was realtimewindow,merged into tool
         // update charts/dials and manage controller
         void updateData(RealtimeData &);      // to update telemetry by push devices
-        void nextDisplayMode();     // show next display mode
         void setStreamController();     // based upon selected device
 
         // this


### PR DESCRIPTION
Since F3 was assigned to Calibration, its use as modifier was deprecated.
Also nextDisplay is not implemented so we can do some cleanup.
F1 is restored to their original function: start/pause and F2 is used
for new lap, in both cases with debouncing to avoid false activations.
This way the same functions enabled for ANT+ remotes are available via HBC:
Start&Pause: F1
Lap/Interval: F2
Load increase/decrease: +/-
Calibration: F3
Stop: Reset