### PR TITLE
Add assignment operators to some classes

### DIFF
--- a/contrib/qtsolutions/segmentcontrol/qtsegmentcontrol.cpp
+++ b/contrib/qtsolutions/segmentcontrol/qtsegmentcontrol.cpp
@@ -49,6 +49,16 @@ public:
        : position(OnlyOneSegment), selectedPosition(NotAdjacent) { }
     QtStyleOptionSegmentControlSegment(const QtStyleOptionSegmentControlSegment &other)
         : QStyleOption(Version, Type) { *this = other; }
+    QtStyleOptionSegmentControlSegment& operator=(const QtStyleOptionSegmentControlSegment &other)
+    {
+        QStyleOption::operator=(other);
+        text = other.text;
+        icon = other.icon;
+        iconSize = other.iconSize;
+        position = other.position;
+        selectedPosition = other.selectedPosition;
+        return *this;
+    }
 
 protected:
     QtStyleOptionSegmentControlSegment(int version);

--- a/qwt/src/qwt_point_3d.h
+++ b/qwt/src/qwt_point_3d.h
@@ -27,6 +27,7 @@ public:
     QwtPoint3D();
     QwtPoint3D( double x, double y, double z );
     QwtPoint3D( const QwtPoint3D & );
+    QwtPoint3D& operator=( const QwtPoint3D & );
     QwtPoint3D( const QPointF & );
 
     bool isNull()    const;
@@ -88,6 +89,17 @@ inline QwtPoint3D::QwtPoint3D( const QwtPoint3D &other ):
     d_y( other.d_y ),
     d_z( other.d_z )
 {
+}
+
+/*!
+    Assignment operator.
+*/
+inline QwtPoint3D& QwtPoint3D::operator=( const QwtPoint3D &other )
+{
+    d_x = other.d_x;
+    d_y = other.d_y;
+    d_z = other.d_z;
+    return *this;
 }
 
 /*!

--- a/src/Core/Measures.h
+++ b/src/Core/Measures.h
@@ -41,11 +41,15 @@ public:
         for (int i = 0; i<MAX_MEASURES; i++) values[i] = 0.0;
     }
     Measure(const Measure &other) {
+        *this = other;
+    }
+    Measure& operator=(const Measure &other) {
         this->when = other.when;
         this->comment = other.comment;
         this->source = other.source;
         this->originalSource = other.originalSource;
         for (int i = 0; i<MAX_MEASURES; i++) this->values[i] = other.values[i];
+        return *this;
     }
     ~Measure() {}
 

--- a/src/FileIO/LocationInterpolation.h
+++ b/src/FileIO/LocationInterpolation.h
@@ -41,6 +41,7 @@ public:
     v3(double a, double b, double c) : m_t(a, b, c) {};
 
     v3(const v3& o) : m_t(o.m_t) {}
+    v3& operator=(const v3& o) { m_t = o.m_t; return *this; }
 
     double  x() const { return std::get<0>(m_t); }
     double  y() const { return std::get<1>(m_t); }

--- a/src/FileIO/RideFile.h
+++ b/src/FileIO/RideFile.h
@@ -562,13 +562,17 @@ public:
             string[i]="";
         }
     }
-    XDataPoint (const XDataPoint &other) {
+    XDataPoint(const XDataPoint &other) {
+        *this = other;
+    }
+    XDataPoint& operator=(const XDataPoint &other) {
         this->secs=other.secs;
         this->km=other.km;
         for(int i=0; i<XDATA_MAXVALUES; i++) {
             this->number[i]= other.number[i];
             this->string[i]= other.string[i];
         }
+        return *this;
     }
 
     double secs, km;
@@ -579,7 +583,8 @@ public:
 class XDataSeries {
 public:
     XDataSeries() {}
-    XDataSeries(XDataSeries &other) {
+    XDataSeries(const XDataSeries& other) { *this = other; }
+    XDataSeries& operator=(const XDataSeries &other) {
         name = other.name;
         valuename = other.valuename;
         unitname = other.unitname;
@@ -589,6 +594,7 @@ public:
         foreach (XDataPoint *p, other.datapoints) {
             datapoints.push_back(new XDataPoint(*p));
         }
+        return *this;
     }
 
     ~XDataSeries() { foreach(XDataPoint *p, datapoints) delete p; }


### PR DESCRIPTION
The implicitly defined assignment operator for classes having custom
defined copy constructor is deprecated. This patch adds explicit
assignment operators.

This is not required for porting to Qt6.