### PR TITLE
Separate metric conversion from formating when value is provided

### DIFF
--- a/src/Charts/OverviewItems.cpp
+++ b/src/Charts/OverviewItems.cpp
@@ -686,9 +686,9 @@ MetricOverviewItem::setData(RideItem *item)
     const RideMetricFactory &factory = RideMetricFactory::instance();
     const RideMetric *m = factory.rideMetric(symbol);
     if (m) {
-        upper = m->toString(GlobalContext::context()->useMetricUnits, max);
-        lower = m->toString(GlobalContext::context()->useMetricUnits, min);
-        mean = m->toString(GlobalContext::context()->useMetricUnits, avg);
+        upper = m->toString(max);
+        lower = m->toString(min);
+        mean = m->toString(avg);
     }
 }
 
@@ -759,7 +759,7 @@ MetricOverviewItem::setDateRange(DateRange dr)
     RideMetric *m = const_cast<RideMetric*>(factory.rideMetric(symbol));
     if (std::isinf(v) || std::isnan(v)) v=0;
     if (m) {
-        value = m->toString(GlobalContext::context()->useMetricUnits, v);
+        value = m->toString(v);
     } else {
         value = Utils::removeDP(QString("%1").arg(v));
         if (value == "nan") value ="";
@@ -3301,8 +3301,8 @@ BubbleViz::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
     const RideMetric *m = factory.rideMetric(parent->xsymbol);
     QString smin, smax;
     if (m) {
-        smin = m->toString(GlobalContext::context()->useMetricUnits, round(minx+xoff));
-        smax = m->toString(GlobalContext::context()->useMetricUnits, round(maxx+xoff));
+        smin = m->toString(round(minx+xoff));
+        smax = m->toString(round(maxx+xoff));
     } else {
         smin = QString("%1").arg(round(minx+xoff));
         smax = QString("%1").arg(round(maxx+xoff));
@@ -3343,7 +3343,7 @@ BubbleViz::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
         // xlabel
         const RideMetric *m = factory.rideMetric(parent->xsymbol);
         QString xlab;
-        if (m)  xlab = m->toString(GlobalContext::context()->useMetricUnits, nearest.x+xoff);
+        if (m)  xlab = m->toString(nearest.x+xoff);
         else xlab = Utils::removeDP(QString("%1").arg(nearest.x+xoff,0,'f',parent->xdp));
         bminx = tfm.tightBoundingRect(QString("%1").arg(xlab));
         bminx.moveTo(center.x() - (bminx.width()/2),  xlabelspace.bottom()-bminx.height());
@@ -3353,7 +3353,7 @@ BubbleViz::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
         // ylabel
         m = factory.rideMetric(parent->ysymbol);
         QString ylab;
-        if (m)  ylab = m->toString(GlobalContext::context()->useMetricUnits, nearest.y+yoff);
+        if (m)  ylab = m->toString(nearest.y+yoff);
         else ylab = Utils::removeDP(QString("%1").arg(nearest.y+yoff,0,'f',parent->ydp));
         bminy = tfm.tightBoundingRect(QString("%1").arg(ylab));
         bminy.moveTo(ylabelspace.right() - bminy.width(),  center.y() - (bminy.height()/2));

--- a/src/Core/RideItem.cpp
+++ b/src/Core/RideItem.cpp
@@ -820,7 +820,7 @@ RideItem::getStringForSymbol(QString name, bool useMetricUnits)
 
             double value = metrics_[m->index()];
             if (std::isinf(value) || std::isnan(value)) value=0;
-            returning = m->toString(useMetricUnits, value);
+            returning = m->toString(m->value(value, useMetricUnits));
         }
     }
     return returning;

--- a/src/Metrics/GOVSS.cpp
+++ b/src/Metrics/GOVSS.cpp
@@ -200,8 +200,8 @@ class XPace : public RideMetric {
         return time_to_string(value(metric)*60);
     }
 
