### PR TITLE
Specify encoding when communicating with TodaysPlan

### DIFF
--- a/src/Cloud/TodaysPlan.cpp
+++ b/src/Cloud/TodaysPlan.cpp
@@ -235,7 +235,7 @@ TodaysPlan::readdir(QString path, QStringList &errors, QDateTime from, QDateTime
             // Prepare the Search Payload for First Call to Search
             QString userId = getSetting(GC_TODAYSPLAN_ATHLETE_ID, "").toString();
             // application/json
-            QByteArray jsonString;
+            QString jsonString;
             jsonString += "{\"criteria\": {";
             if (userId.length()>0)
                 jsonString += "\"user\": "+ QString("%1").arg(userId) +", ";
@@ -248,13 +248,15 @@ TodaysPlan::readdir(QString path, QStringList &errors, QDateTime from, QDateTime
             jsonString += "\"opts\": 1 "; // without fields description
             jsonString += "}";
 
-            printd("request: %s\n", jsonString.toStdString().c_str());
+            printd("request: %s\n", jsonString.toUtf8().toStdString().c_str());
 
-            QByteArray jsonStringDataSize = QByteArray::number(jsonString.size());
+            QByteArray jsonStringAsUTF8 = jsonString.toUtf8();
+
+            QByteArray jsonStringDataSize = QByteArray::number(jsonStringAsUTF8.size());
 
             request.setHeader(QNetworkRequest::ContentTypeHeader,"application/json");
             request.setRawHeader("Content-Length", jsonStringDataSize);
-            reply = nam->post(request, jsonString);
+            reply = nam->post(request, jsonStringAsUTF8);
         } else {
             // get further pages of the Search
             reply = nam->get(request);

--- a/src/Cloud/TodaysPlanBodyMeasures.cpp
+++ b/src/Cloud/TodaysPlanBodyMeasures.cpp
@@ -88,7 +88,7 @@ TodaysPlanBodyMeasures::getBodyMeasures(QString &error, QDateTime from, QDateTim
             // Prepare the Search Payload for First Call to Search
             QString userId = appsettings->cvalue(context->athlete->cyclist, GC_TODAYSPLAN_ATHLETE_ID, "").toString();
             // application/json
-            QByteArray jsonString;
+            QString jsonString;
             jsonString += "{\"criteria\": { ";
             if (userId.length()>0)
                 jsonString += " \"userIds\": [ "+ QString("%1").arg(userId) +" ], ";
@@ -99,11 +99,13 @@ TodaysPlanBodyMeasures::getBodyMeasures(QString &error, QDateTime from, QDateTim
             jsonString += "\"fields\": [\"att.ts\",\"att.weight\", \"att.fat\",\"att.muscleMass\",\"att.boneMass\",\"att.fatMass\", \"att.height\" , \"att.source\"] ";
             jsonString += "}";
 
-            QByteArray jsonStringDataSize = QByteArray::number(jsonString.size());
+            QByteArray jsonStringAsUTF8 = jsonString.toUtf8();
+
+            QByteArray jsonStringDataSize = QByteArray::number(jsonStringAsUTF8.size());
 
             request.setHeader(QNetworkRequest::ContentTypeHeader,"application/json");
             request.setRawHeader("Content-Length", jsonStringDataSize);
-            reply = nam->post(request, jsonString);
+            reply = nam->post(request, jsonStringAsUTF8);
         } else {
             // get further pages of the Search
             reply = nam->get(request);

--- a/src/Train/TodaysPlanWorkoutDownload.cpp
+++ b/src/Train/TodaysPlanWorkoutDownload.cpp
@@ -367,7 +367,7 @@ TodaysPlanWorkoutDownload::getFileList(QString &error, QDateTime from, QDateTime
             // Prepare the Search Payload for First Call to Search
             QString userId = appsettings->cvalue(context->athlete->cyclist, GC_TODAYSPLAN_ATHLETE_ID, "").toString();
             // application/json
-            QByteArray jsonString;
+            QString jsonString;
             jsonString += "{\"criteria\": {";
             if (userId.length()>0)
                 jsonString += "\"user\": "+ QString("%1").arg(userId) +", ";
@@ -379,11 +379,13 @@ TodaysPlanWorkoutDownload::getFileList(QString &error, QDateTime from, QDateTime
             jsonString += "\"opts\": 1 ";
             jsonString += "}";
 
-            QByteArray jsonStringDataSize = QByteArray::number(jsonString.size());
+            QByteArray jsonStringAsUTF8 = jsonString.toUtf8();
+
+            QByteArray jsonStringDataSize = QByteArray::number(jsonStringAsUTF8.size());
 
             request.setHeader(QNetworkRequest::ContentTypeHeader,"application/json");
             request.setRawHeader("Content-Length", jsonStringDataSize);
-            reply = nam->post(request, jsonString);
+            reply = nam->post(request, jsonStringAsUTF8);
         } else {
             // get further pages of the Search
             reply = nam->get(request);


### PR DESCRIPTION
Conversion from QString to QByteArray is deprecated in Qt 6.
It will be required to specify the encoding. This patch
adapts the interaction with TodaysPlans API to specify the
encoding as UTF8.
This should be no behavior change, as encoding in UTF8 was the
default in the now deprecated methods, see
https://doc.qt.io/qt-5/qbytearray-obsolete.html#operator-2b-eq-3
.