### PR TITLE
Fix VLC Hangs with Intentional State and Ordered Async Dispatch

### DIFF
--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -27,6 +27,14 @@
 #include "MeterWidget.h"
 #include "VideoLayoutParser.h"
 
+class Lock
+{
+    QRecursiveMutex& mutex;
+public:
+    Lock(QRecursiveMutex& m) : mutex(m) { mutex.lock(); }
+    ~Lock() { mutex.unlock(); }
+};
+
 VideoWindow::VideoWindow(Context *context)  :
     GcChartWindow(context), context(context), m_MediaChanged(false), layoutSelector(NULL)
 {
@@ -40,6 +48,8 @@ VideoWindow::VideoWindow(Context *context)  :
     videoSyncTimeAdjustFactor = 1.;
 
     curPosition = 1;
+
+    state = PlaybackState::None;
 
     init = true; // assume initialisation was ok ...
 
@@ -166,20 +176,49 @@ VideoWindow::~VideoWindow()
     // VLC
 
     /* No need to keep the media now */
-    if (m) libvlc_media_release (m);
+    if (m) {
+        libvlc_media_t* capture_m = this->m;
+        vlcDispatch.AsyncCall([capture_m]() {libvlc_media_release(capture_m); });
+    }
 
     /* nor the player */
-    libvlc_media_player_release (mp);
+    libvlc_media_player_t* capture_mp = this->mp;
+    vlcDispatch.AsyncCall([capture_mp]() {libvlc_media_player_release(capture_mp); });
 
     // unload vlc
-    libvlc_release (inst);
+    libvlc_instance_t* capture_inst = this->inst;
+    vlcDispatch.AsyncCall([capture_inst]() {libvlc_release(capture_inst); });
 #endif
+
+    vlcDispatch.Drain();
 
 #ifdef GC_VIDEO_QT5
     // QT MEDIA
     delete mp;
     delete wd;
 #endif
+}
+
+// Note: This method should only be called under state lock.
+bool VideoWindow::hasActiveVideo() const
+{
+    if (state == PlaybackState::None)
+        return false;
+
+#ifdef GC_VIDEO_VLC
+    libvlc_media_player_t* capture_mp = this->mp;
+    switch (vlcDispatch.SyncCall<libvlc_state_t>([capture_mp]() {return libvlc_media_player_get_state(capture_mp);})) {
+    case libvlc_Playing:
+    case libvlc_Paused:
+        return true;
+    }
+#endif
+#ifdef GC_VIDEO_QT5
+    if (LoadedMedia == mp->mediaStatus())
+        return true;
+#endif
+
+    return false;
 }
 
 void VideoWindow::layoutChanged()
@@ -226,7 +265,6 @@ void VideoWindow::readVideoLayout(int pos, bool useDefault)
         handler.layoutPositionSelected = pos;
         reader.setContentHandler(&handler);
         reader.parse(source);
