### PR TITLE
Add "Ramp" qName to ZwiftParser

### DIFF
--- a/src/Train/ZwoParser.cpp
+++ b/src/Train/ZwoParser.cpp
@@ -68,7 +68,7 @@ ZwoParser::startElement(const QString &, const QString &, const QString &qName, 
     // POINTS
 
     // basic from/to, with different names for some odd reason
-    if (qName == "Warmup" || qName == "SteadyState"  || qName == "Cooldown" || qName == "FreeRide" || qName == "Freeride") {
+    if (qName == "Warmup" || qName == "SteadyState"  || qName == "Cooldown" || qName == "Ramp" || qName == "FreeRide" || qName == "Freeride") {
 
         int from = int(100.0 * PowerLow);
         int to = int(100.0 * PowerHigh);


### PR DESCRIPTION
Some Zwift workouts may have "Ramp" events, which work just like the "Cooldown"; e.g:
`<Ramp Duration="120" PowerLow="0.65" PowerHigh="0.85">`