### PR TITLE
Improve Clarity of GC Paths in Dialogs

### DIFF
--- a/src/Gui/AboutDialog.cpp
+++ b/src/Gui/AboutDialog.cpp
@@ -64,9 +64,6 @@ AboutPage::AboutPage(Context *context) : context(context)
                 "<p>Source code can be obtained from<br>"
                 "<a href=\"https://www.goldencheetah.org/\">"
                 "https://www.goldencheetah.org/</a>."
-                "<br><p>Activity files and other data are stored in<br>"
-                "<a href=\"%1\">%2</a>"
-                "<p>Athlete ID %3<br>"
                 "<p>Trademarks used with permission<br>"
                 "BikeScore, xPower, SwimScore courtesy of <a href=\"http://www.physfarm.com\">"
                 "Physfarm Training Systems</a>.<br>"
@@ -77,11 +74,7 @@ AboutPage::AboutPage(Context *context) : context(context)
                 "<br> and is patent pending<br>"
                 "<br><img src=\":images/services/strava_compatible.png\"/><br>"
                 "</center>"
-                )
-                .arg(QString(QUrl::fromLocalFile(context->athlete->home->root().absolutePath()).toEncoded()))
-                .arg(context->athlete->home->root().absolutePath().replace(" ", "&nbsp;"))
-                .arg(context->athlete->id.toString())
-    );
+                ));
 
     QVBoxLayout *mainLayout = new QVBoxLayout;
     mainLayout->setSpacing(0);

