### PR TITLE
Remember SRM offset from last successful calibration

### DIFF
--- a/src/ANT/ANTChannel.cpp
+++ b/src/ANT/ANTChannel.cpp
@@ -55,7 +55,9 @@ ANTChannel::init()
     messages_received=0;
     messages_dropped=0;
     setId();
-    srm_offset=400; // default relatively arbitrary, but matches common 'indoors' values
+    // retrieve srm_offset from last successful calibration,
+    // default relatively arbitrary, but matches common 'indoors' values
+    srm_offset=appsettings->value(this, SRM_OFFSET, 400).toDouble();
     burstInit();
     value2=value=0;
     status = Closed;
@@ -413,6 +415,8 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                         // 5 seconds have elapsed since starting calibration, so assume completed
                         qDebug() << "ANT Sport calibration succeeded";
                         srm_offset = srm_offset_instant;
+                        // persist offset value in global settings
+                        appsettings->setValue(SRM_OFFSET, srm_offset);
                         parent->setCalibrationZeroOffset(srm_offset);
                         parent->setCalibrationSlope(srm_slope);
                         parent->setCalibrationState(CALIBRATION_STATE_SUCCESS);

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -229,6 +229,7 @@
 #define FORTIUS_FIRMWARE                "<global-trainmode>fortius/firmware"
 #define FORTIUS_CALIBRATION             "<global-trainmode>fortius/calibration"
 #define IMAGIC_FIRMWARE                 "<global-trainmode>imagic/firmware"
+#define SRM_OFFSET                      "<global-trainmode>srm/offset"
 #define TRAIN_MULTI                     "<global-trainmode>train/multi"
 #define TRAIN_AUTOCONNECT               "<global-trainmode>train/autoconnect"
 #define TRAIN_AUTOHIDE                  "<global-trainmode>train/autohide"


### PR DESCRIPTION
It should be closer to current offset than the fixed default.
Users having issues with calibration can change default value adding:

[srm]
offset=400

to configglobal-trainmode.ini