### PR TITLE
Fix Error Setting Custom Wheel Diameter

### DIFF
--- a/src/Train/AddDeviceWizard.cpp
+++ b/src/Train/AddDeviceWizard.cpp
@@ -1452,7 +1452,9 @@ AddVirtualPower::calcWheelSize()
     int diameter = WheelSize::calcPerimeter(rimSizeCombo->currentIndex(), tireSizeCombo->currentIndex());
     if (diameter > 0)
         wheelSizeEdit->setText(QString("%1").arg(diameter));
-    wizard->wheelSize = diameter;
+    bool fValidDouble = false;
+    double wheelSize = wheelSizeEdit->text().toDouble(&fValidDouble);
+    wizard->wheelSize = fValidDouble ? wheelSize : 0.;
 }
 
 void


### PR DESCRIPTION
Virtual Power change #3410 introduced this error, where wheelsize value was only used if it was set via dropdowns. This change fixes the bad behavior, edit value is used if it is a valid number, whether it came from a dropdown or not.