### PR TITLE
Specify encoding when communicating with DropBox

### DIFF
--- a/src/Cloud/Dropbox.cpp
+++ b/src/Cloud/Dropbox.cpp
@@ -103,7 +103,7 @@ bool Dropbox::createFolder(QString path)
     request.setRawHeader("Content-Type", "application/json");
 
     QByteArray data;
-    data.append(QString("{ \"path\": \"%1\", \"autorename\": false }").arg(path));
+    data.append(QString("{ \"path\": \"%1\", \"autorename\": false }").arg(path).toUtf8());
     QNetworkReply *reply = nam->post(request, data);
 
     // blocking request
@@ -146,11 +146,11 @@ Dropbox::readdir(QString path, QStringList &errors)
         QByteArray data;
 
         if (firstRequest) {
-            data.append(QString("{ \"path\": \"%1\", \"recursive\": false ,\"include_deleted\": false }").arg(path));
+            data.append(QString("{ \"path\": \"%1\", \"recursive\": false ,\"include_deleted\": false }").arg(path).toUtf8());
             firstRequest = false;
         } else {
             request.setUrl(QUrl("https://api.dropboxapi.com/2/files/list_folder/continue"));
-            data.append(QString("{ \"cursor\": \"%1\" }").arg(cursor));
+            data.append(QString("{ \"cursor\": \"%1\" }").arg(cursor).toUtf8());
         }
         QNetworkReply *reply = nam->post(request, data);
 


### PR DESCRIPTION
QByteArray::append(QString) was deprecated. It is now required
to specify an encoding. This patch adds the corresponding calls
to the communication with DropBox.
This should not be a behavior change, as UTF8 was the default
when converting from QString to QByteArray.