### PR TITLE
Monark implement SetGradientWithSimState

### DIFF
--- a/src/Train/MonarkConnection.h
+++ b/src/Train/MonarkConnection.h
@@ -47,7 +47,7 @@ public slots:
     void requestCadence();
     int readConfiguredLoad();
     void identifyModel();
-    void setLoad(unsigned int load);
+    void setLoad(unsigned int load, bool fSetMode = true);
     void setKp(double kp);
 
 private:

--- a/src/Train/MonarkController.cpp
+++ b/src/Train/MonarkController.cpp
@@ -98,7 +98,6 @@ MonarkController::getRealtimeData(RealtimeData &rtData)
     rtData.setWatts(m_monark->power());
     rtData.setHr(m_monark->pulse());
     rtData.setCadence(m_monark->cadence());
-    rtData.setSlope(m_monark->kp());
 }
 
 void MonarkController::pushRealtimeData(RealtimeData &) { } // update realtime data with current values
@@ -108,8 +107,13 @@ void MonarkController::setLoad(double load)
     m_monark->setLoad(load);
 }
 
-void MonarkController::setGradient(double gradient)
+void MonarkController::setGradientWithSimState(double, double targetForce_N, double simSpeedKph)
 {
-    // Repurpose gradient as kp for Monarks
-    m_monark->setKp(gradient);
+    // Set Kp second to keep monark in Kp mode.
+    static const double s_KilopondsPerNewton = 9.80665;                // acceleration due to gravity
+    m_monark->setKp(s_KilopondsPerNewton * targetForce_N);
+
+    // Some monarks dont support kp so set load also.
+    // Do not change device mode.
+    m_monark->setLoad(simSpeedKph * targetForce_N * (1 / 3.6), false); // speed and force to watts
 }

--- a/src/Train/MonarkController.h
+++ b/src/Train/MonarkController.h
@@ -47,7 +47,7 @@ public:
     void pushRealtimeData(RealtimeData &rtData);
     
     void setLoad(double);
-    void setGradient(double);
+    void setGradientWithSimState(double gradient, double targetForce_N, double speed_kph) override;
     void setMode(int) { return ; }
 };
 

--- a/src/Train/RealtimeController.h
+++ b/src/Train/RealtimeController.h
@@ -102,7 +102,12 @@ public:
 
     // only relevant for Computrainer like devices
     virtual void setLoad(double) { return; }
+private:
+    // This function exists to be overridden by existing drivers, but should
+    // not be called by simulation loop.
     virtual void setGradient(double) { return; }
+public:
+    virtual void setGradientWithSimState(double gradient, double, double) { setGradient(gradient); }
     virtual void setMode(int) { return; }
     virtual void setWindSpeed(double) { return; }
     virtual void setWeight(double) { return; }

