### PR TITLE
Fix the request - reply interactions with the Fortius

### DIFF
--- a/src/Train/Fortius.cpp
+++ b/src/Train/Fortius.cpp
@@ -447,6 +447,9 @@ void Fortius::run()
             // If you simply reissue the run command when 24 bytes are
             // received, the following 48 bytes reply will match the force echo
             // of the before last run command.
+            //
+            // On the T1932, replies are always 64 bytes. The best strategy seems to
+            // be simply skipping the first reply.
 
             msleep(50);
             for(int i = 0; i < 5; i++) {

--- a/src/Train/Fortius.h
+++ b/src/Train/Fortius.h
@@ -132,6 +132,7 @@ private:
             SLOPE_Command[12];
     
     // Utility and BG Thread functions
+    int openDevice();
     int openPort();
     int closePort();
 
@@ -170,6 +171,15 @@ private:
     volatile double windSpeed;
     volatile double rollingResistance;
     volatile double windResistance;
+
+    // Model version
+    unsigned int motorBrakeFirmwareVersion;
+    unsigned int motorBrakeRawSerialNumber;
+    unsigned int motorBrakeVersion;
+    unsigned int motorBrakeType;
+    unsigned int motorBrakeYear;
+    unsigned int motorBrakeSerialNumber;
+    bool motorBrake;
     
     // i/o message holder
     uint8_t buf[64];

--- a/src/Train/FortiusController.cpp
+++ b/src/Train/FortiusController.cpp
@@ -22,7 +22,7 @@
 
 FortiusController::FortiusController(TrainSidebar *parent,  DeviceConfiguration *dc) : RealtimeController(parent, dc)
 {
-    myFortius = new Fortius (parent);
+    myFortius = new Fortius (this);
 }
 
 


### PR DESCRIPTION
After a lot of experimentation, I now have something that seems to work well in order to get proper replies to commands sent to the Fortius. The open command gets the version correctly. The run command gets the proper force echo in the same request reply cycle. @mattipee please let me know if that works well for you (getting the correct version number and the force echo in the same cycle).

The open command is in fact to get a reply with the version. However, some already queued messages need to be skipped, before the well formed reply message is received. The open command is sent initially, and each time the device is disconnected and reconnected. The procedure to open the device and get the version was then put in a separate function.

When the run command is sent with a specified force, a reply comes back with the force echoed. However, here again, some messages may need to be skipped before the correct reply comes back.