### PR TITLE
Change QDate to QDateTime conversions, specifying time

### DIFF
--- a/src/Charts/LTMPlot.cpp
+++ b/src/Charts/LTMPlot.cpp
@@ -1301,7 +1301,7 @@ LTMPlot::setData(LTMSettings *set)
         // make start date always fall on a Monday
         if (settings->groupBy == LTM_WEEK) {
             int dow = settings->start.date().dayOfWeek(); // 1-7, where 1=monday
-            settings->start = QDateTime(settings->start.date().addDays((dow-1)*-1));
+            settings->start = QDateTime(settings->start.date().addDays((dow-1)*-1).startOfDay());
         }
 
         // setup the xaxis at the bottom

--- a/src/FileIO/MeasuresCsvImport.cpp
+++ b/src/FileIO/MeasuresCsvImport.cpp
@@ -152,7 +152,7 @@ MeasuresCsvImport::getMeasures(MeasuresGroup *measuresGroup, QString &error, QDa
               }
           } else if (!tsExists && h == "date") {
               // parse date (HRV4Training for Android)
-              m.when = QDateTime(QDate::fromString(i, "yyyy-dd-MM"));
+              m.when = QDateTime(QDate::fromString(i, "yyyy-dd-MM").startOfDay());
               if (m.when.date().isValid()) {
                   // skip line if not in date range
                   if (m.when < from || m.when > to) {

--- a/src/FileIO/SrmRideFile.cpp
+++ b/src/FileIO/SrmRideFile.cpp
@@ -217,7 +217,7 @@ RideFile *SrmFileReader::openRideFile(QFile &file, QStringList &errorStrings, QL
         // it seems safe to always treat this number as signed.
         qint32 hsecsincemidn = readLong(in);
         blockhdrs[i].chunkcnt = version < 9 ? readShort(in) : readLong(in);
-        blockhdrs[i].dt = QDateTime(date);
+        blockhdrs[i].dt = QDateTime(date.startOfDay());
         blockhdrs[i].dt = blockhdrs[i].dt.addMSecs(hsecsincemidn * 10);
         blockchunkcnt += blockhdrs[i].chunkcnt;
     }
@@ -249,7 +249,7 @@ RideFile *SrmFileReader::openRideFile(QFile &file, QStringList &errorStrings, QL
     if( blockcnt < 1 ){
         blockcnt = 0;
         blockhdrs[0].chunkcnt = datacnt;
-        blockhdrs[0].dt = QDateTime(date);
+        blockhdrs[0].dt = QDateTime(date.startOfDay());
     }
 
     // datacnt might overflow at 64k - so, use sum from blocks, instead


### PR DESCRIPTION
The QDateTime constructor taking a QDate as argument is deprecated.
QDate::startOfDay() should be used instead when converting a QDate
to a QDateTime. This makes clear what time is used in this conversion.
This patch adapts the code to this.