### PR TITLE
Fortius USB timing

### DIFF
--- a/src/Train/Fortius.cpp
+++ b/src/Train/Fortius.cpp
@@ -408,6 +408,10 @@ void Fortius::run()
         		return; // couldn't write to the device
 			}
 			
+            // The controller updates faster than the brake. Setting this to a low value (<50ms) increases the frequency of controller
+            // only packages (24byte). Tacx software uses 100ms.
+            msleep(50);
+
             int actualLength = readMessage();
 			if (actualLength < 0) {
 				qDebug() << "usb read error " << actualLength;
@@ -531,11 +535,6 @@ void Fortius::run()
                         
             timer.restart();
         }
-
-        
-        // The controller updates faster than the brake. Setting this to a low value (<50ms) increases the frequency of controller
-        // only packages (24byte). Tacx software uses 100ms.
-        msleep(50);
     }
 }
 


### PR DESCRIPTION
@michelrdagenais @amtriathlon 

The Fortius will echo back the commanded resistance in bytes [40:41] of the frames returned.

I find that with the current timing (send + read + **sleep**), the echo'd resistance is 2 frames out of sync...

  sent **4383**, received 4722
  sent 4299, received 4538
  sent 4273, received **4383**
  sent **4216**, received 4299
  sent 4278, received 4273
  sent 4360, received **4216**

By moving the sleep as in this PR (send + **sleep** + read), the echo'd resistance becomes only 1 frame out of sync...

  sent **3601**, received 3516
  sent 3685, received **3601**
  sent 3744, received 3685
  sent **3710**, received 3744
  sent 3687, received **3710**
  sent 3592, received 3687
