### PR TITLE
Fix 3680: Text, Chim and Lap Issues

### DIFF
--- a/src/FileIO/TTSReader.cpp
+++ b/src/FileIO/TTSReader.cpp
@@ -82,8 +82,6 @@ static const std::map<int, const char*> tts_string_table = {
 
  // Handy utils
 float AsFloat(unsigned u) {
-    return reinterpret_cast<float&>(u);
-
     float t;
     static_assert(sizeof(u) == sizeof(t), "Error: mismatched reinterpret sizes");
     memcpy(&t, &u, sizeof(u));
@@ -91,8 +89,6 @@ float AsFloat(unsigned u) {
 }
 
 float AsFloat(int i) {
-    return reinterpret_cast<float&>(i);
-
     float t;
     static_assert(sizeof(i) == sizeof(t), "Error: mismatched reinterpret sizes");
     memcpy(&t, &i, sizeof(i));

--- a/src/Train/ErgFile.cpp
+++ b/src/Train/ErgFile.cpp
@@ -771,6 +771,10 @@ void ErgFile::parseFromRideFileFactory()
 
         prevPoint = point;
         point = nextPoint;
+
+        if (!point)
+            break;
+
         nextPoint = ((i + 1) < pointCount) ? (ride->dataPoints()[i + 1]) : NULL;
 
         // Determine slope to next point
@@ -915,7 +919,12 @@ void ErgFile::parseTTS()
 
         prevPoint = point;
         point = nextPoint;
+
+        if (!point)
+            break;
+
         nextPoint = ((i + 1) >= pointCount) ? &ttsPoints[i] : &ttsPoints[i + 1];
+
 
         // Determine slope to next point
         double slope = 0.0;
@@ -998,17 +1007,19 @@ void ErgFile::parseTTS()
         // Segment Start
         add.x = segment.startKM * 1000.;
         add.LapNum = (i * 2) + 1;
+        add.LapRangeNum = i + 1;
         add.selected = false;
 
-        add.name = QString::fromStdWString(L"Starting Segment: " + segment.name + rangeString);
+        add.name = QObject::tr("Starting") + ": " + QString::fromStdWString(segment.name + rangeString);
 
         Laps << add;
 
         // Segment End
         add.x = segment.endKM * 1000.;
         add.LapNum = (i * 2) + 2;
+        add.LapRangeNum = i + 1;
         add.selected = false;
-        add.name = QString::fromStdWString(L"Ending Segment: " + segment.name + rangeString);
+        add.name = QObject::tr("Ending") + ": " + QString::fromStdWString(segment.name + rangeString);
         
         Laps << add;
     }
@@ -1025,20 +1036,9 @@ void ErgFile::parseTTS()
     // - End A
     // - End B
 
-    // Sort text and laps:
+    // Sort laps and texts
     sortLaps();
-
-    std::sort(Texts.begin(), Texts.end(), [](const ErgFileText& a, const ErgFileText& b) {
-        // If distance is the same the lesser distance comes first.
-        if (a.x == b.x) return a.duration < b.duration;
-        return a.x < b.x;
-    });
-
-    // Renumber laps to follow the sorted entry distance order:
-    int lapNum = 1;
-    for (auto &a : Laps) {
-        a.LapNum = lapNum++;
-    }
+    sortTexts();
 
     // This is load time so debug print isn't so expensive.
     // Laps seem pretty buggy right now. Lets debug print the data
@@ -1046,7 +1046,7 @@ void ErgFile::parseTTS()
     int xx = 0;
     qDebug() << "LAPS:";
     for (const auto &a : Laps) {
-        qDebug() << xx << ": " << a.LapNum << " start:" << a.x / 1000. << "km, name: " << a.name;
+        qDebug() << xx << ": " << a.LapNum << " start:" << a.x / 1000. << "km, name: " << a.name << " RangeId:" << a.LapRangeNum;
         xx++;
     }
 
@@ -1487,6 +1487,15 @@ void ErgFile::sortLaps() const
     }
 }
 
+void ErgFile::sortTexts() const
+{
+    std::sort(Texts.begin(), Texts.end(), [](const ErgFileText& a, const ErgFileText& b) {
+        // If distance is the same the lesser distance comes first.
+        if (a.x == b.x) return a.duration < b.duration;
+        return a.x < b.x;
+    });
+}
+
 void ErgFile::finalize()
 {
     if (Laps.count() == 0) {
@@ -1509,6 +1518,7 @@ void ErgFile::finalize()
     }
 
     sortLaps();
+    sortTexts();
 }
 
 bool
@@ -1566,36 +1576,62 @@ ErgFile::currentLap(double x) const
     return -1; // No matching lap
 }
 
