### PR TITLE
New check box added to Map menu to display shaded route (60sec power intervals)

### DIFF
--- a/src/Charts/RideMapWindow.cpp
+++ b/src/Charts/RideMapWindow.cpp
@@ -471,7 +471,7 @@ void RideMapWindow::createHtml()
             "routeYellow.on('mousemove', function(event) { webBridge.hoverPath(event.latlng.lat, event.latlng.lng); });\n"
 
             "}\n").arg(styleoptions == "" ? "#FFFF00" : GColor(CPLOTMARKER).name())
-                  .arg(styleoptions == "" ? 0.4 : 1.0);
+            .arg(styleoptions == "" ? 0.4 : 1.0);
     }
     else if (mapCombo->currentIndex() == GOOGLE) {
 
@@ -506,7 +506,7 @@ void RideMapWindow::createHtml()
            "    google.maps.event.addListener(routeYellow, 'mouseover', function(event) { webBridge.hoverPath(event.latLng.lat(), event.latLng.lng()); });\n"
 
            "}\n").arg(styleoptions == "" ? "#FFFF00" : GColor(CPLOTMARKER).name())
-                 .arg(styleoptions == "" ? 0.4f : 1.0f);
+           .arg(styleoptions == "" ? 0.4f : 1.0f);
     }
 
     currentPage += QString("function drawIntervals() { \n"
@@ -642,22 +642,22 @@ void RideMapWindow::createHtml()
 
         if (styleoptions == "") {
 
-            // TERRAIN style map please and make it draggable
-            // note that because QT webkit offers touch/gesture
-            // support the Google API only supports dragging
-            // via gestures - this is alrady registered as a bug
-            // with the google map team
-            currentPage += QString(""
-            "    var controlOptions = {\n"
-            "      style: google.maps.MapTypeControlStyle.DEFAULT\n"
-            "    };\n");
+        // TERRAIN style map please and make it draggable
+        // note that because QT webkit offers touch/gesture
+        // support the Google API only supports dragging
+        // via gestures - this is alrady registered as a bug
+        // with the google map team
+        currentPage += QString(""
+        "    var controlOptions = {\n"
+        "      style: google.maps.MapTypeControlStyle.DEFAULT\n"
+        "    };\n");
 
-        } else {
+    } else {
 
-            // USER DEFINED STYLE OPTIONS
-            currentPage += QString(""
-            "var styledMapType = new google.maps.StyledMapType( %1 "
-            " , {name: 'Styled Map'} );\n" ).arg(styleoptions);
+    // USER DEFINED STYLE OPTIONS
+    currentPage += QString(""
+        "var styledMapType = new google.maps.StyledMapType( %1 "
+        " , {name: 'Styled Map'} );\n" ).arg(styleoptions);
         }
 
         currentPage += QString(
@@ -669,7 +669,7 @@ void RideMapWindow::createHtml()
             "      tilt: 45,\n"
             "      streetViewControl: false,\n"
             "    };\n").arg(styleoptions != "" ? "'styled_map'" : "google.maps.MapTypeId.TERRAIN")
-                       .arg(styleoptions != "" ? "true" : "false");
+            .arg(styleoptions != "" ? "true" : "false");
 
 
 
@@ -687,8 +687,8 @@ void RideMapWindow::createHtml()
 
         if (styleoptions != "") {
             currentPage += QString(""
-            "   map.mapTypes.set('styled_map', styledMapType);\n"
-            "   map.setMapTypeId('styled_map');\n");
+                "   map.mapTypes.set('styled_map', styledMapType);\n"
+                "   map.setMapTypeId('styled_map');\n");
         }
 
         currentPage += QString(""
@@ -744,9 +744,10 @@ RideMapWindow::drawShadedRoute()
 {
     int intervalTime = 60;  // 60 seconds
     double rtime=0; // running total for accumulated data
-    int count=0;  // how many samples ?
-    int rwatts=0; // running total of watts
-    double prevtime=0; // time for previous point
+    int count = 0;  // how many samples processed
+    int rwatts = 0; // running total of watts
+    double prevtime = 0; // time for previous point
+    double endRideItemtime = myRideItem->ride()->dataPoints().last()->secs;
 
     QString code;
 
@@ -783,8 +784,8 @@ RideMapWindow::drawShadedRoute()
         prevtime = rfp->secs;
         count++;
 
-        // end of segment
-        if (rtime >= intervalTime) {
+        // end of segment or the segment is truncated by finding the last data point
+        if ((rtime >= intervalTime) || (rfp->secs >= endRideItemtime)) {
             if (mapCombo->currentIndex() == OSM) {
                 // Finalize variable "latLons" for the segment.
                 if (code.endsWith(", "))
@@ -812,8 +813,8 @@ RideMapWindow::drawShadedRoute()
                                 "polyline.on('mouseup',   function(event) { map.dragging.enable();L.DomEvent.stopPropagation(event);webBridge.mouseup(); });\n" // setOptions ?
                                 "polyline.on('mouseover', function(event) { webBridge.hoverPath(event.latlng.lat, event.latlng.lng); });\n"
                                 "path = polyline.getLatLngs();\n"
-                                "}\n").arg(styleoptions == "" ? color.name() : GColor(CPLOTMARKER).name())
-                                .arg(styleoptions == "" ? 0.5 : 1.0);
+                    "}\n").arg(styleoptions == "" ? color.name() : GColor(CPLOTMARKER).name())
+                    .arg(styleoptions == "" ? 0.5 : 1.0);
             } else if (mapCombo->currentIndex() == GOOGLE) {
                 // color the polyline
                 code += QString("var polyOptions = {\n"
@@ -823,15 +824,15 @@ RideMapWindow::drawShadedRoute()
                                 "    zIndex: 0,\n"
                                 "}\n"
                                 "polyline.setOptions(polyOptions);\n"
-                                "}\n").arg(styleoptions == "" ? color.name() : GColor(CPLOTMARKER).name())
-                                      .arg(styleoptions == "" ? 0.5f : 1.0f);
+                    "}\n").arg(styleoptions == "" ? color.name() : GColor(CPLOTMARKER).name())
+                    .arg(styleoptions == "" ? 0.5f : 1.0f);
 
             }
             view->page()->runJavaScript(code);
         }
     }
 
