### PR TITLE
New Map Chart Menu options 

### DIFF
--- a/src/Charts/RideMapWindow.h
+++ b/src/Charts/RideMapWindow.h
@@ -109,6 +109,8 @@ class RideMapWindow : public GcChartWindow
     Q_PROPERTY(bool showmarkers READ showMarkers WRITE setShowMarkers USER true)
     Q_PROPERTY(bool showfullplot READ showFullPlot WRITE setFullPlot USER true)
     Q_PROPERTY(bool showintervals READ showIntervals WRITE setShowIntervals USER true)
+    Q_PROPERTY(bool hideShadedZones READ hideShadedZones WRITE setHideShadedZones USER true)
+    Q_PROPERTY(bool hideYellowLine READ hideYellowLine WRITE setHideYellowLine USER true)
     Q_PROPERTY(int osmts READ osmTS WRITE setOsmTS USER true)
     Q_PROPERTY(QString googleKey READ googleKey WRITE setGoogleKey USER true)
 
@@ -129,6 +131,12 @@ class RideMapWindow : public GcChartWindow
 
         bool showIntervals() const { return showInt->isChecked(); }
         void setShowIntervals(bool x) { showInt->setChecked(x); }
+
+        bool hideShadedZones() const { return hideShadedZonesCk->isChecked(); }
+        void setHideShadedZones(bool x) { hideShadedZonesCk->setChecked(x); }
+
+        bool hideYellowLine() const { return hideYellowLineCk->isChecked(); }
+        void setHideYellowLine(bool x) { hideYellowLineCk->setChecked(x); }
 
         bool showMarkers() const { return ( showMarkersCk->checkState() == Qt::Checked); }
         void setShowMarkers(bool x) { if (x) showMarkersCk->setCheckState(Qt::Checked); else showMarkersCk->setCheckState(Qt::Unchecked) ;}
@@ -151,6 +159,8 @@ class RideMapWindow : public GcChartWindow
         void tileTypeSelected(int x);
         void showMarkersChanged(int value);
         void showFullPlotChanged(int value);
+        void hideShadedZonesChanged(int value);
+        void hideYellowLineChanged(int value);
         void showIntervalsChanged(int value);
         void osmCustomTSURLEditingFinished();
 
@@ -171,6 +181,7 @@ class RideMapWindow : public GcChartWindow
 
         QComboBox *mapCombo, *tileCombo;
         QCheckBox *showMarkersCk, *showFullPlotCk, *showInt;
+        QCheckBox* hideShadedZonesCk, * hideYellowLineCk;
         QLabel *osmTSTitle, *osmTSLabel, *osmTSUrlLabel;
         QLineEdit *osmTSUrl;
 


### PR DESCRIPTION
### Justification

This change was created out of a discussion in the developers group:

https://groups.google.com/g/golden-cheetah-developers/c/_I8YbKlja44/m/bByJyQAHBQAJ

Please see  text:

_Ale Martinez  Jan 8, 2021, 4:04:16 PM  to golden-cheetah-developers
Histogram and CP charts has Power Shading/Shade Zones as a chart option, it seems reasonable to make that optional in Map chart too.
The clean up also seems a good idea to me._
 
 
 
### The Change:

Note: The OptionsStyle clean up mentioned in the discussion thread is in a separate PR.

I have extended the change in the dev discussion to provide the following Map Chart options for the user:

_Note: Default GC behaviour remains unchanged and that is to display:_

i) The route using the Power Shading Zones in 60sec power intervals (when power data is available), otherwise the route is displayed as a red line.
ii) A background to the route as thick yellow line.

This change allows the user to independently via the new chart checkboxes to:

i) ignore any Power Shading Zones (if power data is available) and always draw the red line **(Hide Shaded Zones)**
i) remove the route background yellow line **(Hide Yellow Line)**


![Capture](https://user-images.githubusercontent.com/46629337/113476035-a034e080-9470-11eb-9fb3-b0973b4ad6d8.JPG)

While testing the above changes it uncovered a minor display issue with the segmented view:

![Run Power Map Gap](https://user-images.githubusercontent.com/46629337/112674923-6d7e5d00-8e5e-11eb-82c1-b587cb7d3bf1.JPG)


Currently a section of route which is too short to be a 60 second interval wasn't drawn, so this is now fixed and any route segment too short at the end of the activity is now included, although in a shorter interval element with a power calculation based upon the smaller time segment. 

