### PR TITLE
Fortius "rolling" calibration

### DIFF
--- a/src/Train/Fortius.h
+++ b/src/Train/Fortius.h
@@ -196,6 +196,7 @@ private:
     // Source: https://github.com/totalreverse/ttyT1941/wiki
     //         - "speed = 'kph * 289.75'"
     static inline double rawSpeed_to_ms (double raw) { return raw / 1043.1; } // 289.75*3.6
+    static inline double ms_to_rawSpeed (double raw) { return raw * 1043.1; } // 289.75*3.6
 
     // Convert double value to type T, clipping to range of type T, if necessary
     template <typename T>

--- a/src/Train/FortiusController.cpp
+++ b/src/Train/FortiusController.cpp
@@ -226,7 +226,7 @@ FortiusController::getCalibrationZeroOffset()
 {
     switch (m_calibrationState)
     {
-        // Waiting for user to kick pedal...
+        // Waiting for user to kick pedal, or speed to decay...
         case CALIBRATION_STATE_REQUESTED:
         {
             int Buttons, Status, Steering;
@@ -240,8 +240,10 @@ FortiusController::getCalibrationZeroOffset()
                 m_calibrationState = CALIBRATION_STATE_STARTING;
             }
 
-            // Return value for presentation in the GUI
-            return 0;
+            // Return value to determine message to user in the GUI
+            //  -  0 instructs user to "Give the pedal a kick"
+            //  - >0 instructs user to "Allow wheel speed to settle"
+            return SpeedKmh;
         }
 
         // Calibration starting, waiting until we have enough values

--- a/src/Train/FortiusController.cpp
+++ b/src/Train/FortiusController.cpp
@@ -233,8 +233,8 @@ FortiusController::getCalibrationZeroOffset()
             double Power, Force_N, HeartRate, Cadence, SpeedKmh, Distance;
             myFortius->getTelemetry(Power, Force_N, HeartRate, Cadence, SpeedKmh, Distance, Buttons, Steering, Status);
 
-            // Once we're up to speed (only takes a second or so), move on to next stage
-            if (SpeedKmh > 0.995 * getCalibrationTargetSpeed()) // Within 0.005 of the target speed
+            // Once we're at target speed (only takes a second or so), move on to next stage
+            if (SpeedKmh > 0.995 * getCalibrationTargetSpeed() && SpeedKmh < 1.005 * getCalibrationTargetSpeed()) // Within 0.005 of the target speed
             {
                 m_calibrationValues.reset();
                 m_calibrationState = CALIBRATION_STATE_STARTING;

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -2417,7 +2417,11 @@ void TrainSidebar::updateCalibration()
                 break;
 
             case CALIBRATION_STATE_REQUESTED:
-                status = QString(tr("Give the pedal a kick to start calibration...\nThe motor will run until calibration is complete."));
+                if (calibrationZeroOffset == 0)
+                    status = QString(tr("Give the pedal a kick to start calibration...\nThe motor will run until calibration is complete."));
+                else
+                    status = QString(tr("Allow wheel speed to settle, DO NOT PEDAL...\nThe motor will run until calibration is complete."));
+
                 break;
 
             case CALIBRATION_STATE_STARTING:


### PR DESCRIPTION
Following on from the introduction of Fortius calibration in #3790, this follow on PR contains a small tweak to gracefully decay wheel speed to the target calibration speed, in the event that calibration is commanded while user is riding in excess of that speed.

The existing implementation results in the motor inducing a very forceful and sudden wheel speed change.