### PR TITLE
Facility to trace all the USB communications

### DIFF
--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -243,8 +243,11 @@ main(int argc, char *argv[])
     bool debug = false;
     QString debugFormat = QString("[%{time h:mm:ss.zzz}] %{type}: %{message}");
 #endif
+
+    // By default, print messages from all categories, but not those from
+    // specialised categories like qt.* or gc.* which can be quite verbose
+    QString debugRules = QString("*.debug=true;gc.*.debug=false;qt.*.debug=false");
     QString debugFile = NULL;
-    QString debugRules = QString("*.debug=true;qt.*.debug=false");
 
     bool server = false;
     nogui = false;


### PR DESCRIPTION
A new logging category is added gc.usb, inactive by default, to log all the USB transfers between GC and the USB trainers. It can be activated by changing the logging filter with the --debug-rules option.