### PR TITLE
Fix compiler error by adding missing include <limits> header for std::numeric_limits

### DIFF
--- a/src/Metrics/BlinnSolver.cpp
+++ b/src/Metrics/BlinnSolver.cpp
@@ -18,6 +18,7 @@
 
 #include <cmath>
 #include <algorithm>
+#include <limits>
 #include "BlinnSolver.h"
 
 int GetExponent(double a) {


### PR DESCRIPTION
On linux, I currently get the following compiler error:
`g++ -c -pipe -DGC_DEBUG -Wno-unused-variable -Wno-sign-compare -g -std=gnu++11 -Wall -Wextra -D_REENTRANT -fPIC -DGC_VIDEO_NONE -DQXT_STATIC -DGC_WANT_HTTP -DGC_HAVE_OVERVIEW -DGC_HAVE_GENERIC -DQT_SVG_LIB -DQT_MULTIMEDIAWIDGETS_LIB -DQT_WEBENGINEWIDGETS_LIB -DQT_PRINTSUPPORT_LIB -DQT_CHARTS_LIB -DQT_OPENGL_LIB -DQT_WIDGETS_LIB -DQT_MULTIMEDIA_LIB -DQT_WEBENGINE_LIB -DQT_WEBENGINECORE_LIB -DQT_QUICK_LIB -DQT_GUI_LIB -DQT_XML_LIB -DQT_SQL_LIB -DQT_QMLMODELS_LIB -DQT_WEBCHANNEL_LIB -DQT_QML_LIB -DQT_NETWORK_LIB -DQT_CONCURRENT_LIB -DQT_SERIALPORT_LIB -DQT_POSITIONING_LIB -DQT_BLUETOOTH_LIB -DQT_CORE_LIB -I. -IANT -ITrain -IFileIO -ICloud -ICharts -IMetrics -IGui -ICore -IPlanning -I../qwt/src -I../contrib/qxt/src -I../contrib/qtsolutions/json -I../contrib/qtsolutions/qwtcurve -I../contrib/lmfit -I../contrib/levmar -I../contrib/boost -I../contrib/httpserver -I/usr/include/qt -I/usr/include/qt/QtSvg -I/usr/include/qt/QtMultimediaWidgets -I/usr/include/qt/QtWebEngineWidgets -I/usr/include/qt/QtPrintSupport -I/usr/include/qt/QtCharts -I/usr/include/qt/QtOpenGL -I/usr/include/qt/QtWidgets -I/usr/include/qt/QtMultimedia -I/usr/include/qt/QtWebEngine -I/usr/include/qt/QtWebEngineCore -I/usr/include/qt/QtQuick -I/usr/include/qt/QtGui -I/usr/include/qt/QtXml -I/usr/include/qt/QtSql -I/usr/include/qt/QtQmlModels -I/usr/include/qt/QtWebChannel -I/usr/include/qt/QtQml -I/usr/include/qt/QtNetwork -I/usr/include/qt/QtConcurrent -I/usr/include/qt/QtSerialPort -I/usr/include/qt/QtPositioning -I/usr/include/qt/QtBluetooth -I/usr/include/qt/QtCore -I. -I/usr/lib/qt/mkspecs/linux-g++ -o BlinnSolver.o Metrics/BlinnSolver.cpp
Metrics/BlinnSolver.cpp: In function 'bool RangedZeroTest(double, Args ...)':
Metrics/BlinnSolver.cpp:47:40: error: 'numeric_limits' is not a member of 'std'
   47 |     const static int s_ExpLimit = std::numeric_limits<double>::digits - T_MantissaBitsNeeded;
      |                                        ^~~~~~~~~~~~~~
Metrics/BlinnSolver.cpp:47:55: error: expected primary-expression before 'double'
   47 |     const static int s_ExpLimit = std::numeric_limits<double>::digits - T_MantissaBitsNeeded;
      |                                                       ^~~~~~
`
This is easily fixed by explicitly specifying the required header <limits>.