### PR TITLE
Add debugging options to select the log file, format and rules, and redirect stderr

### DIFF
--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -162,7 +162,7 @@ void nostderr(QString file)
 
     // On Windows, stderr is not connected to fd_stderr = 2
     // freopen seems the only function available to redirect stderr
-    qDebug() << "GoldenCheetah: redirecting stderr to file " << file;
+    qDebug() << "GoldenCheetah: redirecting log messages (stderr) to file " << file;
     fp = freopen(file.toLocal8Bit(), "w", stderr);
     if (fp == NULL) {
         qDebug() << "GoldenCheetah: cannot redirect stderr, unable to open file " << file;
@@ -238,11 +238,12 @@ main(int argc, char *argv[])
 #endif
 #ifdef GC_DEBUG
     bool debug = true;
+    QString debugFormat = QString("[%{time h:mm:ss.zzz}] %{type}: %{message} (%{file}:%{line})");
 #else
     bool debug = false;
+    QString debugFormat = QString("[%{time h:mm:ss.zzz}] %{type}: %{message}");
 #endif
     QString debugFile = NULL;
-    QString debugFormat = QString("[%{time h:mm:ss.zzz}] %{type}: %{message} (%{file}:%{line})");
     QString debugRules = QString("*.debug=true;qt.*.debug=false");
 
     bool server = false;

--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -159,6 +159,8 @@ void nostderr(QString file)
 #else
 #include <windows.h>
 #include <io.h>
+#include <fcntl.h>
+
 void nostderr(QString file)
 {
     QFile fp(file);
@@ -167,7 +169,7 @@ void nostderr(QString file)
 
     if (file.at(0) == 't') {
         qDebug() << "Creating log file with CreateFile";
-        fileHandle = CreateFile(file.toStdString().c_str(), GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+        fileHandle = CreateFile((const wchar_t*) file.strVariable1.utf16(), GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
         if (fileHandle == INVALID_HANDLE_VALUE) {
             qDebug() << "GoldenCheetah: cannot redirect stderr, unable to open file " << file;
             return;
@@ -180,7 +182,7 @@ void nostderr(QString file)
             qDebug() << "GoldenCheetah: cannot redirect stderr, unable to open file " << file;
             return;
         }
-        fd = fp->handle(); 
+        fd = fp.handle(); 
         if (fd < 0) qDebug() << "GoldenCheetah: invalid handle obtained from QFile::handle " << fd;
         fileHandle = (HANDLE)_get_osfhandle(fd);
         if(fileHandle == INVALID_HANDLE_VALUE) qDebug() << "GoldenCheetah: cannot get handle for redirecting stderr";

--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -181,7 +181,7 @@ void nostderr(QString file)
         fd = _open_osfhandle((intptr_t)fileHandle, O_WRONLY|O_TEXT);
         if (fd < 0) qDebug() << "GoldenCheetah: invalid handle obtained from get_osfhandle " << fd;
         qDebug() << "Open osfhandle returns " << fd; fflush(stderr);
-    } else (file.endsWith(".qf")) {
+    } else if (file.endsWith(".qf")) {
         qDebug() << "Creating log file with QFile::open"; fflush(stderr);
         if (qf.open(QIODevice::WriteOnly|QIODevice::Truncate) == false) {
             qDebug() << "GoldenCheetah: cannot redirect stderr, unable to open file " << file;
@@ -203,14 +203,14 @@ void nostderr(QString file)
         }
         qDebug() << "Open File success"; fflush(stderr);
         fd = fileno(stderr); 
-        qDebug() << "Get handle " << fd << " / " << fileno(fp) ; fflush(stderr);
+        qDebug() << "Get handle " << fd << " / " << fileno(fp); fflush(stderr);
         if (fd < 0) qDebug() << "GoldenCheetah: invalid handle obtained from fileno " << fd;
         fileHandle = (HANDLE)_get_osfhandle(fd);
         if(fileHandle == INVALID_HANDLE_VALUE) qDebug() << "GoldenCheetah: cannot get handle for redirecting stderr";
         qDebug() << "Get HANDLE success"; fflush(stderr);
     }
 
-    bool res = SetStdHandle(STD_ERROR_HANDLE, fileHandle) ;
+    bool res = SetStdHandle(STD_ERROR_HANDLE, fileHandle);
     if (!res) qDebug() << "GoldenCheetah: cannot change STD_ERROR_HANDLE, SetStdHandle returns false";
     qDebug() << "SetStdHandle success"; fflush(stderr);
 
@@ -244,6 +244,7 @@ void nostderr(QString file)
         qDebug() << "Testing qDebug redirection at iteration " << i;
         fprintf(stderr, "Testing fprintf redirection at iteration %d\n", i);
         cerr << "Testing cerr redirection at iteration " << i;
+        fflush(stderr);
     }
 }
 #endif

--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -167,36 +167,43 @@ void nostderr(QString file)
     int fd;
     HANDLE fileHandle;
 
-    if (file.at(0) == 't') {
+    if (file.endsWith(".cf")) {
         qDebug() << "Creating log file with CreateFile";
         fileHandle = CreateFile((const wchar_t*) file.utf16(), GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
         if (fileHandle == INVALID_HANDLE_VALUE) {
             qDebug() << "GoldenCheetah: cannot redirect stderr, unable to open file " << file;
             return;
         }
+        qDebug() << "Create File success"; fflush(stderr);
         fd = _open_osfhandle((intptr_t)fileHandle, O_WRONLY|O_TEXT);
         if (fd < 0) qDebug() << "GoldenCheetah: invalid handle obtained from get_osfhandle " << fd;
+        qDebug() << "Open osfhandle returns " << fd; fflush(stderr);
     } else {
         qDebug() << "Creating log file with QFile::open";
         if (fp.open(QIODevice::WriteOnly|QIODevice::Truncate) == false) {
             qDebug() << "GoldenCheetah: cannot redirect stderr, unable to open file " << file;
             return;
         }
+        qDebug() << "Open File success"; fflush(stderr);
         fd = fp.handle(); 
+        qDebug() << "Get handle " << fd; fflush(stderr);
         if (fd < 0) qDebug() << "GoldenCheetah: invalid handle obtained from QFile::handle " << fd;
         fileHandle = (HANDLE)_get_osfhandle(fd);
         if(fileHandle == INVALID_HANDLE_VALUE) qDebug() << "GoldenCheetah: cannot get handle for redirecting stderr";
+        qDebug() << "Get HANDLE success"; fflush(stderr);
     }
 
     fflush(stderr);
     bool res = SetStdHandle(STD_ERROR_HANDLE, fileHandle) ;
     if (!res) qDebug() << "GoldenCheetah: cannot change STD_ERROR_HANDLE, SetStdHandle returns false";
+    qDebug() << "SetStdHandle success"; fflush(stderr);
     if (fd < 0) return;
     int ret = dup2(fd, 2);
     if (ret < 0) {
         qDebug() << "Goldencheetah: dup2 failed with return value " << ret;
         return;
     }
+    qDebug() << "Dup2 returns " << ret; fflush(stderr);
     ret = close(fd);
     if (ret < 0) qDebug() << "Goldencheetah: close failed with return value " << ret;
     

--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -143,10 +143,10 @@ void sigabort(int x)
 // redirect errors to `home'/goldencheetah.log or to the file specified with --debug-file
 #ifdef WIN32
 #include <windows.h>
-#endif
-
-#include <stdio.h>
+#include <io.h>
+#else
 #include <unistd.h>
+#endif
 
 void nostderr(QString file)
 {

--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -140,7 +140,10 @@ void sigabort(int x)
 }
 #endif
 
-// redirect errors to `home'/goldencheetah.log or to the file specified with --debug-file
+//
+// redirect stderr to `home'/goldencheetah.log or to the file specified with --debug-file
+//
+#include <stdio.h>
 #ifdef WIN32
 #include <windows.h>
 #include <io.h>
@@ -150,15 +153,15 @@ void sigabort(int x)
 
 void nostderr(QString file)
 {
-    // redirect stderr to a file
+    int stderr_fd = fileno(stderr);
     QFile fp(file);
     if (fp.open(QIODevice::WriteOnly|QIODevice::Truncate) == true) {
-        close(STDERR_FILENO);
-        if(dup(fp.handle()) != STDERR_FILENO) fprintf(stderr, "GoldenCheetah: cannot redirect stderr\n");
+        close(stderr_fd);
+        if(dup(fp.handle()) != stderr_fd) fprintf(stderr, "GoldenCheetah: cannot redirect stderr\n");
         fp.close();
 
 #ifdef WIN32
-        HANDLE fileHandle = (HANDLE) _get_osfhandle(STDERR_FILENO);
+        HANDLE fileHandle = (HANDLE) _get_osfhandle(stderr_fd);
         SetStdHandle(STD_ERROR_HANDLE, fileHandle) ;
 #endif
 

--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -239,11 +239,11 @@ void nostderr(QString file)
     char test_wr_str[] = "Testing write(2)\n";
 
     for(int i = 0; i < 10; i++) {
-        WriteFile(test_std_error, test_wf_str, strlen(test_wf_str), &nb_written, NULL);
-        write(2, test_wr_str, strlen(test_wr_str));
+        WriteFile(test_std_error, test_wf_str, (DWORD)strlen(test_wf_str), &nb_written, NULL);
+        write(2, test_wr_str, (unsigned int)strlen(test_wr_str));
         qDebug() << "Testing qDebug redirection at iteration " << i;
         fprintf(stderr, "Testing fprintf redirection at iteration %d\n", i);
-        cerr << "Testing cerr redirection at iteration " << i;
+        std::cerr << "Testing cerr redirection at iteration " << i;
         fflush(stderr);
     }
 }

--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -169,12 +169,12 @@ void nostderr(QString file)
 
     if (file.at(0) == 't') {
         qDebug() << "Creating log file with CreateFile";
-        fileHandle = CreateFile((const wchar_t*) file.strVariable1.utf16(), GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
+        fileHandle = CreateFile((const wchar_t*) file.utf16(), GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
         if (fileHandle == INVALID_HANDLE_VALUE) {
             qDebug() << "GoldenCheetah: cannot redirect stderr, unable to open file " << file;
             return;
         }
-        fd = _open_osfhandle(fileHandle, O_WRONLY|O_TEXT);
+        fd = _open_osfhandle((intptr_t)fileHandle, O_WRONLY|O_TEXT);
         if (fd < 0) qDebug() << "GoldenCheetah: invalid handle obtained from get_osfhandle " << fd;
     } else {
         qDebug() << "Creating log file with QFile::open";

--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -154,24 +154,6 @@ void sigabort(int x)
 #include <unistd.h>
 #endif
 
-void testredirect()
-{
-    char test_wf_str[] = "Testing WriteFile\n";
-    char test_wr_str[] = "Testing write(2)\n";
-
-    for(int i = 0; i < 10; i++) {
-#ifdef WIN32
-        DWORD nb_written;
-        WriteFile(GetStdHandle(STD_ERROR_HANDLE), test_wf_str, (DWORD)strlen(test_wf_str), &nb_written, NULL);
-#endif
-        write(2, test_wr_str, (unsigned int)strlen(test_wr_str));
-        qDebug() << "Testing qDebug redirection at iteration " << i;
-        fprintf(stderr, "Testing fprintf redirection at iteration %d\n", i);
-        std::cerr << "Testing cerr redirection at iteration " << i << std::endl;
-        fflush(stderr);
-    }
-}
-
 void nostderr(QString file)
 {
     int fd;
@@ -180,6 +162,7 @@ void nostderr(QString file)
 
     // On Windows, stderr is not connected to fd_stderr = 2
     // freopen seems the only function available to redirect stderr
+    qDebug() << "GoldenCheetah: redirecting stderr to file " << file;
     fp = freopen(file.toLocal8Bit(), "w", stderr);
     if (fp == NULL) {
         qDebug() << "GoldenCheetah: cannot redirect stderr, unable to open file " << file;
@@ -212,8 +195,6 @@ void nostderr(QString file)
     bool res = SetStdHandle(STD_ERROR_HANDLE, fileHandle);
     if (!res) qDebug() << "GoldenCheetah: cannot redirect STD_ERROR_HANDLE";
 #endif
-
-    testredirect();
 }
 
 //


### PR DESCRIPTION
This NEEDS to be tested on Windows BEFORE merge! 

Recently, when trying to debug an issue, it was very difficult to get proper debugging logs on windows. The redirection of stderr to goldencheetah.log on Windows did not work. When you do not redirect the output to a file, and have a lot of debugging log entries sent to the console, this changes the timing. Moreover, capturing the output log from the console often resulted in only getting the last thousand lines or so. In addition, more information was needed in log entries, like the timestamp, to better understand the timing. 

This PR hopefully solves the stderr redirection problem on Windows. I have read about the issue, and possible solutions, and believe that the PR should work. However, I could not test it. From what @amtriathlon mentioned, the behavior on Windows 10 and Windows 8 is different and both should be tested. Perhaps @mattipee has access to older Windows releases. In addition, this PR has an option to specify the log file (not having to search where goldencheetah.log is hidden, or keeping more than one log file), specify the logging rules (what logging to activate or not) and the logging format. I tried to provide an interesting default logging format. Do not hesitate to propose something better.