### PR TITLE
Replace QLists toSet() method by QSet constructor

### DIFF
--- a/src/Core/Specification.h
+++ b/src/Core/Specification.h
@@ -47,7 +47,7 @@ class FilterSet
 
         // create one with a set
         FilterSet(bool on, QStringList list) {
-            if (on) filters_ << list.toSet();
+            if (on) filters_ << QSet<QString>(list.begin(), list.end());
         }
 
         // create an empty set
@@ -55,7 +55,7 @@ class FilterSet
 
         // add a new filter
         void addFilter(bool on, QStringList list) {
-            if (on) filters_ << list.toSet();
+            if (on) filters_ << QSet<QString>(list.begin(), list.end());
         }
 
         // clear the filter set

--- a/src/Gui/LTMSidebar.cpp
+++ b/src/Gui/LTMSidebar.cpp
@@ -946,7 +946,16 @@ LTMSidebar::filterNotify()
         } else {
 
             // both are set, so merge results
-            QStringList merged = autoFilterFiles.toSet().intersect(queryFilterFiles.toSet()).toList();
+            auto mergedSet =
+                    QSet<QString>(
+                            autoFilterFiles.begin(),
+                            autoFilterFiles.end()).intersect(
+                    QSet<QString>(
+                            queryFilterFiles.begin(),
+                            queryFilterFiles.end()
+                            )
+                    );
+            QStringList merged = QStringList(mergedSet.begin(), mergedSet.end());
             context->setHomeFilter(merged);
         }
 


### PR DESCRIPTION
The toSet() method was deprecated. This patch changes its usages
to use the QSet constructor.