### PR TITLE
Workout: LiveMapWidget in video layout starts with the zoom specified in video-layout.xml

### DIFF
--- a/src/Train/MeterWidget.cpp
+++ b/src/Train/MeterWidget.cpp
@@ -588,8 +588,9 @@ void LiveMapWidget::initLiveMap(Context* context)
     }
     else
     {
+        QString sMapZoom = QString::number(m_Zoom);
         QString js = ("<div><script type=\"text/javascript\">initMap("
-            + startingLat + "," + startingLon + ",16);"
+            + startingLat + "," + startingLon + "," + sMapZoom + ");"
             "showMyMarker(" + startingLat + "," + startingLon + ");</script></div>\n");
         routeLatLngs = "[";
         QString code = "";


### PR DESCRIPTION
I noticed zoom configured in xml file is ignored, and code is always starting with a value of 16 for thee zoom of thee live map widget.
This change uses <Zoom> field of the xml; it was already being parsed but not used, so using it is simple and straightforward