### PR TITLE
Compiler warning in MetricSelect.cpp

### DIFF
--- a/src/Gui/MetricSelect.cpp
+++ b/src/Gui/MetricSelect.cpp
@@ -64,7 +64,7 @@ MetricSelect::MetricSelect(QWidget *parent, Context *context, int scope)
 void
 MetricSelect::setSymbol(QString symbol)
 {
-    if (scope&Metric == 0) return;
+    if ((scope & MetricSelect::Metric) == 0) return;
 
     // get the ridemetric
     RideMetricFactory &factory = RideMetricFactory::instance();


### PR DESCRIPTION
Fixes:

Gui\MetricSelect.cpp(67): warning C4554:  '&': check operator precedence for possible error; use parentheses to clarify