### PR TITLE
TACX Fortius - new formulae and calibration routine

### DIFF
--- a/src/Train/CalibrationData.h
+++ b/src/Train/CalibrationData.h
@@ -26,6 +26,7 @@
 #define CALIBRATION_TYPE_ZERO_OFFSET                 0x02
 #define CALIBRATION_TYPE_ZERO_OFFSET_SRM             0x04
 #define CALIBRATION_TYPE_SPINDOWN                    0x08
+#define CALIBRATION_TYPE_FORTIUS                     0x10
 
 #define CALIBRATION_STATE_IDLE                       0x00
 #define CALIBRATION_STATE_PENDING                    0x01

--- a/src/Train/Fortius.cpp
+++ b/src/Train/Fortius.cpp
@@ -581,18 +581,16 @@ int Fortius::sendRunCommand(int16_t pedalSensor)
 {
     int retCode = 0;
 
-    {
-        Lock lock(pvars);
-
-        int mode = this->mode;
-        double gradient = this->gradient;
-        double load = this->load;
-        double weight = this->weight;
-        double brakeCalibrationFactor = this->brakeCalibrationFactor;
-        double windSpeed_ms = this->windSpeed_ms;
-        double rollingResistance = this->rollingResistance;
-        double windResistance = this->windResistance;
-    }
+    pvars.lock();
+    int mode = this->mode;
+    double gradient = this->gradient;
+    double load = this->load;
+    double weight = this->weight;
+    double brakeCalibrationFactor = this->brakeCalibrationFactor;
+    double windSpeed_ms = this->windSpeed_ms;
+    double rollingResistance = this->rollingResistance;
+    double windResistance = this->windResistance;
+    pvars.unlock();
 
     // The fortius power range only applies at high rpm. The device cannot
     // hold against the torque of high power at low rpm.

--- a/src/Train/Fortius.h
+++ b/src/Train/Fortius.h
@@ -150,11 +150,10 @@ private:
 
     // INBOUND TELEMETRY - all volatile since it is updated by the run() thread
     double devicePower_W;          // current output power in Watts
-    double deviceResistance_raw;   // current output force in ~1/137 N
+    double deviceForce_N;          // current output force N
     double deviceHeartRate_bpm;    // current heartrate in BPM
     double deviceCadence_rpm;      // current cadence in RPM
-    double deviceSpeed_kph;        // current speed in KPH (derived from wheel speed)
-    double deviceWheelSpeed_raw;   // current wheel speed from device
+    double deviceSpeed_ms;         // current speed in m/s
     double deviceDistance_m;       // odometer in meters
     int    deviceButtons_bitfield; // Button status
     int    deviceStatus;           // Device status running, paused, disconnected

--- a/src/Train/Fortius.h
+++ b/src/Train/Fortius.h
@@ -58,7 +58,7 @@
 #define FT_SSMODE      0x02
 #define FT_CALIBRATE   0x04
 
-/* Buttons */
+/* Buttons_bitfield */
 #define FT_PLUS        0x04
 #define FT_MINUS       0x02
 #define FT_CANCEL      0x08
@@ -102,15 +102,15 @@ public:
 
     // SET
     void setCalibrationValue(uint16_t value);   // set the calibration value for ERGOMODE and SSMODE
-    void setLoad(double load);                  // set the load to generate in ERGOMODE
-    void setGradient(double gradient);          // set the load to generate in SSMODE
+    void setLoad(double load_W);                // set the load to generate in ERGOMODE
+    void setGradient(double gradient_percent);  // set the load to generate in SSMODE
     void setBrakeCalibrationFactor(double calibrationFactor);     // Impacts relationship between brake setpoint and load
     void setPowerScaleFactor(double calibrationFactor);         // Scales output power, so user can adjust to match hub or crank power meter
     void setMode(int mode);
-    void setWeight(double weight);                 // set the total weight of rider + bike in kg's
-    void setWindSpeed(double);
-    void setRollingResistance(double);
-    void setWindResistance(double);
+    void setWeight(double weight_kg);           // set the total weight of rider + bike in kg's, for power calculation and virtual flywheel in SSMODE
+    void setWindSpeed(double);                  // set the wind speed for power calculation in SSMODE
+    void setRollingResistance(double);          // set the rolling resistance coefficient for power calculation in SSMODE
+    void setWindResistance(double);             // set the wind resistance coefficient for power calculation in SSMODE
     
     int getMode() const;
     double getGradient() const;
@@ -149,24 +149,24 @@ private:
     mutable QMutex pvars;
 
     // INBOUND TELEMETRY - all volatile since it is updated by the run() thread
-    double devicePower;            // current output power in Watts
-    double deviceResistance;       // current output force in ~1/137 N
-    double deviceHeartRate;        // current heartrate in BPM
-    double deviceCadence;          // current cadence in RPM
-    double deviceSpeed;            // current speed in KPH (derived from wheel speed)
-    double deviceWheelSpeed;       // current wheel speed from device
-    double deviceDistance;         // odometer in meters
-    int    deviceButtons;          // Button status
+    double devicePower_W;          // current output power in Watts
+    double deviceResistance_raw;   // current output force in ~1/137 N
+    double deviceHeartRate_bpm;    // current heartrate in BPM
+    double deviceCadence_rpm;      // current cadence in RPM
+    double deviceSpeed_kph;        // current speed in KPH (derived from wheel speed)
+    double deviceWheelSpeed_raw;   // current wheel speed from device
+    double deviceDistance_m;       // odometer in meters
+    int    deviceButtons_bitfield; // Button status
     int    deviceStatus;           // Device status running, paused, disconnected
-    int    deviceSteering;         // Steering angle
+    int    deviceSteering_deg;     // Steering angle
     
     // OUTBOUND COMMANDS - all volatile since it is updated by the GUI thread
     int    mode;
-    double load;
-    double gradient;
+    double load_W;
+    double gradient_percent;
     double brakeCalibrationFactor;
     double powerScaleFactor;
-    double weight;
+    double weight_kg;
     double windSpeed_ms;
     double rollingResistance;
     double windResistance;

--- a/src/Train/FortiusController.cpp
+++ b/src/Train/FortiusController.cpp
@@ -79,7 +79,7 @@ FortiusController::getRealtimeData(RealtimeData &rtData)
     // Added Distance and Steering here but yet to RealtimeData
 
     int Buttons, Status, Steering;
-    double Power, HeartRate, Cadence, Speed, Distance;
+    double Power, Resistance, HeartRate, Cadence, Speed, Distance;
 
     if(!myFortius->isRunning())
     {
@@ -88,7 +88,7 @@ FortiusController::getRealtimeData(RealtimeData &rtData)
         return;
     }
     // get latest telemetry
-    myFortius->getTelemetry(Power, HeartRate, Cadence, Speed, Distance, Buttons, Steering, Status);
+    myFortius->getTelemetry(Power, Resistance, HeartRate, Cadence, Speed, Distance, Buttons, Steering, Status);
 
     //
     // PASS BACK TELEMETRY
@@ -160,3 +160,162 @@ FortiusController::setWeight(double weight)
     myFortius->setWeight(weight);
 }
 
