### PR TITLE
Fix 3677: Slope Mode Lap Bugs

### DIFF
--- a/src/Train/ErgFile.h
+++ b/src/Train/ErgFile.h
@@ -104,6 +104,8 @@ class ErgFile
 
         ~ErgFile();             // delete the contents
 
+        void finalize();        // finish up ergfile creation
+
         void setFrom(ErgFile *f); // clone an existing workout
         bool save(QStringList &errors); // save back, with changes
 
@@ -126,13 +128,18 @@ class ErgFile
         double Cp;
         int format;             // ERG, CRS, MRC, ERG2 currently supported
 
-public:
         bool hasGradient() const { return CRS == format; }
         bool hasWatts()    const { return ERG == format || MRC == format; }
+
+private:
+        void sortLaps() const;
+public:
 
         double nextLap(double) const;    // return the start value (erg - time(ms) or slope - distance(m)) for the next lap
         double prevLap(double) const;    // return the start value (erg - time(ms) or slope - distance(m)) for the prev lap
         double currentLap(double) const; // return the start value (erg - time(ms) or slope - distance(m)) for the current lap
+
+        int    addNewLap(double loc) const; // creates new lap at location, returns index of new lap.
 
         int  nextText(double) const;   // return the index for the next text cue
 
@@ -157,9 +164,9 @@ public:
         int     mode;
         bool    StrictGradient; // should gradient be strict or smoothed?
 
-        QList<ErgFilePoint> Points;    // points in workout
-        QList<ErgFileLap>   Laps;      // interval markers in the file
-        QList<ErgFileText>  Texts;     // texts to display
+        QList<ErgFilePoint>         Points; // points in workout
+        mutable QList<ErgFileLap>   Laps;   // interval markers in the file
+        QList<ErgFileText>          Texts;  // texts to display
 
         GeoPointInterpolator gpi;      // Location interpolator
 
@@ -206,11 +213,13 @@ public:
     const ErgFile* getErgFile() const     { return ergFile; }
     void     setErgFile(const ErgFile* p) { ergFile = p; }
     void     resetQueryState()            { qs.Reset(); }
+    int      addNewLap(double loc) const;
 
 private:
     const QList<ErgFilePoint>& Points() const { return ergFile->Points; }
     const QList<ErgFileLap>  & Laps()   const { return ergFile->Laps; }
     const QList<ErgFileText> & Texts()  const { return ergFile->Texts; }
+
 
     // Common helper to setup query state for query. Returns false if bracket cannot be established.
     bool   updateQueryStateFromDistance(double x, int& lapnum) const;

--- a/src/Train/TrainSidebar.h
+++ b/src/Train/TrainSidebar.h
@@ -264,14 +264,12 @@ class TrainSidebar : public GcWindow
         double displayLatitude, displayLongitude, displayAltitude; // geolocation
         long load;
         double slope;
-        int displayLap;            // user increment for Lap
         int displayWorkoutLap;     // which Lap in the workout are we at?
         bool lapAudioEnabled;
         bool lapAudioThisLap;
         bool useSimulatedSpeed;
 
-        void updateMetricLapDistance();
-        void updateMetricLapDistanceRemaining();
+        void maintainLapDistanceState();
 
         // for non-zero average calcs
         int pwrcount, cadcount, hrcount, spdcount, lodcount, grdcount; // for NZ average calc


### PR DESCRIPTION
Change consolidates and cleans up slope mode lap code.

FIX BUG: Fix handling of final lap (falls back on route distance).
FIX BUG: FFwd lap on final lap no longer jumps to route start.
FIX BUG: AddLap button now actually creates a new lap in lap list, making it reachable using nextLap and prevLap.

Change also consolidates code to make it simpler to operate:
Create ergfile finalize for every parser to call.
Consolidate lap init into ergfile finalize.
Consolidate lap distance updates into a single method.
Laps now sorted by location.
Workout with no lap is given bracketing laps so lap elapsed and remaining will work automatically.
Remove the displayLap field as it serves no purpose.
