### PR TITLE
Replace qStableSort by std::stable_sort

### DIFF
--- a/src/Core/RideCache.cpp
+++ b/src/Core/RideCache.cpp
@@ -685,7 +685,7 @@ RideCache::getBests(QString symbol, int n, Specification specification, bool use
     }
 
     // now sort
-    qStableSort(results.begin(), results.end(), metric->isLowerBetter() ?
+    std::stable_sort(results.begin(), results.end(), metric->isLowerBetter() ?
                                                 rideCachesummaryBestLowerThan :
                                                 rideCachesummaryBestGreaterThan);
 

--- a/src/Gui/RideNavigatorProxy.h
+++ b/src/Gui/RideNavigatorProxy.h
@@ -533,7 +533,7 @@ public:
             }
 
             // sort by row again
-            qStableSort(rankedRows.begin(), rankedRows.end(), rankx::sortByRow);
+            std::stable_sort(rankedRows.begin(), rankedRows.end(), rankx::sortByRow);
 
 
             // create a QMap from 'group' string to list of rows in that group


### PR DESCRIPTION
qStableSort is deprecated. This patch replaces all usages by
std::stable_sort.