### PR TITLE
Replace QString::null by QString()

### DIFF
--- a/src/Charts/AllPlotSlopeCurve.h
+++ b/src/Charts/AllPlotSlopeCurve.h
@@ -40,7 +40,7 @@ class AllPlotSlopeCurve: public QwtPlotCurve
 
 public:
 
-    explicit AllPlotSlopeCurve( const QString &title = QString::null );
+    explicit AllPlotSlopeCurve( const QString &title = QString() );
     explicit AllPlotSlopeCurve( const QwtText &title );
 
     virtual ~AllPlotSlopeCurve();

--- a/src/Charts/CpPlotCurve.h
+++ b/src/Charts/CpPlotCurve.h
@@ -36,7 +36,7 @@ public:
     //! Paint attributes
     typedef QFlags<PaintAttribute> PaintAttributes;
 
-    explicit CpPlotCurve( const QString &title = QString::null );
+    explicit CpPlotCurve( const QString &title = QString() );
     explicit CpPlotCurve( const QwtText &title );
 
     virtual ~CpPlotCurve();

--- a/src/Charts/IndendPlotMarker.h
+++ b/src/Charts/IndendPlotMarker.h
@@ -53,7 +53,7 @@ class QwtIndPlotMarker: public QwtPlotMarker
 {
 public:
 
-    explicit QwtIndPlotMarker( const QString &title = QString::null );
+    explicit QwtIndPlotMarker( const QString &title = QString() );
     explicit QwtIndPlotMarker( const QwtText &title );
 
     virtual ~QwtIndPlotMarker();


### PR DESCRIPTION
QString::null was deprecated. Using the default constructor
is the way to go now.
