### PR TITLE
FitRideFile.cpp function RideFile * run() can access deleted swimXdata pointer

### DIFF
--- a/src/FileIO/FitRideFile.cpp
+++ b/src/FileIO/FitRideFile.cpp
@@ -138,12 +138,12 @@ struct FitFileReaderState
     double last_altitude; // to avoid problems when records lacks altitude
     QVariant isGarminSmartRecording;
     QVariant GarminHWM;
-    XDataSeries *weatherXdata = nullptr;
-    XDataSeries *gearsXdata = nullptr;
-    XDataSeries *swimXdata = nullptr;
-    XDataSeries *deveXdata = nullptr;
-    XDataSeries *extraXdata = nullptr;
-    XDataSeries *hrvXdata = nullptr;
+    XDataSeries *weatherXdata;
+    XDataSeries *gearsXdata;
+    XDataSeries *swimXdata;
+    XDataSeries *deveXdata;
+    XDataSeries *extraXdata;
+    XDataSeries *hrvXdata;
     QMap<int, QString> deviceInfos, session_device_info_;
     QList<QString> dataInfos, session_data_info_;
 
@@ -3134,10 +3134,10 @@ struct FitFileReaderState
         swimXdata->valuename << "STROKES";
         swimXdata->unitname << "";
 
-	    hrvXdata = new XDataSeries();
-	    hrvXdata->name = "HRV";
-	    hrvXdata->valuename << "R-R";
-	    hrvXdata->unitname << "msecs";
+	hrvXdata = new XDataSeries();
+	hrvXdata->name = "HRV";
+	hrvXdata->valuename << "R-R";
+	hrvXdata->unitname << "msecs";
 
         gearsXdata = new XDataSeries();
         gearsXdata->name = "GEARS";
@@ -3243,7 +3243,7 @@ struct FitFileReaderState
 
             appendXData(rideFile);
 
