### PR TITLE
Initialize QFlags by default constructor

### DIFF
--- a/src/Charts/LTMTool.cpp
+++ b/src/Charts/LTMTool.cpp
@@ -155,7 +155,7 @@ LTMTool::LTMTool(Context *context, LTMSettings *settings) : QWidget(context->mai
     charts->setEditTriggers(QAbstractItemView::SelectedClicked); // allow edit
     charts->setIndentation(0);
 
-    presetLayout->addWidget(charts, 0,0);
+    presetLayout->addWidget(charts, 0, Qt::Alignment());
 
     applyButton = new QPushButton(tr("Apply")); // connected in LTMWindow.cpp (weird!?)
     newButton = new QPushButton(tr("Add Current"));

--- a/src/Gui/GcWindowLayout.cpp
+++ b/src/Gui/GcWindowLayout.cpp
@@ -87,7 +87,7 @@ QLayoutItem *GcWindowLayout::takeAt(int index)
 
 Qt::Orientations GcWindowLayout::expandingDirections() const
 {
-    return 0;
+    return Qt::Orientations();
 }
 
 bool GcWindowLayout::hasHeightForWidth() const

--- a/src/Gui/Pages.cpp
+++ b/src/Gui/Pages.cpp
@@ -840,7 +840,7 @@ RemotePage::RemotePage(QWidget *parent, Context *context) : QWidget(parent), con
 
     fields->setCurrentItem(fields->invisibleRootItem()->child(0));
 
-    mainLayout->addWidget(fields, 0,0);
+    mainLayout->addWidget(fields, 0, Qt::Alignment());
 
     // Load the native command list
     QList <RemoteCmd> nativeCmds = remote->getNativeCmds();

--- a/src/Metrics/RideMetadata.cpp
+++ b/src/Metrics/RideMetadata.cpp
@@ -574,7 +574,7 @@ Form::arrange()
     // special case -- a textbox and its the only field on the tab needs no label
     //                 this is how the "Notes" tab is created
     if (fields.count() == 1 && fields[0]->definition.type == FIELD_TEXTBOX) {
-        hlayout->addWidget(fields[0]->widget, 0, 0);
+        hlayout->addWidget(fields[0]->widget, 0, Qt::Alignment());
         ((GTextEdit*)(fields[0]->widget))->setFrameStyle(QFrame::NoFrame);
         ((GTextEdit*)(fields[0]->widget))->viewport()->setAutoFillBackground(false);
         return;
@@ -608,7 +608,7 @@ Form::arrange()
         Qt::Alignment labelalignment = Qt::AlignLeft|Qt::AlignTop;
         Qt::Alignment alignment = Qt::AlignLeft|Qt::AlignTop;
 
-        if (fields[i]->definition.type < FIELD_SHORTTEXT) alignment = 0; // text types
+        if (fields[i]->definition.type < FIELD_SHORTTEXT) alignment = Qt::Alignment(); // text types
 
         here->addWidget(fields[i]->label, y, 0, labelalignment);
 


### PR DESCRIPTION
Initializing QFlags by "0" is deprecated. This patch changes all
code places which does this to use the default constructor.