### PR TITLE
Adjust time units to compute speed properly for both Cycling Speed an…

### DIFF
--- a/src/Train/BT40Device.cpp
+++ b/src/Train/BT40Device.cpp
@@ -59,6 +59,7 @@ BT40Device::BT40Device(QObject *parent, QBluetoothDeviceInfo devinfo) : parent(p
     prevWheelTime = 0;
     prevWheelRevs = 0;
     prevWheelStaleness = true;
+    wheelTimeUnit = 1024; // Cycling Speed profile reports Wheel time in 1/1024 second units
     prevCrankTime = 0;
     prevCrankRevs = 0;
     prevCrankStaleness = -1; // indicates prev crank data values aren't measured values
@@ -176,6 +177,7 @@ BT40Device::serviceScanDone()
         if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::CyclingPower)) {
 
             has_power = true;
+            wheelTimeUnit = 2048; // Cycling Power profile reports Wheel time in 1/2048 second units
             service->discoverDetails();
 
         } else if (service->serviceUuid() == QBluetoothUuid(QBluetoothUuid::CyclingSpeedAndCadence)) {
@@ -541,7 +543,7 @@ BT40Device::getWheelRpm(QDataStream& ds)
     if(!prevWheelStaleness) {
         quint16 time = wheeltime - prevWheelTime;
         quint32 revs = wheelrevs - prevWheelRevs;
-        if (time) rpm = 2048*60*revs / double(time);
+        if (time) rpm = wheelTimeUnit*60*revs / double(time);
     }
     else prevWheelStaleness = false;
 

--- a/src/Train/BT40Device.h
+++ b/src/Train/BT40Device.h
@@ -78,6 +78,7 @@ private:
     bool prevWheelStaleness;
     quint16 prevWheelTime;
     quint32 prevWheelRevs;
+    int wheelTimeUnit;
     double load;
     double gradient;
     double prevGradient;


### PR DESCRIPTION
…d Cycling Power Bluetooth profiles

Both the CyclingSpeedAndCadence and the CyclingPower Bluetooth profiles have pretty much the same encoding for the wheel position and cadence data. Thus, the same function is used to read from Bluetooth and update those values for the telemetry. For the wheel position, this is in getWheelRpm. However, the time unit granularity differs between the two profiles, Cycling Speed reports wheel event times in 1/1024th seconds while Cycling Power uses 1/2048th seconds. We now define and use the wheelTimeUnit field to account for the difference.