### PR TITLE
Correcting bug with quote character in workout Textevents and ZWO export

### DIFF
--- a/src/Train/ErgFile.cpp
+++ b/src/Train/ErgFile.cpp
@@ -1520,14 +1520,11 @@ ErgFile::save(QStringList &errors)
                                   << "PowerHigh=\"" <<sections[i].end/CP << "\"";
                 if (Texts.count() > 0) {
                     out << ">\n";
-                    QString message = "";
                     foreach (ErgFileText cue, Texts) {
                         if (cue.x >= msecs && cue.x <= msecs+sections[i].duration) {
-                            message = cue.text;
-                            message.replace(R"(")", R"(&quot;)");
                             out << "          <textevent "
                                 << "timeoffset=\""<<(cue.x-msecs)/1000
-                                << "\" message=\"" << message
+                                << "\" message=\"" << Utils::xmlprotect(cue.text)
                                 << "\" duration=\"" << cue.duration << "\"/>\n";
                         }
                     }

--- a/src/Train/ErgFile.cpp
+++ b/src/Train/ErgFile.cpp
@@ -1520,12 +1520,17 @@ ErgFile::save(QStringList &errors)
                                   << "PowerHigh=\"" <<sections[i].end/CP << "\"";
                 if (Texts.count() > 0) {
                     out << ">\n";
-                    foreach (ErgFileText cue, Texts)
-                        if (cue.x >= msecs && cue.x <= msecs+sections[i].duration)
+                    QString message = "";
+                    foreach (ErgFileText cue, Texts) {
+                        if (cue.x >= msecs && cue.x <= msecs+sections[i].duration) {
+                            message = cue.text;
+                            message.replace(R"(")", R"(&quot;)");
                             out << "          <textevent "
                                 << "timeoffset=\""<<(cue.x-msecs)/1000
-                                << "\" message=\"" << cue.text
+                                << "\" message=\"" << message
                                 << "\" duration=\"" << cue.duration << "\"/>\n";
+                        }
+                    }
                     out << "        </" << tag << ">\n";
                 } else {
                     out << "/>\n";


### PR DESCRIPTION
When adding a Zwo workout, modify it (or not) and save it with .zwo format, if some Textevents have "some words" inside quotes, they were not replaced with XML comptible characters "\&quot\;".