--- a/src/Train/RealtimeData.cpp
+++ b/src/Train/RealtimeData.cpp
@@ -25,7 +25,7 @@ RealtimeData::RealtimeData()
 {
     name[0] = '\0';
     hr= watts= altWatts= speed= wheelRpm= load= slope= torque= 0.0;
-    cadence = distance = altDistance = virtualSpeed = wbal = 0.0;
+    cadence = distance = altDistance = virtualSpeed = wbal = resistanceNewtons = 0.0;
     lap = msecs = lapMsecs = lapMsecsRemaining = ergMsecsRemaining = 0;
     thb = smo2 = o2hb = hhb = 0.0;
     lrbalance = rte = lte = lps = rps = 0.0;
@@ -77,6 +77,10 @@ void RealtimeData::setWbal(double wbal)
 void RealtimeData::setVirtualSpeed(double speed)
 {
     this->virtualSpeed = speed;
+}
+void RealtimeData::setResistanceNewtons(double x)
+{
+    this->resistanceNewtons = x;
 }
 void RealtimeData::setWheelRpm(double wheelRpm, bool fMarkWheelRpmTime)
 {
@@ -199,6 +203,10 @@ double RealtimeData::getWbal() const
 double RealtimeData::getVirtualSpeed() const
 {
     return virtualSpeed;
+}
+double RealtimeData::getResistanceNewtons() const
+{
+    return resistanceNewtons;
 }
 double RealtimeData::getWheelRpm() const
 {
@@ -379,6 +387,9 @@ double RealtimeData::value(DataSeries series) const
     case VirtualSpeed: return virtualSpeed;
         break;
 
+    case ResistanceNewtons: return resistanceNewtons;
+        break;
+
     case Cadence: return cadence;
         break;
 
@@ -504,6 +515,7 @@ const QList<RealtimeData::DataSeries> &RealtimeData::listDataSeries()
         seriesList << AvgCadenceLap;
         seriesList << AvgHeartRateLap;
         seriesList << VirtualSpeed;
+        seriesList << ResistanceNewtons;
         seriesList << AltWatts;
         seriesList << LRBalance;
         seriesList << LapTimeRemaining;
@@ -596,6 +608,9 @@ QString RealtimeData::seriesName(DataSeries series)
         break;
 
     case VirtualSpeed: return tr("Virtual Speed");
+        break;
+
+    case ResistanceNewtons: return tr("Resistance Newtons");
         break;
 
     case Cadence: return tr("Cadence");

--- a/src/Train/RealtimeData.h
+++ b/src/Train/RealtimeData.h
@@ -42,7 +42,7 @@ public:
                       Rf, RMV, VO2, VCO2, RER, TidalVolume, FeO2,
                       AvgWatts, AvgSpeed, AvgCadence, AvgHeartRate,
                       AvgWattsLap, AvgSpeedLap, AvgCadenceLap, AvgHeartRateLap,
-                      VirtualSpeed, AltWatts, LRBalance, LapTimeRemaining,
+                      VirtualSpeed, ResistanceNewtons, AltWatts, LRBalance, LapTimeRemaining,
                       LeftTorqueEffectiveness, RightTorqueEffectiveness,
                       LeftPedalSmoothness, RightPedalSmoothness, Slope, 
                       LapDistance, LapDistanceRemaining, ErgTimeRemaining,
@@ -67,6 +67,7 @@ public:
     void setSpeed(double speed);
     void setWbal(double speed);
     void setVirtualSpeed(double speed);
+    void setResistanceNewtons(double newtons);
     void setWheelRpm(double wheelRpm, bool fMarkTimeSample = false);
     void setCadence(double aCadence);
     void setLoad(double load);
@@ -125,6 +126,7 @@ public:
     double getSpeed() const;
     double getWbal() const;
     double getVirtualSpeed() const;
+    double getResistanceNewtons() const;
     double getWheelRpm() const;
     std::chrono::high_resolution_clock::time_point getWheelRpmSampleTime() const;
     double getCadence() const;
@@ -184,6 +186,7 @@ private:
     double lapDistance;
     double lapDistanceRemaining;
     double virtualSpeed;
+    double resistanceNewtons;
     double wbal;
     double hhb, o2hb;
     double rer;

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -1126,7 +1126,7 @@ void TrainSidebar::Start()       // when start button is pressed
         //gui_timer->start(REFRESHRATE);
         if (status & RT_RECORDING) disk_timer->start(SAMPLERATE);
         load_period.restart();
-        if (status & RT_WORKOUT) load_timer->start(LOADRATE);
+        load_timer->start(LOADRATE);
 
 #if !defined GC_VIDEO_NONE
         mediaTree->setEnabled(false);
@@ -1151,7 +1151,7 @@ void TrainSidebar::Start()       // when start button is pressed
         //foreach(int dev, activeDevices) Devices[dev].controller->pause();
         //gui_timer->stop();
         if (status & RT_RECORDING) disk_timer->stop();
-        if (status & RT_WORKOUT) load_timer->stop();
+        load_timer->stop();
         load_msecs += load_period.restart();
 
 #if !defined GC_VIDEO_NONE
@@ -1237,9 +1237,7 @@ void TrainSidebar::Start()       // when start button is pressed
         //    Devices[dev].controller->resetCalibrationState();
         //}
 
-        if (status & RT_WORKOUT) {
-            load_timer->start(LOADRATE);      // start recording
-        }
+        load_timer->start(LOADRATE);      // start recording
 
         if (recordSelector->isChecked()) {
             setStatusFlags(RT_RECORDING);
@@ -1293,7 +1291,7 @@ void TrainSidebar::Pause()        // pause capture to recalibrate
         gui_timer->start(REFRESHRATE);
         if (status & RT_RECORDING) disk_timer->start(SAMPLERATE);
         load_period.restart();
-        if (status & RT_WORKOUT) load_timer->start(LOADRATE);
+        load_timer->start(LOADRATE);
 
 #if !defined GC_VIDEO_NONE
         mediaTree->setEnabled(false);
@@ -1312,7 +1310,7 @@ void TrainSidebar::Pause()        // pause capture to recalibrate
         setStatusFlags(RT_PAUSED);
         gui_timer->stop();
         if (status & RT_RECORDING) disk_timer->stop();
-        if (status & RT_WORKOUT) load_timer->stop();
+        load_timer->stop();
         load_msecs += load_period.restart();
 
         // enable media tree so we can change movie
@@ -1409,10 +1407,8 @@ void TrainSidebar::Stop(int deviceStatus)        // when stop button is pressed
         status &= ~RT_RECORDING;
     }
 
-    if (status & RT_WORKOUT) {
-        load_timer->stop();
-        load_msecs = 0;
-    }
+    load_timer->stop();
+    load_msecs = 0;
 
     // get back to normal after it may have been adusted by the user
     //lastAppliedIntensity=100;
@@ -1914,19 +1910,6 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
 
             // go update the displays...
             context->notifyTelemetryUpdate(rtData); // signal everyone to update telemetry
-
-            // set now to current time when not using a workout
-            // but limit to almost every second (account for
-            // slight timing errors of 100ms or so)
-
-            // Do some rounding to the hundreds because as time goes by, rtData.getMsecs() drifts just below and then it does not pass the mod 1000 < 100 test
-            // For example:  msecs = 42199.  Mod 1000 = 199 versus msecs = 42000.  Mod 1000 = 0
-            // With this, it will now call tick just about every second
-            long rmsecs = round((rtData.getMsecs() + 99) / 100) * 100;
-            // Test for <= 100ms
-            if (!(status&RT_WORKOUT) && ((rmsecs % 1000) <= 100)) {
-                context->notifySetNow(rtData.getMsecs());
-            }
         }
 
 #ifdef Q_OS_MAC
@@ -2084,14 +2067,16 @@ void TrainSidebar::loadUpdate()
     load_msecs += load_period.restart();
 
     if (status&RT_MODE_ERGO) {
-        load = ergFileQueryAdapter.wattsAt(load_msecs, curLap);
+        if (context->currentErgFile()) {
+            load = ergFileQueryAdapter.wattsAt(load_msecs, curLap);
 
-        if(displayWorkoutLap != curLap)
-        {
-            context->notifyNewLap();
-            maintainLapDistanceState();
+            if (displayWorkoutLap != curLap)
+            {
+                context->notifyNewLap();
+                maintainLapDistanceState();
+            }
+            displayWorkoutLap = curLap;
         }
-        displayWorkoutLap = curLap;
 
         // we got to the end!
         if (load == -100) {
@@ -2101,16 +2086,17 @@ void TrainSidebar::loadUpdate()
             context->notifySetNow(load_msecs);
         }
     } else {
+        if (context->currentErgFile()) {
+            // Call gradientAt to obtain current lap num.
+            ergFileQueryAdapter.gradientAt(displayWorkoutDistance * 1000., curLap);
 
-        // Call gradientAt to obtain current lap num.
-        ergFileQueryAdapter.gradientAt(displayWorkoutDistance * 1000., curLap);
-        
-        if(displayWorkoutLap != curLap) {
-            context->notifyNewLap();
-            maintainLapDistanceState();            
+            if (displayWorkoutLap != curLap) {
+                context->notifyNewLap();
+                maintainLapDistanceState();
+            }
+
+            displayWorkoutLap = curLap;
         }
-
-        displayWorkoutLap = curLap;
 
         // we got to the end!
         if (slope == -100) {
@@ -2143,7 +2129,7 @@ void TrainSidebar::toggleCalibration()
         load_period.restart();
 
         clearStatusFlags(RT_CALIBRATING);
-        if (status & RT_WORKOUT) load_timer->start(LOADRATE);
+        load_timer->start(LOADRATE);
         if (status & RT_RECORDING) disk_timer->start(SAMPLERATE);
         context->notifyUnPause(); // get video started again, amongst other things
 
@@ -2177,7 +2163,7 @@ void TrainSidebar::toggleCalibration()
 
         setStatusFlags(RT_CALIBRATING);
         if (status & RT_RECORDING) disk_timer->stop();
-        if (status & RT_WORKOUT) load_timer->stop();
+        load_timer->stop();
         load_msecs += load_period.restart();
 
         context->notifyPause(); // get video started again, amongst other things

--- a/src/Train/TrainSidebar.h
+++ b/src/Train/TrainSidebar.h
@@ -265,6 +265,7 @@ class TrainSidebar : public GcWindow
         double displayLatitude, displayLongitude, displayAltitude; // geolocation
         long load;
         double slope;
+        double resistanceNewtons;  // newtons of resistance for gradient mode.
         int displayWorkoutLap;     // which Lap in the workout are we at?
         bool lapAudioEnabled;
         bool lapAudioThisLap;


### PR DESCRIPTION
Previous monark implementation used gradient for kiloponds. New implementation uses force directly.
Previous monark implementation invented watts using cadence when kp wasn't supported by device, now uses watts directly.

Erg mode is unchanged.

This change is branched off #3778.