### PR TITLE
trainer capabilities request fix

### DIFF
--- a/src/ANT/ANTMessage.cpp
+++ b/src/ANT/ANTMessage.cpp
@@ -1141,7 +1141,7 @@ ANTMessage ANTMessage::fecRequestCapabilities(const uint8_t channel)
                       FITNESS_EQUIPMENT_REQUEST_DATA_PAGE,        // data page request
                       0xFF, 0xFF,  // reserved
                       0xFF, 0xFF,  // descriptors
-                      0x01,        // requested transmission response (1 time only)
+                      0x04,        // requested transmission response
                       FITNESS_EQUIPMENT_TRAINER_CAPABILITIES_PAGE,        // requested page
                       0x01);       // request data page
 }


### PR DESCRIPTION
I believe that this fixes #3784.

Issue I had was I updated the firmware on my Tacx S Smart (to 3.3.40/1.1.6) and the brake/resistance stopped working. Spent a while tracking ant+ messages and the request for trainer capabilities never generated a reply. 

Found this code: https://github.com/alex-hhh/TrainerControl/blob/2c908746e1c193a1e121f8c84d5c0266f9bd5cd1/src/AntStick.h#L232 which sets the 'transmission count to 4' so tried it in GC and it works. I've been using it for several days now.

Tested on linux (Ubuntu 20.04.2 LTS with QT 5.15.2).