### PR TITLE
Fixes the single line appearance of newly imported activities

### DIFF
--- a/src/Gui/RideNavigator.cpp
+++ b/src/Gui/RideNavigator.cpp
@@ -966,6 +966,7 @@ RideNavigator::setRide(RideItem*rideItem)
                 tableView->scrollTo(tableView->model()->index(j,3,group), QAbstractItemView::PositionAtCenter);
 
                 currentItem = rideItem;
+                tableView->doItemsLayout();
                 repaint();
                 active = false;
                 return;


### PR DESCRIPTION
Looking at the #3074 issue a bit more, the addition of "tableView->doItemsLayout();" fixes the problem, and doesn't impact the groups expand/collapse functionality.

Hopefully this closes the issue of: Regression: Newly entered ride details do not display in Details pane until application restart #3074.