### PR TITLE
Don't rewrite gradient course files, allow sim to see original gradient 

### DIFF
--- a/src/Train/RealtimeData.cpp
+++ b/src/Train/RealtimeData.cpp
@@ -74,6 +74,10 @@ void RealtimeData::setWbal(double wbal)
 {
     this->wbal = wbal;
 }
+void RealtimeData::setSimulatedSpeed(double speed)
+{
+    this->simulatedSpeed = speed;
+}
 void RealtimeData::setVirtualSpeed(double speed)
 {
     this->virtualSpeed = speed;
@@ -195,6 +199,10 @@ double RealtimeData::getSpeed() const
 double RealtimeData::getWbal() const
 {
     return wbal;
+}
+double RealtimeData::getSimulatedSpeed() const
+{
+    return simulatedSpeed;
 }
 double RealtimeData::getVirtualSpeed() const
 {

--- a/src/Train/RealtimeData.cpp
+++ b/src/Train/RealtimeData.cpp
@@ -101,6 +101,10 @@ void RealtimeData::setSlope(double slope)
 {
     this->slope = slope;
 }
+void RealtimeData::setSlopeToTrainer(double slope)
+{
+    this->slopeToTrainer = slope;
+}
 void RealtimeData::setLoad(double load)
 {
     this->load = load;
@@ -231,6 +235,10 @@ double RealtimeData::getCadence() const
 double RealtimeData::getSlope() const
 {
     return slope;
+}
+double RealtimeData::getSlopeToTrainer() const
+{
+    return slopeToTrainer;
 }
 double RealtimeData::getLoad() const
 {

--- a/src/Train/RealtimeData.cpp
+++ b/src/Train/RealtimeData.cpp
@@ -74,6 +74,10 @@ void RealtimeData::setWbal(double wbal)
 {
     this->wbal = wbal;
 }
+void RealtimeData::setTrainerSpeed(double speed)
+{
+    this->trainerSpeed = speed;
+}
 void RealtimeData::setSimulatedSpeed(double speed)
 {
     this->simulatedSpeed = speed;
@@ -199,6 +203,10 @@ double RealtimeData::getSpeed() const
 double RealtimeData::getWbal() const
 {
     return wbal;
+}
+double RealtimeData::getTrainerSpeed() const
+{
+    return trainerSpeed;
 }
 double RealtimeData::getSimulatedSpeed() const
 {

--- a/src/Train/RealtimeData.h
+++ b/src/Train/RealtimeData.h
@@ -66,6 +66,7 @@ public:
     void setTime(long time);
     void setSpeed(double speed);
     void setWbal(double speed);
+    void setTrainerSpeed(double speed);
     void setSimulatedSpeed(double speed);
     void setVirtualSpeed(double speed);
     void setWheelRpm(double wheelRpm, bool fMarkTimeSample = false);
@@ -125,6 +126,7 @@ public:
     long getTime() const;
     double getSpeed() const;
     double getWbal() const;
+    double getTrainerSpeed() const;
     double getSimulatedSpeed() const;
     double getVirtualSpeed() const;
     double getWheelRpm() const;
@@ -185,6 +187,7 @@ private:
     double distanceRemaining;
     double lapDistance;
     double lapDistanceRemaining;
+    double trainerSpeed;
     double simulatedSpeed;
     double virtualSpeed;
     double wbal;

--- a/src/Train/RealtimeData.h
+++ b/src/Train/RealtimeData.h
@@ -73,6 +73,7 @@ public:
     void setCadence(double aCadence);
     void setLoad(double load);
     void setSlope(double slope);
+    void setSlopeToTrainer(double slope);
     void setMsecs(long);
     void setLapMsecs(long);
     void setLapMsecsRemaining(long);
@@ -134,6 +135,7 @@ public:
     double getCadence() const;
     double getLoad() const;
     double getSlope() const;
+    double getSlopeToTrainer() const;
     long getMsecs() const;
     long getLapMsecs() const;
     double getDistance() const;
@@ -187,6 +189,7 @@ private:
     double distanceRemaining;
     double lapDistance;
     double lapDistanceRemaining;
+    double slopeToTrainer;
     double trainerSpeed;
     double simulatedSpeed;
     double virtualSpeed;

--- a/src/Train/RealtimeData.h
+++ b/src/Train/RealtimeData.h
@@ -66,6 +66,7 @@ public:
     void setTime(long time);
     void setSpeed(double speed);
     void setWbal(double speed);
+    void setSimulatedSpeed(double speed);
     void setVirtualSpeed(double speed);
     void setWheelRpm(double wheelRpm, bool fMarkTimeSample = false);
     void setCadence(double aCadence);
@@ -124,6 +125,7 @@ public:
     long getTime() const;
     double getSpeed() const;
     double getWbal() const;
+    double getSimulatedSpeed() const;
     double getVirtualSpeed() const;
     double getWheelRpm() const;
     std::chrono::high_resolution_clock::time_point getWheelRpmSampleTime() const;
@@ -183,6 +185,7 @@ private:
     double distanceRemaining;
     double lapDistance;
     double lapDistanceRemaining;
+    double simulatedSpeed;
     double virtualSpeed;
     double wbal;
     double hhb, o2hb;

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -1693,6 +1693,12 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
                 }
             }
 
+            // In order to differentiate trainer speed from simulated speed it would be ideal
+            // to have trainers setTrainerSpeed() directly, instead of setSpeed() as current
+            // Here, we cross populate value, and call setSpeed() later with the correct value
+            // to keep the "Speed" dataseries in the train GUI showing correctly
+            rtData.setTrainerSpeed(rtData.getSpeed());
+
             // If simulated speed is *not* checked then you get speed reported by
             // trainer which in ergo mode will be dictated by your gear and cadence,
             // and in slope mode is whatever the trainer happens to implement.
@@ -1859,11 +1865,14 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
                 rtData.setLapMsecs(lap_elapsed_msec);
             }
 
+            // Set correct value for "Speed" dataseries in GUI, also affects dispalySpeed below
+            rtData.setSpeed(useSimulatedSpeed ? rtData.getSimulatedSpeed() : rtData.getTrainerSpeed());
+
             // local stuff ...
             displayPower = rtData.getWatts();
             displayCadence = rtData.getCadence();
             displayHeartRate = rtData.getHr();
-            displaySpeed = useSimulatedSpeed ? rtData.getSimulatedSpeed() : rtData.getSpeed();
+            displaySpeed = rtData.getSpeed();
             displayLRBalance = rtData.getLRBalance();
             displayLTE = rtData.getLTE();
             displayRTE = rtData.getRTE();

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -1784,7 +1784,8 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
                         // Reading a new slope from ergFile with gradient means we may need to adjust slopeToTrainer, if intensity is not 100%
                         // This (possibly modified) value is used to populate the GUI
                         slopeToTrainer = slope * lastAppliedIntensity/100.;
-                        rtData.setSlope(slopeToTrainer);
+                        rtData.setSlopeToTrainer(slopeToTrainer);
+                        rtData.setSlope(slopeToTrainer); // maintain "Slope" dataseries with modified gradient
 
                         rtData.setAltitude(displayAltitude);
                     }
@@ -2692,7 +2693,6 @@ void TrainSidebar::adjustIntensity(int value)
     if (ergFile->hasGradient()) {
         // Don't rewrite gradient courses, changing lastAppliedIntensity is enough
         lastAppliedIntensity = value;
-        slopeToTrainer = slope * lastAppliedIntensity/100.; // also updated in guiUpdate()
         emit intensityChanged(lastAppliedIntensity);
         return;
     }

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -2684,7 +2684,7 @@ void TrainSidebar::adjustIntensity(int value)
     if (ergFile->hasGradient()) {
         // Don't rewrite gradient courses, changing lastAppliedIntensity is enough
         lastAppliedIntensity = value;
-        slopeToTrainer = slope * lastAppliedIntensity/100.; // also updated in loadUpdate()
+        slopeToTrainer = slope * lastAppliedIntensity/100.; // also updated in guiUpdate()
         emit intensityChanged(lastAppliedIntensity);
         return;
     }

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -1701,9 +1701,8 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
                 BicycleSimState newState(rtData);
                 SpeedDistance ret = bicycle.SampleSpeed(newState);
 
-                rtData.setSpeed(ret.v);
+                rtData.setSimulatedSpeed(ret.v);
 
-                displaySpeed = ret.v;
                 distanceTick = ret.d;
             } else {
                 distanceTick = displaySpeed / (5 * 3600); // assumes 200ms refreshrate
@@ -1864,7 +1863,7 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
             displayPower = rtData.getWatts();
             displayCadence = rtData.getCadence();
             displayHeartRate = rtData.getHr();
-            displaySpeed = rtData.getSpeed();
+            displaySpeed = useSimulatedSpeed ? rtData.getSimulatedSpeed() : rtData.getSpeed();
             displayLRBalance = rtData.getLRBalance();
             displayLTE = rtData.getLTE();
             displayRTE = rtData.getRTE();

--- a/src/Train/TrainSidebar.h
+++ b/src/Train/TrainSidebar.h
@@ -264,7 +264,7 @@ class TrainSidebar : public GcWindow
         double displayLapDistance, displayLapDistanceRemaining;
         double displayLatitude, displayLongitude, displayAltitude; // geolocation
         long load;
-        double slope;
+        double slope, slopeToTrainer;
         int displayWorkoutLap;     // which Lap in the workout are we at?
         bool lapAudioEnabled;
         bool lapAudioThisLap;


### PR DESCRIPTION
PR to fix #3807

There are essentially three main points:
 - slope course is NOT rewritten
 - sim sees original course gradient
 - gradient-scaling is done using slopeToTrainer, instead of course-rewriting


Note: there are a couple of related things that might be good to include, but I'd like the initial commit to be reviewed first, and any subsequent changes either agreed in-scope, or for another PR.

- user message in Higher()/Lower() to reflect change in intensity
  - improve usability
- additional metrics in rtData for completeness:
  - slopeToTrainer, slopeFromTrainer
    - by removing the local.getSlope() in guiUpdate(), we lose slopeFromTrainer, where trainer may "clip" the requested grade
    - it may or may not be useful to have that
  - deviceSpeed, simulatedSpeed
    - currently, displaySpeed is used to store either deviceSpeed, or simulatedSpeed if sim speed is enabled
    - there is value in differentiating the two, probably in addition to how displaySpeed is used currently.

