### PR TITLE
Expand new activity lines on auto import & dynamic resizing of Calendar text within Ride Navigator 

### DIFF
--- a/src/Gui/RideImportWizard.cpp
+++ b/src/Gui/RideImportWizard.cpp
@@ -1000,7 +1000,7 @@ RideImportWizard::abortClicked()
     }
 
     QChar zero = QLatin1Char ( '0' );
-
+    int notifiableRides = 0;
 
     // Saving now - process the files one-by-one
     for (int i=0; i< filenames.count(); i++) {
@@ -1032,13 +1032,13 @@ RideImportWizard::abortClicked()
         QString finalActivitiesFulltarget = homeActivities.canonicalPath() + "/" + activitiesTarget;
 
         // check if a ride at this point of time already exists in /activities - if yes, skip import
-        if (QFileInfo(finalActivitiesFulltarget).exists()) { tableWidget->item(i,STATUS_COLUMN)->setText(tr("Error - Activity file exists")); continue; }
+        if (QFileInfo(finalActivitiesFulltarget).exists()) { tableWidget->item(i, STATUS_COLUMN)->setText(tr("Error - Activity file exists")); continue; }
 
         // in addition, also check the RideCache for a Ride with the same point in Time in UTC, which also indicates
         // that there was already a ride imported - reason is that RideCache start time is in UTC, while the file Name is in "localTime"
         // which causes problems when importing the same file (for files which do not have time/date in the file name),
         // while the computer has been set to a different time zone
-        if (context->athlete->rideCache->getRide(ridedatetime.toUTC())) { tableWidget->item(i,STATUS_COLUMN)->setText(tr("Error - Activity file with same start date/time exists")); continue; };
+        if (context->athlete->rideCache->getRide(ridedatetime.toUTC())) { tableWidget->item(i, STATUS_COLUMN)->setText(tr("Error - Activity file with same start date/time exists")); continue; }
 
         // SAVE STEP 4 - copy the source file to "/imports" directory (if it's not taken from there as source)
         // add the date/time of the target to the source file name (for identification)
@@ -1104,8 +1104,8 @@ RideImportWizard::abortClicked()
                 // - only after the step was successful the file is moved
                 // to the "clean" activities folder
                 context->athlete->addRide(QFileInfo(tmpActivitiesFulltarget).fileName(),
-                                          tableWidget->rowCount() < 20 ? true : false, // don't signal if mass importing
-                                          true, true);                                       // file is available only in /tmpActivities, so use this one please
+                                          notifiableRides++ < 20 ? true : false,    // only notify first 20 successful activities, don't signal everthing if mass importing
+                                          true, true);                              // file is available only in /tmpActivities, so use this one please
                 // rideCache is successfully updated, let's move the file to the real /activities
                 if (moveFile(tmpActivitiesFulltarget, finalActivitiesFulltarget)) {
                     tableWidget->item(i,STATUS_COLUMN)->setText(tr("File Saved"));

--- a/src/Gui/RideNavigator.cpp
+++ b/src/Gui/RideNavigator.cpp
@@ -966,7 +966,6 @@ RideNavigator::setRide(RideItem*rideItem)
                 tableView->scrollTo(tableView->model()->index(j,3,group), QAbstractItemView::PositionAtCenter);
 
                 currentItem = rideItem;
-                tableView->doItemsLayout();
                 repaint();
                 active = false;
                 return;

--- a/src/Gui/RideNavigator.cpp
+++ b/src/Gui/RideNavigator.cpp
@@ -966,6 +966,7 @@ RideNavigator::setRide(RideItem*rideItem)
                 tableView->scrollTo(tableView->model()->index(j,3,group), QAbstractItemView::PositionAtCenter);
 
                 currentItem = rideItem;
+                tableView->doItemsLayout();
                 repaint();
                 active = false;
                 return;

--- a/src/Gui/RideNavigator.cpp
+++ b/src/Gui/RideNavigator.cpp
@@ -35,6 +35,11 @@
 #include <QStyleFactory>
 #include <QScrollBar>
 
+const int SINGLE_ROW = 1;
+const int GROUP_BY_ROWS = 2;
+const int CALENDAR_TEXT_ROWS = 3;
+const int MAX_ACTIVITY_ROWS = 4;
+
 RideNavigator::RideNavigator(Context *context, bool mainwindow) : GcChartWindow(context), context(context), active(false), _groupBy(-1)
 {
     // get column headings
@@ -114,14 +119,14 @@ RideNavigator::RideNavigator(Context *context, bool mainwindow) : GcChartWindow(
         tableView->setWhatsThis(helpTableView->getWhatsThisText(HelpWhatsThis::ChartDiary_Navigator));
 
     // good to go
+    refresh();
     tableView->show();
-    resetView();
-
+   
     // refresh when config changes (metric/imperial?)
     connect(context, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));
 
     // refresh when rides added/removed
-    connect(context, SIGNAL(rideAdded(RideItem*)), this, SLOT(refresh()));
+    connect(context, SIGNAL(rideAdded(RideItem*)), this, SLOT(rideAdded(RideItem*)));
     connect(context, SIGNAL(rideDeleted(RideItem*)), this, SLOT(rideDeleted(RideItem*)));
     connect(context, SIGNAL(rideSelected(RideItem*)), this, SLOT(setRide(RideItem*)));
 
@@ -199,6 +204,17 @@ RideNavigator::configChanged(qint32 state)
 }
 
 void
+RideNavigator::rideAdded(RideItem* /* item */)
+{
+    active = false;
+
+    setWidth(geometry().width());
+
+    tableView->doItemsLayout();
+    repaint();
+}
+
+void
 RideNavigator::rideDeleted(RideItem*item)
 {
     if (currentItem == item) currentItem = NULL;
@@ -212,6 +228,9 @@ RideNavigator::refresh()
 
     setWidth(geometry().width());
     cursorRide();
+
+    tableView->doItemsLayout();
+    repaint();
 }
 
 void
@@ -223,11 +242,7 @@ RideNavigator::backgroundRefresh()
 void
 RideNavigator::resizeEvent(QResizeEvent*)
 {
-    // ignore if main window .. we get told to resize
-    // by the splitter mover
-    if (mainwindow) return;
-
-    setWidth(geometry().width());
+    refresh();
 }
 
 void
@@ -949,7 +964,7 @@ void
 RideNavigator::setRide(RideItem*rideItem)
 {
     // if we have a selection and its this one just ignore.
-    if (rideItem == NULL || (currentItem == rideItem && tableView->selectionModel()->selectedRows().count() != 0)) return;
+    if (rideItem == NULL || (currentItem == rideItem && tableView->selectionModel()->selectedRows().count() != 0)) { return; }
 
     for (int i=0; i<tableView->model()->rowCount(); i++) {
 
@@ -966,7 +981,6 @@ RideNavigator::setRide(RideItem*rideItem)
                 tableView->scrollTo(tableView->model()->index(j,3,group), QAbstractItemView::PositionAtCenter);
 
                 currentItem = rideItem;
-                tableView->doItemsLayout();
                 repaint();
                 active = false;
                 return;
@@ -1070,14 +1084,42 @@ void NavigatorCellDelegate::updateEditorGeometry(QWidget *, const QStyleOptionVi
 void NavigatorCellDelegate::setModelData(QWidget *, QAbstractItemModel *, const QModelIndex &) const { }
 bool NavigatorCellDelegate::helpEvent(QHelpEvent*, QAbstractItemView*, const QStyleOptionViewItem&, const QModelIndex&) { return true; }
 
-QSize NavigatorCellDelegate::sizeHint(const QStyleOptionViewItem & /*option*/, const QModelIndex &index) const 
+QSize NavigatorCellDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const 
 {
     QSize s;
 
-    if (rideNavigator->groupByModel->mapToSource(rideNavigator->sortModel->mapToSource(index)) != QModelIndex() &&
-        rideNavigator->groupByModel->data(rideNavigator->sortModel->mapToSource(index), Qt::UserRole).toString() != "") {
-        s.setHeight((rideNavigator->fontHeight+2) * 4);
-    } else s.setHeight(rideNavigator->fontHeight + 2);
+    // default to a single row
+    s.setHeight(rideNavigator->fontHeight + 2);
+
+    if (rideNavigator->groupByModel->mapToSource(rideNavigator->sortModel->mapToSource(index)) == QModelIndex())
+    {
+        // set the group by separator to the height of two rows
+        s.setHeight((rideNavigator->fontHeight + 2) * GROUP_BY_ROWS);
+    } else {
+
+        QString cellTxt = rideNavigator->groupByModel->data(rideNavigator->sortModel->mapToSource(index), Qt::UserRole).toString();
+
+        // calculate the calendar text dynamically from the string length, when rendered it uses textwrap,
+        // so will automatically fit the rows allowed for here
+        if (cellTxt != "")
+        {
+            // pwidth can be undefined at startup, so protect against divide by zero
+            if (rideNavigator->pwidth > 0) {
+
+                // Allow for for the scrollbar & text indent (20) width as this is included in the pwidth value.
+                double calendarTxtLength = QFontMetrics(option.font).horizontalAdvance(cellTxt) + 20;
+
+                // add a row for the activity
+                int rowsRequired = SINGLE_ROW + ceil(calendarTxtLength / rideNavigator->pwidth);
+
+                // limit the number of rows for the activity & calendar text
+                if (rowsRequired > MAX_ACTIVITY_ROWS) rowsRequired = MAX_ACTIVITY_ROWS;
+
+                s.setHeight((rideNavigator->fontHeight + 2) * rowsRequired);
+            }
+        }
+    }
+    
     return s;
 }
 
@@ -1213,12 +1255,13 @@ void NavigatorCellDelegate::paint(QPainter *painter, const QStyleOptionViewItem 
 
         // now get the calendar text to appear ...
         if (calendarText != "") {
-            QRect high(myOption.rect.x()+myOption.rect.width() - (7*dpiXFactor), myOption.rect.y(), (7*dpiXFactor), (rideNavigator->fontHeight+2) * 4);
+            QRect high(myOption.rect.x()+myOption.rect.width() - (7*dpiXFactor), myOption.rect.y(), (7*dpiXFactor), (rideNavigator->fontHeight+2) * MAX_ACTIVITY_ROWS);
 
             myOption.rect.setX(0);
+            // shift calendar text rect down one row
             myOption.rect.setY(myOption.rect.y() + rideNavigator->fontHeight + 2);//was +23
             myOption.rect.setWidth(rideNavigator->pwidth);
-            myOption.rect.setHeight(rideNavigator->fontHeight * 3); //was 36
+            myOption.rect.setHeight(rideNavigator->fontHeight * CALENDAR_TEXT_ROWS); //was 36
             //myOption.font.setPointSize(myOption.font.pointSize());
             myOption.font.setWeight(QFont::Normal);
 
@@ -1263,7 +1306,8 @@ void NavigatorCellDelegate::paint(QPainter *painter, const QStyleOptionViewItem 
         if (value != "") {
             myOption.displayAlignment = Qt::AlignLeft | Qt::AlignBottom;
             myOption.rect.setX(0);
-            myOption.rect.setHeight(rideNavigator->fontHeight + 2);
+            myOption.rect.setY(myOption.rect.y() + rideNavigator->fontHeight + 2);
+            myOption.rect.setHeight((rideNavigator->fontHeight + 2) * GROUP_BY_ROWS); // rect height is 2 rows, as per that returned in setHint
             myOption.rect.setWidth(rideNavigator->pwidth);
             painter->fillRect(myOption.rect, GColor(CPLOTBACKGROUND));
         }

--- a/src/Gui/RideNavigator.cpp
+++ b/src/Gui/RideNavigator.cpp
@@ -35,6 +35,11 @@
 #include <QStyleFactory>
 #include <QScrollBar>
 
+const int SINGLE_ROW = 1;
+const int GROUP_BY_ROWS = 2;
+const int CALENDAR_TEXT_ROWS = 3;
+const int MAX_ACTIVITY_ROWS = 4;
+
 RideNavigator::RideNavigator(Context *context, bool mainwindow) : GcChartWindow(context), context(context), active(false), _groupBy(-1)
 {
     // get column headings
@@ -114,14 +119,14 @@ RideNavigator::RideNavigator(Context *context, bool mainwindow) : GcChartWindow(
         tableView->setWhatsThis(helpTableView->getWhatsThisText(HelpWhatsThis::ChartDiary_Navigator));
 
     // good to go
+    refresh();
     tableView->show();
-    resetView();
    
     // refresh when config changes (metric/imperial?)
     connect(context, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));
 
     // refresh when rides added/removed
-    connect(context, SIGNAL(rideAdded(RideItem*)), this, SLOT(refresh()));
+    connect(context, SIGNAL(rideAdded(RideItem*)), this, SLOT(rideAdded(RideItem*)));
     connect(context, SIGNAL(rideDeleted(RideItem*)), this, SLOT(rideDeleted(RideItem*)));
     connect(context, SIGNAL(rideSelected(RideItem*)), this, SLOT(setRide(RideItem*)));
 
@@ -199,6 +204,17 @@ RideNavigator::configChanged(qint32 state)
 }
 
 void
+RideNavigator::rideAdded(RideItem* /* item */)
+{
+    active = false;
+
+    setWidth(geometry().width());
+
+    tableView->doItemsLayout();
+    repaint();
+}
+
+void
 RideNavigator::rideDeleted(RideItem*item)
 {
     if (currentItem == item) currentItem = NULL;
@@ -212,6 +228,9 @@ RideNavigator::refresh()
 
     setWidth(geometry().width());
     cursorRide();
+
+    tableView->doItemsLayout();
+    repaint();
 }
 
 void
@@ -223,11 +242,7 @@ RideNavigator::backgroundRefresh()
 void
 RideNavigator::resizeEvent(QResizeEvent*)
 {
-    // ignore if main window .. we get told to resize
-    // by the splitter mover
-    if (mainwindow) return;
-
-    setWidth(geometry().width());
+    refresh();
 }
 
 void
@@ -949,7 +964,7 @@ void
 RideNavigator::setRide(RideItem*rideItem)
 {
     // if we have a selection and its this one just ignore.
-    if (rideItem == NULL || (currentItem == rideItem && tableView->selectionModel()->selectedRows().count() != 0)) return;
+    if (rideItem == NULL || (currentItem == rideItem && tableView->selectionModel()->selectedRows().count() != 0)) { return; }
 
     for (int i=0; i<tableView->model()->rowCount(); i++) {
 
@@ -1069,14 +1084,42 @@ void NavigatorCellDelegate::updateEditorGeometry(QWidget *, const QStyleOptionVi
 void NavigatorCellDelegate::setModelData(QWidget *, QAbstractItemModel *, const QModelIndex &) const { }
 bool NavigatorCellDelegate::helpEvent(QHelpEvent*, QAbstractItemView*, const QStyleOptionViewItem&, const QModelIndex&) { return true; }
 
-QSize NavigatorCellDelegate::sizeHint(const QStyleOptionViewItem & /*option*/, const QModelIndex &index) const 
+QSize NavigatorCellDelegate::sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const 
 {
     QSize s;
 
-    if (rideNavigator->groupByModel->mapToSource(rideNavigator->sortModel->mapToSource(index)) != QModelIndex() &&
-        rideNavigator->groupByModel->data(rideNavigator->sortModel->mapToSource(index), Qt::UserRole).toString() != "") {
-        s.setHeight((rideNavigator->fontHeight+2) * 4);
-    } else s.setHeight(rideNavigator->fontHeight + 2);
+    // default to a single row
+    s.setHeight(rideNavigator->fontHeight + 2);
+
+    if (rideNavigator->groupByModel->mapToSource(rideNavigator->sortModel->mapToSource(index)) == QModelIndex())
+    {
+        // set the group by separator to the height of two rows
+        s.setHeight((rideNavigator->fontHeight + 2) * GROUP_BY_ROWS);
+    } else {
+
+        QString cellTxt = rideNavigator->groupByModel->data(rideNavigator->sortModel->mapToSource(index), Qt::UserRole).toString();
+
+        // calculate the calendar text dynamically from the string length, when rendered it uses textwrap,
+        // so will automatically fit the rows allowed for here
+        if (cellTxt != "")
+        {
+            // pwidth can be undefined at startup, so protect against divide by zero
+            if (rideNavigator->pwidth > 0) {
+
+                // Allow for for the scrollbar & text indent (20) width as this is included in the pwidth value.
+                double calendarTxtLength = QFontMetrics(option.font).horizontalAdvance(cellTxt) + 20;
+
+                // add a row for the activity
+                int rowsRequired = SINGLE_ROW + ceil(calendarTxtLength / rideNavigator->pwidth);
+
+                // limit the number of rows for the activity & calendar text
+                if (rowsRequired > MAX_ACTIVITY_ROWS) rowsRequired = MAX_ACTIVITY_ROWS;
+
+                s.setHeight((rideNavigator->fontHeight + 2) * rowsRequired);
+            }
+        }
+    }
+    
     return s;
 }
 
@@ -1212,12 +1255,13 @@ void NavigatorCellDelegate::paint(QPainter *painter, const QStyleOptionViewItem 
 
         // now get the calendar text to appear ...
         if (calendarText != "") {
-            QRect high(myOption.rect.x()+myOption.rect.width() - (7*dpiXFactor), myOption.rect.y(), (7*dpiXFactor), (rideNavigator->fontHeight+2) * 4);
+            QRect high(myOption.rect.x()+myOption.rect.width() - (7*dpiXFactor), myOption.rect.y(), (7*dpiXFactor), (rideNavigator->fontHeight+2) * MAX_ACTIVITY_ROWS);
 
             myOption.rect.setX(0);
+            // shift calendar text rect down one row
             myOption.rect.setY(myOption.rect.y() + rideNavigator->fontHeight + 2);//was +23
             myOption.rect.setWidth(rideNavigator->pwidth);
-            myOption.rect.setHeight(rideNavigator->fontHeight * 3); //was 36
+            myOption.rect.setHeight(rideNavigator->fontHeight * CALENDAR_TEXT_ROWS); //was 36
             //myOption.font.setPointSize(myOption.font.pointSize());
             myOption.font.setWeight(QFont::Normal);
 
@@ -1262,7 +1306,8 @@ void NavigatorCellDelegate::paint(QPainter *painter, const QStyleOptionViewItem 
         if (value != "") {
             myOption.displayAlignment = Qt::AlignLeft | Qt::AlignBottom;
             myOption.rect.setX(0);
-            myOption.rect.setHeight(rideNavigator->fontHeight + 2);
+            myOption.rect.setY(myOption.rect.y() + rideNavigator->fontHeight + 2);
+            myOption.rect.setHeight((rideNavigator->fontHeight + 2) * GROUP_BY_ROWS); // rect height is 2 rows, as per that returned in setHint
             myOption.rect.setWidth(rideNavigator->pwidth);
             painter->fillRect(myOption.rect, GColor(CPLOTBACKGROUND));
         }

--- a/src/Gui/RideNavigator.h
+++ b/src/Gui/RideNavigator.h
@@ -122,6 +122,9 @@ class RideNavigator : public GcChartWindow
         // bring it back in view
         void cursorRide();
 
+        // Update table height and layout
+        void rideAdded(RideItem*);
+
         // if current ride is deleted we need to invaldate
         void rideDeleted(RideItem*);
 

--- a/src/Gui/RideNavigator.h
+++ b/src/Gui/RideNavigator.h
@@ -122,9 +122,6 @@ class RideNavigator : public GcChartWindow
         // bring it back in view
         void cursorRide();
 
-        // Update table height and layout
-        void rideAdded(RideItem*);
-
         // if current ride is deleted we need to invaldate
         void rideDeleted(RideItem*);
 


### PR DESCRIPTION
This change addresses a number of issues with the activity presentation and updates within the Ride Navigator. I did think of trying to separate them into more than one pull request, but they are all intertwined functions.

**#3074 - Activity list row height is not updated when data changes:**
This issue is within the batch importation (RideImportWixard.cpp), if you import too many files and only a few are new files, then the tableWidget->rowCount() is always going to be greater than 20, see code below from RideImportWixard.cpp:

 _// to the "clean" activities folder
 context->athlete->addRide(QFileInfo(tmpActivitiesFulltarget).fileName(),
                                 tableWidget->rowCount() < 20 ? true : false, // don't signal if mass importing
                                 true, true);                    // file is available only in /tmpActivities, so use this one please_

Therefore the signalling code below in RideCache.cpp ever gets executed, and there is never a ridesAdded signal emitted:

_if (dosignal) context->notifyRideAdded(last); // here so emitted BEFORE rideSelected is emitted!_

Additionally Ride Navigator only listens for rideSelected, and not rideAdded, so it never received rideAdded, so the table was never refreshed to recalculate & update the table list entries.

**Note**: The above changes to RideImportWixard.cpp in this pull request should be considered a patch, as it just ensures the first 20 processed updates cause a rideAdded signal to be emitted, but ideally it would be better for only the last of the valid updates in a mass importation to raise a rideAdded and rideSelected signal. 
**_This change has now been implemented in RideImportWixard.cpp by pull request #3770 Auto import filtering and file import exclusion, by slightly restructuring phase 3 of the importation processing, ensuring rideAdded & rideSelected is only notified for the last successful activity._** 


**Addition of rideAdded signal to RideNavigator**

Adding rideAdded signal listening to RideNavigator.ccp ensures the table is refreshed to recalculate & update the table list entries, therefore the height and positioning of the activities and calendar text is now correctly displayed.

**Dynamic resizing of calendar text** 
This change provides dynamic resizing of the calendar text from a single line up to three lines, depending on the calendar field contents and the width of the Ride Navigator field. Dragging the separator between the Ride Navigator and the main window allows the calendar text to occupy a single line if only short content calendar items are selected for display.

