### PR TITLE
Fix 3710:Geoloc double to string precision

### DIFF
--- a/src/FileIO/FixElevation.cpp
+++ b/src/FileIO/FixElevation.cpp
@@ -147,9 +147,10 @@ FixElevation::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString
             if (latLngCollection.length() != 0) {
                 latLngCollection.append(',');
             }
-            latLngCollection.append(QString::number(point->lat));
+            // these values need extended precision or place marker jumps around.
+            latLngCollection.append(QString::number(point->lat,'g',10));
             latLngCollection.append(',');
-            latLngCollection.append(QString::number(point->lon));
+            latLngCollection.append(QString::number(point->lon,'g',10));
             if (pointCount == 400) {
                 elevationPoints = elevationPoints + FetchElevationDataFromMapQuest(latLngCollection);
                 latLngCollection = "";

--- a/src/Train/LiveMapWebPageWindow.cpp
+++ b/src/Train/LiveMapWebPageWindow.cpp
@@ -139,8 +139,9 @@ void LiveMapWebPageWindow::ergFileSelected(ErgFile* f)
     if (f && f->filename != "" )
     {
         setIsBlank(false);
-        QString startingLat = QString::number(((f->Points)[0]).lat);
-        QString startingLon = QString::number(((f->Points)[0]).lon);
+        // these values need extended precision or place marker jumps around.
+        QString startingLat = QString::number(((f->Points)[0]).lat, 'g', 10);
+        QString startingLon = QString::number(((f->Points)[0]).lon, 'g', 10);
         if (startingLat == "0" && startingLon == "0")
         {
             markerIsVisible = false;

--- a/src/Train/MeterWidget.cpp
+++ b/src/Train/MeterWidget.cpp
@@ -622,8 +622,9 @@ void LiveMapWidget::initLiveMap(Context* context)
 void LiveMapWidget::plotNewLatLng(double dLat, double dLon)
 {
     QString code = "";
-    QString sLat = QString::number(dLat);
-    QString sLon = QString::number(dLon);
+    // these values need extended precision or place marker jumps around.
+    QString sLat = QString::number(dLat, 'g', 10);
+    QString sLon = QString::number(dLon, 'g', 10);
     QString sMapZoom = QString::number(m_Zoom);
 
     if (!routeInitialized)


### PR DESCRIPTION
Fixed 3 places in sources where lat/lon precision was using qstring default of 6 digits precision. That is only ~10m precision which made live map pointer move follow x/y axis instead of the route. Increased to 10 digits which is ~1cm. Thread here explains geo accuracy obtained by digits on right side of decimal point:

https://stackoverflow.com/questions/7167604/how-accurately-should-i-store-latitude-and-longitude#:~:text=0.01524%20%2F%20110.574%20%3D%201%2F7255%20of%20a%20degree,DECIMAL%20%287%2C4%29%20should%20be%20plenty%20for%20your%20needs.