-    QString toString(bool metric, double v) const {
-        return time_to_string(value(v, metric)*60, true);
+    QString toString(double v) const {
+        return time_to_string(v*60, true);
     }
 
     void initialize() {

--- a/src/Metrics/PeakPace.cpp
+++ b/src/Metrics/PeakPace.cpp
@@ -57,8 +57,8 @@ class PeakPace : public RideMetric {
     QString toString(bool metric) const {
         return time_to_string(value(metric)*60, true);
     }
-    QString toString(bool metric, double v) const {
-        return time_to_string(value(v, metric)*60, true);
+    QString toString(double v) const {
+        return time_to_string(v*60, true);
     }
     void setSecs(double secs) { this->secs=secs; }
 
@@ -407,8 +407,8 @@ class PeakPaceSwim : public RideMetric {
     QString toString(bool metric) const {
         return time_to_string(value(metric)*60, true);
     }
-    QString toString(bool metric, double v) const {
-        return time_to_string(value(v, metric)*60, true);
+    QString toString(double v) const {
+        return time_to_string(v*60, true);
     }
     void setSecs(double secs) { this->secs=secs; }
 
@@ -743,8 +743,8 @@ class BestTime : public RideMetric {
     QString toString(bool metric) const {
         return time_to_string(value(metric)*60, true);
     }
-    QString toString(bool metric, double v) const {
-        return time_to_string(value(v, metric)*60, true);
+    QString toString(double v) const {
+        return time_to_string(v*60, true);
     }
     void setMeters(double meters) { this->meters=meters; }
 

--- a/src/Metrics/RideMetric.cpp
+++ b/src/Metrics/RideMetric.cpp
@@ -317,9 +317,9 @@ RideMetric::toString(bool useMetricUnits) const
 }
 
 QString
-RideMetric::toString(bool useMetricUnits, double v) const
+RideMetric::toString(double v) const
 {
-    if (isDate()) { QDate date(1900,01,01); date = date.addDays(value(v, useMetricUnits)); return date.toString("dd MMM yy"); }
-    if (isTime()) return time_to_string(value(v, useMetricUnits));
-    return QString("%1").arg(value(v, useMetricUnits), 0, 'f', this->precision());
+    if (isDate()) { QDate date(1900,01,01); date = date.addDays(v); return date.toString("dd MMM yy"); }
+    if (isTime()) return time_to_string(v);
+    return QString("%1").arg(v, 0, 'f', this->precision());
 }

--- a/src/Metrics/RideMetric.h
+++ b/src/Metrics/RideMetric.h
@@ -173,7 +173,7 @@ public:
 
     // Convert value to string, taking into account metric pref
     virtual QString toString(bool useMetricUnits) const;
-    virtual QString toString(bool useMetricUnits, double value) const;
+    virtual QString toString(double value) const;
 
     // Criterium to compare values, overridden by Pace metrics
     // Default just see if it is a RideMetric::Low

--- a/src/Metrics/RunMetrics.cpp
+++ b/src/Metrics/RunMetrics.cpp
@@ -293,8 +293,8 @@ class Pace : public RideMetric {
         return time_to_string(value(metric)*60, true);
     }
 
-    QString toString(bool metric, double v) const {
-        return time_to_string(value(v, metric)*60, true);
+    QString toString(double v) const {
+        return time_to_string(v*60, true);
     }
 
     void initialize() {

--- a/src/Metrics/SwimMetrics.cpp
+++ b/src/Metrics/SwimMetrics.cpp
@@ -125,8 +125,8 @@ class PaceSwim : public RideMetric {
         return time_to_string(value(metric)*60, true);
     }
 
-    QString toString(bool metric, double v) const {
-        return time_to_string(value(v, metric)*60, true);
+    QString toString(double v) const {
+        return time_to_string(v*60, true);
     }
 
     void initialize() {
@@ -210,8 +210,8 @@ class SwimPace : public RideMetric {
         return time_to_string(value(metric)*60, true);
     }
 
-    QString toString(bool metric, double v) const {
-        return time_to_string(value(v, metric)*60, true);
+    QString toString(double v) const {
+        return time_to_string(v*60, true);
     }
 
     void initialize() {
@@ -502,8 +502,8 @@ class SwimPaceStroke : public RideMetric {
         return time_to_string(value(metric)*60, true);
     }
 
-    QString toString(bool metric, double v) const {
-        return time_to_string(value(v, metric)*60, true);
+    QString toString(double v) const {
+        return time_to_string(v*60, true);
     }
 
     void initialize() {

--- a/src/Metrics/SwimScore.cpp
+++ b/src/Metrics/SwimScore.cpp
@@ -158,8 +158,8 @@ class XPaceSwim : public RideMetric {
     QString toString(bool metric) const {
         return time_to_string(value(metric)*60);
     }
-    QString toString(bool metric, double v) const {
-        return time_to_string(value(v, metric)*60);
+    QString toString(double v) const {
+        return time_to_string(v*60);
     }
     void initialize() {
         setName(tr("xPace Swim"));

--- a/travis/osx/after_success.sh
+++ b/travis/osx/after_success.sh
@@ -48,8 +48,9 @@ do
 done
 popd
 
-# Final deployment to generate dmg
-/usr/local/opt/qt5/bin/macdeployqt GoldenCheetah.app -verbose=2 -fs=hfs+ -dmg
+# Final deployment to generate dmg (may take longer than 10' wihout output)
+python3.7 -m pip install travis-wait-improved
+/Library/Frameworks/Python.framework/Versions/3.7/bin/travis-wait-improved --timeout 20m /usr/local/opt/qt5/bin/macdeployqt GoldenCheetah.app -verbose=2 -fs=hfs+ -dmg
 
 echo "Renaming dmg file to branch and build number ready for deploy"
 export FINAL_NAME=GoldenCheetah_v3.6-DEV_x64.dmg


### PR DESCRIPTION
Overview chart needs to do computations with metric values converted
to selected units and format results accordingly, for this purpose
RideMetric::toString(useMetricUnits, value) should not do the units
conversion again, so it is changed to do formatting only and useMetricUnits
parameter is removed.
The original meaning is used only in RideItem where it is replaced by
the composition of toString with value.
Fixes #3647