### PR TITLE
Enable Athlete Open menu to allow creation of new athletes

### DIFF
--- a/src/Gui/AthleteView.cpp
+++ b/src/Gui/AthleteView.cpp
@@ -29,35 +29,42 @@ AthleteView::AthleteView(Context *context) : ChartSpace(context, OverviewScope::
     connect(GlobalContext::context(), SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));
 
     // lets look for athletes
-    int row=0, col=0;
+    row=0; col=0;
     QStringListIterator i(QDir(gcroot).entryList(QDir::Dirs | QDir::NoDotAndDotDot));
     while (i.hasNext()) {
 
         QString name = i.next();
 
-        // ignore non-athlete folders created by Qt or users
-        AthleteDirectoryStructure athleteHome(QDir(gcroot + "/" + name));
-        if (!athleteHome.upgradedDirectoriesHaveData()) continue;
-
-        // add a card for each athlete
-        AthleteCard *ath = new AthleteCard(this, name);
-        addItem(row,col,gl_athletes_deep,ath);
-
-        // we have 3 athletes per row
-        if (++col >= gl_athletes_per_row) {
-            col=0;
-            row++;
-        }
+        newAthlete(name);
     }
 
     // set colors
     configChanged(0);
 
+    // athlete config dialog...
+    connect(this, SIGNAL(itemConfigRequested(ChartSpaceItem*)), this, SLOT(configItem(ChartSpaceItem*)));
+    // new athlete
+    connect(context->mainWindow, SIGNAL(newAthlete(QString)), this, SLOT(newAthlete(QString)));
+}
+
+void
+AthleteView::newAthlete(QString name)
+{
+    // ignore non-athlete folders created by Qt or users
+    AthleteDirectoryStructure athleteHome(QDir(gcroot + "/" + name));
+    if (!athleteHome.upgradedDirectoriesHaveData()) return;
+
+    // add a card for each athlete
+    AthleteCard *ath = new AthleteCard(this, name);
+    addItem(row,col,gl_athletes_deep,ath);
+
+    // we have 5 athletes per row
+    if (++col >= gl_athletes_per_row) {
+        col=0;
+        row++;
+    }
     // setup geometry
     updateGeometry();
-
-    // athelte config dialog...
-    connect(this, SIGNAL(itemConfigRequested(ChartSpaceItem*)), this, SLOT(configItem(ChartSpaceItem*)));
 }
 
 void

--- a/src/Gui/AthleteView.h
+++ b/src/Gui/AthleteView.h
@@ -11,7 +11,10 @@ public:
 public slots:
     void configChanged(qint32);
     void configItem(ChartSpaceItem*);
+    void newAthlete(QString);
 
+private:
+    int row, col;
 };
 
 // the athlete display

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -454,8 +454,8 @@ MainWindow::MainWindow(const QDir &home)
     // ATHLETE (FILE) MENU
     QMenu *fileMenu = menuBar()->addMenu(tr("&Athlete"));
 
-    //openTabMenu = fileMenu->addMenu(tr("Open...")); use athlete view
-    //connect(openTabMenu, SIGNAL(aboutToShow()), this, SLOT(setOpenTabMenu()));
+    openTabMenu = fileMenu->addMenu(tr("Open..."));
+    connect(openTabMenu, SIGNAL(aboutToShow()), this, SLOT(setOpenTabMenu()));
 
     tabMapper = new QSignalMapper(this); // maps each option
     connect(tabMapper, SIGNAL(mapped(const QString &)), this, SLOT(openTab(const QString &)));
@@ -1690,7 +1690,10 @@ MainWindow::newCyclistTab()
     QDir newHome = currentTab->context->athlete->home->root();
     newHome.cdUp();
     QString name = ChooseCyclistDialog::newCyclistDialog(newHome, this);
-    if (!name.isEmpty()) openTab(name);
+    if (!name.isEmpty()) {
+        emit newAthlete(name);
+        openTab(name);
+    }
 }
 
 void

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -125,6 +125,7 @@ class MainWindow : public QMainWindow
         void backClicked();
         void forwardClicked();
         void openingAthlete(QString, Context *);
+        void newAthlete(QString);
 
     public slots:
 


### PR DESCRIPTION
Objective is to allow creation of new athletes, without the need to
exit GoldenCheetah, using Athlete > Open > New Athlete like in v3.5
When a new athlete is created MainWindow emits newAthlete signal
so AthleteView can create the corresponding AthleteCard.