### PR TITLE
Use hex and endl from Qt namespace

### DIFF
--- a/src/Charts/CPPlot.cpp
+++ b/src/Charts/CPPlot.cpp
@@ -2252,7 +2252,7 @@ CPPlot::exportBests(QString filename)
 
     // open stream and write header
     QTextStream stream(&f);
-    stream << "seconds, value," << (expmodel ? " model, date" : " date") << endl;
+    stream << "seconds, value," << (expmodel ? " model, date" : " date") << Qt::endl;
 
     // output a row for each second
     foreach(QwtPlotCurve *bestsCurve, bestsCurves) {
@@ -2270,8 +2270,8 @@ CPPlot::exportBests(QString filename)
             }
 
             // values
-            if (expmodel) stream << int(xvalue * 60.00f) << "," << yvalue << "," << modelvalue << "," << date.toString(Qt::ISODate) << endl;
-            else stream << int(xvalue * 60.00f) << "," << yvalue << "," << date.toString(Qt::ISODate) << endl;
+            if (expmodel) stream << int(xvalue * 60.00f) << "," << yvalue << "," << modelvalue << "," << date.toString(Qt::ISODate) << Qt::endl;
+            else stream << int(xvalue * 60.00f) << "," << yvalue << "," << date.toString(Qt::ISODate) << Qt::endl;
         }
     }
 

