### PR TITLE
Teach ttsreader to process routes and segments

### DIFF
--- a/src/FileIO/TTSReader.cpp
+++ b/src/FileIO/TTSReader.cpp
@@ -61,6 +61,21 @@ const log_disabled_output& operator << (const log_disabled_output& any, const st
 
 using namespace NS_TTSReader;
 
+// This is the static const string table that tts files may refer to by string key.
+static const std::map<int, const char*> tts_string_table = {
+    {1001, "route name" },
+    {1002, "route description"},
+    {1041, "segment name"},
+    {1042, "segment description"},
+    {2001, "company"},
+    {2004, "serial"},
+    {2005, "time"},
+    {2007, "link"},
+    {5001, "product"},
+    {5002, "video name"},
+    {6001, "infobox #1"}
+};
+
 /*
  * Utility Routines For TTS Reader
  */
@@ -282,7 +297,7 @@ void videoInfo(int version, ByteArray & data) {
     Q_UNUSED(data);
 }
 
-void segmentRange(int version, ByteArray &data) {
+void TTSReader::segmentRange(int version, ByteArray &data) {
 
     Q_UNUSED(version);
 
@@ -290,11 +305,16 @@ void segmentRange(int version, ByteArray &data) {
         DEBUG_LOG << "Segment Range data wrong length " << data.size() << "\n";
     }
 
-    DEBUG_LOG << "[segment range]\n";
+    DEBUG_LOG << "[segment range token]";
 
+    // In the files I've seen this segmentRange token is only set once and contains the route length.
+    // Note this code seems to permit a segment to have multiple ranges. I have no example so not sure.
     for (unsigned int i = 0; i < data.size() / 10; i++) {
 
-        DEBUG_LOG << " [" << i << "=" << (getUInt(data, i * 10 + 0) / 100000.0) << "-" << (getUInt(data, i * 10 + 4) / 100000.0) << "\n";
+        double startKM = (getUInt(data, i * 10 + 0) / 100000.0);
+        double endKM = (getUInt(data, i * 10 + 4) / 100000.0);
+
+        DEBUG_LOG << " [" << i << "=" << startKM << "-" << endKM << "\n";
 
         if (getUShort(data, i * 10 + 6) != 0) {
             DEBUG_LOG << "/0x" << std::hex << (getUShort(data, i * 10 + 6)) << std::dec << "\n";
@@ -305,13 +325,29 @@ void segmentRange(int version, ByteArray &data) {
 }
 
 // segment range; 548300 is 5.483km. What is short value in "old" files?
-void segmentInfo(int version, ByteArray &data) {
+void TTSReader::segmentInfo(int version, ByteArray &data) {
 
     if ((version == 1104) && (data.size() == 8)) {
-        DEBUG_LOG << "[segment range] " << (getUInt(data, 0) / 100000.0) << "-" << (getUInt(data, 4) / 100000.0) << "\n";
+        double startKM = (getUInt(data, 0) / 100000.0);
+        double endKM = (getUInt(data, 4) / 100000.0);
+
+        pendingSegment.startKM = startKM;
+        pendingSegment.endKM = endKM;
+
+        DEBUG_LOG << "[segment range] " << startKM << "-" << endKM << "\n";
     }
 
     if ((version == 1000) && (data.size() == 10)) {
+        double startKM = (getUInt(data, 2) / 100000.0);
+        double endKM = (getUInt(data, 6) / 100000.0);
+
+        // NOTE: From the wattzapp debug print it looks like this 3rd value is a divisor.
+        // In my test files its always 1. so no harm to divide - but beware I'm just guessing.
+        double divisor = getUShort(data, 0);
+
+        pendingSegment.startKM = startKM / divisor;
+        pendingSegment.endKM = endKM / divisor;
+
         DEBUG_LOG << "[segment range] " << (getUInt(data, 2) / 100000.0) << "-" << (getUInt(data, 6) / 100000.0) << "/" << getUShort(data, 0) << "\n";
     }
 }
@@ -370,8 +406,19 @@ const std::vector<Point> & TTSReader::getPoints() const {
     return points;
 }
 
+const std::vector<Segment>& TTSReader::getSegments() const {
+    return segmentList;
+}
+
+const std::wstring& TTSReader::getRouteName()        const {
+    return routeName; 
+}
+
+const std::wstring& TTSReader::getRouteDescription() const {
+    return routeDescription;
+}
+
 double TTSReader::getDistanceMeters() const {
-    // TODO Auto-generated method stub
     return totalDistance;
 }
 
@@ -380,12 +427,10 @@ int TTSReader::routeType() const {
 }
 
 double TTSReader::getMaxSlope() const {
-    // TODO Auto-generated method stub
     return maxSlope;
 }
 
 double TTSReader::getMinSlope() const {
-    // TODO Auto-generated method stub
     return minSlope;
 }
 
@@ -642,8 +687,6 @@ bool TTSReader::loadHeaders() {
 
             DEBUG_LOG << "::";
 
-            //String result = null;
-
             switch (stringType) {
 
             case CRC:
@@ -665,32 +708,45 @@ bool TTSReader::loadHeaders() {
 
             case STRING:
 
-                // GOLDEN CHEETAH TODO: Strings? Pssht!
+            {
+                if (tts_string_table.count(blockType + stringId)) {
+                    DEBUG_LOG << "[" << tts_string_table.at(blockType + stringId) << "]";
+                } else {
+                    DEBUG_LOG << "[" << blockType << "." << stringId << "]";
+                }
 
-                //if (strings.containsKey(blockType + stringId)) {
-                //    logger.debug("[" + strings.get(blockType + stringId)
-                //        + "]");
-                //}
-                //else {
-                //    logger.debug("[" + blockType + "." + stringId + "]");
-                //}
-                //
-                //StringBuilder str = new StringBuilder();
-                //for (int i = 0; i < decrD.length / 2; i++) {
-                //    Char c = (Char)(decrD[2 * i] | (int)decrD[2 * i + 1] << 8);
-                //    str.append(c);
-                //}
-                //
-                //result = str.toString();
-                //switch (blockType + stringId) {
-                //case 5002: // Video Name
-                //    ttsName = result;
-                //    break;
-                //default:
-                //    logger.debug("[" + result + "]");
-                //}
+                std::wstring result;
 
-                break;
+                for (int i = 0; i < decrD.size() / 2; i++) {
+                    Char c = (Char)(decrD[2 * i] | (int)decrD[2 * i + 1] << 8);
+                    result.append(1, c);
+                }
+
+                switch (blockType + stringId) {
+                case 5002: // Video Name
+                    ttsName = result;
+                    break;
+                case 1001: // Route Name
+                    routeName = result;
+                    break;
+                case 1002: // Route Description
+                    routeDescription = result;
+                    break;
+                case 1041: // Segment Name
+                    // Push of pending segment to segment list is triggered by finding a new
+                    // segment name. If pending segment is valid then push it, then clear
+                    // pending to start a new one.
+                    flushPendingSegment();
+                    pendingSegment.name = result;
+                    break;
+                case 1042: // Segment Description
+                    pendingSegment.description = result;
+                    break;
+                }
+
+                DEBUG_LOG << "[" << result << "]";
+            }
+            break;
 
             case BLOCK:
             {
@@ -702,8 +758,6 @@ bool TTSReader::loadHeaders() {
             }
         }
 
-        DEBUG_LOG << "\n";
-
         bytes += (int)data.size();
     }
 
@@ -711,6 +765,7 @@ bool TTSReader::loadHeaders() {
     // - pointList holds framemapping info (if any)
     // - programList holds slope info
     // - gpsList holds gps info
+    // - segmentList holds the segments and their names
     //
     // GPS Info is optional.
     // FrameMapping Info is optional.
@@ -725,6 +780,10 @@ bool TTSReader::loadHeaders() {
     // One stream is chosen to be the basis for the interpolation of
     // the other streams. Choose whichever has the most data points,
     // then interpolate the other two onto it.
+
+    // First thing, flush any pending segment.
+    flushPendingSegment();
+
     size_t gpsCount = gpsPoints.size();
     size_t slopeCount = programList.size();
     size_t frameMapCount = pointList.size();

--- a/src/Train/ErgFile.cpp
+++ b/src/Train/ErgFile.cpp
@@ -919,6 +919,9 @@ void ErgFile::parseTTS()
         return;
     }
 
+    Name = QString::fromStdWString(ttsReader.getRouteName());               // description in file
+    Description = QString::fromStdWString(ttsReader.getRouteDescription()); // long narrative for workout
+
     const NS_TTSReader::Point *prevPoint, *point, *nextPoint;
 
     prevPoint = NULL;

--- a/src/Train/ErgFile.h
+++ b/src/Train/ErgFile.h
@@ -77,7 +77,7 @@ class ErgFileText
 {
     public:
         ErgFileText() : x(0), duration(0), text("") {}
-        ErgFileText(double x, int duration, QString text) : x(x), duration(duration), text(text) {}
+        ErgFileText(double x, int duration, const QString &text) : x(x), duration(duration), text(text) {}
 
         double x;
         int duration;
@@ -87,10 +87,13 @@ class ErgFileText
 class ErgFileLap
 {
     public:
-        long x;     // when does this LAP marker occur? (time in msecs or distance in meters
-        int LapNum;     // from 1 - n
-        bool selected; // used by the editor
+        ErgFileLap() : name(""), x(0), LapNum(0), selected(false) {}
+        ErgFileLap(double x, int LapNum, const QString& name) : name(name), x(x), LapNum(LapNum), selected(false) {}
+
         QString name;
+        double x;      // when does this LAP marker occur? (time in msecs or distance in meters
+        int LapNum;    // from 1 - n
+        bool selected; // used by the editor
 };
 
 class ErgFile
@@ -126,8 +129,8 @@ class ErgFile
         double gradientAt(double, int&); // return the gradient value for the passed meter
         bool locationAt  (double x, int& lapnum, geolocation &geoLoc, double &slope100); // location at meter
 
-        int nextLap(long);      // return the start value (erg - time(ms) or slope - distance(m)) for the next lap
-        int currentLap(long);   // return the start value (erg - time(ms) or slope - distance(m)) for the current lap
+        double nextLap(long);            // return the start value (erg - time(ms) or slope - distance(m)) for the next lap
+        double currentLap(long);         // return the start value (erg - time(ms) or slope - distance(m)) for the current lap
 
         int nextText(long);     // return the index for the next text cue
 


### PR DESCRIPTION
#3667 

TTS reader previously ignored routes, segments and strings.
With this change the route name, route description, segments,
segment descriptions are now all parsed into ttsreader object.

With this change the route name and description are assigned to
the ergfile, so route name now appears while riding a tts file.

With this change there is still no place to put segments in ergfile.

With this change none of the new information is assigned into the
activity file.

The segments and segment descriptions are used by tacx software
so user can select a named region of a long ride. Example ride
was >200km long and contained 12 named segments, each with a nice
description. Would be nice to bubble that info up to train mode.