### PR TITLE
Add Measures configuration to General Settings

### DIFF
--- a/src/Core/Athlete.cpp
+++ b/src/Core/Athlete.cpp
@@ -485,7 +485,10 @@ Athlete::getWeight(QDate date, RideFile *ride)
     double weight;
 
     // daily weight first
-    weight = measures->getGroup(Measures::Body)->getFieldValue(date);
+    if (measures->getGroup(Measures::Body))
+        weight = measures->getGroup(Measures::Body)->getFieldValue(date);
+    else
+        weight = 0.0;
 
     // ride (if available)
     if (!weight && ride)

--- a/src/Core/Measures.cpp
+++ b/src/Core/Measures.cpp
@@ -249,49 +249,105 @@ MeasuresGroup::unserialize(QFile &file, QList<Measure> &data)
     return true;
 }
 
+MeasuresField
+MeasuresGroup::getField(int field)
+{
+    MeasuresField fieldSettings;
+
+    if (field >= 0 && field < symbols.count()) {
+
+        fieldSettings.symbol = symbols[field];
+        fieldSettings.name = names[field];
+        fieldSettings.metricUnits = metricUnits[field];
+        fieldSettings.imperialUnits = imperialUnits[field];
+        fieldSettings.unitsFactor = unitsFactors[field];
+        fieldSettings.headers = headers[field];
+    }
+
+    return fieldSettings;
+}
+
+void
+MeasuresGroup::addField(MeasuresField &fieldSettings)
+{
+    symbols.append(fieldSettings.symbol);
+    names.append(fieldSettings.name);
+    metricUnits.append(fieldSettings.metricUnits);
+    imperialUnits.append(fieldSettings.imperialUnits);
+    unitsFactors.append(fieldSettings.unitsFactor);
+    headers.append(fieldSettings.headers);
+}
+
+void
+MeasuresGroup::setField(int field, MeasuresField &fieldSettings)
+{
+    if (field >= 0 && field < symbols.count()) {
+        symbols[field] = fieldSettings.symbol;
+        names[field] = fieldSettings.name;
+        metricUnits[field] = fieldSettings.metricUnits;
+        imperialUnits[field] = fieldSettings.imperialUnits;
+        unitsFactors[field] = fieldSettings.unitsFactor;
+        headers[field] = fieldSettings.headers;
+    }
+}
+
+void
+MeasuresGroup::removeField(int field)
+{
+    if (field >= 0 && field < symbols.count()) {
+        symbols.removeAt(field);
+        names.removeAt(field);
+        metricUnits.removeAt(field);
+        imperialUnits.removeAt(field);
+        unitsFactors.removeAt(field);
+        headers.removeAt(field);
+    }
+}
+
 ///////////////////////////// Measures class ////////////////////////////////
 
 Measures::Measures(QDir dir, bool withData) : dir(dir), withData(withData)
 {
-    // pre-load mandatory measures in MeasuresGroupType order
-
-    groups.append(new MeasuresGroup("Body", tr("Body"),
-        QStringList()<<"WEIGHTKG"<<"FATKG"<<"MUSCLEKG"<<"BONESKG"<<"LEANKG"<<"FATPERCENT",
-        QStringList()<<tr("Weight")<<tr("Fat Mass")<<tr("Muscle Mass")<<tr("Bone Mass")<<tr("Lean Mass")<<tr("Fat Percent"),
-        QStringList()<<tr("kg")<<tr("kg")<<tr("kg")<<tr("kg")<<tr("kg")<<tr("%"),
-        QStringList()<<tr("lbs")<<tr("lbs")<<tr("lbs")<<tr("lbs")<<tr("lbs")<<tr("%"),
-        QList<double>()<<LB_PER_KG<<LB_PER_KG<<LB_PER_KG<<LB_PER_KG<<LB_PER_KG<<1.0,
-        QList<QStringList>()<<
-            (QStringList()<<"weightkg")<<
-            (QStringList()<<"fatkg")<<
-            (QStringList()<<"musclekg")<<
-            (QStringList()<<"boneskg")<<
-            (QStringList()<<"leankg")<<
-            (QStringList()<<"fatpercent"),
-        dir, withData));
-
-    groups.append(new MeasuresGroup("Hrv", tr("Hrv"),
-        QStringList()<<"RMSSD"<<"HR"<<"AVNN"<<"SDNN"<<"PNN50"<<"LF"<<"HF"<<"RECOVERY_POINTS",
-        QStringList()<<tr("RMSSD")<<tr("HR")<<tr("AVNN")<<tr("SDNN")<<tr("PNN50")<<tr("LF")<<tr("HF")<<tr("Recovery Points"),
-        QStringList()<<tr("msec")<<tr("bpm")<<tr("msec")<<tr("msec")<<tr("%")<<tr("msec^2")<<tr("msec^2")<<tr("Rec.Points"),
-        QStringList()<<tr("msec")<<tr("bpm")<<tr("msec")<<tr("msec")<<tr("%")<<tr("msec^2")<<tr("msec^2")<<tr("Rec.Points"),
-        QList<double>()<<1.0<<1.0<<1.0<<1.0<<1.0<<1.0<<1.0<<1.0,
-        QList<QStringList>()<<
-            (QStringList()<<"rMSSD"<<"rMSSD_lying"<<"Rmssd")<<
-            (QStringList()<<"HR"<<"HR_lying")<<
-            (QStringList()<<"AVNN"<<"AVNN_lying")<<
-            (QStringList()<<"SDNN"<<"SDNN_lying"<<"Sdnn")<<
-            (QStringList()<<"pNN50"<<"pNN50_lying"<<"Pnn50")<<
-            (QStringList()<<"LF"<<"LF_lying")<<
-            (QStringList()<<"HF"<<"HF_lying")<<
-            (QStringList()<<"HRV4T_Recovery_Points"<<"lnRmssd"),
-        dir, withData));
-
     // load user defined measures from measures.ini
     QString filename = QDir(gcroot).canonicalPath() + "/measures.ini";
+
     if (!QFile(filename).exists()) {
-        // other standard measures can be loaded from resources
-        filename = ":/ini/measures.ini";
+        // pre-load mandatory measures in MeasuresGroupType order
+
+        groups.append(new MeasuresGroup("Body", tr("Body"),
+            QStringList()<<"WEIGHTKG"<<"FATKG"<<"MUSCLEKG"<<"BONESKG"<<"LEANKG"<<"FATPERCENT",
+            QStringList()<<tr("Weight")<<tr("Fat Mass")<<tr("Muscle Mass")<<tr("Bone Mass")<<tr("Lean Mass")<<tr("Fat Percent"),
+            QStringList()<<tr("kg")<<tr("kg")<<tr("kg")<<tr("kg")<<tr("kg")<<tr("%"),
+            QStringList()<<tr("lbs")<<tr("lbs")<<tr("lbs")<<tr("lbs")<<tr("lbs")<<tr("%"),
+            QList<double>()<<LB_PER_KG<<LB_PER_KG<<LB_PER_KG<<LB_PER_KG<<LB_PER_KG<<1.0,
+            QList<QStringList>()<<
+                (QStringList()<<"weightkg")<<
+                (QStringList()<<"fatkg")<<
+                (QStringList()<<"musclekg")<<
+                (QStringList()<<"boneskg")<<
+                (QStringList()<<"leankg")<<
+                (QStringList()<<"fatpercent"),
+            dir, withData));
+
+        groups.append(new MeasuresGroup("Hrv", tr("Hrv"),
+            QStringList()<<"RMSSD"<<"HR"<<"AVNN"<<"SDNN"<<"PNN50"<<"LF"<<"HF"<<"RECOVERY_POINTS",
+            QStringList()<<tr("RMSSD")<<tr("HR")<<tr("AVNN")<<tr("SDNN")<<tr("PNN50")<<tr("LF")<<tr("HF")<<tr("Recovery Points"),
+            QStringList()<<tr("msec")<<tr("bpm")<<tr("msec")<<tr("msec")<<tr("%")<<tr("msec^2")<<tr("msec^2")<<tr("Rec.Points"),
+            QStringList()<<tr("msec")<<tr("bpm")<<tr("msec")<<tr("msec")<<tr("%")<<tr("msec^2")<<tr("msec^2")<<tr("Rec.Points"),
+            QList<double>()<<1.0<<1.0<<1.0<<1.0<<1.0<<1.0<<1.0<<1.0,
+            QList<QStringList>()<<
+                (QStringList()<<"rMSSD"<<"rMSSD_lying"<<"Rmssd")<<
+                (QStringList()<<"HR"<<"HR_lying")<<
+                (QStringList()<<"AVNN"<<"AVNN_lying")<<
+                (QStringList()<<"SDNN"<<"SDNN_lying"<<"Sdnn")<<
+                (QStringList()<<"pNN50"<<"pNN50_lying"<<"Pnn50")<<
+                (QStringList()<<"LF"<<"LF_lying")<<
+                (QStringList()<<"HF"<<"HF_lying")<<
+                (QStringList()<<"HRV4T_Recovery_Points"<<"lnRmssd"),
+            dir, withData));
+
+            // other standard measures can be loaded from resources
+            filename = ":/ini/measures.ini";
     }
 
     QSettings config(filename, QSettings::IniFormat);
@@ -309,19 +365,34 @@ Measures::Measures(QDir dir, bool withData) : dir(dir), withData(withData)
         if (fields.count() == 0 || fields.count() > MAX_MEASURES) continue;
 
         QStringList names = config.value("Names", "").toStringList();
-        if (names.count() == 0) names = fields;
+        if (names.count() == 1 && names[0] == "") names = fields;
         if (fields.count() != names.count()) continue;
 
         QStringList units = config.value("MetricUnits", "").toStringList();
-        if (units.count() == 0) foreach (QString field, fields) units << "";
+        if (units.count() == 1 && units[0] == "") {
+            units = QStringList();
+            for (int i=0; i<fields.count(); i++) units << "";
+        }
         if (fields.count() != units.count()) continue;
 
         QStringList imperialUnits = config.value("ImperialUnits", units).toStringList();
+        if (imperialUnits.count() == 1 && imperialUnits[0] == "") {
+            imperialUnits = QStringList();
+            for (int i=0; i<fields.count(); i++) imperialUnits << "";
+        }
         if (fields.count() != imperialUnits.count()) continue;
 
+        QStringList factors = config.value("UnitsFactors", "").toStringList();
+        if (factors.count() == 1 && factors[0] == "") {
+            factors = QStringList();
+            for (int i=0; i<fields.count(); i++) factors << "1";
+        }
+        if (fields.count() != factors.count()) continue;
         QList<double> unitsFactors;
-        foreach (QString field, fields) {
-            unitsFactors.append(1.0);
+        foreach (QString factor, factors) {
+            bool ok;
+            double unitFactor = factor.toDouble(&ok);
+            unitsFactors.append(ok ? unitFactor : 1.0);
         }
 
         QList<QStringList> headersList;
@@ -340,6 +411,38 @@ Measures::~Measures()
 {
     foreach (MeasuresGroup* measuresGroup, groups)
         delete measuresGroup;
+}
+
+void
+Measures::saveConfig()
+{
+    // save measures configuration to measures.ini
+    QString filename = QDir(gcroot).canonicalPath() + "/measures.ini";
+    QSettings config(filename, QSettings::IniFormat);
+    config.setIniCodec("UTF-8"); // to allow translated names
+    config.clear();
+
+    foreach (MeasuresGroup* group, getGroups()) {
+
+        config.beginGroup(group->getSymbol());
+
+        config.setValue("Name", group->getName());
+        config.setValue("Fields", group->getFieldSymbols());
+        config.setValue("Names", group->getFieldNames());
+        config.setValue("MetricUnits", group->getFieldMetricUnits());
+        config.setValue("ImperialUnits", group->getFieldImperialUnits());
+
+        QStringList unitsFactors;
+        foreach (double unitsFactor, group->getFieldUnitsFactors())
+            unitsFactors<<QString::number(unitsFactor);
+        config.setValue("UnitsFactors", unitsFactors);
+
+        for (int i=0; i < group->getFieldSymbols().count(); i++)
+            config.setValue(group->getField(i).symbol, group->getFieldHeaders(i));
+
+        config.endGroup();
+    }
+    config.sync();
 }
 
 QStringList
@@ -367,6 +470,21 @@ Measures::getGroup(int group)
         return groups[group];
     else
         return NULL;
+}
+
+void
+Measures::removeGroup(int group)
+{
+    if (group >= 0 && group < groups.count())
+        groups.removeAt(group);
+}
+
+void
+Measures::addGroup(MeasuresGroup* measuresGroup)
+{
+    if (!getGroupSymbols().contains(measuresGroup->getSymbol()) &&
+        !getGroupNames().contains(measuresGroup->getName()))
+        groups.append(measuresGroup);
 }
 
 QStringList

--- a/src/Core/RideItem.cpp
+++ b/src/Core/RideItem.cpp
@@ -691,7 +691,7 @@ RideItem::getWeight(int type)
 {
     // get any body measurements first
     MeasuresGroup* pBodyMeasures = context->athlete->measures->getGroup(Measures::Body);
-    double m = pBodyMeasures->getFieldValue(dateTime.date(), type);
+    double m = pBodyMeasures ? pBodyMeasures->getFieldValue(dateTime.date(), type) : 0.0;
 
     // return what was asked for!
     if (type == Measure::WeightKg) {

--- a/src/Gui/ConfigDialog.cpp
+++ b/src/Gui/ConfigDialog.cpp
@@ -64,6 +64,7 @@ ConfigDialog::ConfigDialog(QDir _home, Context *context) :
     static QIcon dataIcon(QPixmap(":/images/toolbar/data.png"));
     static QIcon metricsIcon(QPixmap(":/images/toolbar/abacus.png"));
     static QIcon intervalIcon(QPixmap(":/images/stopwatch.png"));
+    static QIcon measuresIcon(QPixmap(":/images/toolbar/main/measures.png"));
     static QIcon devicesIcon(QPixmap(":/images/devices/kickr.png"));
 
     // Setup the signal mapping so the right config
@@ -96,10 +97,14 @@ ConfigDialog::ConfigDialog(QDir _home, Context *context) :
     connect(added, SIGNAL(triggered()), iconMapper, SLOT(map()));
     iconMapper->setMapping(added, 4);
 
+    added =head->addAction(measuresIcon, tr("Measures"));
+    connect(added, SIGNAL(triggered()), iconMapper, SLOT(map()));
+    iconMapper->setMapping(added, 5);
+
 
     added =head->addAction(devicesIcon, tr("Training"));
     connect(added, SIGNAL(triggered()), iconMapper, SLOT(map()));
-    iconMapper->setMapping(added, 5);
+    iconMapper->setMapping(added, 6);
 
     // more space
     spacer = new QWidget(this);
@@ -135,6 +140,11 @@ ConfigDialog::ConfigDialog(QDir _home, Context *context) :
     HelpWhatsThis *intervalHelp = new HelpWhatsThis(interval);
     interval->setWhatsThis(intervalHelp->getWhatsThisText(HelpWhatsThis::Preferences_Intervals));
     pagesWidget->addWidget(interval);
+
+    measures = new MeasuresConfig(_home, context);
+    HelpWhatsThis *measuresHelp = new HelpWhatsThis(measures);
+    measures->setWhatsThis(intervalHelp->getWhatsThisText(HelpWhatsThis::Preferences_Measures));
+    pagesWidget->addWidget(measures);
 
     train = new TrainConfig(_home, context);
     HelpWhatsThis *trainHelp = new HelpWhatsThis(train);
@@ -209,6 +219,7 @@ void ConfigDialog::saveClicked()
     changed |= data->saveClicked();
     changed |= train->saveClicked();
     changed |= interval->saveClicked();
+    changed |= measures->saveClicked();
 
     hide();
 
@@ -313,7 +324,7 @@ qint32 DataConfig::saveClicked()
     return dataPage->saveClicked();
 }
 
-// GENERAL CONFIG
+// METRIC CONFIG
 MetricConfig::MetricConfig(QDir home, Context *context) :
     home(home), context(context)
 {
@@ -348,6 +359,7 @@ qint32 MetricConfig::saveClicked()
     return state;
 }
 
+// INTERVALS CONFIG
 IntervalConfig::IntervalConfig(QDir home, Context *context) :
     home(home), context(context)
 {
@@ -372,7 +384,31 @@ qint32 IntervalConfig::saveClicked()
     return state;
 }
 
-// GENERAL CONFIG
+// MEASURES CONFIG
+MeasuresConfig::MeasuresConfig(QDir home, Context *context) :
+    home(home), context(context)
+{
+    // the widgets
+    measuresPage = new MeasuresConfigPage(this, context);
+
+    setContentsMargins(0,0,0,0);
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    mainLayout->setSpacing(0);
+    mainLayout->setContentsMargins(0,0,0,0);
+
+    mainLayout->addWidget(measuresPage);
+}
+
+qint32 MeasuresConfig::saveClicked()
+{
+    qint32 state = 0;
+
+    state |= measuresPage->saveClicked();
+
+    return state;
+}
+
+// TRAIN CONFIG
 TrainConfig::TrainConfig(QDir home, Context *context) :
     home(home), context(context)
 {

--- a/src/Gui/ConfigDialog.h
+++ b/src/Gui/ConfigDialog.h
@@ -149,6 +149,24 @@ class IntervalConfig : public QWidget
         IntervalsPage *intervalsPage;
 };
 
+// MEASURES PAGE
+class MeasuresConfig : public QWidget
+{
+    Q_OBJECT
+
+    public:
+        MeasuresConfig(QDir home, Context *context);
+
+    public slots:
+        qint32 saveClicked();
+
+    private:
+        QDir home;
+        Context *context;
+
+        MeasuresConfigPage *measuresPage;
+};
+
 class ConfigDialog : public QMainWindow
 {
     Q_OBJECT
@@ -178,6 +196,7 @@ class ConfigDialog : public QMainWindow
         DataConfig *data;
         MetricConfig *metric;
         IntervalConfig *interval;
+        MeasuresConfig *measures;
         TrainConfig *train;
 };
 #endif

--- a/src/Gui/HelpWhatsThis.h
+++ b/src/Gui/HelpWhatsThis.h
@@ -161,6 +161,7 @@ Q_OBJECT
                  Preferences_Passwords,
                  Preferences_Appearance,
                  Preferences_Intervals,
+                 Preferences_Measures,
                  Preferences_DataFields,
                  Preferences_DataFields_Fields,
                  Preferences_DataFields_Notes_Keywords,

--- a/src/Gui/Pages.h
+++ b/src/Gui/Pages.h
@@ -709,4 +709,86 @@ class IntervalsPage : public QWidget
     private slots:
 };
 
+class MeasuresConfigPage : public QWidget
+{
+    Q_OBJECT
+    G_OBJECT
+
+    public:
+        MeasuresConfigPage(QWidget *parent, Context *context);
+        ~MeasuresConfigPage();
+        qint32 saveClicked();
+
+    public slots:
+
+    private:
+        Context *context;
+        Measures *measures;
+
+        QTreeWidget *measuresTable;
+        QTreeWidget *measuresFieldsTable;
+
+        QPushButton *resetMeasures, *editMeasures, *addMeasures, *removeMeasures;
+        QPushButton *editMeasuresField, *addMeasuresField, *removeMeasuresField;
+
+        void refreshMeasuresTable();
+        void refreshMeasuresFieldsTable();
+
+    private slots:
+        void measuresSelected();
+        void measuresDoubleClicked(QTreeWidgetItem *item, int column);
+        void measuresFieldDoubleClicked(QTreeWidgetItem *item, int column);
+
+        void resetMeasuresClicked();
+        void editMeasuresClicked();
+        void addMeasuresClicked();
+        void removeMeasuresClicked();
+
+        void editMeasuresFieldClicked();
+        void addMeasuresFieldClicked();
+        void removeMeasuresFieldClicked();
+};
+
+class MeasuresSettingsDialog : public QDialog
+{
+    Q_OBJECT
+
+    public:
+        MeasuresSettingsDialog(QWidget *parent, QString &symbol, QString &name);
+
+    private slots:
+        void okClicked();
+
+    private:
+        QString &symbol, &name;
+
+        QLineEdit *symbolEdit;
+        QLineEdit *nameEdit;
+
+        QPushButton *cancelButton, *okButton;
+
+};
+
+class MeasuresFieldSettingsDialog : public QDialog
+{
+    Q_OBJECT
+
+    public:
+        MeasuresFieldSettingsDialog(QWidget *parent, MeasuresField &field);
+
+    private slots:
+        void okClicked();
+
+    private:
+        MeasuresField &field;
+        QLineEdit *symbolEdit;
+        QLineEdit *nameEdit;
+        QLineEdit *metricUnitsEdit;
+        QLineEdit *imperialUnitsEdit;
+        QDoubleSpinBox *unitsFactorEdit;
+        QLineEdit *headersEdit;
+
+        QPushButton *cancelButton, *okButton;
+};
+
 #endif

--- a/src/Resources/application.qrc
+++ b/src/Resources/application.qrc
@@ -88,6 +88,7 @@
         <file>images/activity.png</file>
         <file>images/metadata.png</file>
         <file>images/stopwatch.png</file>
+        <file>images/toolbar/main/measures.png</file>
         <file>images/settings.png</file>
         <file>images/addchart.png</file>
         <file>images/library.png</file>

--- a/src/Resources/ini/measures.ini
+++ b/src/Resources/ini/measures.ini
@@ -1,5 +1,5 @@
 ; Sample measures.ini configuration file,
-; it's looked for in Athlete's config folder
+; it's looked for in GC root folder
 
 ; Nutrition data group
 [Nutrition]


### PR DESCRIPTION
It allows to add/edit/remove Measures Groups and Measures Fields.
Reset is a rescue option to go back to default configuration.
Fixes #2872

![MeasuresConfig](https://user-images.githubusercontent.com/1444784/101949380-48791d80-3bd2-11eb-936c-c736e879cade.png)