-            if (swimXdata != nullptr) {   // ptj need to check swimXdata
+            if (!swimXdata->datapoints.empty()) {
                 // Build synthetic kph, km and cad sample data for Lap Swims
                 DataProcessor* fixLapDP = DataProcessorFactory::instance().getProcessors(true).value("Fix Lap Swim");
                 if (fixLapDP) fixLapDP->postProcess(rideFile, NULL, "NEW");
@@ -3280,37 +3280,31 @@ struct FitFileReaderState
             rf->addXData("WEATHER", weatherXdata);
         else
             delete weatherXdata;
-            weatherXdata = nullptr;
 
         if (!swimXdata->datapoints.empty())
             rf->addXData("SWIM", swimXdata);
         else
             delete swimXdata;
-            swimXdata = nullptr;
 
         if (!hrvXdata->datapoints.empty())
             rf->addXData("HRV", hrvXdata);
         else
             delete hrvXdata;
-            hrvXdata = nullptr;
 
         if (!gearsXdata->datapoints.empty())
             rf->addXData("GEARS", gearsXdata);
         else
             delete gearsXdata;
-            gearsXdata = nullptr;
 
         if (!deveXdata->datapoints.empty())
             rf->addXData("DEVELOPER", deveXdata);
         else
             delete deveXdata;
-            deveXdata = nullptr;
 
         if (!extraXdata->datapoints.empty())
             rf->addXData("EXTRA", extraXdata);
         else
             delete extraXdata;
-            extraXdata = nullptr;
     }
 
     RideFile *splitSessions(QList<RideFile*> *rides) {

--- a/src/FileIO/FitRideFile.cpp
+++ b/src/FileIO/FitRideFile.cpp
@@ -138,12 +138,12 @@ struct FitFileReaderState
     double last_altitude; // to avoid problems when records lacks altitude
     QVariant isGarminSmartRecording;
     QVariant GarminHWM;
-    XDataSeries *weatherXdata;
-    XDataSeries *gearsXdata;
-    XDataSeries *swimXdata;
-    XDataSeries *deveXdata;
-    XDataSeries *extraXdata;
-    XDataSeries *hrvXdata;
+    XDataSeries *weatherXdata = nullptr;
+    XDataSeries *gearsXdata = nullptr;
+    XDataSeries *swimXdata = nullptr;
+    XDataSeries *deveXdata = nullptr;
+    XDataSeries *extraXdata = nullptr;
+    XDataSeries *hrvXdata = nullptr;
     QMap<int, QString> deviceInfos, session_device_info_;
     QList<QString> dataInfos, session_data_info_;
 
@@ -3134,10 +3134,10 @@ struct FitFileReaderState
         swimXdata->valuename << "STROKES";
         swimXdata->unitname << "";
 
-	hrvXdata = new XDataSeries();
-	hrvXdata->name = "HRV";
-	hrvXdata->valuename << "R-R";
-	hrvXdata->unitname << "msecs";
+	    hrvXdata = new XDataSeries();
+	    hrvXdata->name = "HRV";
+	    hrvXdata->valuename << "R-R";
+	    hrvXdata->unitname << "msecs";
 
         gearsXdata = new XDataSeries();
         gearsXdata->name = "GEARS";
@@ -3243,7 +3243,7 @@ struct FitFileReaderState
 
             appendXData(rideFile);
 
-            if (!swimXdata->datapoints.empty()) {
+            if (swimXdata != nullptr) {   // ptj need to check swimXdata
                 // Build synthetic kph, km and cad sample data for Lap Swims
                 DataProcessor* fixLapDP = DataProcessorFactory::instance().getProcessors(true).value("Fix Lap Swim");
                 if (fixLapDP) fixLapDP->postProcess(rideFile, NULL, "NEW");
@@ -3280,31 +3280,37 @@ struct FitFileReaderState
             rf->addXData("WEATHER", weatherXdata);
         else
             delete weatherXdata;
+            weatherXdata = nullptr;
 
         if (!swimXdata->datapoints.empty())
             rf->addXData("SWIM", swimXdata);
         else
             delete swimXdata;
+            swimXdata = nullptr;
 
         if (!hrvXdata->datapoints.empty())
             rf->addXData("HRV", hrvXdata);
         else
             delete hrvXdata;
+            hrvXdata = nullptr;
 
         if (!gearsXdata->datapoints.empty())
             rf->addXData("GEARS", gearsXdata);
         else
             delete gearsXdata;
+            gearsXdata = nullptr;
 
         if (!deveXdata->datapoints.empty())
             rf->addXData("DEVELOPER", deveXdata);
         else
             delete deveXdata;
+            deveXdata = nullptr;
 
         if (!extraXdata->datapoints.empty())
             rf->addXData("EXTRA", extraXdata);
         else
             delete extraXdata;
+            extraXdata = nullptr;
     }
 
     RideFile *splitSessions(QList<RideFile*> *rides) {

--- a/src/FileIO/FitRideFile.cpp
+++ b/src/FileIO/FitRideFile.cpp
@@ -138,12 +138,12 @@ struct FitFileReaderState
     double last_altitude; // to avoid problems when records lacks altitude
     QVariant isGarminSmartRecording;
     QVariant GarminHWM;
-    XDataSeries *weatherXdata;
-    XDataSeries *gearsXdata;
-    XDataSeries *swimXdata;
-    XDataSeries *deveXdata;
-    XDataSeries *extraXdata;
-    XDataSeries *hrvXdata;
+    XDataSeries *weatherXdata = nullptr;
+    XDataSeries *gearsXdata = nullptr;
+    XDataSeries *swimXdata = nullptr;
+    XDataSeries *deveXdata = nullptr;
+    XDataSeries *extraXdata = nullptr;
+    XDataSeries *hrvXdata = nullptr;
     QMap<int, QString> deviceInfos, session_device_info_;
     QList<QString> dataInfos, session_data_info_;
 
@@ -2189,8 +2189,7 @@ struct FitFileReaderState
         time_t time = 0;
         if (time_offset > 0)
             time = last_time + time_offset;
-        double km = 0;
-
+        
         int length_type = 0;
         int swim_stroke = 0;
         int total_strokes = 0;
@@ -3243,7 +3242,7 @@ struct FitFileReaderState
 
             appendXData(rideFile);
 
-            if (!swimXdata->datapoints.empty()) {
+            if (swimXdata != nullptr) {
                 // Build synthetic kph, km and cad sample data for Lap Swims
                 DataProcessor* fixLapDP = DataProcessorFactory::instance().getProcessors(true).value("Fix Lap Swim");
                 if (fixLapDP) fixLapDP->postProcess(rideFile, NULL, "NEW");
@@ -3280,16 +3279,19 @@ struct FitFileReaderState
             rf->addXData("WEATHER", weatherXdata);
         else
             delete weatherXdata;
+            weatherXdata = nullptr;
 
         if (!swimXdata->datapoints.empty())
             rf->addXData("SWIM", swimXdata);
         else
             delete swimXdata;
+            swimXdata = nullptr;
 
         if (!hrvXdata->datapoints.empty())
             rf->addXData("HRV", hrvXdata);
         else
             delete hrvXdata;
+            hrvXdata = nullptr;
 
         if (!gearsXdata->datapoints.empty())
             rf->addXData("GEARS", gearsXdata);
@@ -3300,11 +3302,13 @@ struct FitFileReaderState
             rf->addXData("DEVELOPER", deveXdata);
         else
             delete deveXdata;
+            deveXdata = nullptr;
 
         if (!extraXdata->datapoints.empty())
             rf->addXData("EXTRA", extraXdata);
         else
             delete extraXdata;
+            extraXdata = nullptr;
     }
 
     RideFile *splitSessions(QList<RideFile*> *rides) {


### PR DESCRIPTION
resolves #3740

In FitRideFile.cpp
function RideFile * run()

It would appear that the swimXdata test after appendXdata call is unecessary, and to make matters worse swimXdata can be deleted in appendXdata leading to random crashes on imports.

appendXdata(rideFile)

if (!swimXdata->datapoints.empty()) {
// Build synthetic kph, km and cad sample data for Lap Swims
DataProcessor* fixLapDP = DataProcessorFactory::instance().getProcessors(true).value("Fix Lap Swim");
if (fixLapDP) fixLapDP->postProcess(rideFile, NULL, "NEW");
else qDebug()<<"Fix Lap Swim Data Processor not found.";
}

I have summitted a fix to test the swimXdata pointer, but now I'm wondering why the test is required in the first place.