--- a/src/Gui/AthletePages.cpp
+++ b/src/Gui/AthletePages.cpp
@@ -201,6 +201,7 @@ AboutRiderPage::AboutRiderPage(QWidget *parent, Context *context) : QWidget(pare
     QLabel *sexlabel = new QLabel(tr("Sex"));
     weightlabel = new QLabel(tr("Weight"));
     heightlabel = new QLabel(tr("Height"));
+    QLabel* athleteIDlabel = new QLabel(tr("Athlete ID"));
 
     nickname = new QLineEdit(this);
     nickname->setText(appsettings->cvalue(context->athlete->cyclist, GC_NICKNAME, "").toString());
@@ -307,6 +308,16 @@ AboutRiderPage::AboutRiderPage(QWidget *parent, Context *context) : QWidget(pare
     connect(tireSizeCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(calcWheelSize()));
     connect(wheelSizeEdit, SIGNAL(textEdited(QString)), this, SLOT(resetWheelSize()));
 
+    athleteID = new QLineEdit(this);
+    athleteID->setText(context->athlete->id.toString());
+    athleteID->setEnabled(false);
+
+    QVariant activeAthleteDir = context->athlete->home->root().absolutePath();
+    QLabel* activeAthleteLabel = new QLabel(tr("Athlete Library Path"));
+    QLineEdit* activeAthleteDirectory = new QLineEdit;
+    activeAthleteDirectory->setText(activeAthleteDir.toString());
+    activeAthleteDirectory->setEnabled(false);
+
     Qt::Alignment alignment = Qt::AlignLeft|Qt::AlignVCenter;
 
     grid->addWidget(nicklabel, 0, 0, alignment);
@@ -325,6 +336,12 @@ AboutRiderPage::AboutRiderPage(QWidget *parent, Context *context) : QWidget(pare
     grid->addWidget(crankLengthCombo, 5, 1, alignment);
     grid->addWidget(wheelSizeLabel, 6, 0, alignment);
     grid->addLayout(wheelSizeLayout, 6, 1, 1, 2, alignment);
+
+    grid->addWidget(athleteIDlabel, 8, 0, alignment);
+    grid->addWidget(athleteID, 8, 1, 1, 2);
+
+    grid->addWidget(activeAthleteLabel, 9, 0, alignment);
+    grid->addWidget(activeAthleteDirectory, 9, 1, 1, 2);
 
     grid->addWidget(avatarButton, 0, 1, 4, 2, Qt::AlignRight|Qt::AlignVCenter);
     all->addLayout(grid);

--- a/src/Gui/AthletePages.h
+++ b/src/Gui/AthletePages.h
@@ -114,6 +114,7 @@ class AboutRiderPage : public QWidget
         bool metricUnits;
 
         QLineEdit *nickname;
+        QLineEdit *athleteID;
         QDateEdit *dob;
         QComboBox *sex;
         QLabel *weightlabel;

--- a/src/Gui/Pages.cpp
+++ b/src/Gui/Pages.cpp
@@ -19,6 +19,7 @@
 #include "Athlete.h"
 #include <QtGui>
 #include <QIntValidator>
+#include <qtooltip.h>
 
 #include <assert.h>
 
@@ -226,18 +227,36 @@ GeneralPage::GeneralPage(Context *context) : context(context)
     // Athlete directory (home of athletes)
     //
     QVariant athleteDir = appsettings->value(this, GC_HOMEDIR);
-    athleteLabel = new QLabel(tr("Athlete Library"));
+    athleteLabel = new QLabel(tr("Default Athlete Library"));
     athleteDirectory = new QLineEdit;
     athleteDirectory->setText(athleteDir.toString() == "0" ? "" : athleteDir.toString());
     athleteWAS = athleteDirectory->text(); // remember what we started with ...
     athleteBrowseButton = new QPushButton(tr("Browse"));
     //XXathleteBrowseButton->setFixedWidth(120);
 
+    QString defaultLib(tr("The Default Athlete Library is the path GC will use at startup to find the\n"
+                          "Athlete database; it can overridden when a path is provided on the command line.\n"));
+    athleteLabel->setToolTip(defaultLib);
+    athleteDirectory->setToolTip(defaultLib);
     configLayout->addWidget(athleteLabel, 9 + offset,0, Qt::AlignRight);
     configLayout->addWidget(athleteDirectory, 9 + offset,1);
     configLayout->addWidget(athleteBrowseButton, 9 + offset,2);
 
     connect(athleteBrowseButton, SIGNAL(clicked()), this, SLOT(browseAthleteDir()));
+    offset++;
+
+    activeAthleteLabel = new QLabel(tr("Active Athlete Library"));
+    activeAthleteDirectory = new QLineEdit;
+    activeAthleteDirectory->setText(gcroot);
+    activeAthleteDirectory->setEnabled(false);
+
+    QString activeLib(tr("The Active Athlete Library is the path GC is currently using to access the Athlete data.\n"));
+    activeAthleteLabel->setToolTip(activeLib);
+    activeAthleteDirectory->setToolTip(activeLib);
+
+    configLayout->addWidget(activeAthleteLabel, 9 + offset, 0, Qt::AlignRight);
+    configLayout->addWidget(activeAthleteDirectory, 9 + offset, 1);
+    offset++;
 
 #ifdef GC_WANT_R
     //

--- a/src/Gui/Pages.h
+++ b/src/Gui/Pages.h
@@ -116,6 +116,7 @@ class GeneralPage : public QWidget
         QLineEdit *garminHWMarkedit;
         QLineEdit *hystedit;
         QLineEdit *athleteDirectory;
+        QLineEdit *activeAthleteDirectory;
         QPushButton *athleteBrowseButton;
 
 #ifdef GC_WANT_PYTHON
@@ -131,6 +132,7 @@ class GeneralPage : public QWidget
         QLabel *langLabel;
         QLabel *warningLabel;
         QLabel *athleteLabel;
+        QLabel* activeAthleteLabel;
 
         struct {
             int unit;


### PR DESCRIPTION
**Justification:**

This proposal aims to clarify the location of the current Athlete database being used by GC. The reason I created this PR was to unravel the directories GC attempts to open at start-up, see #3767 for more details.

**The changes:**

i) Currently the About Dialog displays the current Athlete ID and the path to the Athletes Database which seems a slightly odd location for this information, it certainly wasn't the first place I looked for this information! So this change aims to move this information from the About dialog to the Athlete page as shown below:

![116155850-9b1b2800-a6e2-11eb-809c-dcedf74bd71b](https://user-images.githubusercontent.com/46629337/121776288-e8186800-cb83-11eb-83ac-539fcdd7f77c.jpg)

ii) The Athlete Library displayed in the Options Dialog (see below) isn't necessarily the path GC is using to access the Athlete's data, as passing a directory path on the command line, or should GC fail open this path it will use a number of candidates in priority order. Therefore I propose to add an additional read-only field which displays "gcroot" the actual path GC is using to locate the Athletes database, designated the "Active Athlete Library", see below. Note. Both fields have tooltips which explain the contents of the fields, and the functionality associated with the Default Athlete Library remains unchanged, but now if GC uses a different path there shouldn't be any surprises.

![OptionsCapture](https://user-images.githubusercontent.com/46629337/116155905-af5f2500-a6e2-11eb-9261-b51d7ade8088.JPG)

iii) The About Dialog is now simplified with the removal of the Athlete ID and Athlete Database path

![HelpCapture](https://user-images.githubusercontent.com/46629337/116156487-75425300-a6e3-11eb-9a67-c8a8de8bf212.JPG)

