### PR TITLE
Replace QStyleOptionFrameV3 by QStyleOptionFrame in qwt

### DIFF
--- a/qwt/src/qwt_plot_canvas.cpp
+++ b/qwt/src/qwt_plot_canvas.cpp
@@ -937,7 +937,7 @@ void QwtPlotCanvas::drawBorder( QPainter *painter )
     else
     {
 #if QT_VERSION >= 0x040500
-        QStyleOptionFrameV3 opt;
+        QStyleOptionFrame opt;
         opt.init(this);
 
         int frameShape  = frameStyle() & QFrame::Shape_Mask;


### PR DESCRIPTION
QStyleOptionFrameV3 is deprecated. QStyleOptionFrame
can be used instead. For details, see
https://doc.qt.io/qt-6/widgets-changes-qt6.html

No need to merge this if you upgrade qwt.