### PR TITLE
Specify text encoding in several places

### DIFF
--- a/src/Core/Measures.cpp
+++ b/src/Core/Measures.cpp
@@ -42,7 +42,7 @@ Measure::getFingerprint() const
     for (int i = 0; i<MAX_MEASURES; i++) x += 1000.0 * values[i];
 
     QByteArray ba = QByteArray::number(x);
-    ba.append(comment);
+    ba.append(comment.toUtf8());
 
     return qChecksum(ba, ba.length());
 }

--- a/src/Core/RideItem.cpp
+++ b/src/Core/RideItem.cpp
@@ -164,8 +164,8 @@ RideItem::metaCRC()
         // with configuration, not user updates
         if (i.key() == "Calendar Text") continue;
 
-        ba.append(i.key());
-        ba.append(i.value());
+        ba.append(i.key().toUtf8());
+        ba.append(i.value().toUtf8());
     }
     return qChecksum(ba, ba.length());
 }

--- a/src/FileIO/JsonRideFile.y
+++ b/src/FileIO/JsonRideFile.y
@@ -467,7 +467,7 @@ JsonFileReader::openRideFile(QFile &file, QStringList &errors, QList<RideFile*>*
 QByteArray
 JsonFileReader::toByteArray(Context *, const RideFile *ride, bool withAlt, bool withWatts, bool withHr, bool withCad) const
 {
-    QByteArray out;
+    QString out;
 
     // start of document and ride
     out += "{\n\t\"RIDE\":{\n";
@@ -766,7 +766,7 @@ JsonFileReader::toByteArray(Context *, const RideFile *ride, bool withAlt, bool 
     // end of ride and document
     out += "\n\t}\n}\n";
 
-    return out;
+    return out.toUtf8();
 }
 
 // Writes valid .json (validated at www.jsonlint.com)

--- a/src/Gui/Colors.cpp
+++ b/src/Gui/Colors.cpp
@@ -97,7 +97,7 @@ unsigned long Colors::fingerprint(const Colors *set)
 {
     QByteArray ba;
     while(set->name != "") {
-        ba.append(set->color.name());
+        ba.append(set->color.name().toUtf8());
         set++;
     }
     return qChecksum(ba, ba.length());

--- a/src/Metrics/RideMetadata.cpp
+++ b/src/Metrics/RideMetadata.cpp
@@ -1300,11 +1300,11 @@ FieldDefinition::fingerprint(QList<FieldDefinition> list)
 
     foreach(FieldDefinition def, list) {
 
-        ba.append(def.tab);
-        ba.append(def.name);
+        ba.append(def.tab.toUtf8());
+        ba.append(def.name.toUtf8());
         ba.append(def.type);
         ba.append(def.diary);
-        ba.append(def.values.join(""));
+        ba.append(def.values.join("").toUtf8());
     }
 
     return qChecksum(ba, ba.length());
@@ -1363,9 +1363,9 @@ KeywordDefinition::fingerprint(QList<KeywordDefinition> list)
 
     foreach(KeywordDefinition def, list) {
 
-        ba.append(def.name);
-        ba.append(def.color.name());
-        ba.append(def.tokens.join(""));
+        ba.append(def.name.toUtf8());
+        ba.append(def.color.name().toUtf8());
+        ba.append(def.tokens.join("").toUtf8());
     }
 
     return qChecksum(ba, ba.length());


### PR DESCRIPTION
Conversion from QString to QByteArray is deprecated in Qt 6.
It will be required to specify the encoding. This patch
adapts several places to specify the encoding as UTF8.
This should be no behavior change, as encoding in UTF8 was the
default in the now deprecated methods, see
https://doc.qt.io/qt-5/qbytearray-obsolete.html#operator-2b-eq-3