### PR TITLE
Remove modal dialog for Fortius disconnect

### DIFF
--- a/src/Train/FortiusController.cpp
+++ b/src/Train/FortiusController.cpp
@@ -83,10 +83,7 @@ FortiusController::getRealtimeData(RealtimeData &rtData)
 
     if(!myFortius->isRunning())
     {
-        QMessageBox msgBox;
-        msgBox.setText(tr("Cannot Connect to Fortius"));
-        msgBox.setIcon(QMessageBox::Critical);
-        msgBox.exec();
+        emit setNotification(tr("Cannot Connect to Fortius"), 2);
         parent->Stop(1);
         return;
     }

--- a/src/Train/FortiusController.h
+++ b/src/Train/FortiusController.h
@@ -20,8 +20,6 @@
 #include "RealtimeController.h"
 #include "Fortius.h"
 
-#include <QMessageBox>
-
 // Abstract base class for Realtime device controllers
 
 #ifndef _GC_FortiusController_h


### PR DESCRIPTION
This is the Same fix applied to the Computrainer a few months ago to remove the modal dialog that would be issued in a loop upon connection problems. The modal dialog loop made the interface completely unusable. Now a notification is emitted but the interface remains available.