-// Adds new lap at location, returns lap index.
+// Adds new lap at location, returns index of new lap
 int
 ErgFile::addNewLap(double loc) const
 {
-    if (!isValid()) return -1; // not a valid ergfile
+    if (isValid())
+    {
+        ErgFileLap add;
 
-    ErgFileLap add;
+        add.x = loc;
+        add.LapNum = Laps.count();
+        add.selected = false;
+        add.name = "user lap";
+        Laps.append(add);
 
-    add.x = loc;
-    add.LapNum = Laps.count();
-    add.selected = false;
-    add.name = "user lap";
-    Laps.append(add);
+        sortLaps();
 
-    sortLaps();
+        auto itr = std::find_if(Laps.begin(), Laps.end(), [&add](const ErgFileLap& otherLap) {
+            return add.x == otherLap.x && add.LapRangeNum == otherLap.LapRangeNum && add.name == otherLap.name;
+        });
+        if (itr != Laps.end()) 
+            return (*itr).LapNum;
+    }
+
+    return -1;
 }
 
-
-// Retrieve the index of next text cue.
-// Params: x - current workout distance (m) / time (ms)
-// Returns: index of next text cue.
-int ErgFile::nextText(double x) const
+bool ErgFile::textsInRange(double searchStart, double searchRange, int& rangeStart, int& rangeEnd) const
 {
-    if (!isValid()) return -1; // not a valid ergfile
+    bool retVal = false;
 
-    // If the current position is before the text, then the text is next
-    for (int i=0; i<Texts.count(); i++) {
-        if (x <= Texts.at(i).x) return i;
+    if (isValid()) {
+
+        searchStart = std::floor(searchStart);
+
+        // find first text in range, continue to last text in range.
+        rangeStart = -1;
+        rangeEnd = -1;
+
+        double searchLimit = searchStart + searchRange;
+
+        for (int i = 0; i < Texts.count(); i++) {
+            double distance = Texts.at(i).x;
+            if (distance >= searchStart && distance <= searchLimit) {
+                if (rangeStart < 0) {
+                    rangeStart = i;
+                    retVal = true;
+                }
+                rangeEnd = i;
+            }
+
+            // Texts are sorted by distance so no need to look further.
+            if (distance > searchLimit)
+                break;
+        }
     }
-    return -1; // nope, no marker ahead of there
+    return retVal;
 }
 
 void
@@ -1910,3 +1946,4 @@ int ErgFileQueryAdapter::addNewLap(double loc) const
 {
     return getErgFile() ? getErgFile()->addNewLap(loc) : -1;
 }
+

--- a/src/Train/ErgFile.cpp
+++ b/src/Train/ErgFile.cpp
@@ -1007,7 +1007,6 @@ void ErgFile::parseTTS()
         // Segment Start
         add.x = segment.startKM * 1000.;
         add.LapNum = (i * 2) + 1;
-        add.LapRangeNum = i + 1;
         add.selected = false;
 
         add.name = QObject::tr("Starting") + ": " + QString::fromStdWString(segment.name + rangeString);
@@ -1017,7 +1016,6 @@ void ErgFile::parseTTS()
         // Segment End
         add.x = segment.endKM * 1000.;
         add.LapNum = (i * 2) + 2;
-        add.LapRangeNum = i + 1;
         add.selected = false;
         add.name = QObject::tr("Ending") + ": " + QString::fromStdWString(segment.name + rangeString);
         
@@ -1046,7 +1044,7 @@ void ErgFile::parseTTS()
     int xx = 0;
     qDebug() << "LAPS:";
     for (const auto &a : Laps) {
-        qDebug() << xx << ": " << a.LapNum << " start:" << a.x / 1000. << "km, name: " << a.name << " RangeId:" << a.LapRangeNum;
+        qDebug() << xx << ": " << a.LapNum << " start:" << a.x / 1000. << "km, name: " << a.name;
         xx++;
     }
 
@@ -1593,7 +1591,7 @@ ErgFile::addNewLap(double loc) const
         sortLaps();
 
         auto itr = std::find_if(Laps.begin(), Laps.end(), [&add](const ErgFileLap& otherLap) {
-            return add.x == otherLap.x && add.LapRangeNum == otherLap.LapRangeNum && add.name == otherLap.name;
+            return add.x == otherLap.x && add.name == otherLap.name;
         });
         if (itr != Laps.end()) 
             return (*itr).LapNum;

--- a/src/Train/ErgFile.h
+++ b/src/Train/ErgFile.h
@@ -87,14 +87,12 @@ class ErgFileText
 class ErgFileLap
 {
     public:
-        ErgFileLap() : name(""), x(0), LapNum(0), LapRangeNum(0), selected(false) {}
-        ErgFileLap(double x, int LapNum, const QString& name) : name(name), x(x), LapNum(LapNum), LapRangeNum(0), selected(false) {}
-        ErgFileLap(double x, int LapNum, int LapRangeNum, const QString& name) : name(name), x(x), LapNum(LapNum), LapRangeNum(LapRangeNum), selected(false) {}
+        ErgFileLap() : name(""), x(0), LapNum(0), selected(false) {}
+        ErgFileLap(double x, int LapNum, const QString& name) : name(name), x(x), LapNum(LapNum), selected(false) {}
 
         QString name;
         double x;      // when does this LAP marker occur? (time in msecs or distance in meters
         int LapNum;    // from 1 - n
-        int LapRangeNum; // Identify laps that are part of the same range or series.
         bool selected; // used by the editor
 };
 

--- a/src/Train/ErgFile.h
+++ b/src/Train/ErgFile.h
@@ -87,12 +87,14 @@ class ErgFileText
 class ErgFileLap
 {
     public:
-        ErgFileLap() : name(""), x(0), LapNum(0), selected(false) {}
-        ErgFileLap(double x, int LapNum, const QString& name) : name(name), x(x), LapNum(LapNum), selected(false) {}
+        ErgFileLap() : name(""), x(0), LapNum(0), LapRangeNum(0), selected(false) {}
+        ErgFileLap(double x, int LapNum, const QString& name) : name(name), x(x), LapNum(LapNum), LapRangeNum(0), selected(false) {}
+        ErgFileLap(double x, int LapNum, int LapRangeNum, const QString& name) : name(name), x(x), LapNum(LapNum), LapRangeNum(LapRangeNum), selected(false) {}
 
         QString name;
         double x;      // when does this LAP marker occur? (time in msecs or distance in meters
         int LapNum;    // from 1 - n
+        int LapRangeNum; // Identify laps that are part of the same range or series.
         bool selected; // used by the editor
 };
 
@@ -133,6 +135,7 @@ class ErgFile
 
 private:
         void sortLaps() const;
+        void sortTexts() const;
 public:
 
         double nextLap(double) const;    // return the start value (erg - time(ms) or slope - distance(m)) for the next lap
@@ -141,7 +144,7 @@ public:
 
         int    addNewLap(double loc) const; // creates new lap at location, returns index of new lap.
 
-        int  nextText(double) const;   // return the index for the next text cue
+        bool textsInRange(double searchStart, double searchRange, int& rangeStart, int& rangeEnd) const;
 
         // turn the ergfile into a series of sections rather
         // than a list of points
@@ -166,7 +169,7 @@ public:
 
         QList<ErgFilePoint>         Points; // points in workout
         mutable QList<ErgFileLap>   Laps;   // interval markers in the file
-        QList<ErgFileText>          Texts;  // texts to display
+        mutable QList<ErgFileText>  Texts;  // texts to display
 
         GeoPointInterpolator gpi;      // Location interpolator
 
@@ -232,7 +235,10 @@ public:
     double nextLap   (double x) const { return !ergFile ? -1 : ergFile->nextLap(x);    }
     double prevLap   (double x) const { return !ergFile ? -1 : ergFile->prevLap(x);    }
     double currentLap(double x) const { return !ergFile ? -1 : ergFile->currentLap(x); }
-    int    nextText  (double x) const { return !ergFile ? -1 : ergFile->nextText(x);   }
+
+    bool   textsInRange(double searchStart, double searchRange, int& rangeStart, int& rangeEnd) const {
+        return !ergFile ? false : ergFile->textsInRange(searchStart, searchRange, rangeStart, rangeEnd);
+    }
 
     double currentTime() const { return !ergFile ? 0. : ergFile->Points.at(qs.rightPoint).x; }
 

--- a/src/Train/TrainSidebar.h
+++ b/src/Train/TrainSidebar.h
@@ -190,6 +190,7 @@ class TrainSidebar : public GcWindow
         void Lower();       // set load/gradient higher
         void newLap();      // start new Lap!
         void resetLapTimer(); //reset the lap timer
+        void resetTextAudioEmitTracking();
         void steerScroll(int scrollAmount);   // Scroll the train display
 
         void toggleCalibration();
@@ -267,6 +268,7 @@ class TrainSidebar : public GcWindow
         int displayWorkoutLap;     // which Lap in the workout are we at?
         bool lapAudioEnabled;
         bool lapAudioThisLap;
+        double textPositionEmitted;
         bool useSimulatedSpeed;
 
         void maintainLapDistanceState();


### PR DESCRIPTION
Several Minor Fixes for Texts, Laps and Audio Chimes.

- Some files have multiple 'texts' to be emitted at the same location. Currently we emit only the last.
- TTS Reader texts and lap names should use tr for common prefixes like start and end.
- Audio Chime and text emit limit should be reset on ffwd, rewind, ffwdlap, rewindlap and newlap.
- Add LapRangeNum to lap so lapmarkers can be grouped, for example into start/end ranges. This will be useful to connect lap boundaries so we can display lap ranges in chart.
- newLap method doesnt return on all paths. Fix so returns lapnum of new lap.

Also:
- Fix type punning error in ttsreader.
