### PR TITLE
RideNavigator - Use uniform row height

### DIFF
--- a/src/Gui/RideNavigator.cpp
+++ b/src/Gui/RideNavigator.cpp
@@ -49,6 +49,7 @@ RideNavigator::RideNavigator(Context *context, bool mainwindow) : GcChartWindow(
     fontHeight = QFontMetrics(QFont()).height();
     reverseColor = GlobalContext::context()->colorEngine->reverseColor;
     currentItem = NULL;
+    hasCalendarText = false;
 
     init = false;
 
@@ -168,6 +169,7 @@ RideNavigator::configChanged(qint32 state)
 {
     fontHeight = QFontMetrics(QFont()).height();
     reverseColor = GlobalContext::context()->colorEngine->reverseColor;
+    hasCalendarText = GlobalContext::context()->rideMetadata->hasCalendarText();
 
     // hide ride list scroll bar ?
 #ifndef Q_OS_MAC
@@ -1074,7 +1076,7 @@ QSize NavigatorCellDelegate::sizeHint(const QStyleOptionViewItem & /*option*/, c
     QSize s;
 
     if (rideNavigator->groupByModel->mapToSource(rideNavigator->sortModel->mapToSource(index)) != QModelIndex() &&
-        rideNavigator->groupByModel->data(rideNavigator->sortModel->mapToSource(index), Qt::UserRole).toString() != "") {
+        rideNavigator->hasCalendarText) {
         s.setHeight((rideNavigator->fontHeight+2) * 4);
     } else s.setHeight(rideNavigator->fontHeight + 2);
     return s;
@@ -1211,7 +1213,7 @@ void NavigatorCellDelegate::paint(QPainter *painter, const QStyleOptionViewItem 
         painter->setFont(isFont);
 
         // now get the calendar text to appear ...
-        if (calendarText != "") {
+        if (rideNavigator->hasCalendarText) {
             QRect high(myOption.rect.x()+myOption.rect.width() - (7*dpiXFactor), myOption.rect.y(), (7*dpiXFactor), (rideNavigator->fontHeight+2) * 4);
 
             myOption.rect.setX(0);

--- a/src/Gui/RideNavigator.h
+++ b/src/Gui/RideNavigator.h
@@ -185,6 +185,7 @@ class RideNavigator : public GcChartWindow
         NavigatorCellDelegate *delegate;
         QVBoxLayout *mainLayout;
         RideItem *currentItem;
+        bool hasCalendarText;
 
         // properties
         int _sortByIndex;

--- a/src/Metrics/RideMetadata.cpp
+++ b/src/Metrics/RideMetadata.cpp
@@ -445,6 +445,16 @@ QVector<FormField *> RideMetadata::getFormFields()
     return formFields;
 }
 
+// Are there fields enabled for CalendarText?
+bool
+RideMetadata::hasCalendarText()
+{
+    foreach (FieldDefinition field, getFields()) {
+        if (field.diary) return true;
+    }
+    return false;
+}
+
 // Construct the summary text used on the calendar
 QString
 RideMetadata::calendarText(RideItem *rideItem)

--- a/src/Metrics/RideMetadata.h
+++ b/src/Metrics/RideMetadata.h
@@ -159,6 +159,7 @@ class RideMetadata : public QWidget
         QList<KeywordDefinition> getKeywords() { return keywordDefinitions; }
         QList<FieldDefinition> getFields() { return fieldDefinitions; }
         QList<DefaultDefinition> getDefaults() { return defaultDefinitions; }
+        bool hasCalendarText();
         QString calendarText(RideItem *rideItem);
 
         QString getColorField() const { return colorfield; }


### PR DESCRIPTION
Variable row height, depending on activity calendar text being empty or not,
provokes refresh issues when calendar text changes from empty to not, or
viceversa.
Instead to try to solve this issue with specific code, I think it is
simpler, and more regular from UX point of view, to have a uniform row height.
After this change row height depends on metadata config only:
1) a new RideMetadata method is introduced (hasCalendarText) to check if
   Calendar Text can be non empty, i.e. if some field has diary checked.
2) RideNavigator uses this method when config changes to set hasCalendarText
   member used to determine row height for all activities.

Fixes #3074