### PR TITLE
Use QPainter::setTransform instead of QPainter::setMatrix

### DIFF
--- a/src/Charts/LogTimeScaleDraw.cpp
+++ b/src/Charts/LogTimeScaleDraw.cpp
@@ -33,8 +33,6 @@
 #include "qwt_scale_map.h"
 #include "qwt_scale_draw.h"
 
-#include <qmatrix.h>
-#define QwtMatrix QMatrix
 #define QwtPointArray QPolygon
 
 struct tick_info_t {

--- a/src/Charts/LogTimeScaleDraw.cpp
+++ b/src/Charts/LogTimeScaleDraw.cpp
@@ -93,10 +93,10 @@ LogTimeScaleDraw::drawLabel(QPainter *painter, double value) const
     if ( labelSize.toSize().height() % 2 )
         labelSize.setHeight(labelSize.height() + 1);
 
-    const QwtMatrix m = labelTransformation( pos, labelSize).toAffine();
+    const QTransform m = labelTransformation( pos, labelSize);
 
     painter->save();
-    painter->setMatrix(m, true);
+    painter->setTransform(m, true);
 
     lbl.draw (painter, QRect(QPoint(0, 0), labelSize.toSize()) );
     painter->restore();


### PR DESCRIPTION
QPainter::setMatrix is deprecated. This patch replaces
usage of setMatrix by usage of setTransform.