### PR TITLE
Python processor import fix, file import exclusion and file overwrite option

### DIFF
--- a/src/Core/RideCache.cpp
+++ b/src/Core/RideCache.cpp
@@ -256,14 +256,14 @@ RideCache::itemChanged()
 }
 
 // add a new ride
-void
+RideItem*
 RideCache::addRide(QString name, bool dosignal, bool select, bool useTempActivities, bool planned)
 {
     RideItem *prior = context->ride;
 
     // ignore malformed names
     QDateTime dt;
-    if (!RideFile::parseRideFileName(name, &dt)) return;
+    if (!RideFile::parseRideFileName(name, &dt)) return NULL;
 
     // new ride item
     RideItem *last;
@@ -316,6 +316,8 @@ RideCache::addRide(QString name, bool dosignal, bool select, bool useTempActivit
 
     // model estimates (lazy refresh)
     estimator->refresh();
+
+    return last;
 }
 
 void

--- a/src/Core/RideCache.h
+++ b/src/Core/RideCache.h
@@ -92,7 +92,7 @@ class RideCache : public QObject
 	    QVector<RideItem*>&rides() { return rides_; } 
 
         // add/remove a ride to the list
-        void addRide(QString name, bool dosignal, bool select, bool useTempActivities, bool planned);
+        RideItem* addRide(QString name, bool dosignal, bool select, bool useTempActivities, bool planned);
         void removeCurrentRide();
 
         // export metrics in CSV format


### PR DESCRIPTION

This PR contains the following fixes to issues that are all closely related, so they are combined in this single update, plus a number of tidy ups of the ImportWizard processing. The change for the Python processing was made simpler by the restructuring for the improved import reporting:

The fix to allow python processors to work on import (issue: Python API - activityMetrics and setTag/delTag/hasTag don't work in automatic DP #4095)

The capability to exclude files from importation has been requested (Issue: Deletion of workouts for auto-import #3696)

The capability to overwrite files  #621 "Re-introduce overwrite files on import" has been reinstated.

Improved import file reporting status for #621, #3696 & #4095

**Python processors to work on import change**

The Python processors failed to work correctly as the Python data processor passes the context and ride file to the Python environment, and they must be matching. The original import wizard code was written before the introduction of the python processors and the ride file was processed before the corresponding ride item was created. So although the raw data processing aspect of the python processor would work, any modification or tests of the metadata tags (using hasTag/setTag/delTag, etc) or processing that relied upon them would fail. The built-in core data processors are immune to this issue as they only work on the raw ride file data which only requires the ride file so they work correctly. The change has been to move the invocation of the "import" data processing after both the ride file and ride item have been created, and to ensure the ride item in the context matches. 

**The File Import Exclusion change:**

The exclusion of imported files is also now possible, as the import window validating process now checks each file to see whether it is in the exclusion list (./imports/GC_Auto_Import_Exclusion_List.txt) and marks imported files as excluded if they are in the list. You can manually edit the exclusion list and add the full path and filename on the next empty line for any files you wish to exclude.

Alternatively, an easier way to exclude activities is during import you can use the ComboBox _(double left click on the entry's import field, see picture below)_ to mark it as excluded while the Save Button is displayed. It will then be added to the exclusion list and not imported, this is simplest way to create the exclusion list and build up its entries.  If the exclusion list doesn't exist, GC will create the exclusion file in /imports and add any excluded files.

![CaptureA](https://user-images.githubusercontent.com/46629337/172545023-ecf39671-75d8-4301-8328-6040a202c2b8.PNG)

To remove an activity from the exclusion list you just need to manually delete it from the list, as adding this interactively would require structural change to the import processing, as when the Save Button is displayed GC has completed some of the processing. Therefore the ComboBox is disabled for all activities with an entry in the exclusion list.

Given the new import states, the auto import status when the Finish button is displayed now identifies the number of files successfully imported, those activities that already exist, those excluded and those that created an error, see improved reporting below.

**Reinstated the overwrite files option.**

 #621 "Re-introduce overwrite files on import" has now been implemented, and the successful import status messages now indicate whether the activity is new or an overwritten existing activity. Additionally the import overall status has been updated to reflect the number of files and their type of import processing.

_Import Complete: successful [ newfiles %1, overwritten %2 ]   unsuccessful [ existing skipped %3, excluded %4, errors %5 ]   total of %6 files._

![CaptureC](https://user-images.githubusercontent.com/46629337/172546273-610f23bd-3878-4546-964d-438caf7beea5.PNG)

**Improved imported file reporting status for #621, #3696 & #4095:**

Once the “save” button is pressed, the additional "Import" column indicates whether a file has been copied to imports successfully, is excluded from import, or it is not copied due an import processing error.

The Import Status column now includes improved reporting of processing to more clearly distinguish between typical failed processing cases and the real error cases:

**_Typical reports:_**
Failed - File added to the exclusion list in /imports  _(user had requested the activity be added to the exclusion list)_
Failed - File is already in the exclusion list in /imports _(File previously set as excluded from import)_
Failed - Activity already exists in /activities  _(typical case when file has previously been imported)_ 
Import successful - Overwritten in /activities _(only occurs if overwrite files has been selected)_
Import successful - Saved in /activities _(new activity is imported)_

**_Exceptional reports (error cases):_**
Failed - Activity with same start date/time exists in /activities _(usually due to a time zone issue)_
Error - Import of activity file failed
Error - .JSON creation failed
Error - %1 cannot be found in RideCache!
Error - Moving %1 to /activities
Error - %1 cannot open ride file to process!

**Corner Cases**

In RideImportWizard.cpp there was the possibility that a file could be copied to /Imports, but fail validation and importation into GC which seems wrong, so I have moved the copy to /Imports functionality so that it is only invoked once the importation process is successful.
 
Another corner case is that it is possible to import a new activity successfully, but there could already be a file in the imports area that has the same file name as the imported file, in this case to maintain the integrity between the /activities and files in /import directories the old imported file will be overwritten.

**Update to the Save import processing stage:**

Access to the new RideItem has been modified to avoid the implicit use of the last selected ride, making it more robust, and allowing the signalling of the only the last ride. The progress bar has been updated to take account of the split processing for duplicate, excluded and errored files, and those which can be successfully processed.

**Miscellaneous:**

And finally, the Auto Import dialogues window close icon once the Finish button is now available, as it seems logical that the user should be able to remove the window at this stage via “Finish” or “X” on the window banner.

Ensured /tmpActivities is tidied at the end of a completely error free importation. In all other cases of errored importation, or GC ungracefully exiting then the contents of /tmpActivities are retained for fault finding.


