### PR TITLE
Daum: Fix signed byte issues

### DIFF
--- a/src/Train/Daum.cpp
+++ b/src/Train/Daum.cpp
@@ -255,10 +255,10 @@ void Daum::requestRealtimeData() {
     }
 
     // local cache of telemetry data
-    int pwr = data[5];
-    int rpm = data[6];
+    int pwr = (unsigned char) data[5];
+    int rpm = (unsigned char) data[6];
     int speed = data[7];
-    int pulse = data[14];
+    int pulse = (unsigned char) data[14];
 
     // sanity check
     if (pwr >= 5 && pwr <= 160) {


### PR DESCRIPTION
Because of QByteArray, the member bytes are signed chars, so a raw byte of 0x80 is interpreted as -128 and not as 128 as expected by the code. So all values above 127 were wrong.

Tested with a Daum 8008 TRS pro