### PR TITLE
Fixes: "Device" tag not tracking changes to the DeviceType field

### DIFF
--- a/src/Metrics/RideMetadata.cpp
+++ b/src/Metrics/RideMetadata.cpp
@@ -956,6 +956,7 @@ FormField::editFinished()
         if (ourRideItem->ride()->deviceType() != text) {
             changed = true;
             ourRideItem->ride()->setDeviceType(text);
+            ourRideItem->ride()->setTag("Device", text);
         }
 
     } else if (definition.name == "Identifier") {


### PR DESCRIPTION
This fix only applies to updating the "Device" tag field and it ensures the "Device" tag tracks the DeviceType field fixing #3760

The "device" which recorded the activity appears in two separate locations within the activity json file, and different windows/fields in GC display either one or the other.

"DEVICETYPE":"Garmin 1234 ",
"TAGS":{
        .................
       "Device":"Garmin 1234 ",
        .................