### PR TITLE
Power Spike Filtering

### DIFF
--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -593,6 +593,8 @@ GSettings::upgradeGlobal() {
     migrateValue(GC_DPFG_STOP);
     migrateValue(GC_DPFS_MAX);
     migrateValue(GC_DPFS_VARIANCE);
+    migrateValue(GC_DPFS_WINDOWTIME);
+    migrateValue(GC_DPFS_DROPOUTS);
     migrateValue(GC_DPTA);
     migrateValue(GC_DPPA);
     migrateValue(GC_DPFHRS_MAX);

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -281,8 +281,8 @@
 #define GC_AVATAR                       "<athlete-preferences>avatar"
 #define GC_DISCOVERY                    "<athlete-preferences>intervals/discovery"   // intervals to discover
 #define GC_SB_TODAY                     "<athlete-preferences>PMshowSBtoday"
-#define GC_LTS_DAYS                     "<athlete-preferences>LTSdays"
-#define GC_STS_DAYS                     "<athlete-preferences>STSdays"
+#define GC_LTS_DAYS                             "<athlete-preferences>LTSdays"
+#define GC_STS_DAYS                             "<athlete-preferences>STSdays"
 #define GC_CRANKLENGTH                  "<athlete-preferences>crankLength"
 #define GC_WHEELSIZE                    "<athlete-preferences>wheelsize"
 #define GC_USE_CP_FOR_FTP               "<athlete-preferences>cp/useforftp"                       // use CP for FTP

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -181,6 +181,8 @@
 #define GC_DPFG_STOP                    "<global-general>dataprocess/fixgaps/stop"
 #define GC_DPFS_MAX                     "<global-general>dataprocess/fixspikes/max"
 #define GC_DPFS_VARIANCE                "<global-general>dataprocess/fixspikes/variance"
+#define GC_DPFS_WINDOWTIME              "<global-general>dataprocess/fixspikes/avgWindow"
+#define GC_DPFS_DROPOUTS                "<global-general>dataprocess/fixspikes/dropouts"
 #define GC_DPTA                         "<global-general>dataprocess/torqueadjust/adjustment"
 #define GC_DPPA                         "<global-general>dataprocess/poweradjust/adjustment"
 #define GC_DPPA_ABS                     "<global-general>dataprocess/poweradjust/adjustment_abs"
@@ -279,8 +281,8 @@
 #define GC_AVATAR                       "<athlete-preferences>avatar"
 #define GC_DISCOVERY                    "<athlete-preferences>intervals/discovery"   // intervals to discover
 #define GC_SB_TODAY                     "<athlete-preferences>PMshowSBtoday"
-#define GC_LTS_DAYS                             "<athlete-preferences>LTSdays"
-#define GC_STS_DAYS                             "<athlete-preferences>STSdays"
+#define GC_LTS_DAYS                     "<athlete-preferences>LTSdays"
+#define GC_STS_DAYS                     "<athlete-preferences>STSdays"
 #define GC_CRANKLENGTH                  "<athlete-preferences>crankLength"
 #define GC_WHEELSIZE                    "<athlete-preferences>wheelsize"
 #define GC_USE_CP_FOR_FTP               "<athlete-preferences>cp/useforftp"                       // use CP for FTP

--- a/src/FileIO/FixSpikes.cpp
+++ b/src/FileIO/FixSpikes.cpp
@@ -48,18 +48,18 @@ class FixSpikesConfig : public DataProcessorConfig
             layout->setContentsMargins(0,0,0,0);
             setContentsMargins(0,0,0,0);
 
-            maxLabel = new QLabel(tr("Max"));
-            varianceLabel = new QLabel(tr("Variance"));
+            maxLabel = new QLabel(tr("Max Watts"));
+            varianceLabel = new QLabel(tr("Watt Variance"));
 
             max = new QDoubleSpinBox();
-            max->setMaximum(9999.99);
+            max->setMaximum(9995);
             max->setMinimum(0);
-            max->setSingleStep(1);
+            max->setSingleStep(5);
 
             variance = new QDoubleSpinBox();
-            variance->setMaximum(9999);
+            variance->setMaximum(9995);
             variance->setMinimum(0);
-            variance->setSingleStep(10);
+            variance->setSingleStep(5);
 
             layout->addWidget(maxLabel);
             layout->addWidget(max);
@@ -74,24 +74,24 @@ class FixSpikesConfig : public DataProcessorConfig
 
         QString explain() {
             return(QString(tr("Power meters will occasionally report erroneously "
-                           " high values for power. For crank based "
-                           "power meters such as SRM and Quarq this is "
-                           "caused by an erroneous cadence reading "
-                           "as a result of triggering a reed switch "
-                           "whilst pushing off\n\n"
-                           "This function will look for spikes/anomalies "
-                           "in power data and replace the erroneous data "
-                           "by smoothing/interpolating the data from either "
-                           "side of the point in question\n\n"
-                           "It takes the following parameters:\n\n"
-                           "Absolute Max - this defines an absolute value "
-                           "for watts, and will smooth any values above this "
-                           "absolute value that have been identified as being "
-                           "anomalies (i.e. at odds with the data surrounding it)\n\n"
-                           "Variance (%) - this will smooth any values which "
-                           "are higher than this percentage of the rolling "
-                           "average wattage for the 30 seconds leading up "
-                           "to the spike.\n\n")));
+                " high values for power. For crank based "
+                "power meters such as SRM and Quarq this is "
+                "caused by an erroneous cadence reading "
+                "as a result of triggering a reed switch "
+                "whilst pushing off.\n\n"
+                "This function will look for spikes/anomalies "
+                "in power data and replace the erroneous data "
+                "by smoothing/interpolating the data from either "
+                "side of the point in question.\n\n"
+                "It takes the following parameters:\n\n"
+                "Absolute Max - this defines an absolute value "
+                "for watts, and will smooth any values above this "
+                "absolute value that have been identified as being "
+                "anomalies (i.e. at odds with the data surrounding it)\n\n"
+                "Watt Variance - data values that differ by more "
+                "than this variance wattage from the 30 second "
+                "rolling average preceding the spike will be "
+                "considered anomalous/spikes.\n\n")));
         }
 
         void readConfig() {
@@ -180,7 +180,7 @@ FixSpikes::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op
 
         // An entry is a fixup candidate only if its variance is high AND it is above a concerning power level.
         double y = outliers->getYForRank(i);
-        if (   outliers->getDeviationForRank(i) < variance
+        if (fabs(outliers->getDeviationForRank(i)) < variance
             || y < max)
             continue;
 

--- a/src/FileIO/FixSpikes.cpp
+++ b/src/FileIO/FixSpikes.cpp
@@ -32,10 +32,13 @@ class FixSpikesConfig : public DataProcessorConfig
 
     friend class ::FixSpikes;
     protected:
-        QHBoxLayout*layout;
-        QLabel *maxLabel, *varianceLabel, *avgWindowLabel;
-        QDoubleSpinBox *max, *variance, *avgWindow;
-        QCheckBox * dropOuts;
+        QHBoxLayout *layout;
+        QLabel *maxLabel, *varianceLabel;
+        QDoubleSpinBox *max,
+                       *variance;
+        QLabel* avgWindowLabel;
+        QDoubleSpinBox *avgWindow;
+        QCheckBox *dropOuts;
 
     public:
         FixSpikesConfig(QWidget *parent) : DataProcessorConfig(parent) {
@@ -53,14 +56,14 @@ class FixSpikesConfig : public DataProcessorConfig
             avgWindowLabel = new QLabel(tr("Avg Window (secs)"));
 
             max = new QDoubleSpinBox();
-            max->setMaximum(9995);
+            max->setMaximum(9999.99);
             max->setMinimum(0);
-            max->setSingleStep(5);
+            max->setSingleStep(1);
 
             variance = new QDoubleSpinBox();
-            variance->setMaximum(9995);
+            variance->setMaximum(9999);
             variance->setMinimum(0);
-            variance->setSingleStep(5);
+            variance->setSingleStep(10);
 
             avgWindow = new QDoubleSpinBox();
             avgWindow->setMaximum(61);
@@ -100,9 +103,12 @@ class FixSpikesConfig : public DataProcessorConfig
                 "absolute value that have been identified as being "
                 "anomalies (i.e. at odds with the data surrounding it)\n\n"
                 "Watt Variance - data values that differ by more "
-                "than this variance wattage from the 30 second "
-                "rolling average preceding the spike will be "
-                "considered anomalous/spikes.\n\n")));
+                "than this variance wattage from the rolling average "
+                "preceding the spike will be considered anomalous/spikes.\n\n"
+                "Avg Window - defines the duration of the rolling average window (default 30sec).\n\n"
+                "Fix Dropouts - data values that differ by less "
+                "than the variance wattage from the rolling average "
+                "preceding the spike will be considered anomalous/dropouts.\n\n")));
         }
 
         void readConfig() {


### PR DESCRIPTION
Looking at the power spike filtering I found that it wouldn't remove negative spikes (dropouts) from the file and so I have now made this optionality selectable in the Fix Power Spikes menu. Also while making this improvement I also noticed that the "Variance (%)" field isn't actually a percentage, its a wattage value above which data values are considered anomalous to their neighbours relative to a 30 second moving average and therefore are considered a spike to be fixed. So I have updated the explanatory text in the dialog to correct the variance wattage value description. And finally, I've provided the option to adjust the the length of the 30 second window averaging from 5secs to 60seconds, so you can now experiment to see the window's affect on power spike fixing.


![Capture2](https://user-images.githubusercontent.com/46629337/107693231-c080c400-6ca5-11eb-8793-b9f745c4349c.JPG)

The window length and dropout functions are also available for auto imported files:

![Capture3](https://user-images.githubusercontent.com/46629337/107693852-9085f080-6ca6-11eb-9417-464cc393d28b.JPG)

Selecting and saving the window length & dropouts options modifies the behaviour of the power spikes and power dropout detection in the data window:

![Capture1](https://user-images.githubusercontent.com/46629337/107693981-b8755400-6ca6-11eb-997d-8c638f6b939c.JPG)


As a way of example, my original file looked like:

![GC1](https://user-images.githubusercontent.com/46629337/106505198-dd581300-64bf-11eb-932f-3351c9efe560.JPG)

Using the unmodified Power Spike functionality with Absolute watts set to zero, and wattage "%" at 10, it removes some of the small positive spikes:

![GC1-5](https://user-images.githubusercontent.com/46629337/106505256-f9f44b00-64bf-11eb-973b-cf67078c59d0.JPG)

So after this change, using the same values and dropout correction enabled, I now get:

![GC2](https://user-images.githubusercontent.com/46629337/106505297-08dafd80-64c0-11eb-969e-1de818c2bcec.JPG)