-        if(context->isRunning) showMeters();
     }
     else
     {
@@ -250,6 +288,10 @@ void VideoWindow::showMeters()
 
 void VideoWindow::resizeEvent(QResizeEvent * )
 {
+    Lock lock(stateLock);
+    if (!hasActiveVideo())
+        return;
+
     foreach(MeterWidget* p_meterWidget , m_metersWidget)
         p_meterWidget->AdjustSizePos();
     prevPosition = mapToGlobal(pos());
@@ -265,24 +307,29 @@ VideoSyncFilePoint VideoWindow::VideoSyncPointAdjust(const VideoSyncFilePoint& v
 
 void VideoWindow::startPlayback()
 {
+    Lock lock(stateLock);
+
 #ifdef GC_VIDEO_VLC
     if (!m) return; // ignore if no media selected
 
     // stop playback & wipe player
-    libvlc_media_player_stop (mp);
+    libvlc_media_player_t* capture_mp = this->mp;
+    vlcDispatch.AsyncCall([capture_mp](){libvlc_media_player_stop(capture_mp); });
 
     /* set the media to playback */
-    libvlc_media_player_set_media (mp, m);
+    libvlc_media_t* capture_m = this->m;
+    vlcDispatch.AsyncCall([capture_mp, capture_m](){libvlc_media_player_set_media(capture_mp, capture_m); });
 
     /* Reset playback rate */
     /* If video speed will be controlled by a sync file, set almost stationary
        until first telemetry update. Otherwise (re)set to normal rate */
+    float rate = 1.0f;
     if (context->currentVideoSyncFile() && context->currentVideoSyncFile()->Points.count() > 1)
-        libvlc_media_player_set_rate(mp, 0.1f);
-    else libvlc_media_player_set_rate(mp, 1.0f);
+        rate = 0.1f;
+    vlcDispatch.AsyncCall([capture_mp, rate](){libvlc_media_player_set_rate(capture_mp, rate); });
 
     /* play the media_player */
-    libvlc_media_player_play (mp);
+    vlcDispatch.AsyncCall([capture_mp] () { libvlc_media_player_play(capture_mp); });
 
     m_MediaChanged = false;
 #endif
@@ -335,7 +382,8 @@ void VideoWindow::startPlayback()
 #ifdef GC_VIDEO_VLC
         double videoSyncFrameRate = currentVideoSyncFile->VideoFrameRate;
         if (videoSyncFrameRate > 0.) {
-            double mediaFrameRate = libvlc_media_player_get_fps(mp);
+            libvlc_media_player_t* capture_mp = this->mp;
+            double mediaFrameRate = vlcDispatch.SyncCall<double>([capture_mp] () { return libvlc_media_player_get_fps(capture_mp); });
             if (mediaFrameRate > 0.) {
                 videoSyncTimeAdjustFactor = videoSyncFrameRate / mediaFrameRate;
             }
@@ -353,37 +401,70 @@ void VideoWindow::startPlayback()
 #endif
     }
 
+    state = PlaybackState::Playing;
 
     showMeters();
 }
 
 void VideoWindow::stopPlayback()
 {
+    Lock lock(stateLock);
+
+    // Widget communication... its very important that all widgets
+    // are done and do not try to paint after 'the stop' has begun.
+    // QT paints on a different thread from widget paint method, so
+    // we must get acknowledgement from all widgets that someone has
+    // attempted to paint after stop was seen. If we don't see that
+    // we must assume qt is still painting a widget.
+
+    // Careful notification process:
+
+    // 1.) If we havent started playback then do nothing here.
+    if (state == PlaybackState::None)
+        return;
+
+    // 2.) Let everyone know we're now officially not running,
+    //     even before we actually call video stop.
+    state = PlaybackState::None;
+
+    // 3.) Tell all the widgets to stop, and tell them to hide.
+    //     The hide means they will no longer see paint.
+
+    // We do this stuff before calling stop, because stop is a
+    // synchronous operation that expects to be able to tear
+    // down decoder and its resources.
+    foreach(MeterWidget * p_meterWidget, m_metersWidget) {
+        p_meterWidget->stopPlayback();
+        p_meterWidget->hide();
+    }
 
 #ifdef GC_VIDEO_VLC
     if (!m) return; // ignore if no media selected
 
     // stop playback & wipe player
-    libvlc_media_player_stop (mp);
+    libvlc_media_player_t* capture_mp = this->mp;
+    vlcDispatch.AsyncCall([capture_mp]{ libvlc_media_player_stop(capture_mp); });
 #endif
 
 #ifdef GC_VIDEO_QT5
     mp->stop();
 #endif
-
-    foreach(MeterWidget * p_meterWidget, m_metersWidget) {
-        p_meterWidget->stopPlayback();
-        p_meterWidget->hide();
-    }
 }
 
 void VideoWindow::pausePlayback()
 {
+    Lock lock(stateLock);
+    if (!hasActiveVideo())
+        return;
+
+    state = PlaybackState::Paused;
+
 #ifdef GC_VIDEO_VLC
     if (!m) return; // ignore if no media selected
 
     // stop playback & wipe player
-    libvlc_media_player_set_pause(mp, true);
+    libvlc_media_player_t* capture_mp = this->mp;
+    vlcDispatch.AsyncCall([capture_mp]{libvlc_media_player_set_pause(capture_mp, true); });
 #endif
 
 #ifdef GC_VIDEO_QT5
@@ -393,23 +474,35 @@ void VideoWindow::pausePlayback()
 
 void VideoWindow::resumePlayback()
 {
+    Lock lock(stateLock);
+    if (!hasActiveVideo())
+        return;
+
 #ifdef GC_VIDEO_VLC
     if (!m) return; // ignore if no media selected
 
     // stop playback & wipe player
     if(m_MediaChanged)
         startPlayback();
-    else
-        libvlc_media_player_set_pause(mp, false);
+    else {
+        libvlc_media_player_t* capture_mp = this->mp;
+        vlcDispatch.AsyncCall([capture_mp]{libvlc_media_player_set_pause(capture_mp, false); });
+    }
 #endif
 
 #ifdef GC_VIDEO_QT5
     mp->play();
 #endif
+
+    state = PlaybackState::Playing;
 }
 
 void VideoWindow::telemetryUpdate(RealtimeData rtd)
 {
+    Lock lock(stateLock);
+    if (!hasActiveVideo())
+        return;
+
     bool metric = GlobalContext::context()->useMetricUnits;
 
     foreach(MeterWidget* p_meterWidget , m_metersWidget)
@@ -457,14 +550,9 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
                 // show/plot or hide depending on existance of valid location
                 // data, only when there is a video to play
                 geolocation geo(dLat, dLon, dAlt);
-                if (m && geo.IsReasonableGeoLocation())
+                if (geo.IsReasonableGeoLocation())
                 {
                     liveMapWidget->plotNewLatLng(dLat, dLon);
-                    liveMapWidget->show();
-                }
-                else
-                {
-                    liveMapWidget->hide();
                 }
             }
         }
@@ -581,7 +669,7 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
 #endif
 
 #ifdef GC_VIDEO_VLC
-    if (!m || !context->isRunning || context->isPaused)
+    if (PlaybackState::Playing != state)
         return;
 
     // find the curPosition
@@ -647,7 +735,9 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
         // set video rate ( theoretical : video rate = training speed / ghost speed)
         float rate;
         float video_time_shift_ms;
-        video_time_shift_ms = (rfp.secs*1000.0 - (double) libvlc_media_player_get_time(mp));
+
+        libvlc_media_player_t* capture_mp = this->mp;
+        video_time_shift_ms = (rfp.secs * 1000.0 - vlcDispatch.SyncCall<double>([capture_mp]{ return libvlc_media_player_get_time(capture_mp); }));
         if (rfp.kph == 0.0)
             rate = 1.0;
         else
@@ -656,19 +746,20 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
         //if video is far (empiric) from ghost:
         if (fabs(video_time_shift_ms) > 5000)
         {
-            libvlc_media_player_set_time(mp, (libvlc_time_t) (rfp.secs*1000.0));
+            double rfp_secs = rfp.secs;
+            vlcDispatch.AsyncCall([capture_mp, rfp_secs]{ libvlc_media_player_set_time(capture_mp, (libvlc_time_t)(rfp_secs * 1000.0)); });
         }
         else {
             // otherwise add "small" empiric corrective parameter to get video back to ghost position:
             rate *= 1.0 + (video_time_shift_ms / 10000.0);
         }
 
-        libvlc_media_player_set_pause(mp, (rate < 0.01));
+        vlcDispatch.AsyncCall([capture_mp, rate]{ libvlc_media_player_set_pause(capture_mp, (rate < 0.01)); });
 
         // change video rate but only if there is a significant change
         if ((rate != 0.0) && (fabs((rate - currentVideoRate) / rate) > 0.05))
         {
-            libvlc_media_player_set_rate(mp, rate );
+            vlcDispatch.AsyncCall([capture_mp, rate]{ libvlc_media_player_set_rate(capture_mp, rate); });
             currentVideoRate = rate;
         }
     }
@@ -683,6 +774,10 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
 
 void VideoWindow::seekPlayback(long ms)
 {
+    Lock lock(stateLock);
+    if (!hasActiveVideo())
+        return;
+
 #ifdef GC_VIDEO_NONE
     Q_UNUSED(ms)
 #endif
@@ -698,7 +793,8 @@ void VideoWindow::seekPlayback(long ms)
     else
     {
         // seek to ms position in current file
-        libvlc_media_player_set_time(mp, (libvlc_time_t) ms);
+        libvlc_media_player_t* capture_mp = this->mp;
+        vlcDispatch.AsyncCall([capture_mp, ms]{ libvlc_media_player_set_time(capture_mp, (libvlc_time_t)ms); });
     }
 #endif
 
@@ -721,7 +817,10 @@ void VideoWindow::mediaSelected(QString filename)
     stopPlayback();
 
     // release whatever is already loaded
-    if (m) libvlc_media_release(m);
+    if (m) {
+        libvlc_media_t* capture_m = this->m;
+        vlcDispatch.AsyncCall([capture_m]{ libvlc_media_release(capture_m); });
+    }
     m = NULL;
 
     if (filename.endsWith("/DVD") || (filename != "" && QFile(filename).exists())) {
@@ -734,12 +833,19 @@ void VideoWindow::mediaSelected(QString filename)
         // A Windows "c:\xyz\abc def.avi" filename should become file:///c:/xyz/abc%20def.avi
         QString fileURL = "file:///" + filename.replace("\\", "/");
 #endif
+
         //qDebug()<<"file url="<<fileURL;
         /* open media */
-        m = libvlc_media_new_location(inst, filename.endsWith("/DVD") ? "dvd://" : fileURL.toLocal8Bit());
+        std::string loc = filename.endsWith("/DVD") ? "dvd://" : fileURL.toLocal8Bit().constData();
+        libvlc_instance_t* capture_inst = this->inst;
+        m = vlcDispatch.SyncCall<libvlc_media_t*>([capture_inst, loc]{ return libvlc_media_new_location(capture_inst, loc.c_str()); });
 
         /* set the media to playback */
-        if (m) libvlc_media_player_set_media (mp, m);
+        if (m) {
+            libvlc_media_player_t* capture_mp = this->mp;
+            libvlc_media_t* capture_m = this->m;
+            vlcDispatch.AsyncCall([capture_mp, capture_m]{ libvlc_media_player_set_media(capture_mp, capture_m); });
+        }
 
         m_MediaChanged = true;
     }

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -188,9 +188,9 @@ VideoWindow::~VideoWindow()
     // unload vlc
     libvlc_instance_t* capture_inst = this->inst;
     vlcDispatch.AsyncCall([capture_inst]() {libvlc_release(capture_inst); });
-#endif
 
     vlcDispatch.Drain();
+#endif
 
 #ifdef GC_VIDEO_QT5
     // QT MEDIA
@@ -211,6 +211,8 @@ bool VideoWindow::hasActiveVideo() const
     case libvlc_Playing:
     case libvlc_Paused:
         return true;
+    default:
+        break; // needed for compiler warning
     }
 #endif
 #ifdef GC_VIDEO_QT5


### PR DESCRIPTION
Fix for #3756:

Two main parts to this change.
- a thread locked managed player state
- all calls to VLC are now made via an ordered Async dispatch.

Probably the ordered async dispatch is the more important of
the two as it moves calls to vlc stop() off the gui thread.

Tested by repetitively seeking and stopping on 50+ virtual rides on windows 10 with vlc 3.9.0 and 3.10.0.

Zero hangs in three days of trying.