### PR TITLE
Lat and Lon now get DegreesToRadians

### DIFF
--- a/src/FileIO/FixDerivePower.cpp
+++ b/src/FileIO/FixDerivePower.cpp
@@ -28,6 +28,12 @@
 #define MATHCONST_PI 		    3.141592653589793238462643383279502884L /* pi */
 #endif
 
+static double DegreesToRadians(double degrees) {
+    static const double degToRad = MATHCONST_PI / 180.;
+
+    return degrees * degToRad;
+}
+
 // Config widget used by the Preferences/Options config panes
 class FixDerivePower;
 class FixDerivePowerConfig : public DataProcessorConfig
@@ -271,9 +277,17 @@ FixDerivePower::postProcess(RideFile *ride, DataProcessorConfig *config=0, QStri
                 // ensure a movement occurred and valid lat/lon in order to compute cyclist direction
                 if (  (prevPoint->lat != p->lat || prevPoint->lon != p->lon )
                    && (prevPoint->lat != 0 || prevPoint->lon != 0 )
-                   && (p->lat != 0 || p->lon != 0 ) )
-                            bearing = atan2(cos(p->lat)*sin(p->lon - prevPoint->lon),
-                                            cos(prevPoint->lat)*sin(p->lat)-sin(prevPoint->lat)*cos(p->lat)*cos(p->lon - prevPoint->lon));
+                   && (p->lat != 0 || p->lon != 0 ) ) {
+                            double phi0   = DegreesToRadians(prevPoint->lat);
+                            double phi1   = DegreesToRadians(p->lat);
+                            double lamda0 = DegreesToRadians(prevPoint->lon);
+                            double lamda1 = DegreesToRadians(p->lon);
+
+                            double y = sin(lamda1 - lamda0) * cos(phi1);
+                            double x = cos(phi0) * sin(phi1) - sin(phi0) * cos(phi1) * cos(lamda1 - lamda0);
+
+                            bearing = atan2(y, x);
+                }
             }
             // else keep previous bearing (or 0 at the beginning)
 

--- a/src/FileIO/FixRunningPower.cpp
+++ b/src/FileIO/FixRunningPower.cpp
@@ -21,6 +21,7 @@
 #include "Settings.h"
 #include "Units.h"
 #include "HelpWhatsThis.h"
+#include "LocationInterpolation.h"
 #include <algorithm>
 #include <QVector>
 
@@ -221,11 +222,16 @@ FixRunningPower::postProcess(RideFile *ride, DataProcessorConfig *config=0, QStr
                 RideFilePoint *prevPoint = ride->dataPoints()[i-1];
 
                 // ensure a movement occurred and valid lat/lon in order to compute cyclist direction
-                if (  (prevPoint->lat != p->lat || prevPoint->lon != p->lon )
-                   && (prevPoint->lat != 0 || prevPoint->lon != 0 )
-                   && (p->lat != 0 || p->lon != 0 ) )
-                            bearing = atan2(cos(p->lat)*sin(p->lon - prevPoint->lon),
-                                            cos(prevPoint->lat)*sin(p->lat)-sin(prevPoint->lat)*cos(p->lat)*cos(p->lon - prevPoint->lon));
+                if (prevPoint->lat != p->lat || prevPoint->lon != p->lon)
+                {
+                    geolocation prevLoc(prevPoint->lat, prevPoint->lon, prevPoint->alt);
+                    geolocation loc(p->lat, p->lon, p->alt);
+
+                    if (prevLoc.IsReasonableGeoLocation() && loc.IsReasonableGeoLocation())
+                    {
+                        bearing = prevLoc.BearingTo(loc);
+                    }
+                }
             }
             // else keep previous bearing (or 0 at the beginning)
 

--- a/src/FileIO/LocationInterpolation.cpp
+++ b/src/FileIO/LocationInterpolation.cpp
@@ -54,6 +54,27 @@ xyz geolocation::toxyz() const
     return(xyz(dx, dy, dz));                             //Return x, y, z in ECEF
 }
 
+// Compute initial bearing from this geoloc to another, in RADIANS.
+// Note that unless bearing is 0 or pi it will vary on the path from one to the other.
+double geolocation::BearingTo(const geolocation& to) const
+{
+    if (this->Lat() == to.Lat() && this->Long() == to.Long())
+        return 0.;
+
+    double phi0   = degreestoradians(this->Lat());
+    double phi1   = degreestoradians(to.Lat());
+    double lamda0 = degreestoradians(this->Long());
+    double lamda1 = degreestoradians(to.Long());
+
+    double y = sin(lamda1 - lamda0) * cos(phi1);
+    double x = cos(phi0) * sin(phi1) - sin(phi0) * cos(phi1) * cos(lamda1 - lamda0);
+
+    double bearing = atan2(y, x);
+
+    return bearing;
+}
+
+
 geolocation xyz::togeolocation() const
 {
     // Approach developed by:

--- a/src/FileIO/LocationInterpolation.h
+++ b/src/FileIO/LocationInterpolation.h
@@ -24,13 +24,13 @@
 
 #include "qwt_math.h"
 
-struct geolocation;
-
 #if defined(_MSC_VER)
 #define NOINLINE __declspec(noinline)
 #else
 #define NOINLINE
 #endif
+
+struct geolocation;
 
 class v3
 {
@@ -130,6 +130,9 @@ struct geolocation : v3
             this->Alt() >= -1000 && this->Alt() < 10000);
     }
 
+    // Compute initial bearing from this geoloc to another, in RADIANS.
+    // Note that unless bearing is 0 or pi it will vary on the path from one to the other.
+    double BearingTo(const geolocation& to) const;
 };
 
 // Class to wrap classic game spherical interpolation


### PR DESCRIPTION
Convert lat/lon degrees to radians to determine rider bearing. Only matters when wind is specified.

Issue described in this thread:

https://groups.google.com/g/golden-cheetah-users/c/hECb3KdRPQU