+void
+FortiusController::setWindSpeed(double ws)
+{
+    myFortius->setWindSpeed(ws);
+}
+
+void
+FortiusController::setRollingResistance(double rr)
+{
+    myFortius->setRollingResistance(rr);
+}
+
+void
+FortiusController::setWindResistance(double wr)
+{
+    myFortius->setWindResistance(wr);
+}
+
+
+// Calibration
+
+uint8_t
+FortiusController::getCalibrationType()
+{
+    return CALIBRATION_TYPE_FORTIUS;
+}
+
+double
+FortiusController::getCalibrationTargetSpeed()
+{
+    return 20;
+}
+
+uint8_t
+FortiusController::getCalibrationState()
+{
+    return calibrationState;
+}
+
+void
+FortiusController::setCalibrationState(uint8_t state)
+{
+    calibrationState = state;
+    switch (state)
+    {
+    case CALIBRATION_STATE_IDLE:
+        myFortius->setMode(FT_IDLE);
+        break;
+
+    case CALIBRATION_STATE_PENDING:
+        myFortius->setMode(FT_CALIBRATE);
+        calibrationState = CALIBRATION_STATE_STARTING;
+        break;
+
+    default:
+        break;
+    }
+}
+
+uint16_t
+FortiusController::getCalibrationZeroOffset()
+{
+    static int final_calibration_value = 0;
+
+    switch (calibrationState)
+    {
+        // Waiting for use to kick pedal...
+        case CALIBRATION_STATE_STARTING:
+        {
+            final_calibration_value = 0;
+            if (readCurrentSpeedValue() > 19.9)
+            {
+                calibrationState = CALIBRATION_STATE_STARTED;
+            }
+            return 0;
+        }
+
+        // Calibration running
+        case CALIBRATION_STATE_STARTED:
+        {
+            // keep a note of the last N calibration values
+            // keep running calibration until the last N values differ by less than some threshold M
+            static const int num_samples = 20; // N
+            static const int difference_threshold = 10; // M
+            static std::list<int> calibration_values;
+           
+            // Get current value and push onto the list of recent values 
+            double calibration_value = readCurrentCalibrationValue();
+            calibration_values.push_back(calibration_value);
+
+            // Only do anything if we have a sufficient number of samples
+            if (calibration_values.size() > num_samples)
+            {
+                // maintain a constant number of samples
+                calibration_values.pop_front();
+
+                // unexpected resistance (pedalling) will cause calibration to terminate
+                if (calibration_value > 0)
+                {
+                    calibrationState = CALIBRATION_STATE_FAILURE;
+                    return 0;
+                }
+
+                // calculate the difference between the minimum and maximum calibration values of those recently received
+                const int min_calibration_value = *std::min_element(calibration_values.begin(), calibration_values.end());
+                const int max_calibration_value = *std::max_element(calibration_values.begin(), calibration_values.end());
+                if (abs(min_calibration_value - max_calibration_value) < difference_threshold) // termination (settling) condition
+                {
+                    // Difference between min and max is within threshold, stop here.
+                    calibrationState = CALIBRATION_STATE_SUCCESS;
+
+                    // accept the average as the final valibration value
+                    final_calibration_value = std::accumulate(calibration_values.begin(), calibration_values.end(), 0.0) / calibration_values.size();
+                    calibration_values.clear();
+
+                    // Tell the trainer object what the calibration value is
+                    myFortius->setCalibrationValue(-final_calibration_value);
+                    myFortius->setMode(FT_IDLE);
+
+                    return final_calibration_value;
+                }
+            }
+            return calibration_value; 
+        }
+
+        case CALIBRATION_STATE_SUCCESS:
+            // return the last determined calibration value to be displayed to user in GUI
+            return final_calibration_value;
+
+        default:
+            return 0;
+    }
+}
+
+void
+FortiusController::resetCalibrationState()
+{
+    calibrationState = CALIBRATION_STATE_IDLE;
+    myFortius->setMode(FT_IDLE);
+}
+
+// FIXME dirty pair of functions - refactor
+double
+FortiusController::readCurrentCalibrationValue()
+{
+    double power, resistance, heartrate, cadence, speed, distance;
+    int buttons, steering, status;
+    myFortius->getTelemetry(power, resistance, heartrate, cadence, speed, distance, buttons, steering, status);
+    return resistance;
+}
+
+double
+FortiusController::readCurrentSpeedValue()
+{
+    double power, resistance, heartrate, cadence, speed, distance;
+    int buttons, steering, status;
+    myFortius->getTelemetry(power, resistance, heartrate, cadence, speed, distance, buttons, steering, status);
+    return speed;
+}

