### PR TITLE
Do not plot or show the live map without VLC

### DIFF
--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -443,6 +443,7 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
                 elevationMeterWidget->gradientValue = rtd.getSlope();
             }
         }
+#ifdef GC_VIDEO_VLC
         else if (p_meterWidget->Source() == QString("LiveMap"))
         {
             LiveMapWidget* liveMapWidget = dynamic_cast<LiveMapWidget*>(p_meterWidget);
@@ -468,6 +469,7 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
                 }
             }
         }
+#endif
         else if (p_meterWidget->Source() == QString("Cadence"))
         {
             p_meterWidget->Value = rtd.getCadence();


### PR DESCRIPTION
`m` is only defined with VLC, hence this code causes a compile error when GC_VIDEO_VLC isn't defined.

Fixes https://github.com/GoldenCheetah/GoldenCheetah/issues/3747

@amtriathlon please let me know if this is the way you intended it.