### PR TITLE
Replace QList::swap by QList::swapItemsAt

### DIFF
--- a/src/Charts/AllPlotWindow.cpp
+++ b/src/Charts/AllPlotWindow.cpp
@@ -1171,7 +1171,7 @@ AllPlotWindow::moveUserDataUp()
     int index = customTable->row(items.first());
 
     if (index > 0) {
-        userDataSeries.swap(index, index-1);
+        userDataSeries.swapItemsAt(index, index-1);
          // refresh
         refreshCustomTable(index-1);
 
@@ -1193,7 +1193,7 @@ AllPlotWindow::moveUserDataDown()
     int index = customTable->row(items.first());
 
     if (index+1 <  userDataSeries.size()) {
-        userDataSeries.swap(index, index+1);
+        userDataSeries.swapItemsAt(index, index+1);
          // refresh
         refreshCustomTable(index+1);
 

--- a/src/Charts/LTMTool.cpp
+++ b/src/Charts/LTMTool.cpp
@@ -1432,7 +1432,7 @@ LTMTool::moveMetricUp()
     int index = customTable->row(items.first());
 
     if (index > 0) {
-        settings->metrics.swap(index, index-1);
+        settings->metrics.swapItemsAt(index, index-1);
          // refresh
         refreshCustomTable(index-1);
         curvesChanged();
@@ -1448,7 +1448,7 @@ LTMTool::moveMetricDown()
     int index = customTable->row(items.first());
 
     if (index+1 <  settings->metrics.size()) {
-        settings->metrics.swap(index, index+1);
+        settings->metrics.swapItemsAt(index, index+1);
          // refresh
         refreshCustomTable(index+1);
         curvesChanged();


### PR DESCRIPTION
QList::swap was renamed to QList::swapItemsAt. This patch adapts
the source code accordingly.