### PR TITLE
Usage of QDesktopWidget is deprecated. Adapt code

### DIFF
--- a/src/Charts/LTMWindow.cpp
+++ b/src/Charts/LTMWindow.cpp
@@ -36,7 +36,6 @@
 #include "GcOverlayWidget.h"
 
 #include <QWebEngineSettings>
-#include <QDesktopWidget>
 
 #include <QtGlobal>
 #include <QtGui>
@@ -144,7 +143,7 @@ LTMWindow::LTMWindow(Context *context) :
     //XXXdataSummary->setEnabled(false); // stop grabbing focus
     if (dpiXFactor > 1) {
     // 80 lines per page on hidpi screens (?)
-        int pixelsize = pixelSizeForFont(defaultFont, QApplication::desktop()->geometry().height()/80);
+        int pixelsize = pixelSizeForFont(defaultFont, QApplication::primaryScreen()->geometry().height()/80);
         dataSummary->settings()->setFontSize(QWebEngineSettings::DefaultFontSize, pixelsize);
     } else {
         dataSummary->settings()->setFontSize(QWebEngineSettings::DefaultFontSize, defaultFont.pointSize()+1);

--- a/src/Charts/RideEditor.cpp
+++ b/src/Charts/RideEditor.cpp
@@ -1093,9 +1093,10 @@ RideEditor::pasteSpecial()
     PasteSpecialDialog *paster = new PasteSpecialDialog(this);
 
     // center the dialog
-    QDesktopWidget *desktop = QApplication::desktop();
-    int x = (desktop->width() - paster->size().width()) / 2;
-    int y = ((desktop->height() - paster->size().height()) / 2) -(50*dpiYFactor);
+    QScreen* screen = QGuiApplication::primaryScreen();
+    auto availableGeometry = screen->availableGeometry();
+    int x = (availableGeometry.width() - paster->size().width()) / 2;
+    int y = ((availableGeometry.height() - paster->size().height()) / 2) - (50 * dpiYFactor);
 
     // move window to desired coordinates
     paster->move(x,y);

--- a/src/Charts/RideEditor.h
+++ b/src/Charts/RideEditor.h
@@ -35,7 +35,6 @@
 #include <QTableWidget>
 #include <QHeaderView>
 #include <QMessageBox>
-#include <QDesktopWidget>
 #include <QToolBar>
 #include <QItemDelegate>
 #include <QStackedWidget>

--- a/src/Cloud/CloudDBChart.cpp
+++ b/src/Cloud/CloudDBChart.cpp
@@ -42,7 +42,6 @@
 #include <QJsonArray>
 #include <QXmlInputSource>
 #include <QXmlSimpleReader>
-#include <QDesktopWidget>
 
 CloudDBChartClient::CloudDBChartClient()
 {
@@ -1172,7 +1171,7 @@ CloudDBChartListDialog::cellDoubleClicked(int row, int /*column */) {
 
 CloudDBChartShowPictureDialog::CloudDBChartShowPictureDialog(QByteArray imageData) : imageData(imageData) {
 
-    QRect rec = QApplication::desktop()->screenGeometry();
+    QRect rec = QApplication::primaryScreen()->screenGeometry();
     imageLabel = new QLabel();
     imageLabel->setMinimumSize(150,100); // not scaled to hi-dpi screens (cloud db constraint not device)
     chartImage.loadFromData(imageData);

--- a/src/Cloud/CloudDBUserMetric.cpp
+++ b/src/Cloud/CloudDBUserMetric.cpp
@@ -35,7 +35,6 @@
 #include <QJsonArray>
 #include <QXmlInputSource>
 #include <QXmlSimpleReader>
-#include <QDesktopWidget>
 
 CloudDBUserMetricClient::CloudDBUserMetricClient()
 {

--- a/src/Cloud/CloudService.cpp
+++ b/src/Cloud/CloudService.cpp
@@ -33,7 +33,6 @@
 #include <QFileIconProvider>
 #include <QMessageBox>
 #include <QHeaderView>
-#include <QDesktopWidget>
 
 #include "../qzip/zipwriter.h"
 #include "../qzip/zipreader.h"

--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -30,7 +30,6 @@
 #include "GcCrashDialog.h" // for versionHTML
 
 #include <QApplication>
-#include <QDesktopWidget>
 #include <QtGui>
 #include <QFile>
 #include <QMessageBox>
@@ -69,7 +68,6 @@ static int gc_opened=0;
 //
 QString gcroot;
 QApplication *application;
-QDesktopWidget *desktop = NULL;
 
 #ifdef GC_WANT_HTTP
 #include "APIWebService.h"
@@ -439,9 +437,6 @@ main(int argc, char *argv[])
     // use the default before taking into account screen size
     baseFont = font;
 
-    // hidpi ratios -- single desktop for now
-    desktop = QApplication::desktop();
-
 
     // since almost all dialogs are sized for a screen resolution
     // of 1280x1024, to save issues we will scale DIALOGS to the
@@ -480,7 +475,8 @@ main(int argc, char *argv[])
        double height = screenSize.height() / 70;
 
        // points = height in inches * dpi
-       double pointsize = (height / QApplication::desktop()->logicalDpiY()) * 72;
+       double pointsize = (height / QApplication::primaryScreen()->
+               logicalDotsPerInchY()) * 72;
        baseFont.setPointSizeF(pointsize);
 
        // fixup some style issues from QT not adjusting defaults on hidpi displays

--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -459,13 +459,13 @@ main(int argc, char *argv[])
     // 2560x1700 chromebook pixel before we get to truly hi-dpi
     // resolutions like apples MBP retina 2880x1800 up through
     // UHD, 4k and 5k displays at 3840x2160, 4096x2304 and 5120 x 2160.
-    QRect screenSize = desktop->availableGeometry();
+    QRect screenSize = QGuiApplication::screens()[0]->availableGeometry();
 
     // if we're running with dpiawareness of 0 the screen resolution
     // will be expressed taking into account the scaling applied
     // so for example a 3840x2160 screen will likely be expressed as
     // being 1920 x 1080 rather than the native resolution
-    if (desktop->screen()->devicePixelRatio() <= 1 && screenSize.width() > 2160) {
+    if (QGuiApplication::screens()[0]->devicePixelRatio() <= 1 && screenSize.width() > 2160) {
        // we're on a hidpi screen - lets create a multiplier - always use smallest
        dpiXFactor = screenSize.width() / 1280.0;
        dpiYFactor = screenSize.height() / 1024.0;

--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -454,13 +454,13 @@ main(int argc, char *argv[])
     // 2560x1700 chromebook pixel before we get to truly hi-dpi
     // resolutions like apples MBP retina 2880x1800 up through
     // UHD, 4k and 5k displays at 3840x2160, 4096x2304 and 5120 x 2160.
-    QRect screenSize = QGuiApplication::screens()[0]->availableGeometry();
+    QRect screenSize = QGuiApplication::primaryScreen()->availableGeometry();
 
     // if we're running with dpiawareness of 0 the screen resolution
     // will be expressed taking into account the scaling applied
     // so for example a 3840x2160 screen will likely be expressed as
     // being 1920 x 1080 rather than the native resolution
-    if (QGuiApplication::screens()[0]->devicePixelRatio() <= 1 && screenSize.width() > 2160) {
+    if (QGuiApplication::primaryScreen()->devicePixelRatio() <= 1 && screenSize.width() > 2160) {
        // we're on a hidpi screen - lets create a multiplier - always use smallest
        dpiXFactor = screenSize.width() / 1280.0;
        dpiYFactor = screenSize.height() / 1024.0;

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -197,7 +197,7 @@ MainWindow::MainWindow(const QDir &home)
      } else {
          // first run -- lets set some sensible defaults...
          // lets put it in the middle of screen 1
-        QRect screenSize = desktop->availableGeometry();
+         QRect screenSize = QGuiApplication::screens()[0]->availableGeometry();
          struct SizeSettings app = GCColor::defaultSizes(screenSize.height(), screenSize.width());
 
          // center on the available screen (minus toolbar/sidebar)
@@ -783,7 +783,7 @@ MainWindow::setSplash(bool first)
 
     if (first) {
         // middle of screen
-        splash->move(desktop->availableGeometry().center()-QPoint(50, 25));
+        splash->move(QGuiApplication::screens()[0]->availableGeometry().center()-QPoint(50, 25));
     } else {
         // middle of mainwindow is appropriate
         splash->move(geometry().center()-QPoint(50, 25));

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -195,7 +195,7 @@ MainWindow::MainWindow(const QDir &home)
      } else {
          // first run -- lets set some sensible defaults...
          // lets put it in the middle of screen 1
-         QRect screenSize = QGuiApplication::screens()[0]->availableGeometry();
+         QRect screenSize = QGuiApplication::primaryScreen()->availableGeometry();
          struct SizeSettings app = GCColor::defaultSizes(screenSize.height(), screenSize.width());
 
          // center on the available screen (minus toolbar/sidebar)
@@ -781,7 +781,7 @@ MainWindow::setSplash(bool first)
 
     if (first) {
         // middle of screen
-        splash->move(QGuiApplication::screens()[0]->availableGeometry().center()-QPoint(50, 25));
+        splash->move(QGuiApplication::primaryScreen()->availableGeometry().center()-QPoint(50, 25));
     } else {
         // middle of mainwindow is appropriate
         splash->move(geometry().center()-QPoint(50, 25));

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -21,7 +21,6 @@
 #include <QApplication>
 #include <QtGui>
 #include <QRegExp>
-#include <QDesktopWidget>
 #include <QNetworkProxyQuery>
 #include <QMenuBar>
 #include <QStyle>
@@ -123,7 +122,6 @@
 
 // We keep track of all theopen mainwindows
 QList<MainWindow *> mainwindows;
-extern QDesktopWidget *desktop;
 extern ConfigDialog *configdialog_ptr;
 extern QString gl_version;
 extern double gl_major; // 1.x 2.x 3.x - we insist on 2.x or higher to enable OpenGL
@@ -1075,7 +1073,7 @@ void
 MainWindow::toggleFullScreen()
 {
 #ifdef Q_OS_MAC
-    QRect screenSize = desktop->availableGeometry();
+    QRect screenSize = QGuiApplication::primaryScreen()->availableGeometry();
     if (screenSize.width() > frameGeometry().width() ||
         screenSize.height() > frameGeometry().height())
         showFullScreen();

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -73,7 +73,6 @@ class Tab;
 
 
 extern QList<MainWindow *> mainwindows; // keep track of all the MainWindows we have open
-extern QDesktopWidget *desktop;         // how many screens / res etc
 extern QString gcroot;                  // root directory for gc
 
 class MainWindow : public QMainWindow

--- a/src/Gui/Perspective.cpp
+++ b/src/Gui/Perspective.cpp
@@ -1199,7 +1199,7 @@ GcWindowDialog::GcWindowDialog(GcWinID type, Context *context, GcChartWindow **h
     setWindowFlags(windowFlags());
     setWindowTitle(tr("Chart Setup"));
 
-    QRect size= QGuiApplication::screens()[0]->availableGeometry();
+    QRect size= QGuiApplication::primaryScreen()->availableGeometry();
     setMinimumHeight(500);
 
     // chart and settings side by side need to be big!

--- a/src/Gui/Perspective.cpp
+++ b/src/Gui/Perspective.cpp
@@ -37,7 +37,6 @@
 #include "RTool.h"
 #endif
 
-#include <QDesktopWidget>
 #include <QStyle>
 #include <QStyleFactory>
 #include <QScrollBar>

--- a/src/Gui/Perspective.cpp
+++ b/src/Gui/Perspective.cpp
@@ -1200,7 +1200,7 @@ GcWindowDialog::GcWindowDialog(GcWinID type, Context *context, GcChartWindow **h
     setWindowFlags(windowFlags());
     setWindowTitle(tr("Chart Setup"));
 
-    QRect size= desktop->availableGeometry();
+    QRect size= QGuiApplication::screens()[0]->availableGeometry();
     setMinimumHeight(500);
 
     // chart and settings side by side need to be big!

--- a/src/Gui/Views.cpp
+++ b/src/Gui/Views.cpp
@@ -28,9 +28,6 @@
 #include "TrainBottom.h"
 #include "Specification.h"
 
-#include <QDesktopWidget>
-extern QDesktopWidget *desktop;
-
 AnalysisView::AnalysisView(Context *context, QStackedWidget *controls) : TabView(context, VIEW_ANALYSIS)
 {
     analSidebar = new AnalysisSidebar(context);


### PR DESCRIPTION
This patch adapts the code to not use QDesktopWidget but to
use QGuiApplication::screens instead. It defaults to screen number 0.