### PR TITLE
Fix 3702: VideoSync Errors

### DIFF
--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -36,7 +36,8 @@ VideoWindow::VideoWindow(Context *context)  :
     QHBoxLayout *layout = new QHBoxLayout();
     setChartLayout(layout);
 
-    videoSyncTimeAdjustFactor = 1.f;
+    videoSyncDistanceAdjustFactor = 1.;
+    videoSyncTimeAdjustFactor = 1.;
 
     curPosition = 1;
 
@@ -358,9 +359,6 @@ void VideoWindow::startPlayback()
 
 void VideoWindow::stopPlayback()
 {
-    foreach(MeterWidget * p_meterWidget, m_metersWidget) {
-        p_meterWidget->hide();
-    }
 
 #ifdef GC_VIDEO_VLC
     if (!m) return; // ignore if no media selected
@@ -375,6 +373,7 @@ void VideoWindow::stopPlayback()
 
     foreach(MeterWidget * p_meterWidget, m_metersWidget) {
         p_meterWidget->stopPlayback();
+        p_meterWidget->hide();
     }
 }
 

--- a/src/Train/VideoWindow.h
+++ b/src/Train/VideoWindow.h
@@ -170,6 +170,17 @@ class VideoWindow : public GcChartWindow
 
         void resizeEvent(QResizeEvent *);
 
+        // media data
+
+         // Support case where media fps and videosync fps disagree.
+        double videoSyncTimeAdjustFactor;
+
+        // Support case where workout distance and videosync distance disagree.
+        double videoSyncDistanceAdjustFactor;
+
+        // Adjust time in videosync file point on load.
+        VideoSyncFilePoint VideoSyncPointAdjust(const VideoSyncFilePoint& vsfp) const;
+
         // current data
         int curPosition;
         RideFilePoint rfp;


### PR DESCRIPTION
#3702 

Debugging tacx bluray videosync issue, lead to two different problems.

Case  1: is that it is common for tts files to have their own private framerate that is independent of their associated video file. That means the correct mapping from tts to time must first multiply by a factor so time is in terms of media playback file.

Case 2: is that frequently we will use a private gpx file as a workout for when a tts file has no location data. In that case there may be a difference in distance between videosync file and workout file. When this occurs we must translate the videosync distance field into workout distance field.

This fixes tacx bluray that had case 1. Turns out case 1 is very frequent generally, but was common to see it mostly undone because we didn't support case 2 correctly. With both of these issues fixed the video sync is now slightly better in case 1/2, and improved by up to 6% for case 1.

For non vlc videosync we rely on qtvideo which grants no access to media fps. In that case I'm faking it with duration. I haven't tested this scenario.