### PR TITLE
Optional uniform activity heights

### DIFF
--- a/src/Gui/AnalysisSidebar.cpp
+++ b/src/Gui/AnalysisSidebar.cpp
@@ -64,6 +64,7 @@ AnalysisSidebar::AnalysisSidebar(Context *context) : QWidget(context->mainWindow
     context->rideNavigator = rideNavigator = new RideNavigator(context, true);
     rideNavigator->showMore(false);
     groupByMapper = NULL;
+    activitySizeMapper = NULL;
 
     // retrieve settings (properties are saved when we close the window)
     if (appsettings->cvalue(context->athlete->cyclist, GC_NAVHEADINGS, "").toString() != "") {
@@ -424,7 +425,7 @@ AnalysisSidebar::showActivityMenu(const QPoint &pos)
 
         } else {
 
-            QMenu *groupByMenu = new QMenu(tr("Group By"), rideNavigator);
+            QMenu* groupByMenu = new QMenu(tr("Group By"), this);
             groupByMenu->setEnabled(true);
             menu.addMenu(groupByMenu);
 
@@ -453,6 +454,35 @@ AnalysisSidebar::showActivityMenu(const QPoint &pos)
         QAction *collapseAll = new QAction(tr("Collapse All"), rideNavigator);
         connect(collapseAll, SIGNAL(triggered(void)), rideNavigator->tableView, SLOT(collapseAll()));
         menu.addAction(collapseAll);
+
+        QMenu* activitySizeMenu = new QMenu(tr("Activity Lines"), this);
+        activitySizeMenu->setEnabled(true);
+        menu.addMenu(activitySizeMenu);
+
+        if (activitySizeMapper) delete activitySizeMapper;
+        activitySizeMapper = new QSignalMapper(this);
+        connect(activitySizeMapper, SIGNAL(mapped(const QString&)), rideNavigator, SLOT(setActivitySize(QString)));
+
+        // add menu options for Activity Size
+        QAction* activitySizeAct = new QAction("Default", rideNavigator);
+        connect(activitySizeAct, SIGNAL(triggered()), activitySizeMapper, SLOT(map()));
+        activitySizeMenu->addAction(activitySizeAct);
+        activitySizeMapper->setMapping(activitySizeAct, "Default");
+
+        activitySizeAct = new QAction("3 Lines", rideNavigator);
+        connect(activitySizeAct, SIGNAL(triggered()), activitySizeMapper, SLOT(map()));
+        activitySizeMenu->addAction(activitySizeAct);
+        activitySizeMapper->setMapping(activitySizeAct, "3-Lines");
+
+        activitySizeAct = new QAction("2 Lines", rideNavigator);
+        connect(activitySizeAct, SIGNAL(triggered()), activitySizeMapper, SLOT(map()));
+        activitySizeMenu->addAction(activitySizeAct);
+        activitySizeMapper->setMapping(activitySizeAct, "2-Lines");
+
+        activitySizeAct = new QAction("1 Line", rideNavigator);
+        connect(activitySizeAct, SIGNAL(triggered()), activitySizeMapper, SLOT(map()));
+        activitySizeMenu->addAction(activitySizeAct);
+        activitySizeMapper->setMapping(activitySizeAct, "1-Line");
 
         // reset to default
         QAction *resetToDefault = new QAction(tr("Reset to default"), rideNavigator);

--- a/src/Gui/AnalysisSidebar.h
+++ b/src/Gui/AnalysisSidebar.h
@@ -97,6 +97,7 @@ class AnalysisSidebar : public QWidget
         QWidget *activityHistory;
         GcSplitterItem *activityItem;
         QSignalMapper *groupByMapper;
+        QSignalMapper* activitySizeMapper;
 
         GcSplitterItem *calendarItem;
         GcMultiCalendar *calendarWidget;

--- a/src/Gui/RideNavigator.cpp
+++ b/src/Gui/RideNavigator.cpp
@@ -35,6 +35,9 @@
 #include <QStyleFactory>
 #include <QScrollBar>
 
+ // Default GC activity display
+const int DEFAULT_ACT_ROWS = 4;
+
 RideNavigator::RideNavigator(Context *context, bool mainwindow) : GcChartWindow(context), context(context), active(false), _groupBy(-1)
 {
     // get column headings
@@ -47,6 +50,8 @@ RideNavigator::RideNavigator(Context *context, bool mainwindow) : GcChartWindow(
     this->mainwindow = mainwindow;
     _groupBy = -1;
     fontHeight = QFontMetrics(QFont()).height();
+    numActivityRows = DEFAULT_ACT_ROWS;
+
     reverseColor = GlobalContext::context()->colorEngine->reverseColor;
     currentItem = NULL;
     hasCalendarText = false;
@@ -341,6 +346,9 @@ RideNavigator::resetView()
         columnnumber++;
     }
 
+    // Reset the displayed activity lines to the default
+    numActivityRows = DEFAULT_ACT_ROWS;
+
     setGroupByColumn();
 
     active = false;
@@ -391,6 +399,26 @@ QStringList
 RideNavigator::columnNames() const
 {
     return visualHeadings;
+}
+
+void
+RideNavigator::setActivitySize(QString size)
+{
+    if (size == "1-Line") {
+        numActivityRows = 1; // ensure the same appearance as no calendar data
+    }
+    else if (size == "2-Lines") {
+        numActivityRows = 2;
+    }
+    else if (size == "3-Lines") {
+        numActivityRows = 3;
+    }
+    else if (size == "Default") {
+        numActivityRows = DEFAULT_ACT_ROWS; // ensure the same default GC behavior
+    }
+
+    // Update the heights
+    tableView->doItemsLayout();
 }
 
 void
@@ -1077,7 +1105,7 @@ QSize NavigatorCellDelegate::sizeHint(const QStyleOptionViewItem & /*option*/, c
 
     if (rideNavigator->groupByModel->mapToSource(rideNavigator->sortModel->mapToSource(index)) != QModelIndex() &&
         rideNavigator->hasCalendarText) {
-        s.setHeight((rideNavigator->fontHeight+2) * 4);
+        s.setHeight((rideNavigator->fontHeight+2) * (rideNavigator->numActivityRows));
     } else s.setHeight(rideNavigator->fontHeight + 2);
     return s;
 }
@@ -1214,12 +1242,12 @@ void NavigatorCellDelegate::paint(QPainter *painter, const QStyleOptionViewItem 
 
         // now get the calendar text to appear ...
         if (rideNavigator->hasCalendarText) {
-            QRect high(myOption.rect.x()+myOption.rect.width() - (7*dpiXFactor), myOption.rect.y(), (7*dpiXFactor), (rideNavigator->fontHeight+2) * 4);
+            QRect high(myOption.rect.x()+myOption.rect.width() - (7*dpiXFactor), myOption.rect.y(), (7*dpiXFactor), (rideNavigator->fontHeight+2) * (rideNavigator->numActivityRows));
 
             myOption.rect.setX(0);
             myOption.rect.setY(myOption.rect.y() + rideNavigator->fontHeight + 2);//was +23
             myOption.rect.setWidth(rideNavigator->pwidth);
-            myOption.rect.setHeight(rideNavigator->fontHeight * 3); //was 36
+            myOption.rect.setHeight(rideNavigator->fontHeight * (rideNavigator->numActivityRows-1)); //was 36
             //myOption.font.setPointSize(myOption.font.pointSize());
             myOption.font.setWeight(QFont::Normal);
 

--- a/src/Gui/RideNavigator.h
+++ b/src/Gui/RideNavigator.h
@@ -155,6 +155,7 @@ class RideNavigator : public GcChartWindow
         QStringList columnNames() const;
         void setGroupByColumnName(QString); // set blank turns it off
         void noGroups() { currentColumn=-1; setGroupByColumn(); }
+        void setActivitySize(QString); // set activity lines displayed
 
         QString widths() const { return _widths; }
         void setWidths (QString x="") { _widths = x; resetView(); } // only reset once widths are set, witdths="" resets to default columns
@@ -171,6 +172,7 @@ class RideNavigator : public GcChartWindow
         // keep track of the headers
         QList<QString> logicalHeadings;
         QList<QString> visualHeadings;
+        int numActivityRows;
 
         // this maps friendly names to metric names
         QMap <QString, QString> nameMap;


### PR DESCRIPTION
**Justification**
#3890 Uniform activity heights resolves many issues in RideNavigator's presentation , although if you choose to only have one or two calendar fields displayed the list appears sparsely populated, and I appreciate this is subjective, but I thought it would be good to provide an option for the user to select the number of displayed rows, see two examples below showing the display behaviour when the number of calendar items changes:

![4 lines](https://user-images.githubusercontent.com/46629337/118395371-f71e0000-b641-11eb-9d3f-02232e1fb735.JPG)![Sparse](https://user-images.githubusercontent.com/46629337/118395369-f4230f80-b641-11eb-921e-e0f1388abf85.JPG)

It should be noted that the proposed change always defaults to the standard GC behaviour at startup, and also reverts to this appearance should the display of calendar items be modified.

**Change:**
An additional submenu has been added to the RideNavigator menu, allowing the user to select either Default, or fewer lines:

![Menu](https://user-images.githubusercontent.com/46629337/118395402-364c5100-b642-11eb-9ec6-c0b42ca06cbb.JPG)

Examples of appearance for options:

Default (standard GC behaviour from #3890):

![4 lines](https://user-images.githubusercontent.com/46629337/118395473-81666400-b642-11eb-803e-9b3765dc6bce.JPG)

3 Lines: will truncate displayed calendar items if required

![3 lines](https://user-images.githubusercontent.com/46629337/118395478-89260880-b642-11eb-861f-5395ca2d9c1c.JPG)

2 Lines: will truncate displayed calendar items if required

![2 lines](https://user-images.githubusercontent.com/46629337/118395480-8d522600-b642-11eb-8af8-b835e6b7f2fb.JPG)

1 Line (same as no calendar items selected for display), will hide calendar items even they are selected for display.

![1 line](https://user-images.githubusercontent.com/46629337/118395493-9b07ab80-b642-11eb-9bba-9c1f396ae02f.JPG)

Note: This change works in conjunction with Expand, Group & Collapse options.

