### PR TITLE
Fixes: #3074 - Activity list row height is not updated when data changes

### DIFF
--- a/src/Core/Context.h
+++ b/src/Core/Context.h
@@ -217,6 +217,7 @@ class Context : public QObject
         void notifyRideDeleted(RideItem *x) { ride=x; rideDeleted(x); }
         void notifyRideChanged(RideItem *x) { rideChanged(x); }
         void notifyRideSaved(RideItem *x) { rideSaved(x); }
+        void notifyRidesImportComplete() { ridesImportComplete(); }
 
         void notifyIntervalZoom(IntervalItem*x) { emit intervalZoom(x); }
         void notifyZoomOut() { emit zoomOut(); }
@@ -296,6 +297,7 @@ class Context : public QObject
         void rideDeleted(RideItem *);
         void rideChanged(RideItem *);
         void rideSaved(RideItem*);
+        void ridesImportComplete();
 
         void intervalSelected();
         void intervalsChanged();

--- a/src/Gui/RideImportWizard.cpp
+++ b/src/Gui/RideImportWizard.cpp
@@ -1134,6 +1134,10 @@ RideImportWizard::abortClicked()
         this->repaint();
     }
 
+    // Notify others that the rides importation is complete, useful when more
+    // than 20 rides are imported as they are not then individual signalled.
+    context->notifyRidesImportComplete();
+
     // how did we get on in the end then ...
     int completed = 0;
     for (int i=0; i< filenames.count(); i++)


### PR DESCRIPTION
So I think I’ve now identified all the issues with #3074… they are:

**ISSUE 1:**

When the rides are first loaded into RideNavigator they are not registered for the “rideMetadataChanged” signal, so selecting a ride and updating the metadata, for example the notes, means the ride in the table never receives the notification, so never resizes or updates its data. 

**ISSUE 2:**

When more than 20 rides are imported at the same time, including those that already exist and get rejected as duplicates, results in the RideImportWizard stopping the “rideAdded”  signalling to prevent too many updates on mass importation. But this has the effect that RideNavigator doesn’t get a prompt to re-evaluate their size or data for each ride when this threshold is exceeded. This gives the confusing behaviour that once the number of imported files increases above 20 rides, they are no longer signalled and the display may not be correct.

**The proposed resolution:**

i)	Update RideNavigator to register the “rideMetadataChanged” signal for the currentItem, this ensures changes to metadata for the currently selected ride are always immediately reflected in the RideNavigator table (note: you need to click in another field to enter/commit the data change). When the selected ride changes, the code un-manages the old rides “rideMetadataChanged” signal, and registers the signal for the new ride so preventing multiple unwanted updates.

ii)	Improve the “refresh()” function to ensure it fully updates the table.

iii)	Add a new “ridesImportComplete” signal which RideImportWizard emits at the end of any importation process (manual or automatic) independent of the number of rides imported. This signal is captured by RideNavigator to generate a single table update, ensuring all ride and calendar data is displayed.
