### PR TITLE
Replace qVariantFromValue by QVariant::fromValue

### DIFF
--- a/src/Gui/AnalysisSidebar.cpp
+++ b/src/Gui/AnalysisSidebar.cpp
@@ -106,7 +106,7 @@ AnalysisSidebar::AnalysisSidebar(Context *context) : QWidget(context->mainWindow
 
     // create tree for user intervals, so its always at the top
     QTreeWidgetItem *tree = new QTreeWidgetItem(intervalTree->invisibleRootItem(), RideFileInterval::USER);
-    tree->setData(0, Qt::UserRole, qVariantFromValue((void *)NULL)); // no intervalitem related
+    tree->setData(0, Qt::UserRole, QVariant::fromValue((void *)NULL)); // no intervalitem related
     tree->setText(0, RideFileInterval::typeDescription(RideFileInterval::USER));
     tree->setForeground(0, GColor(CPLOTMARKER));
     QFont bold;
@@ -243,7 +243,7 @@ AnalysisSidebar::setRide(RideItem*ride)
             QTreeWidgetItem *tree = trees.value(interval->type, NULL);
             if (tree == NULL) {
                 tree = new QTreeWidgetItem(intervalTree->invisibleRootItem(), interval->type);
-                tree->setData(0, Qt::UserRole, qVariantFromValue((void *)NULL)); // no intervalitem related
+                tree->setData(0, Qt::UserRole, QVariant::fromValue((void *)NULL)); // no intervalitem related
                 tree->setText(0, RideFileInterval::typeDescription(interval->type));
                 tree->setForeground(0, GColor(CPLOTMARKER));
                 tree->setFont(0, bold);
@@ -257,7 +257,7 @@ AnalysisSidebar::setRide(RideItem*ride)
             // add this interval to the tree
             QTreeWidgetItem *add = new QTreeWidgetItem(tree, interval->type);
             add->setText(0, interval->name);
-            add->setData(0, Qt::UserRole, qVariantFromValue((void*)interval));
+            add->setData(0, Qt::UserRole, QVariant::fromValue((void*)interval));
             add->setData(0, Qt::UserRole+1, QVariant(interval->color));
             add->setData(0, Qt::UserRole+2, QVariant(interval->test));
             add->setFlags(Qt::ItemIsEnabled

--- a/src/Gui/SolveCPDialog.cpp
+++ b/src/Gui/SolveCPDialog.cpp
@@ -329,7 +329,7 @@ SolveCPDialog::SolveCPDialog(QWidget *parent, Context *context) : QDialog(parent
         t->setTextAlignment(2, Qt::AlignHCenter);
 
         // remember which rideitem this is for
-        t->setData(0, Qt::UserRole, qVariantFromValue(static_cast<void*>(item)));
+        t->setData(0, Qt::UserRole, QVariant::fromValue(static_cast<void*>(item)));
 
         // checkbox
         QCheckBox *check = new QCheckBox(this);


### PR DESCRIPTION
The function qVariantFromValue is deprecated and was replaced
by QVariant::fromValue. This patch adapts the code accordingly.