--- a/src/Train/FortiusController.h
+++ b/src/Train/FortiusController.h
@@ -51,6 +51,23 @@ public:
     void setGradient(double);
     void setMode(int);
     void setWeight(double);
+    void setWindSpeed(double);
+    void setRollingResistance(double);
+    void setWindResistance(double);
+
+    // calibration
+    uint8_t  getCalibrationType();
+    double   getCalibrationTargetSpeed();
+    uint8_t  getCalibrationState();
+    void     setCalibrationState(uint8_t state);
+    uint16_t getCalibrationZeroOffset();
+    void     resetCalibrationState();
+
+private:
+    uint8_t  calibrationState = CALIBRATION_STATE_IDLE;
+
+    double readCurrentCalibrationValue();
+    double readCurrentSpeedValue();
 };
 
 #endif // _GC_FortiusController_h

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -2422,6 +2422,45 @@ void TrainSidebar::updateCalibration()
             }
             break;
 
+        case CALIBRATION_TYPE_FORTIUS:
+
+            switch (calibrationState) {
+
+            case CALIBRATION_STATE_IDLE:
+            case CALIBRATION_STATE_PENDING:
+            case CALIBRATION_STATE_REQUESTED:
+                break;
+
+            case CALIBRATION_STATE_STARTING:
+                status = QString(tr("Give the pedal a kick to start calibration...\nThe motor will run until calibration is complete."));
+                break;
+
+            case CALIBRATION_STATE_STARTED:
+                status = QString(tr("Calibrating... DO NOT PEDAL, remain seated...\nWaiting for calibration value to stabilize: %1")).arg(QString::number((int16_t)calibrationZeroOffset));
+                break;
+
+            case CALIBRATION_STATE_POWER:
+            case CALIBRATION_STATE_COAST:
+                break;
+
+            case CALIBRATION_STATE_SUCCESS:
+                status = QString(tr("Calibration completed successfully!\nFinal calibration value %1")).arg(QString::number((int16_t)calibrationZeroOffset));
+
+                // No further ANT messages to set state, so must move ourselves on..
+                if ((stateCount % 25) == 0)
+                    finishCalibration = true;
+                break;
+
+            case CALIBRATION_STATE_FAILURE:
+                status = QString(tr("Calibration failed! Do not pedal which calibration is taking place."));
+
+                // No further ANT messages to set state, so must move ourselves on..
+                if ((stateCount % 25) == 0)
+                    finishCalibration = true;
+                break;
+            }
+            break;
+
         }
 
         lastState = calibrationState;


### PR DESCRIPTION
- Fortius device (ie USBheadunit+motorunit+motor)
  - does not implement slope or ergo mode itself
  - interface is "resistance" mode only
  - has a configurable "virtual flywheel"

- Fortius driver (Train/FortiusController.cpp and Train/Fortius.cpp)
  - this PR now implements both slope and ergo (corrected the previous, incorrect formulae)
  - device's virtual flywheel is employed by the driver's implementation of slope mode.
  - presents to GC a controllable trainer which operates in a closed loop.