--- a/src/FileIO/JouleDevice.cpp
+++ b/src/FileIO/JouleDevice.cpp
@@ -209,7 +209,7 @@ JouleDevice::download( const QDir &tmpdir,
                 files.append(file);
 
                 QTextStream os(&tmp);
-                os << hex;
+                os << Qt::hex;
 
                 qDebug() << tmp.fileName() << "-" << tmpl;
                 tmp.write(versionResponse.dataArray());

--- a/src/FileIO/MacroDevice.cpp
+++ b/src/FileIO/MacroDevice.cpp
@@ -180,7 +180,7 @@ MacroDevice::download( const QDir &tmpdir,
     files.append(file);
 
     QTextStream os(&tmp);
-    os << hex;
+    os << Qt::hex;
 
     for (int i = 0; i < count; i++)
     {

--- a/src/FileIO/PowerTapDevice.cpp
+++ b/src/FileIO/PowerTapDevice.cpp
@@ -295,7 +295,7 @@ PowerTapDevice::download( const QDir &tmpdir,
     file.name = tmp.fileName();
 
     QTextStream os(&tmp);
-    os << hex;
+    os << Qt::hex;
     os.setPadChar('0');
 
     bool time_set = false;

--- a/src/Train/BT40Device.cpp
+++ b/src/Train/BT40Device.cpp
@@ -337,7 +337,7 @@ BT40Device::serviceStateChanged(QLowEnergyService::ServiceState s)
                             inride_BTDeviceInfoToSystemID(deviceInfo(), systemID);
 
                             qDebug() << "Starting indication for char with UUID: " << characteristic.uuid().toString() << " Kurt Inride Control";
-                            qDebug() << "InRide SystemID:" << hex << systemID[0] << systemID[1] << systemID[2] << systemID[3] << systemID[4] << systemID[5];
+                            qDebug() << "InRide SystemID:" << Qt::hex << systemID[0] << systemID[1] << systemID[2] << systemID[3] << systemID[4] << systemID[5];
 
                             loadService = service;
                             loadCharacteristic = characteristic;
@@ -814,7 +814,7 @@ BT40Device::setMode(int m)
                 inride_BTDeviceInfoToSystemID(deviceInfo(), systemID);
 
                 qDebug() << tr("Kurt_InRide: STARTING CALIBRATION:") << 
-                    hex <<
+                    Qt::hex <<
                     systemID[0] << systemID[1] << systemID[2] <<
                     systemID[3] << systemID[4] << systemID[5];
 
@@ -847,7 +847,7 @@ BT40Device::setMode(int m)
                 inride_BTDeviceInfoToSystemID(deviceInfo(), systemID);
 
                 qDebug() << tr("Kurt_InRide: STOPPING CALIBRATION, systemID:") <<
-                    hex <<
+                    Qt::hex <<
                     systemID[0] << systemID[1] << systemID[2] <<
                     systemID[3] << systemID[4] << systemID[5];
 

--- a/src/Train/WorkoutWizard.cpp
+++ b/src/Train/WorkoutWizard.cpp
@@ -375,22 +375,22 @@ void AbsWattagePage::SaveWorkout()
     QVector<QPair<QString, QString> > rawData;
     we->rawData(rawData);
     double currentX = 0;
-    stream << "[COURSE DATA]" << endl;
+    stream << "[COURSE DATA]" << Qt::endl;
     QPair<QString, QString > p;
     foreach (p,rawData)
     {
         if(p.first == "LAP")
         {
-            stream << currentX << " LAP" << endl;
+            stream << currentX << " LAP" << Qt::endl;
         }
         else
         {
-            stream << currentX << " " << p.second << endl;
+            stream << currentX << " " << p.second << Qt::endl;
             currentX += p.first.toDouble();
-            stream << currentX << " " << p.second << endl;
+            stream << currentX << " " << p.second << Qt::endl;
         }
     }
-    stream << "[END COURSE DATA]" << endl;
+    stream << "[END COURSE DATA]" << Qt::endl;
     f.close();
 
     // import them via the workoutimporter
@@ -514,22 +514,22 @@ void RelWattagePage::SaveWorkout()
     QVector<QPair<QString, QString> > rawData;
     we->rawData(rawData);
     double currentX = 0;
-    stream << "[COURSE DATA]" << endl;
+    stream << "[COURSE DATA]" << Qt::endl;
     QPair<QString, QString > p;
     foreach (p,rawData)
     {
         if(p.first == "LAP")
         {
-            stream << currentX << " LAP" << endl;
+            stream << currentX << " LAP" << Qt::endl;
         }
         else
         {
-            stream << currentX << " " << p.second << endl;
+            stream << currentX << " " << p.second << Qt::endl;
             currentX += p.first.toDouble();
-            stream << currentX << " " << p.second << endl;
+            stream << currentX << " " << p.second << Qt::endl;
         }
     }
-    stream << "[END COURSE DATA]" << endl;
+    stream << "[END COURSE DATA]" << Qt::endl;
     f.close();
 
     // import them via the workoutimporter
@@ -613,22 +613,22 @@ void GradientPage::SaveWorkout()
     SaveWorkoutHeader(stream,f.fileName(),QString("golden cheetah"),QString("DISTANCE GRADE WIND"));
     QVector<QPair<QString, QString> > rawData;
     we->rawData(rawData);
-    stream << "[COURSE DATA]" << endl;
+    stream << "[COURSE DATA]" << Qt::endl;
     QPair<QString, QString > p;
     foreach (p,rawData)
     {
         if(p.first == "LAP")
         {
-            stream << "LAP" << endl;
+            stream << "LAP" << Qt::endl;
         }
         else
         {
             // header indicates metric units, so convert accordingly
             double currentX = p.first.toDouble()*(metricUnits ? 1.0 : KM_PER_MILE);
-            stream << currentX << " " << p.second << " 0" << endl;
+            stream << currentX << " " << p.second << " 0" << Qt::endl;
         }
     }
-    stream << "[END COURSE DATA]" << endl;
+    stream << "[END COURSE DATA]" << Qt::endl;
     f.close();
 
     // import them via the workoutimporter
@@ -768,17 +768,17 @@ void ImportPage::SaveWorkout()
     QTextStream stream(&f);
     // create the header
     SaveWorkoutHeader(stream,f.fileName(),QString("golden cheetah"),QString("DISTANCE GRADE WIND"));
-    stream << "[COURSE DATA]" << endl;
+    stream << "[COURSE DATA]" << Qt::endl;
     QPair<double,double> p;
     double prevDistance = 0;
     foreach (p,rideProfile)
     {
         // header indicates metric units, so convert accordingly
         double curDistance = p.first * (metricUnits ? 1.0 : KM_PER_MILE);
-        stream << curDistance - prevDistance << " " << p.second <<" 0" << endl;
+        stream << curDistance - prevDistance << " " << p.second <<" 0" << Qt::endl;
         prevDistance = curDistance;
     }
-    stream << "[END COURSE DATA]" << endl;
+    stream << "[END COURSE DATA]" << Qt::endl;
     f.close();
 
     // import them via the workoutimporter

--- a/src/Train/WorkoutWizard.h
+++ b/src/Train/WorkoutWizard.h
@@ -223,13 +223,13 @@ public:
     virtual void SaveWorkout() = 0;
     void SaveWorkoutHeader(QTextStream &stream, QString fileName, QString description, QString units)
     {
-        stream << "[COURSE HEADER]" << endl;
-        stream << "VERSION = 2" << endl;
-        stream << "UNITS = METRIC" << endl;
-        stream << "DESCRIPTION = " << description << endl;
-        stream << "FILE NAME = " << fileName << endl;
-        stream <<  units << endl;
-        stream << "[END COURSE HEADER]" << endl;
+        stream << "[COURSE HEADER]" << Qt::endl;
+        stream << "VERSION = 2" << Qt::endl;
+        stream << "UNITS = METRIC" << Qt::endl;
+        stream << "DESCRIPTION = " << description << Qt::endl;
+        stream << "FILE NAME = " << fileName << Qt::endl;
+        stream <<  units << Qt::endl;
+        stream << "[END COURSE HEADER]" << Qt::endl;
     }
 
 };


### PR DESCRIPTION
Using hex and endl from QTextStream's namespace is deprecated.
Using those from Qt:: namespace instead.