### PR TITLE
Add Zwift intervals to Erg intervals + Add intervals to FIT export

### DIFF
--- a/src/Core/RideItem.cpp
+++ b/src/Core/RideItem.cpp
@@ -927,8 +927,10 @@ RideItem::updateIntervals()
            (interval->start <= begin->secs && (interval->stop+f->recIntSecs()) >= end->secs))))
              continue;
 
-        // skip empty backward intervals
-        if (interval->start >= interval->stop) continue;
+        // skip empty backward intervals --> No because FIT intervals lenght (in sec) is "interval->stop - interval->start + 1" and start/stops are defined in secs: so what append if start = 3s and stop=3.8s ?
+        // So skip empty backward intervals only if start==stop==0;
+        if (interval->start == 0 || interval->stop == 0) continue;
+        qDebug() << "RideItem: " + QString::number(interval->start);
 
         // create a new interval item
         const int seq = count; // if passed directly, it could be incremented BEFORE being evaluated for the sequence arg as arg eval order is undefined

--- a/src/FileIO/FitRideFile.cpp
+++ b/src/FileIO/FitRideFile.cpp
@@ -3719,36 +3719,44 @@ void write_lap(QByteArray *array, const RideFile *ride) {
     write_field_definition(array, 2, 4, 134); // start_time (2)
     write_field_definition(array, 24, 1, 2); // trigger (24)
 
+    foreach (RideFileInterval *i, ride->intervals()) {
+        if (i->stop > 0) {
+            // Record ------
+            int record_header = 0;
+            write_int8(array, record_header);
 
-    // Record ------
-    int record_header = 0;
-    write_int8(array, record_header);
 
-    // 1. timestamp
-    int value = ride->startTime().toTime_t() - qbase_time.toTime_t();;
-    if (ride->dataPoints().count() > 0) {
-        value += ride->dataPoints().last()->secs+ride->recIntSecs();
+            // 1. timestamp
+            int stop_ = i->stop -1 + ride->startTime().toTime_t() - qbase_time.toTime_t();
+            //if (ride->dataPoints().count() > 0) {
+            //    value += ride->dataPoints().last()->secs+ride->recIntSecs();
+            //}
+            write_int32(array, stop_, true);
+
+            // 2. message_index (254)
+            write_int16(array, 0, true);
+
+            // 3. event
+            int value = 9; // session=8, lap=9
+            write_int8(array, value);
+
+            // 4. event_type
+            value = 1; // stop_all=9, stop=1
+            write_int8(array, value);
+
+            // 5. start_time
+            int start_ = stop_ - i->stop + i->start ;
+            write_int32(array, start_, true);
+
+            // 6. trigger
+            value = 7; // session_end
+            write_int8(array, value);
+
+            // 7. Debug
+            qDebug() << "Start: " + QString::number(i->start) + " -> Stop:" + QString::number(i->stop);
+            qDebug() << "Start Timestamp: " + QString::number(start_) + " -> Stop Timestamp:" + QString::number(stop_);QString::number(start_);
+        }
     }
-    write_int32(array, value, true);
-
-    // 2. message_index (254)
-    write_int16(array, 0, true);
-
-    // 3. event
-    value = 9; // session=8, lap=9
-    write_int8(array, value);
-
-    // 4. event_type
-    value = 1; // stop_all=9, stop=1
-    write_int8(array, value);
-
-    // 5. start_time
-    value = ride->startTime().toTime_t() - qbase_time.toTime_t();;
-    write_int32(array, value, true);
-
-    // 6. trigger
-    value = 7; // session_end
-    write_int8(array, value);
 
 }
 

--- a/src/FileIO/RideFile.h
+++ b/src/FileIO/RideFile.h
@@ -317,6 +317,10 @@ class RideFile : public QObject // QObject to emit signals
         void setId(const QString &value) { id_ = value; }
 
         // Working with INTERVALS
+
+        // Moving from "protected" to "public" so we can use "Intervals" in the Fit export.
+        const QList<RideFileInterval*> &intervals() const { return intervals_; }
+
         void addInterval(RideFileInterval::IntervalType type, double start, double stop, const QString &name, QColor color=Qt::black, bool test=false) {
             intervals_.append(new RideFileInterval(type, start, stop, name, color, test));
         }
@@ -400,10 +404,11 @@ class RideFile : public QObject // QObject to emit signals
 
     protected:
 
-        //  should access via IntervalItem
-        const QList<RideFileInterval*> &intervals() const { return intervals_; }
-
-        // xdata series
+        //  should access via IntervalItem <- Yes, But FitRideFile, for example, uses RideFile *ride and not RideItem nor IntervalItem *item
+        // => moving it to public is the simplest way I think
+        //const QList<RideFileInterval*> &intervals() const { return intervals_; }
+		
+		// xdata series
         QMap<QString, XDataSeries*> xdata_;
 
         void clearIntervals();

--- a/src/Train/ErgFile.cpp
+++ b/src/Train/ErgFile.cpp
@@ -174,6 +174,9 @@ void ErgFile::parseZwift()
         Duration = p.x;
     }
 
