### PR TITLE
Replace QTime by QElapsedTimer to measure timings

### DIFF
--- a/src/Charts/CPPlot.cpp
+++ b/src/Charts/CPPlot.cpp
@@ -2491,7 +2491,7 @@ void
 CPPlot::plotCentile(RideItem *rideItem)
 {
     qDebug() << "calculateCentile";
-    QTime elapsed;
+    QElapsedTimer elapsed;
     elapsed.start();
 
     qDebug() << "prepare datas ";

--- a/src/Charts/LTMPlot.cpp
+++ b/src/Charts/LTMPlot.cpp
@@ -223,7 +223,7 @@ LTMPlot::setAxisTitle(QwtAxisId axis, QString label)
 void
 LTMPlot::setData(LTMSettings *set)
 {
-    QTime timer;
+    QElapsedTimer timer;
     timer.start();
 
     curveColors->isolated = false;
@@ -1393,7 +1393,7 @@ LTMPlot::setData(LTMSettings *set)
 void
 LTMPlot::setCompareData(LTMSettings *set)
 {
-    QTime timer;
+    QElapsedTimer timer;
     timer.start();
 
     MAXX=0.0; // maximum value for x, always from 0-n

--- a/src/Core/DataFilter.cpp
+++ b/src/Core/DataFilter.cpp
@@ -6684,7 +6684,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, const Result &x, long it, R
                 // CPU and 'hang' for badly written code..
                 static int maxwhile = 1000000;
                 int count=0;
-                QTime timer;
+                QElapsedTimer timer;
                 timer.start();
 
                 Result returning(0);

--- a/src/Core/RideItem.cpp
+++ b/src/Core/RideItem.cpp
@@ -1042,7 +1042,7 @@ RideItem::updateIntervals()
         // anything longer than a day or negative is skipped
         if (arraySize >= 0 && arraySize < (24*3600)) { // no indent, as added late
 
-        QTime timer;
+        QElapsedTimer timer;
         timer.start();
 
         // setup an integrated series

--- a/src/FileIO/RideFileCache.cpp
+++ b/src/FileIO/RideFileCache.cpp
@@ -376,7 +376,7 @@ QVector<float> RideFileCache::meanMaxPowerFor(Context *context, QVector<float> &
 
 QVector<float> RideFileCache::meanMaxPowerFor(Context *context, QVector<float>&wpk, QString fileName)
 {
-    QTime start;
+    QElapsedTimer start;
     start.start();
 
     QVector<float> returning;
@@ -436,7 +436,7 @@ QVector<float> RideFileCache::meanMaxPowerFor(Context *context, QVector<float>&w
 // API bests for a ride
 QVector<float> RideFileCache::meanMaxFor(QString cacheFilename, RideFile::SeriesType series)
 {
-    QTime start;
+    QElapsedTimer start;
     start.start();
 
     QVector<float> returning;
@@ -485,7 +485,7 @@ QVector<float> RideFileCache::meanMaxFor(QString cacheFilename, RideFile::Series
 // API bests for a date range
 QVector<float> RideFileCache::meanMaxFor(QString cacheDir, RideFile::SeriesType series, QDate from, QDate to)
 {
-    QTime start;
+    QElapsedTimer start;
     start.start();
 
     bool first = true;

--- a/src/Gui/SolveCPDialog.cpp
+++ b/src/Gui/SolveCPDialog.cpp
@@ -357,7 +357,12 @@ SolveCPDialog::eventFilter(QObject *o, QEvent *e)
     // this is a hack related to mouse event compression
     // and is not required after QT5.6, but does no harm
     // and reduces processing overhead anyway.
-    static QTime t;
+    static QElapsedTimer t;
+    static bool started = false;
+    if (!started) {
+        t.start();
+        started = true;
+    }
     static int gc__last = 0;
 
     if (e->type()==QEvent::Paint) return false;

--- a/src/Metrics/CPSolver.cpp
+++ b/src/Metrics/CPSolver.cpp
@@ -186,7 +186,7 @@ CPSolver::start()
     s0.W =    constraints.wto;
     s0.TAU =  constraints.tto;
 
-    QTime p;
+    QElapsedTimer p;
     p.start();
 
     // initial conditions

--- a/src/Metrics/PMCData.cpp
+++ b/src/Metrics/PMCData.cpp
@@ -127,7 +127,7 @@ void PMCData::refresh()
         else stsDays_ = sts.toInt();
     }
 
-    QTime timer;
+    QElapsedTimer timer;
     timer.start();
 
     //

--- a/src/Metrics/UserMetric.cpp
+++ b/src/Metrics/UserMetric.cpp
@@ -204,7 +204,7 @@ UserMetric::isRelevantForRide(const RideItem *item) const
 void
 UserMetric::compute(RideItem *item, Specification spec, const QHash<QString,RideMetric*> &pc)
 {
-    QTime timer;
+    QElapsedTimer timer;
     timer.start();
 
     //qDebug()<<"CODE";

--- a/src/Metrics/WPrime.cpp
+++ b/src/Metrics/WPrime.cpp
@@ -105,7 +105,7 @@ WPrime::setRide(RideFile *input)
 {
     bool integral = (appsettings->value(NULL, GC_WBALFORM, "int").toString() == "int");
 
-    QTime time; // for profiling performance of the code
+    QElapsedTimer time; // for profiling performance of the code
     time.start();
 
     // remember the ride for next time
@@ -374,7 +374,7 @@ WPrime::setWatts(Context *context, QVector<int>&wattsArray, int CP, int WPRIME)
 {
     bool integral = (appsettings->value(NULL, GC_WBALFORM, "int").toString() == "int");
 
-    QTime time; // for profiling performance of the code
+    QElapsedTimer time; // for profiling performance of the code
     time.start();
 
     // reset from previous
@@ -473,7 +473,7 @@ WPrime::setErg(ErgFile *input)
 {
     bool integral = (appsettings->value(NULL, GC_WBALFORM, "int").toString() == "int");
 
-    QTime time; // for profiling performance of the code
+    QElapsedTimer time; // for profiling performance of the code
     time.start();
 
     // reset from previous

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -339,9 +339,9 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
     start_timer = new QTimer(this);
     start_timer->setSingleShot(true);
 
-    session_time = QTime();
+    session_time.start();
     session_elapsed_msec = 0;
-    lap_time = QTime();
+    lap_time.start();
     lap_elapsed_msec = 0;
     secs_to_start = 0;
 

--- a/src/Train/TrainSidebar.h
+++ b/src/Train/TrainSidebar.h
@@ -298,10 +298,10 @@ class TrainSidebar : public GcWindow
         long total_msecs,
              lap_msecs,
              load_msecs;
-        QTime load_period;
+        QElapsedTimer load_period;
 
         uint session_elapsed_msec, lap_elapsed_msec, secs_to_start;
-        QTime session_time, lap_time;
+        QElapsedTimer session_time, lap_time;
 
         QTimer      *gui_timer,     // refresh the gui
                     *load_timer,    // change the load on the device


### PR DESCRIPTION
Usage of QTime to measure timings is deprecated. This patch
replaces all usages by QElapsedTimer.