### PR TITLE
Populate Details > Route field during Import - new feature.

### DIFF
--- a/src/Gui/RideImportWizard.h
+++ b/src/Gui/RideImportWizard.h
@@ -87,6 +87,7 @@ private:
     QPushButton *abortButton; // also used for save and finish
     QPushButton *cancelButton; // cancel when asking for dates
     QComboBox *todayButton;    // set date to today when asking for dates
+    QComboBox *workoutNameToRoute;  // Option to populate Route field
     // QCheckBox *overFiles;      // chance to set overwrite when asking for dates // deprecate for this release... XXX
     // bool overwriteFiles; // flag to overwrite files from checkbox               // deprecate for this release... XXX
     Context *context; // caller


### PR DESCRIPTION
New feature which can populate Details > Route field. It works with
both "Import from file" and "Train view" workouts. Can be used when
importing multiple files with "Import from file". Details > Route
field will be populated with "Train view" workout filename or with
filename which will be imported with "Import from file".
Fixes #3630

Some extra info is posted here:
https://github.com/GoldenCheetah/GoldenCheetah/issues/3630#issuecomment-729945568