### PR TITLE
Sort routes when they are added to an activity

### DIFF
--- a/src/Core/IntervalItem.h
+++ b/src/Core/IntervalItem.h
@@ -89,8 +89,8 @@ class IntervalItem
         RideFileInterval *rideInterval;
 
         // used by qSort()
-        bool operator< (IntervalItem right) const {
-            return (start < right.start);
+        bool operator< (const IntervalItem& right) const {
+            return std::tie(start, stop) < std::tie(right.start, right.stop);
         }
 };
 

--- a/src/Core/RideItem.cpp
+++ b/src/Core/RideItem.cpp
@@ -1447,6 +1447,15 @@ RideItem::updateIntervals()
         QList<IntervalItem*> here;
         context->athlete->routes->search(this, f, here);
 
+        // Sort routes so they are added by start time to the activity.
+        std::sort(
+            here.begin(),
+            here.end(),
+            [](IntervalItem* i1, IntervalItem* i2) {
+                return *i1 < *i2;
+            }
+        );
+
         // add to ride !
         foreach(IntervalItem *add, here) {
             add->rideInterval = NULL;


### PR DESCRIPTION
Before this change, when looking at an activity, the routes seemed to
appear in order of creation in the interval section. This patch instead
sorts them by their start time in the activity (or by their end
time if the start times are the same).

Note that the routes are also known as segments.

This fixes bug #2132.