### PR TITLE
rotational inertial for custom virtual power

### DIFF
--- a/src/Train/AddDeviceWizard.h
+++ b/src/Train/AddDeviceWizard.h
@@ -76,9 +76,10 @@ public:
     DeviceScanner *scanner;
 
     // Device Data
-    int virtualPowerIndex;      // index of selected virtual power function
-    int wheelSize;
-    int strideLength;
+    int    virtualPowerIndex;      // index of selected virtual power function
+    int    wheelSize;
+    int    strideLength;
+    double rotationalInertiaKG; // rotational inertia of system flywheel, in grams
 
 public slots:
 
@@ -239,12 +240,13 @@ private:
     AddDeviceWizard* wizard;
     RealtimeController* controller; // copy of controller, for lazy re-init
 
-    QLineEdit* name;
-    QComboBox* virtualPower;
-    QComboBox* rimSizeCombo;
-    QComboBox* tireSizeCombo;
-    QLineEdit* wheelSizeEdit;
-    QLineEdit* stridelengthEdit;
+    QLineEdit*      name;
+    QComboBox*      virtualPower;
+    QComboBox*      rimSizeCombo;
+    QComboBox*      tireSizeCombo;
+    QLineEdit*      wheelSizeEdit;
+    QLineEdit*      stridelengthEdit;
+    QDoubleSpinBox* rotationalInertiaKGEdit;
 
     QLabel*         virtualPowerNameLabel;
     QLineEdit*      virtualPowerNameEdit;

--- a/src/Train/DeviceConfiguration.h
+++ b/src/Train/DeviceConfiguration.h
@@ -39,6 +39,7 @@ class DeviceConfiguration
 
     QString defaultString;      // PHCS for power/heartrate/cadence/speed from this device
     int wheelSize;              // set wheel size for each device
+    double rotationalInertiaKG; // flywheel inertia in kg
     int stridelength;           // stride length in cm
 
     int postProcess;

--- a/src/Train/PolynomialRegression.h
+++ b/src/Train/PolynomialRegression.h
@@ -25,6 +25,7 @@ template <typename T_fptype>
 struct PolyFit {
     typedef T_fptype value_type;
     virtual value_type Fit(value_type v) const = 0;
+    virtual value_type Slope(value_type v) const = 0;
     virtual void append(std::string& s) const = 0;
 };
 

--- a/src/Train/RealtimeController.h
+++ b/src/Train/RealtimeController.h
@@ -36,6 +36,13 @@ struct VirtualPowerTrainer {
     const char*            m_pName;
     const PolyFit<double>* m_pf;
     bool                   m_fUseWheelRpm;
+    double                 m_rotationalInertiaKG;
+
+    VirtualPowerTrainer() :
+        m_pName(""), m_pf(NULL), m_fUseWheelRpm(false), m_rotationalInertiaKG(0.) {}
+
+    VirtualPowerTrainer(const char* pName, const PolyFit<double>*pf, bool fUseWheelRpm, double rotationalInertiaKG = 0.) :
+        m_pName(pName),m_pf(pf), m_fUseWheelRpm(fUseWheelRpm), m_rotationalInertiaKG(rotationalInertiaKG) {}
 
     void to_string(std::string& s) const;
 };
@@ -129,6 +136,10 @@ private:
 
     const PolyFit<double>* polyFit; // Speed to power fit.
     bool fUseWheelRpm;              // If power is derived from wheelrpm instead of speed.
+    double rotationalInertiaKG;
+
+    double inertiaPrevRpm;
+    std::chrono::high_resolution_clock::time_point inertiaPrevTime;
 
 public:
     VirtualPowerTrainerManager virtualPowerTrainerManager;


### PR DESCRIPTION
Adds field to hold trainers rotational inertia. This allows power
calculation to track energy that passes in and out of trainers
flywheel so that acceleration and deceleration power can be
reported immediately.

All existing defined trainers are using 0kg for inertia. Probably
most should be updated with user data.

#3650 