### PR TITLE
RealtimeController::setWindResistance() should be passed CdARho, not just CdA

### DIFF
--- a/src/Train/BicycleSim.h
+++ b/src/Train/BicycleSim.h
@@ -168,7 +168,7 @@ public:
     double EquivalentMassKG() const;         // Additional mass due to rotational inertia
     double KEMass() const;                   // Total effective kinetic mass
     double RollingResistance() const { return m_constants.m_crr; }
-    double WindResistance() const { return m_constants.m_Cd * m_constants.m_A; }
+    double WindResistance(double altitude) const { return m_constants.m_Cd * m_constants.m_A * AirDensity(altitude, m_constants.m_T); }
 
     const BicycleWheel &FrontWheel() const { return m_frontWheel; }
     const BicycleWheel &RearWheel() const { return m_rearWheel; }

--- a/src/Train/Fortius.cpp
+++ b/src/Train/Fortius.cpp
@@ -62,7 +62,7 @@ Fortius::Fortius(QObject *parent) : QThread(parent)
     weight = DEFAULT_WEIGHT;
     windSpeed = DEFAULT_WINDSPEED;
     rollingResistance = DEFAULT_Crr;
-    windResistance = DEFAULT_CdA;
+    windResistance = DEFAULT_CdARho;
     brakeCalibrationForce_N = appsettings->value(this, FORTIUS_CALIBRATION, DEFAULT_CALIBRATION_FORCE_N).toDouble();
     brakeCalibrationFactor = DEFAULT_CALIBRATION_FACTOR;
     powerScaleFactor = DEFAULT_SCALING;
@@ -731,14 +731,14 @@ double Fortius::NewtonsForV(double v) const
     const double gradient = this->gradient;
     const double m        = this->weight;
     const double Crr      = this->rollingResistance;
-    const double CdA      = this->windResistance;
+    const double CdARho   = this->windResistance;
     const double v_wind   = this->windSpeed;
     pvars.unlock();
 
     // Resistive forces due to gravity, rolling resistance and aerodynamic drag
     const double F_slope = gradient/100 * m * g;
     const double F_roll  = Crr * m * g;
-    const double F_air   = 0.5 * CdA * (v + v_wind) * abs(v + v_wind);
+    const double F_air   = 0.5 * CdARho * (v + v_wind) * abs(v + v_wind);
 
     // Return sum of resistive forces
     return F_slope + F_roll + F_air;

--- a/src/Train/Fortius.h
+++ b/src/Train/Fortius.h
@@ -77,7 +77,7 @@
 #define DEFAULT_SCALING      1.00
 #define DEFAULT_WINDSPEED    0.00
 #define DEFAULT_Crr          0.004
-#define DEFAULT_CdA          0.51
+#define DEFAULT_CdARho       0.51
 
 #define FT_USB_TIMEOUT      500
 
@@ -110,7 +110,7 @@ public:
     void setWeight(double weight);                 // set the total weight of rider + bike in kg's
     void setWindSpeed(double windSpeed);                 // set the wind speed in m/s
     void setRollingResistance(double rollingResistance); // set the rolling resistance (Crr)
-    void setWindResistance(double windResistance);       // set the wind resistance (CdA)
+    void setWindResistance(double windResistance);       // set the wind resistance (CdARho)
     
     int getMode();
     double getGradient();

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -1517,7 +1517,6 @@ void TrainSidebar::Connect()
     foreach(int dev, activeDevices) {
         Devices[dev].controller->setWheelCircumference(Devices[dev].wheelSize);
         Devices[dev].controller->setRollingResistance(bicycle.RollingResistance());
-        Devices[dev].controller->setWindResistance(bicycle.WindResistance());
         Devices[dev].controller->setWeight(bicycle.MassKG());
         Devices[dev].controller->setWindSpeed(0); // Move to loadUpdate when wind simulation is added
 
@@ -2102,7 +2101,10 @@ void TrainSidebar::loadUpdate()
         if (slope == -100) {
             Stop(DEVICE_OK);
         } else {
-            foreach(int dev, activeDevices) Devices[dev].controller->setGradient(slope);
+            foreach(int dev, activeDevices) {
+                Devices[dev].controller->setGradient(slope);
+                Devices[dev].controller->setWindResistance(bicycle.WindResistance(displayAltitude));
+            }
             context->notifySetNow(displayWorkoutDistance * 1000);
         }
     }


### PR DESCRIPTION
Source: ANT+ Fitness Equipment Device Profile, section 8.8.3:
  - Wind Resistance Coefficient - Product of Frontal Surface Area, Drag Coefficient **and Air Density** - 0.00 to 1.86 kg/m

I assume the same is true for the equivalent in BT.

Certainly the way in which Fortius::NewtonsForV() is implemented, this is now correct to the best of my knowledge.