### PR TITLE
Followup to 3599: Preserve Endpoints when Route Smoothing

### DIFF
--- a/src/FileIO/LocationInterpolation.h
+++ b/src/FileIO/LocationInterpolation.h
@@ -124,10 +124,14 @@ struct geolocation : v3
         return dist;
     }
 
+    bool IsReasonableAltitude() const {
+        return (this->Alt() >= -1000 && this->Alt() < 10000);
+    }
+
     bool IsReasonableGeoLocation() const {
         return  (this->Lat() && this->Lat() >= double(-90) && this->Lat() <= double(90) &&
             this->Long() && this->Long() >= double(-180) && this->Long() <= double(180) &&
-            this->Alt() >= -1000 && this->Alt() < 10000);
+            IsReasonableAltitude());
     }
 
     // Compute initial bearing from this geoloc to another, in RADIANS.


### PR DESCRIPTION
After altitude smoothing fix ( #3599 ) I reviewed and fixed the same issue that was present with route smoothing.

Route end points must be preserved in order to force spline to cover entire route. Without this endpoint preservation the smoothing spline might not cover the entire route. Non-covered distance query will fail which causes smoothing pass to fail.

While making this change I noticed a private (but identical) version of IsReasonableGeolocation, so I removed private impl and instead use the implementation in the geolocation class.
