### PR TITLE
src/Core/Context.cpp: include Settings.h

### DIFF
--- a/src/Core/Context.cpp
+++ b/src/Core/Context.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "Context.h"
+#include "Settings.h"
 #include "Athlete.h"
 #include "RideMetadata.h"
 


### PR DESCRIPTION
Build fails here with:
```
Core/Context.cpp: In member function ‘void GlobalContext::readConfig()’:
Core/Context.cpp:52:21: error: ‘appsettings’ was not declared in this scope
   52 |     QVariant unit = appsettings->value(NULL, GC_UNIT, GC_UNIT_METRIC);
      |                     ^~~~~~~~~~~
Core/Context.cpp:52:46: error: ‘GC_UNIT’ was not declared in this scope
   52 |     QVariant unit = appsettings->value(NULL, GC_UNIT, GC_UNIT_METRIC);
      |                                              ^~~~~~~
Core/Context.cpp:52:55: error: ‘GC_UNIT_METRIC’ was not declared in this scope
   52 |     QVariant unit = appsettings->value(NULL, GC_UNIT, GC_UNIT_METRIC);
      |                                                       ^~~~~~~~~~~~~~
Core/Context.cpp:55:98: error: ‘GC_UNIT_IMPERIAL’ was not declared in this scope
   55 |         unit = QLocale::system().measurementSystem() == QLocale::MetricSystem ? GC_UNIT_METRIC : GC_UNIT_IMPERIAL;
      |                                                                                                  ^~~~~~~~~~~~~~~~
make[1]: *** [Makefile:20772: Context.o] Error 1
```
