### PR TITLE
Trainer Work Part 1: Move manual modes onto common load timer path.

### DIFF
--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -1126,7 +1126,7 @@ void TrainSidebar::Start()       // when start button is pressed
         //gui_timer->start(REFRESHRATE);
         if (status & RT_RECORDING) disk_timer->start(SAMPLERATE);
         load_period.restart();
-        if (status & RT_WORKOUT) load_timer->start(LOADRATE);
+        load_timer->start(LOADRATE);
 
 #if !defined GC_VIDEO_NONE
         mediaTree->setEnabled(false);
@@ -1151,7 +1151,7 @@ void TrainSidebar::Start()       // when start button is pressed
         //foreach(int dev, activeDevices) Devices[dev].controller->pause();
         //gui_timer->stop();
         if (status & RT_RECORDING) disk_timer->stop();
-        if (status & RT_WORKOUT) load_timer->stop();
+        load_timer->stop();
         load_msecs += load_period.restart();
 
 #if !defined GC_VIDEO_NONE
@@ -1237,9 +1237,7 @@ void TrainSidebar::Start()       // when start button is pressed
         //    Devices[dev].controller->resetCalibrationState();
         //}
 
-        if (status & RT_WORKOUT) {
-            load_timer->start(LOADRATE);      // start recording
-        }
+        load_timer->start(LOADRATE);      // start recording
 
         if (recordSelector->isChecked()) {
             setStatusFlags(RT_RECORDING);
@@ -1293,7 +1291,7 @@ void TrainSidebar::Pause()        // pause capture to recalibrate
         gui_timer->start(REFRESHRATE);
         if (status & RT_RECORDING) disk_timer->start(SAMPLERATE);
         load_period.restart();
-        if (status & RT_WORKOUT) load_timer->start(LOADRATE);
+        load_timer->start(LOADRATE);
 
 #if !defined GC_VIDEO_NONE
         mediaTree->setEnabled(false);
@@ -1312,7 +1310,7 @@ void TrainSidebar::Pause()        // pause capture to recalibrate
         setStatusFlags(RT_PAUSED);
         gui_timer->stop();
         if (status & RT_RECORDING) disk_timer->stop();
-        if (status & RT_WORKOUT) load_timer->stop();
+        load_timer->stop();
         load_msecs += load_period.restart();
 
         // enable media tree so we can change movie
@@ -1409,10 +1407,8 @@ void TrainSidebar::Stop(int deviceStatus)        // when stop button is pressed
         status &= ~RT_RECORDING;
     }
 
-    if (status & RT_WORKOUT) {
-        load_timer->stop();
-        load_msecs = 0;
-    }
+    load_timer->stop();
+    load_msecs = 0;
 
     // get back to normal after it may have been adusted by the user
     //lastAppliedIntensity=100;
@@ -1914,19 +1910,6 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
 
             // go update the displays...
             context->notifyTelemetryUpdate(rtData); // signal everyone to update telemetry
-
-            // set now to current time when not using a workout
-            // but limit to almost every second (account for
-            // slight timing errors of 100ms or so)
-
-            // Do some rounding to the hundreds because as time goes by, rtData.getMsecs() drifts just below and then it does not pass the mod 1000 < 100 test
-            // For example:  msecs = 42199.  Mod 1000 = 199 versus msecs = 42000.  Mod 1000 = 0
-            // With this, it will now call tick just about every second
-            long rmsecs = round((rtData.getMsecs() + 99) / 100) * 100;
-            // Test for <= 100ms
-            if (!(status&RT_WORKOUT) && ((rmsecs % 1000) <= 100)) {
-                context->notifySetNow(rtData.getMsecs());
-            }
         }
 
 #ifdef Q_OS_MAC
@@ -2084,14 +2067,16 @@ void TrainSidebar::loadUpdate()
     load_msecs += load_period.restart();
 
     if (status&RT_MODE_ERGO) {
-        load = ergFileQueryAdapter.wattsAt(load_msecs, curLap);
+        if (context->currentErgFile()) {
+            load = ergFileQueryAdapter.wattsAt(load_msecs, curLap);
 
-        if(displayWorkoutLap != curLap)
-        {
-            context->notifyNewLap();
-            maintainLapDistanceState();
+            if (displayWorkoutLap != curLap)
+            {
+                context->notifyNewLap();
+                maintainLapDistanceState();
+            }
+            displayWorkoutLap = curLap;
         }
-        displayWorkoutLap = curLap;
 
         // we got to the end!
         if (load == -100) {
@@ -2101,16 +2086,17 @@ void TrainSidebar::loadUpdate()
             context->notifySetNow(load_msecs);
         }
     } else {
+        if (context->currentErgFile()) {
+            // Call gradientAt to obtain current lap num.
+            ergFileQueryAdapter.gradientAt(displayWorkoutDistance * 1000., curLap);
 
-        // Call gradientAt to obtain current lap num.
-        ergFileQueryAdapter.gradientAt(displayWorkoutDistance * 1000., curLap);
-        
-        if(displayWorkoutLap != curLap) {
-            context->notifyNewLap();
-            maintainLapDistanceState();            
+            if (displayWorkoutLap != curLap) {
+                context->notifyNewLap();
+                maintainLapDistanceState();
+            }
+
+            displayWorkoutLap = curLap;
         }
-
-        displayWorkoutLap = curLap;
 
         // we got to the end!
         if (slope == -100) {
@@ -2143,7 +2129,7 @@ void TrainSidebar::toggleCalibration()
         load_period.restart();
 
         clearStatusFlags(RT_CALIBRATING);
-        if (status & RT_WORKOUT) load_timer->start(LOADRATE);
+        load_timer->start(LOADRATE);
         if (status & RT_RECORDING) disk_timer->start(SAMPLERATE);
         context->notifyUnPause(); // get video started again, amongst other things
 
@@ -2177,7 +2163,7 @@ void TrainSidebar::toggleCalibration()
 
         setStatusFlags(RT_CALIBRATING);
         if (status & RT_RECORDING) disk_timer->stop();
-        if (status & RT_WORKOUT) load_timer->stop();
+        load_timer->stop();
         load_msecs += load_period.restart();
 
         context->notifyPause(); // get video started again, amongst other things


### PR DESCRIPTION
Simplify handling of manual modes so they use the same path and load_timer as the non-manual modes. This means one less path to maintain and modify.