### PR TITLE
Replace QColor::dark by QColor::darker and light by lighter

### DIFF
--- a/contrib/qxt/src/qxtspanslider.cpp
+++ b/contrib/qxt/src/qxtspanslider.cpp
@@ -108,14 +108,14 @@ void QxtSpanSliderPrivate::setupPainter(QPainter* painter, Qt::Orientation orien
 {
     QColor highlight = qxt_p().palette().color(QPalette::Highlight);
     QLinearGradient gradient(x1, y1, x2, y2);
-    gradient.setColorAt(0, highlight.dark(120));
-    gradient.setColorAt(1, highlight.light(108));
+    gradient.setColorAt(0, highlight.darker(120));
+    gradient.setColorAt(1, highlight.lighter(108));
     painter->setBrush(gradient);
 
     if (orientation == Qt::Horizontal)
-        painter->setPen(QPen(highlight.dark(130), 0));
+        painter->setPen(QPen(highlight.darker(130), 0));
     else
-        painter->setPen(QPen(highlight.dark(150), 0));
+        painter->setPen(QPen(highlight.darker(150), 0));
 }
 
 void QxtSpanSliderPrivate::drawSpan(QStylePainter* painter, const QRect& rect) const
@@ -132,7 +132,7 @@ void QxtSpanSliderPrivate::drawSpan(QStylePainter* painter, const QRect& rect) c
         groove.adjust(0, 0, 0, -1);
 
     // pen & brush
-    painter->setPen(QPen(p->palette().color(QPalette::Dark).light(110), 0));
+    painter->setPen(QPen(p->palette().color(QPalette::Dark).lighter(110), 0));
     if (opt.orientation == Qt::Horizontal)
         setupPainter(painter, opt.orientation, groove.center().x(), groove.top(), groove.center().x(), groove.bottom());
     else


### PR DESCRIPTION
QColor::dark and QColor::light are deprecated. This patch adapts
the code to use QColor::darker and QColor::lighter.