### PR TITLE
Use default constructor for QFlags in QWT

### DIFF
--- a/qwt/src/qwt_plot_layout.h
+++ b/qwt/src/qwt_plot_layout.h
@@ -82,7 +82,7 @@ public:
     virtual QSize minimumSizeHint( const QwtPlot * ) const;
 
     void update( const QwtPlot *,
-        const QRectF &rect, Options options = 0x00 );
+        const QRectF &rect, Options options = Options() );
 
     virtual void invalidate();
 


### PR DESCRIPTION
Conversion from int is deprecated.

Only to be merged if qwt is not updated.