### PR TITLE
Get the Altitude for CRS files even when Fast Forwarding

### DIFF
--- a/src/Train/ErgFile.cpp
+++ b/src/Train/ErgFile.cpp
@@ -1949,6 +1949,26 @@ ErgFileQueryAdapter::gradientAt(double x, int& lapnum) const
     return gradient;
 }
 
+// Altitude
+double
+ErgFileQueryAdapter::altitudeAt(double x, int& lapnum) const
+{
+    // Establish index bracket for query.
+    if (!updateQueryStateFromDistance(x, lapnum))
+        return -1000;
+
+    assert(hasGradient()); // altitudeAt should not be called if ergfile has no gradient and altitude.
+    if (!hasGradient())
+        return -1000;
+
+    ErgFilePoint p1 = Points().at(qs.leftPoint);
+    ErgFilePoint p2 = Points().at(qs.rightPoint);
+    double altitude = p1.y;
+    if(p1.x != p2.x) altitude += (p2.y - p1.y) * (x - p1.x) / (p2.x - p1.x);
+
+    return altitude;
+}
+
 // Returns true if a location is determined, otherwise returns false.
 // This is the const stateless edition(tm), which does not rely on location
 // state. This method is used to make queries independant of the main ergfile

--- a/src/Train/ErgFile.cpp
+++ b/src/Train/ErgFile.cpp
@@ -1901,9 +1901,10 @@ ErgFileQueryAdapter::wattsAt(double x, int& lapnum) const
     if (!updateQueryStateFromDistance(x, lapnum))
         return -100;
 
-    assert(hasWatts()); // wattsAt should not be called unless ergfile has watts.
-    if (!hasWatts())
+    if (!hasWatts()) {
+        qDebug() << "wattsAt should not be called unless ergfile has watts";
         return -100;
+    }
 
     // two different points in time but the same watts
     // at both, it doesn't really matter which value
@@ -1940,9 +1941,10 @@ ErgFileQueryAdapter::gradientAt(double x, int& lapnum) const
     if (!updateQueryStateFromDistance(x, lapnum))
         return -100;
 
-    assert(hasGradient()); // gradientAt should not be called if ergfile has no gradient.
-    if (!hasGradient())
+    if (!hasGradient()) {
+        qDebug() << "gradientAt should not be called if ergfile has no gradient";
         return -100;
+    }
 
     double gradient = Points().at(qs.leftPoint).val;
 
@@ -1957,9 +1959,10 @@ ErgFileQueryAdapter::altitudeAt(double x, int& lapnum) const
     if (!updateQueryStateFromDistance(x, lapnum))
         return -1000;
 
-    assert(hasGradient()); // altitudeAt should not be called if ergfile has no gradient and altitude.
-    if (!hasGradient())
+    if (!hasGradient()) {
+        qDebug() << "altitudeAt should not be called if ergfile has no gradient";
         return -1000;
+    }
 
     ErgFilePoint p1 = Points().at(qs.leftPoint);
     ErgFilePoint p2 = Points().at(qs.rightPoint);
@@ -1979,9 +1982,10 @@ bool ErgFileQueryAdapter::locationAt(double meters, int& lapnum, geolocation& ge
     if (!updateQueryStateFromDistance(meters, lapnum))
         return false;
 
-    assert(hasGradient()); // locationAt should not be called if ergfile has no gradient.
-    if (!hasGradient())
+    if (!hasGradient()) {
+        qDebug() << "locationAt should not be called if ergfile has no gradient";
         return false;
+    }
 
     // At this point leftpoint and rightpoint bracket the query distance. Three cases:
     // Bracket Covered: If query bracket compatible with the current interpolation bracket then simply interpolate

--- a/src/Train/ErgFile.h
+++ b/src/Train/ErgFile.h
@@ -130,7 +130,7 @@ class ErgFile
         double Cp;
         int format;             // ERG, CRS, MRC, ERG2 currently supported
 
-        bool hasGradient() const { return CRS == format; }
+        bool hasGradient() const { return CRS == format; } // Has Gradient and Altitude
         bool hasWatts()    const { return ERG == format || MRC == format; }
 
 private:
@@ -247,6 +247,7 @@ public:
     // State queries (maintain mutable state.)
     double wattsAt(double msec, int& lapnum) const;
     double gradientAt(double meters, int& lapnum) const;
+    double altitudeAt(double meters, int& lapnum) const;
     bool   locationAt(double meters, int& lapnum, geolocation& geoLoc, double& slope100) const;
 };
 

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -1780,12 +1780,8 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
                         }
 
                         if (!fAltitudeSet) {
-                            // For classic rlv with no location data:
-                            // Estimate vertical change based upon time passed and slope.
-                            // Note this isn't exactly right but is very close - we should use the previous slope for the time passed.
-                            double altitudeDeltaMeters = slope * (10 * distanceTick); // ((slope / 100) * distanceTick) * 1000
-
-                            displayAltitude += altitudeDeltaMeters;
+                            // Since we have gradient, we also have altitude
+                            displayAltitude = ergFileQueryAdapter.altitudeAt(displayWorkoutDistance * 1000, displayWorkoutLap);
                         }
 
                         rtData.setSlope(slope);


### PR DESCRIPTION
In the TrainSidebar main loop, the altitude is derived from the gradient for some CRS files. However, this computation does not take into account when the displayDistance is changed with fastForward or fastRewind. Thus, when advancing in this mode in a .pgmf file, the altitude would not be updated.

However, when CRS workout files are read, the altitude is already derived and precomputed from the gradient for all formats handled. A new function was added, altitudeAt, that accesses this value, avoiding to derive anew the altitude from the gradient in the TrainSidebar main loop, and getting the correct altitude value when FastForward.

Fixes #3805 