### PR TITLE
Ensure that new activities imported into the RideNavigator are displayed expanded

### DIFF
--- a/src/Gui/RideNavigator.cpp
+++ b/src/Gui/RideNavigator.cpp
@@ -966,6 +966,7 @@ RideNavigator::setRide(RideItem*rideItem)
                 tableView->scrollTo(tableView->model()->index(j,3,group), QAbstractItemView::PositionAtCenter);
 
                 currentItem = rideItem;
+                tableView->expandAll();
                 repaint();
                 active = false;
                 return;


### PR DESCRIPTION
Currently when auto importing activities into GC they appear as a single line (date/time) when the other activities are expanded, this change ensures the Ride Navigator expands the new activities.

Note: There maybe a more targetted way to expand just the new field(s), but I spent time trying to use "setExpanded()" & "expand()" but failed, while the sledgehammer "expandAll()" approach works. 