-}
+    }
 
 void
 RideMapWindow::clearTempInterval() {

--- a/src/Charts/RideMapWindow.cpp
+++ b/src/Charts/RideMapWindow.cpp
@@ -746,7 +746,7 @@ void RideMapWindow::createHtml()
 
 QColor RideMapWindow::GetColor(int watts)
 {
-    if (range < 0) return Qt::red;
+    if (range < 0 || !showShadedZones()) return Qt::red;
     else return zoneColor(context->athlete->zones(myRideItem ? myRideItem->isRun : false)->whichZone(range, watts), 7);
 }
 

--- a/src/Charts/RideMapWindow.cpp
+++ b/src/Charts/RideMapWindow.cpp
@@ -654,22 +654,22 @@ void RideMapWindow::createHtml()
 
         if (styleoptions == "") {
 
-        // TERRAIN style map please and make it draggable
-        // note that because QT webkit offers touch/gesture
-        // support the Google API only supports dragging
-        // via gestures - this is alrady registered as a bug
-        // with the google map team
-        currentPage += QString(""
-        "    var controlOptions = {\n"
-        "      style: google.maps.MapTypeControlStyle.DEFAULT\n"
-        "    };\n");
+            // TERRAIN style map please and make it draggable
+            // note that because QT webkit offers touch/gesture
+            // support the Google API only supports dragging
+            // via gestures - this is alrady registered as a bug
+            // with the google map team
+            currentPage += QString(""
+            "    var controlOptions = {\n"
+            "      style: google.maps.MapTypeControlStyle.DEFAULT\n"
+            "    };\n");
 
         } else {
 
             // USER DEFINED STYLE OPTIONS
             currentPage += QString(""
-                "var styledMapType = new google.maps.StyledMapType( %1 "
-                " , {name: 'Styled Map'} );\n" ).arg(styleoptions);
+            "var styledMapType = new google.maps.StyledMapType( %1 "
+            " , {name: 'Styled Map'} );\n" ).arg(styleoptions);
         }
 
         currentPage += QString(
@@ -681,7 +681,7 @@ void RideMapWindow::createHtml()
             "      tilt: 45,\n"
             "      streetViewControl: false,\n"
             "    };\n").arg(styleoptions != "" ? "'styled_map'" : "google.maps.MapTypeId.TERRAIN")
-            .arg(styleoptions != "" ? "true" : "false");
+                       .arg(styleoptions != "" ? "true" : "false");
 
 
 
