### PR TITLE
New Median Power Spike filtering dialog

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -181,6 +181,8 @@
 #define GC_DPFG_STOP                    "<global-general>dataprocess/fixgaps/stop"
 #define GC_DPFS_MAX                     "<global-general>dataprocess/fixspikes/max"
 #define GC_DPFS_VARIANCE                "<global-general>dataprocess/fixspikes/variance"
+#define GC_DPFSM_MED_WIN                "<global-general>dataprocess/fixspikesmed/medwindow"
+#define GC_DPFSM_MED_VARIANCE           "<global-general>dataprocess/fixspikesmed/medvariance"
 #define GC_DPTA                         "<global-general>dataprocess/torqueadjust/adjustment"
 #define GC_DPPA                         "<global-general>dataprocess/poweradjust/adjustment"
 #define GC_DPPA_ABS                     "<global-general>dataprocess/poweradjust/adjustment_abs"

--- a/src/FileIO/FixSpikesMed.cpp
+++ b/src/FileIO/FixSpikesMed.cpp
@@ -1,0 +1,239 @@
+/*
+ *  * Copyright (c) 2010 Mark Liversedge (liversedge@gmail.com)
+ *  * Copyright (c) 2021 Paul Johnson ( paulj49457@gmail.com )
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "DataProcessor.h"
+#include "Settings.h"
+#include "Units.h"
+#include "HelpWhatsThis.h"
+#include <gsl/gsl_statistics.h>
+#include <gsl/gsl_sort.h>
+
+ // Config widget used by the Preferences/Options config panes
+class FixSpikesMed;
+class FixSpikesMedConfig : public DataProcessorConfig {
+	Q_DECLARE_TR_FUNCTIONS(FixSpikesMedConfig)
+
+		friend class ::FixSpikesMed;
+protected:
+	QHBoxLayout* layout;
+	QLabel* medWinLabel, * varianceLabel;
+	QSpinBox* medWinSize, * variance;
+
+public:
+	FixSpikesMedConfig(QWidget* parent) : DataProcessorConfig(parent) {
+
+		HelpWhatsThis* help = new HelpWhatsThis(parent);
+		parent->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Edit_FixPowerSpikesMed));
+
+		layout = new QHBoxLayout(this);
+
+		layout->setContentsMargins(0, 0, 0, 0);
+		setContentsMargins(0, 0, 0, 0);
+
+		medWinLabel = new QLabel(tr("Median Window Size"));
+		varianceLabel = new QLabel(tr("Variance (Watts)"));
+
+		medWinSize = new QSpinBox();
+		medWinSize->setMaximum(21);
+		medWinSize->setMinimum(5);
+		medWinSize->setSingleStep(2);
+		medWinSize->setValue(13);
+
+		// Ensure only odd numbers are set for the median window
+		connect(medWinSize, QOverload<int>::of(&QSpinBox::valueChanged),
+			[=](int i) {(i % 2) ? medWinSize->setValue(i) : medWinSize->setValue(i + 1); });
+
+		variance = new QSpinBox();
+		variance->setMaximum(100);
+		variance->setMinimum(0);
+		variance->setSingleStep(1);
+		variance->setValue(10);
+
+		layout->addWidget(medWinLabel);
+		layout->addWidget(medWinSize);
+		layout->addWidget(varianceLabel);
+		layout->addWidget(variance);
+
+		layout->addStretch();
+	}
+
+	//~FixSpikesMedConfig() {} // deliberately not declared since Qt will delete
+						  // the widget and its children when the config pane is deleted
+
+
+	QString explain() {
+		return(QString(tr("Power meters will occasionally report "
+			"erroneously high values for power. For crank based "
+			"power meters such as SRM and Quarq this is caused "
+			"by an erroneous cadence reading as a result of "
+			"triggering a reed switch whilst pushing off.\n\n"
+
+			"This function applies median filtering which is "
+			"considered robust to local outliers, and preserves "
+			"sharp edges while at the same time removing signal "
+			"noise.\n\n"
+
+			"This function will search for spikes/anomalies in the "
+			"power data and replace the erroneous data which differs "
+			"from the median value of a window centred upon the "
+			"erronous data point.\n\n"
+
+			"It takes the following parameters:\n\n"
+
+			"Median Window Size - this defines the number of "
+			"neighbouring points used to determine a median "
+			"value; the window size is always odd to ensure "
+			"we have a central median value.\n\n"
+
+			"Variance Watts - Determines the threshold beyond which a "
+			"data point will be fixed, if the difference between the "
+			"data point value and the median value exceeds this parameter.\n\n")));
+	}
+
+	void readConfig() {
+		int mWin = appsettings->value(NULL, GC_DPFSM_MED_WIN, "13").toInt();
+		int mVar = appsettings->value(NULL, GC_DPFSM_MED_VARIANCE, "10").toInt();
+		medWinSize->setValue(mWin);
+		variance->setValue(mVar);
+	}
+
+	void saveConfig() {
+		appsettings->setValue(GC_DPFSM_MED_WIN, medWinSize->value());
+		appsettings->setValue(GC_DPFSM_MED_VARIANCE, variance->value());
+	}
+};
+
+
+// RideFile Dataprocessor -- used to handle gaps in recording
+//                           by inserting interpolated/zero samples
+//                           to ensure dataPoints are contiguous in time
+//
+class FixSpikesMed : public DataProcessor {
+	Q_DECLARE_TR_FUNCTIONS(FixSpikesMed)
+
+public:
+	FixSpikesMed() {}
+	~FixSpikesMed() {}
+
+	// the processor
+	bool postProcess(RideFile*, DataProcessorConfig* config, QString op);
+
+	// the config widget
+	DataProcessorConfig* processorConfig(QWidget* parent, const RideFile* ride = NULL) {
+		Q_UNUSED(ride);
+		return new FixSpikesMedConfig(parent);
+	}
+
+	// Localized Name
+	QString name() {
+		return (tr("Fix Power Spikes Median"));
+	}
+};
+
+static bool FixSpikesMedAdded = DataProcessorFactory::instance().registerProcessor(QString("Fix Power Spikes Median"), new FixSpikesMed());
+
+bool
+FixSpikesMed::postProcess(RideFile* ride, DataProcessorConfig* config = 0, QString op = "") {
+	Q_UNUSED(op)
+
+		// does this ride have power?
+		if (ride->areDataPresent()->watts == false) return false;
+
+	// get settings
+	double variance;
+	int medianWinSize; // this nummber must be odd to align the centre of the median window with the point being tested/corrected
+
+	if (config == NULL) { // being called automatically
+		medianWinSize = appsettings->value(NULL, GC_DPFSM_MED_WIN, "13").toInt();
+		variance = appsettings->value(NULL, GC_DPFSM_MED_VARIANCE, "10").toInt();
+	}
+	else { // being called manually
+		medianWinSize = ((FixSpikesMedConfig*)(config))->medWinSize->value();
+		variance = ((FixSpikesMedConfig*)(config))->variance->value();
+	}
+
+	// We use a median window to find spikes if the ride is
+	// shorter than the window don't bother, as there is no way
+	// of post processing anyway (e.g. manual workouts)
+	if (medianWinSize > ride->dataPoints().count()) return false;
+
+	// Keep track of the power outliers
+	int spikes = 0;
+	double spiketime = 0.0;
+
+	double* data = new double[medianWinSize];
+	int halfMedianWin = medianWinSize / 2;
+
+	ride->command->startLUW("Fix Spikes Median in Recording");
+
+	int numDataPnts = ride->dataPoints().count();
+	for (int dataPntPosn = 0; dataPntPosn < ride->dataPoints().count(); dataPntPosn++) {
+
+		double wattsAtPnt = ride->dataPoints()[dataPntPosn]->watts;
+
+		// load median window with values
+		for (int medianWin = 0; medianWin < medianWinSize; medianWin++) {
+
+			int dp = dataPntPosn + medianWin - halfMedianWin;
+
+			// Load the median window...
+
+			if (dp < 0) {
+				// At the beginning of the ride, the left-hand side of the median window doesn't align with any ride data, it's
+				// somewhat arbitrary how to pad this data, but choosing a single data point to replicate runs the risk of
+				// skewing the median filter so choose some reasonably close ride data to avoid this scenario.
+				data[medianWin] = ride->dataPoints()[dataPntPosn + medianWin + halfMedianWin + 1]->watts;
+			}
+			else if (dp > numDataPnts - 1) {
+				// Again at the end of the ride, the right-hand side of the median window doesn't align with any ride data, it's
+				// best to avoid a single data point to replicate as this runs the risk of skewing the median filter
+				// so choose some reasonably close ride data to avoid this scenario.
+				data[medianWin] = ride->dataPoints()[dataPntPosn - halfMedianWin - (medianWinSize - medianWin)]->watts;
+			}
+			else {
+				// The Median window lies completely within the ride data.
+				data[medianWin] = ride->dataPoints()[dp]->watts;
+			}
+		}
+
+		// Sort entries into ascending numerical order. 
+		gsl_sort(data, 1, medianWinSize);
+
+		double medianVal = gsl_stats_median_from_sorted_data(data, 1, medianWinSize);
+
+		// An entry is a fixup candidate if it differs by more than the variance threshold.
+		if (fabs(medianVal - wattsAtPnt) < variance) continue; // Note: Only works for two positive numbers.
+
+		// Record spike
+		spikes++;
+		spiketime += ride->recIntSecs();
+
+		// Fix data point
+		ride->command->setPointValue(dataPntPosn, RideFile::watts, medianVal);
+	}
+
+	ride->command->endLUW();
+
+	delete[] data;
+
+	ride->setTag("Spikes", QString("%1").arg(spikes));
+	ride->setTag("Spike Time", QString("%1").arg(spiketime));
+
+	return (bool)spikes;
+}

--- a/src/Gui/HelpWhatsThis.cpp
+++ b/src/Gui/HelpWhatsThis.cpp
@@ -164,6 +164,8 @@ HelpWhatsThis::getText(GCHelp chapter) {
         return text.arg("Menu%20Bar_Edit").arg(tr("Fix HR Spikes"));
     case MenuBar_Edit_FixPowerSpikes:
         return text.arg("Menu%20Bar_Edit").arg(tr("Fix Power Spikes"));
+    case MenuBar_Edit_FixPowerSpikesMed:
+        return text.arg("Menu%20Bar_Edit").arg(tr("Fix Power Spikes Median"));
     case MenuBar_Edit_FixSpeed:
         return text.arg("Menu%20Bar_Edit").arg(tr("Fix Speed"));
     case MenuBar_Edit_FixFreewheeling:

--- a/src/Gui/HelpWhatsThis.h
+++ b/src/Gui/HelpWhatsThis.h
@@ -85,6 +85,7 @@ Q_OBJECT
                  MenuBar_Edit_FixGPSErrors,
                  MenuBar_Edit_FixHRSpikes,
                  MenuBar_Edit_FixPowerSpikes,
+                 MenuBar_Edit_FixPowerSpikesMed,
                  MenuBar_Edit_FixSpeed,
                  MenuBar_Edit_FixLapSwim,
                  MenuBar_Edit_FixFreewheeling,

--- a/src/src.pro
+++ b/src/src.pro
@@ -803,7 +803,7 @@ SOURCES += FileIO/ArchiveFile.cpp FileIO/AthleteBackup.cpp FileIO/Bin2RideFile.c
            FileIO/FitlogParser.cpp FileIO/FitlogRideFile.cpp FileIO/FitRideFile.cpp FileIO/FixAeroPod.cpp FileIO/FixDeriveDistance.cpp \
            FileIO/FixDeriveHeadwind.cpp FileIO/FixDerivePower.cpp FileIO/FixDeriveTorque.cpp FileIO/FixElevation.cpp FileIO/FixLapSwim.cpp \
            FileIO/FixFreewheeling.cpp FileIO/FixGaps.cpp FileIO/FixGPS.cpp FileIO/FixRunningCadence.cpp FileIO/FixRunningPower.cpp \
-           FileIO/FixHRSpikes.cpp FileIO/FixMoxy.cpp FileIO/FixPower.cpp FileIO/FixSmO2.cpp FileIO/FixSpeed.cpp FileIO/FixSpikes.cpp \
+           FileIO/FixHRSpikes.cpp FileIO/FixMoxy.cpp FileIO/FixPower.cpp FileIO/FixSmO2.cpp FileIO/FixSpeed.cpp FileIO/FixSpikes.cpp FileIO/FixSpikesMed.cpp \
            FileIO/FixTorque.cpp FileIO/GcRideFile.cpp FileIO/GpxParser.cpp FileIO/GpxRideFile.cpp FileIO/JouleDevice.cpp FileIO/LapsEditor.cpp \
            FileIO/MacroDevice.cpp FileIO/ManualRideFile.cpp FileIO/MoxyDevice.cpp \
            FileIO/PolarRideFile.cpp FileIO/PowerTapDevice.cpp FileIO/PowerTapUtil.cpp FileIO/PwxRideFile.cpp FileIO/QuarqParser.cpp \


### PR DESCRIPTION
### Story & Justification:
I've been getting more than my fair share of power spikes when using GC in training mode with my Kickr Core. So using the power spike filtering within GC to correct my files I found that it wasn't effective on spikes of more than a single data point, as the algorithm uses the average of the two adjacent neighbours to fix the erroneous data point. When the spike is a number of points wide this just reduces the spike and subsequent attempts with the filter never completely removes the spike.

The issue of spikes was also discussed here:
https://groups.google.com/g/golden-cheetah-users/c/_bxIzhFPVWA/m/Q5PizsveBAAJ

### Proposal:
Therefore I have created a new dialog "Fix Power Spikes Median" which as the name suggests uses a median window method on the data samples as the median filter is robust to local outliers, and using a suitable window will remove multi sample spikes completely, whilst preserving sharp edges/changes in power output, see:

https://www.gnu.org/software/gsl/doc/html/filter.html?highlight=median#standard-median-filter

The reason for proposing a separate new dialog is that it retains the existing GC functionality, so minimising impact, and will provide the opportunity for the two approaches to be compared.

### Change

So a demonstration of the median filtering, starting with the typical case:

![Normal Spike case](https://user-images.githubusercontent.com/46629337/112752551-83f5f700-8fcb-11eb-8086-eb3e53f64622.JPG)

after running the median filter with the default values:

![Normal Spike case - Median Fixed](https://user-images.githubusercontent.com/46629337/112752570-96703080-8fcb-11eb-9c69-cbef9af9f285.JPG)


So now a demonstration of the median filtering on my worst case (and its bad), and no I cannot suddenly generate 2KW+

![Big Spike case](https://user-images.githubusercontent.com/46629337/112752592-ae47b480-8fcb-11eb-961c-c7743011b7d9.JPG)

after running the median filter with the default values:

![Big Spike case - Median Fixed](https://user-images.githubusercontent.com/46629337/112752598-b69fef80-8fcb-11eb-9c10-acb643948834.JPG)


The Edit menu now has an additional entry "Fix Power Spikes Median...":

![Median Dialog](https://user-images.githubusercontent.com/46629337/112752727-4d6cac00-8fcc-11eb-9818-7bbbaa9df7e9.JPG)

And the import processing has an additional entry "Fix Power Spikes Median":

![Import](https://user-images.githubusercontent.com/46629337/112752754-6bd2a780-8fcc-11eb-9929-b1cbc126d5c1.JPG)

The new dialog looks like:

![Median](https://user-images.githubusercontent.com/46629337/112752807-af2d1600-8fcc-11eb-8f9c-eeea237ab3fa.JPG)

The dialog takes the following parameters:

> 

`Median` Window Size` - this defines the number of neighbouring points used to determine a median value; the window size is always odd to ensure we have a central median value.

`Variance` Watts` - Determines the threshold beyond which a data point will be fixed, if the difference between the data point value and the median value exceeds this parameter.