+    // Laps
+    Laps = handler.laps;
+
     // texts
     Texts = handler.texts;
 

--- a/src/Train/ZwoParser.cpp
+++ b/src/Train/ZwoParser.cpp
@@ -24,6 +24,7 @@ bool ZwoParser::startDocument()
     secs = 0;
     sSecs = 0;
     watts = 0;
+    laps_count = 0;
     return true;
 }
 
@@ -95,6 +96,9 @@ ZwoParser::startElement(const QString &, const QString &, const QString &qName, 
         points << ErgFilePoint(secs * 1000, to, to);
         watts = to;
 
+        // LAPS
+        laps << ErgFileLap(sSecs * 1000, laps_count, "Z"+QString::number(laps_count+1));
+        laps_count ++;
     // repeated intervals with a recovery portion
     } else if (qName == "IntervalsT") {
 
@@ -131,6 +135,9 @@ ZwoParser::startElement(const QString &, const QString &, const QString &qName, 
 
         sSecs = secs;
         while (count--) {
+            // LAPS
+            laps << ErgFileLap(secs * 1000, laps_count, "Z"+QString::number(laps_count+1));
+            laps_count ++;
 
             // add if not already on that wattage
             if (watts != onLow) {
@@ -143,6 +150,9 @@ ZwoParser::startElement(const QString &, const QString &, const QString &qName, 
 
             // recovery interval (if defined)
             if (offDuration > 0) {
+                // LAPS
+                laps << ErgFileLap(secs * 1000, laps_count, "Z"+QString::number(laps_count+1));
+                laps_count ++;
                 if (watts != offLow) {
                     points << ErgFilePoint(secs * 1000, offLow, offLow);
                     watts = offLow;

--- a/src/Train/ZwoParser.h
+++ b/src/Train/ZwoParser.h
@@ -40,6 +40,7 @@ public:
     int secs;  // rolling secs as points read
     int sSecs; // rolling starting secs as points read
     int watts; // watts set at last point
+    int laps_count; // to count the laps
 
     // the data in it
     QString name,               // <name>
@@ -58,5 +59,7 @@ public:
     // texts
     QList<ErgFileText> texts;
 
+    // Laps
+    QList<ErgFileLap> laps;
 };
 #endif //ZwoParser


### PR DESCRIPTION
Hey, I just add the possibility to have Zwo training sessions beeing automatically divided into intervals (laps) in order to be able to analyze the phases of the training afterwards. (and in the future to add cadence target for each interval: i'm working on that, pull request soon normally).

The intervals created during workout are now integrated into the FIT export (which I personally use). In addition, I added the possibility of having intervals of a duration of 1s in the RideDB.json and in the summary (just to be synchronous with the JSON files of the saved activities).
