### PR TITLE
Correctly recognize the Sigmasport iD.FREE product

### DIFF
--- a/src/FileIO/FitRideFile.cpp
+++ b/src/FileIO/FitRideFile.cpp
@@ -493,8 +493,11 @@ struct FitFileReaderState
                 default: return QString("Stages Cycling %1").arg(prod);
             }
         } else if (manu == 70) {
-            // does not set product at this point
-           return "Sigmasport ROX";
+            // Sigma
+            switch (prod) {
+                case 45: return "Sigmasport iD.FREE";
+                default: return "Sigmasport ROX";
+            }
         } else if (manu == 76) {
             // Moxy
             return "Moxy Monitor";


### PR DESCRIPTION
The Sigmasport ROX devices do not set a produduct ID, hence GC shows any Sigmasport fit import as "Sigmasport ROX". The Sigmasport wearable "iD.FREE", however, sets a product ID of 45. This adds specific logic to the fit ride file detection logic, while leaving the ROX default for backwards compatibility.

This is my very first contribution to this project. I haven't done any cpp the last few months, hence still setting up a decent IDE and test environment to check the build.

Product ID was extracted using https://github.com/adriangibbons/php-fit-file-analysis

![Bildschirmfoto von 2021-01-01 19-26-37](https://user-images.githubusercontent.com/1374172/103444272-510bc380-4c67-11eb-8d0e-7e0ebdb76ae0.png)

Ref https://github.com/GoldenCheetah/GoldenCheetah/issues/1286