### PR TITLE
Daum: Improve support for more cockpits

### DIFF
--- a/src/Train/Daum.cpp
+++ b/src/Train/Daum.cpp
@@ -240,19 +240,14 @@ bool Daum::configureForCockpitType(int cockpitType) {
 
     switch (cockpitType) {
     case COCKPIT_CARDIO:
-        return true;
     case COCKPIT_FITNESS:
-        return true;
     case COCKPIT_VITA_DE_LUXE:
-        return true;
-    case COCKPIT_8008:
-        return true;
-    case COCKPIT_8080:
-        return true;
     case COCKPIT_UNKNOWN:
-        return true;
     case COCKPIT_THERAPIE:
         return true;
+    case COCKPIT_8008:
+    case COCKPIT_8080:
+    case COCKPIT_8008_TRS:
     case COCKPIT_8008_TRS_PRO:
         serialWriteDelay_ = 50;
         playSound_ = true;

--- a/src/Train/Daum.cpp
+++ b/src/Train/Daum.cpp
@@ -26,7 +26,7 @@ Daum::Daum(QObject *parent, QString device, QString profile) : QThread(parent),
     deviceAddress_(-1),
     maxDeviceLoad_(800),
     serialWriteDelay_(0),
-    playSound_(false),
+    playSound_(profile.contains("sound", Qt::CaseInsensitive)),
     paused_(false),
     devicePower_(0),
     deviceHeartRate_(0),
@@ -34,7 +34,8 @@ Daum::Daum(QObject *parent, QString device, QString profile) : QThread(parent),
     deviceSpeed_(0),
     load_(kDefaultLoad),
     loadToWrite_(kDefaultLoad),
-    forceUpdate_(profile.contains("force", Qt::CaseInsensitive)) {
+    forceUpdate_(profile.contains("force", Qt::CaseInsensitive)),
+    profile_(profile) {
 }
 
 int Daum::start() {
@@ -211,6 +212,8 @@ void Daum::initializeConnection() {
 
     if (configureForCockpitType(dat)) {
         qDebug() << "Daum cockpit type: " << Qt::hex << dat;
+        qDebug() << "  Using communication delay:" << serialWriteDelay_ << "msec";
+        qDebug() << "  Playing sound:" << playSound_;
     } else {
         qWarning() << "unable to identify daum cockpit type" << Qt::hex << dat;
         exit(-1);
@@ -236,7 +239,11 @@ void Daum::initializeConnection() {
 
 bool Daum::configureForCockpitType(int cockpitType) {
     serialWriteDelay_ = 0;
-    playSound_ = false;
+
+    if (configureFromProfile()) {
+        // the profile string contains a valid configuration
+        return true;
+    }
 
     switch (cockpitType) {
     case COCKPIT_CARDIO:
@@ -254,6 +261,27 @@ bool Daum::configureForCockpitType(int cockpitType) {
         return true;
     }
     return false;
+}
+
+bool Daum::configureFromProfile() {
+    QRegularExpression re("(\\d+)");
+    QRegularExpressionMatch match = re.match(profile_);
+    bool ok = false;
+
+    if (!match.hasMatch() || match.lastCapturedIndex() == 0) {
+        // no delay found in the profile
+
+        // if the string sound was found, use delay 0 and enable sound
+        return playSound_;
+    }
+
+    uint delay = match.captured(1).toUInt(&ok);
+    if (ok) {
+        // use the matched number found as the command delay
+        serialWriteDelay_ = delay;
+    }
+
+    return true;
 }
 
 void Daum::requestRealtimeData() {

--- a/src/Train/Daum.h
+++ b/src/Train/Daum.h
@@ -67,6 +67,7 @@ private:
     bool closePort();
     void initializeConnection();
     bool configureForCockpitType(int cockpitType);
+    bool configureFromProfile();
 
     bool ResetDevice();
     bool StartProgram(unsigned int prog);
@@ -108,6 +109,7 @@ private:
     // outbound
     volatile int load_, loadToWrite_;
     const bool forceUpdate_;
+    const QString profile_;
 
     enum CockpitType {
         COCKPIT_CARDIO = 0x10,

--- a/src/Train/Daum.h
+++ b/src/Train/Daum.h
@@ -112,6 +112,7 @@ private:
     enum CockpitType {
         COCKPIT_CARDIO = 0x10,
         COCKPIT_FITNESS = 0x20,
+        COCKPIT_8008_TRS = 0x2a,
         COCKPIT_VITA_DE_LUXE = 0x30,
         COCKPIT_8008 = 0x40,
         COCKPIT_8080 = 0x50,


### PR DESCRIPTION
The following things change here:
- adds explicit support for Daum 8008 TRS with cockpit id 0x2a
- use 8008 TRS pro parameter also for 8008 TRS, 8008 and 8080 cockpits
- support unknown cockpit ids by utilizing the profile string, see commit messages for details

This should fix #3772 