### PR TITLE
Unwanted precision in corrected points in the Fix Power Spikes Data Processor's Averaging/Smoothing Algo

### DIFF
--- a/src/FileIO/FixSpikes.cpp
+++ b/src/FileIO/FixSpikes.cpp
@@ -238,7 +238,8 @@ FixSpikes::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op
             if (pos > 0) left = ride->dataPoints()[pos-1]->watts;
             if (pos < (ride->dataPoints().count()-1)) right = ride->dataPoints()[pos+1]->watts;
 
-            ride->command->setPointValue(pos, RideFile::watts, (left+right)/2.0);
+            // Integer precision should be prefectly adequate for our correction.
+            ride->command->setPointValue(pos, RideFile::watts, floor(((left + right) / 2.0)+ 0.5));
         }
 
         delete outliers;


### PR DESCRIPTION
Whilst experimenting with the Averaging/smoothing algorithm within the "Fix Power Fixes" data processor dialogue, I noticed an issue when correcting the following dataset:

![RawData](https://user-images.githubusercontent.com/46629337/118087883-2290b880-b3be-11eb-828c-82897e14cf41.JPG)

Setting the ""Fix Power Fixes" data processor to Averaging/smooth Algorithm (the default) with max=0 & variance=10, I got the corrections to my file shown below, which introduces excessive precision in the corrected values.
 
![Avg-Smooth-Unchanged](https://user-images.githubusercontent.com/46629337/118087987-4d7b0c80-b3be-11eb-854a-948abe761cc2.JPG)

The precision issue is due to the average/smoothing algorithm's division of odd numbers, leading in some cases to unnecessary precision being created in the corrected points, and this seems unwanted given wattage values are usually integers.

This change truncates the corrected point values to the nearest whole wattage value.

Giving:

![Capture1](https://user-images.githubusercontent.com/46629337/118183891-910f5e00-b432-11eb-88f6-d68ffa48056d.JPG)
