### PR TITLE
Insure that Web pages are deleted before the Web Profile

### DIFF
--- a/src/Charts/LTMWindow.cpp
+++ b/src/Charts/LTMWindow.cpp
@@ -356,6 +356,7 @@ LTMWindow::LTMWindow(Context *context) :
 LTMWindow::~LTMWindow()
 {
     delete popup;
+    if (dataSummary) delete dataSummary->page();
 }
 
 void

--- a/src/Charts/PythonChart.cpp
+++ b/src/Charts/PythonChart.cpp
@@ -410,6 +410,10 @@ PythonChart::PythonChart(Context *context, bool ridesummary) : GcChartWindow(con
     web->setChecked(true);
 }
 
+PythonChart::~PythonChart()
+{
+    if (canvas) delete canvas->page();
+}
 
 // switch between rendering to a web page and rendering to a chart page
 void

--- a/src/Charts/PythonChart.h
+++ b/src/Charts/PythonChart.h
@@ -101,6 +101,7 @@ class PythonChart : public GcChartWindow, public PythonHost {
 
     public:
         PythonChart(Context *context, bool ridesummary);
+        ~PythonChart();
 
         // reveal
         bool hasReveal() { return true; }

--- a/src/Charts/RideMapWindow.cpp
+++ b/src/Charts/RideMapWindow.cpp
@@ -173,6 +173,7 @@ RideMapWindow::RideMapWindow(Context *context, int mapType) : GcChartWindow(cont
 RideMapWindow::~RideMapWindow()
 {
     delete webBridge;
+    if (view) delete view->page();
 }
 
 void

--- a/src/Charts/RideSummaryWindow.cpp
+++ b/src/Charts/RideSummaryWindow.cpp
@@ -146,6 +146,7 @@ RideSummaryWindow::~RideSummaryWindow()
     // cancel background thread if needed
     future.cancel();
     future.waitForFinished();
+    if (rideSummary) delete rideSummary->page();
 }
 
 void

--- a/src/Cloud/OAuthDialog.cpp
+++ b/src/Cloud/OAuthDialog.cpp
@@ -203,6 +203,12 @@ OAuthDialog::OAuthDialog(Context *context, OAuthSite site, CloudService *service
     }
 }
 
+OAuthDialog::~OAuthDialog()
+{
+  if (view) delete view->page();
+  delete view;  // view was constructed without a parent to delete it
+}
+
 // just ignore SSL handshake errors at all times
 void
 OAuthDialog::onSslErrors(QNetworkReply *reply, const QList<QSslError>&)

--- a/src/Cloud/OAuthDialog.h
+++ b/src/Cloud/OAuthDialog.h
@@ -62,6 +62,7 @@ public:
 
     // will work with old config via site and new via cloudservice (which is null for calendar and withings for now)
     OAuthDialog(Context *context, OAuthSite site, CloudService *service, QString baseURL="", QString clientsecret="");
+    ~OAuthDialog();
 
     bool sslLibMissing() { return noSSLlib; }
 

--- a/src/Core/GcUpgrade.cpp
+++ b/src/Core/GcUpgrade.cpp
@@ -981,6 +981,11 @@ GcUpgradeLogDialog::GcUpgradeLogDialog(QDir homeDir) : QDialog(NULL, Qt::Dialog)
     report->page()->setHtml(reportText);
 }
 
+GcUpgradeLogDialog::~GcUpgradeLogDialog()
+{
+    if (report) delete report->page();
+}
+
 void
 GcUpgradeLogDialog::saveAs()
 {

--- a/src/Core/GcUpgrade.h
+++ b/src/Core/GcUpgrade.h
@@ -125,6 +125,7 @@ class GcUpgradeLogDialog : public QDialog
 
     public:
         GcUpgradeLogDialog(QDir);
+        ~GcUpgradeLogDialog();
         void enableButtons();
         void append(QString, int level=0);
 

--- a/src/Gui/GcCrashDialog.cpp
+++ b/src/Gui/GcCrashDialog.cpp
@@ -154,6 +154,11 @@ GcCrashDialog::GcCrashDialog(QDir homeDir) : QDialog(NULL, Qt::Dialog), home(hom
     setHTML();
 }
 
+GcCrashDialog::~GcCrashDialog()
+{
+    if (report) delete report->page();
+}
+
 QString GcCrashDialog::versionHTML()
 {
     // -- OS ----

--- a/src/Gui/GcCrashDialog.h
+++ b/src/Gui/GcCrashDialog.h
@@ -35,6 +35,7 @@ class GcCrashDialog : public QDialog
 
     public:
         GcCrashDialog(QDir);
+        ~GcCrashDialog();
         AthleteDirectoryStructure home;
         static QString versionHTML();
 

--- a/src/Train/LiveMapWebPageWindow.cpp
+++ b/src/Train/LiveMapWebPageWindow.cpp
@@ -131,6 +131,7 @@ void LiveMapWebPageWindow::userUrl()
 
 LiveMapWebPageWindow::~LiveMapWebPageWindow()
 {
+  if (view) delete view->page();
 }
 
 void LiveMapWebPageWindow::ergFileSelected(ErgFile* f)

--- a/src/Train/WebPageWindow.cpp
+++ b/src/Train/WebPageWindow.cpp
@@ -181,6 +181,7 @@ WebPageWindow::WebPageWindow(Context *context) : GcChartWindow(context), context
 
 WebPageWindow::~WebPageWindow()
 {
+  if (view) delete view->page();
 }
 
 void 


### PR DESCRIPTION
Every time when exiting, GC complains that the Web Profile is released before Web pages that refer to it, with the message: "Release of profile requested but WebEnginePage still not deleted. Expect troubles !". Being told to "expect troubles" is not very welcoming. With these small changes, the Web pages are now released explicitly in the destructor, to insure that they are freed earlier than the Profile. It solves issue #3844