@@ -699,8 +699,8 @@ void RideMapWindow::createHtml()
 
         if (styleoptions != "") {
             currentPage += QString(""
-                "   map.mapTypes.set('styled_map', styledMapType);\n"
-                "   map.setMapTypeId('styled_map');\n");
+            "   map.mapTypes.set('styled_map', styledMapType);\n"
+            "   map.setMapTypeId('styled_map');\n");
         }
 
         currentPage += QString(""
@@ -826,8 +826,8 @@ RideMapWindow::drawShadedRoute()
                                 "polyline.on('mouseup',   function(event) { map.dragging.enable();L.DomEvent.stopPropagation(event);webBridge.mouseup(); });\n" // setOptions ?
                                 "polyline.on('mouseover', function(event) { webBridge.hoverPath(event.latlng.lat, event.latlng.lng); });\n"
                                 "path = polyline.getLatLngs();\n"
-                    "}\n").arg(styleoptions == "" ? color.name() : GColor(CPLOTMARKER).name())
-                    .arg(styleoptions == "" ? 0.5 : 1.0);
+                                "}\n").arg(styleoptions == "" ? color.name() : GColor(CPLOTMARKER).name())
+                                .arg(styleoptions == "" ? 0.5 : 1.0);
             } else if (mapCombo->currentIndex() == GOOGLE) {
                 // color the polyline
                 code += QString("var polyOptions = {\n"
@@ -837,15 +837,15 @@ RideMapWindow::drawShadedRoute()
                                 "    zIndex: 0,\n"
                                 "}\n"
                                 "polyline.setOptions(polyOptions);\n"
-                    "}\n").arg(styleoptions == "" ? color.name() : GColor(CPLOTMARKER).name())
-                    .arg(styleoptions == "" ? 0.5f : 1.0f);
+                                "}\n").arg(styleoptions == "" ? color.name() : GColor(CPLOTMARKER).name())
+                                      .arg(styleoptions == "" ? 0.5f : 1.0f);
 
             }
             view->page()->runJavaScript(code);
         }
     }
 
-    }
+}
 
 void
 RideMapWindow::clearTempInterval() {

--- a/src/Charts/RideMapWindow.h
+++ b/src/Charts/RideMapWindow.h
@@ -109,6 +109,7 @@ class RideMapWindow : public GcChartWindow
     Q_PROPERTY(bool showmarkers READ showMarkers WRITE setShowMarkers USER true)
     Q_PROPERTY(bool showfullplot READ showFullPlot WRITE setFullPlot USER true)
     Q_PROPERTY(bool showintervals READ showIntervals WRITE setShowIntervals USER true)
+    Q_PROPERTY(bool showShadedZones READ showShadedZones WRITE setShowShadedZones USER true)
     Q_PROPERTY(int osmts READ osmTS WRITE setOsmTS USER true)
     Q_PROPERTY(QString googleKey READ googleKey WRITE setGoogleKey USER true)
     Q_PROPERTY(QString styleoptions READ getStyleOptions WRITE setStyleOptions  USER false)
@@ -128,8 +129,11 @@ class RideMapWindow : public GcChartWindow
         int mapType() const { return mapCombo->currentIndex(); }
         void setMapType(int x) { mapCombo->setCurrentIndex(x >= 0 && x < mapCombo->count() ? x : OSM); } // default to OSM for invalid mapType, s.t. deprecated Bing
 
-        bool showIntervals() const { return showInt->isChecked(); }
-        void setShowIntervals(bool x) { showInt->setChecked(x); }
+        bool showIntervals() const { return showIntCk->isChecked(); }
+        void setShowIntervals(bool x) { showIntCk->setChecked(x); }
+
+        bool showShadedZones() const { return showShadedZonesCk->isChecked(); }
+        void setShowShadedZones(bool x) { showShadedZonesCk->setChecked(x); }
 
         bool showMarkers() const { return ( showMarkersCk->checkState() == Qt::Checked); }
         void setShowMarkers(bool x) { if (x) showMarkersCk->setCheckState(Qt::Checked); else showMarkersCk->setCheckState(Qt::Unchecked) ;}
@@ -155,6 +159,7 @@ class RideMapWindow : public GcChartWindow
         void tileTypeSelected(int x);
         void showMarkersChanged(int value);
         void showFullPlotChanged(int value);
+        void showShadedZonesChanged(int value);
         void showIntervalsChanged(int value);
         void osmCustomTSURLEditingFinished();
 
@@ -175,7 +180,7 @@ class RideMapWindow : public GcChartWindow
         QString styleoptions;
 
         QComboBox *mapCombo, *tileCombo;
-        QCheckBox *showMarkersCk, *showFullPlotCk, *showInt;
+        QCheckBox *showMarkersCk, *showFullPlotCk, *showShadedZonesCk, *showIntCk;
         QLabel *osmTSTitle, *osmTSLabel, *osmTSUrlLabel;
         QLineEdit *osmTSUrl;
 


### PR DESCRIPTION
i) New check box added to Map menu to allow the user to select the display of the shaded route (avg watts per 60s interval). This switches the displayed route between the complete activity ("the red line with thick yellow border") to the segmented view of the shaded route, colours dependent on wattage.

This uncovered another minor display issue with the segmented view:

ii) Fixed the display of the shaded route (when selected) on the map, as previously a section of route too short to be a 60 second interval wasn't drawn, so now any route segment too short at the end of the activity is now included, although in a shorter interval element with appropriate calculation of power in the smaller time segment. Note: The thicker yellow border has been disabled in this mode as the mixing of the various power "colours" and opacity the line segments aren't always visible.

Note: Apologies that there are a few unintended/unwanted whitespace changes, these are not picked up by my VisualStudio SourceTree tools, but once uploaded to GitHub these are detected, these are due to extracting the changes from an earlier rejected pull request.