### PR TITLE
ChartBar - Add menu to select charts without scrolling

### DIFF
--- a/src/Charts/ChartBar.cpp
+++ b/src/Charts/ChartBar.cpp
@@ -33,6 +33,7 @@ ChartBar::ChartBar(Context *context) : QWidget(context->mainWindow), context(con
     // left / right scroller icon
     static QIcon leftIcon = iconFromPNG(":images/mac/left.png");
     static QIcon rightIcon = iconFromPNG(":images/mac/right.png");
+    static QIcon showIcon = iconFromPNG(":images/mac/show.png");
 
     setContentsMargins(0,0,0,0);
 
@@ -94,6 +95,18 @@ ChartBar::ChartBar(Context *context) : QWidget(context->mainWindow), context(con
     right->setFocusPolicy(Qt::NoFocus);
     mlayout->addWidget(right);
     connect(right, SIGNAL(clicked()), this, SLOT(scrollRight()));
+
+    showButton = new QToolButton(this);
+    showButton->setStyleSheet("QToolButton { border: none; padding: 0px; }");
+    showButton->setAutoFillBackground(false);
+    showButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
+    showButton->setIcon(showIcon);
+    showButton->setIconSize(QSize(20*dpiXFactor,20*dpiYFactor));
+    showButton->setFocusPolicy(Qt::NoFocus);
+    mlayout->addWidget(showButton);
+
+    showMenu = new QMenu("Show");
+    connect(showButton, SIGNAL(clicked()), this, SLOT(showPopup()));
 
     // spacer to make the menuButton on the right
     QLabel *spacer = new QLabel("", this);
@@ -216,6 +229,17 @@ ChartBar::menuPopup()
 }
 
 void
+ChartBar::showPopup()
+{
+    showMenu->clear();
+    foreach (ChartBarItem *button, buttons) {
+        showMenu->addAction(button->text, button, SLOT(clicked()));
+    }
+    // set the point for the menu and call below
+    showMenu->exec(this->mapToGlobal(QPoint(menuButton->pos().x(), menuButton->pos().y()+20)));
+}
+
+void
 ChartBar::setText(int index, QString text)
 {
     buttons[index]->setText(text);
@@ -248,9 +272,9 @@ ChartBar::tidy(bool setwidth)
     }
 
     if (buttonBar->width() > scrollArea->width()) {
-        left->show(); right->show();
+        left->show(); right->show(); showButton->show();
     } else {
-        left->hide(); right->hide();
+        left->hide(); right->hide(); showButton->hide();
     }
 }
 
@@ -630,4 +654,10 @@ ChartBarItem::event(QEvent *e)
         update(); // in case hovering over stuff
     }
     return QWidget::event(e);
+}
+
+void
+ChartBarItem::clicked()
+{
+    emit clicked(true);
 }

--- a/src/Charts/ChartBar.h
+++ b/src/Charts/ChartBar.h
@@ -63,6 +63,7 @@ public slots:
     void tidy(bool setwidth);
     void setChartMenu();
     void menuPopup();
+    void showPopup();
     void configChanged(qint32); // appearance
 
 signals:
@@ -84,14 +85,14 @@ private:
     Context *context;
 
     ButtonBar *buttonBar;
-    QToolButton *left, *right; // scrollers, hidden if menu fits
+    QToolButton *left, *right, *showButton; // scrollers, hidden if menu fits
     QPropertyAnimation *anim; // scroll left and right - animated to show whats happening
     QToolButton *menuButton;
 
     QFont buttonFont;
     QSignalMapper *signalMapper, *menuMapper;
 
-    QMenu *barMenu, *chartMenu;
+    QMenu *barMenu, *chartMenu, *showMenu;
 
     int currentIndex_;
     bool state;
@@ -139,6 +140,7 @@ class ChartBarItem : public QWidget
     public slots:
         void paintEvent(QPaintEvent *);
         bool event(QEvent *e);
+        void clicked();
 
     private:
         ChartBar *chartbar;


### PR DESCRIPTION
Enabled when scrolling is enabled, allows faster selection of
invisible charts without scrolling.
This is an experimental feature, let's see how it works.

![ChartBarSelectionList](https://user-images.githubusercontent.com/1444784/122308361-a15ba280-cee2-11eb-8781-ac60a5ad429c.PNG)

Ideally it should be complemented with ChartBar autoscrolling, which would also be useful for other cases s.t. Add/Download/Library when you need to scroll to access the chart menu of the active chart.