### PR TITLE
Replace QDate::shortDayName by QLocale::dayName

### DIFF
--- a/src/Charts/LTMPlot.h
+++ b/src/Charts/LTMPlot.h
@@ -237,7 +237,7 @@ class LTMScaleDraw: public QwtScaleDraw
                 int year=group/12;
                 int month=group%12;
                 if (!month) { year--; month=12; }
-                label = QString("%1\n%2").arg(QDate::shortMonthName(month)).arg(year);
+                label = QString("%1\n%2").arg(QLocale::system().monthName(month, QLocale::ShortFormat)).arg(year);
             }
             break;
 

--- a/src/Core/GcCalendarModel.h
+++ b/src/Core/GcCalendarModel.h
@@ -369,7 +369,8 @@ public:
             QDate today = date(proxyIndex);
             if (today.month() != month &&
                 (today.addDays(1).month() == month || today.addDays(-1).month() == month))
-                return QString("%1 %2").arg(today.day()).arg(QDate::shortMonthName(today.month()));
+                return QString("%1 %2").arg(today.day()).arg(
+                        QLocale::system().monthName(today.month(), QLocale::ShortFormat));
             else
                 return QString("%1").arg(today.day());
             }
@@ -395,7 +396,7 @@ public:
 
         if (role == Qt::DisplayRole) {
             if (orientation == Qt::Horizontal) {
-                return QDate::shortDayName(section+1);
+                return QLocale::system().dayName(section+1, QLocale::ShortFormat);
             } else {
                 return QString("%1").arg(date(index(section,0)).weekNumber());
             }


### PR DESCRIPTION
QDate::shortDayName was deprecated. This patch replaces all usages
by QLocale::dayName.