### PR TITLE
Add up and down button to NamedSearch dialog

### DIFF
--- a/src/Core/NamedSearch.h
+++ b/src/Core/NamedSearch.h
@@ -113,12 +113,16 @@ class EditNamedSearches : public QDialog
         QTreeWidget *searchList;
         QPushButton *addButton,
                     *updateButton,
+                    *upButton,
+                    *downButton,
                     *deleteButton;
         QIcon searchIcon, filterIcon;
 
     private slots:
         void addClicked();
         void updateClicked();
+        void upClicked();
+        void downClicked();
         void deleteClicked();
         void selectionChanged();
 };


### PR DESCRIPTION
Also know as the Manage Filters dialog. Reordering was not possible in
the interface yet, you were forced to edit the xml file to do any
reordering.

Relevant issue: https://github.com/GoldenCheetah/GoldenCheetah/issues/3656

I used the updateClicked function as a "template". Let me know if I messed anything up.