### PR TITLE
Qt6: specifying utf8 for QTextStream is the default

### DIFF
--- a/src/Charts/GoldenCheetah.cpp
+++ b/src/Charts/GoldenCheetah.cpp
@@ -932,7 +932,6 @@ GcChartWindow::saveChart()
 
     // lets go to it
     QTextStream out(&outfile);
-    out.setCodec ("UTF-8");
 
     serializeChartToQTextStream(out);
 
@@ -996,7 +995,6 @@ GcChartWindow::chartPropertiesFromFile(QString filename)
         // read in the whole thing
         QTextStream in(&file);
         // GC .JSON is stored in UTF-8 with BOM(Byte order mark) for identification
-        in.setCodec ("UTF-8");
         contents = in.readAll();
         file.close();
     }
@@ -1079,7 +1077,6 @@ GcChartWindow::exportChartToCloudDB()
     chart.Header.GcVersion =  QString::number(version);
     // get the gchart - definition json
     QTextStream out(&chart.ChartDef);
-    out.setCodec ("UTF-8");
     serializeChartToQTextStream(out);
     out.flush();
     // get Type and View from properties

--- a/src/Charts/LTMChartParser.cpp
+++ b/src/Charts/LTMChartParser.cpp
@@ -96,7 +96,6 @@ LTMChartParser::serialize(QString filename, QList<LTMSettings> charts)
     };
     file.resize(0);
     QTextStream out(&file);
-    out.setCodec("UTF-8");
 
     serializeToQTextStream(out, charts);
 
@@ -108,7 +107,6 @@ void
 LTMChartParser::serializeToQString(QString* string, QList<LTMSettings> charts)
 {
     QTextStream out(string);
-    out.setCodec("UTF-8");
 
     serializeToQTextStream(out, charts);
 

--- a/src/Charts/LTMWindow.cpp
+++ b/src/Charts/LTMWindow.cpp
@@ -1669,7 +1669,6 @@ LTMWindow::exportData()
 
         // open stream and write header
         QTextStream stream(&f);
-        stream.setCodec("UTF-8"); // Names and Units can be translated
         stream << content;
 
         // and we're done

--- a/src/Charts/UserChart.cpp
+++ b/src/Charts/UserChart.cpp
@@ -305,7 +305,6 @@ UserChart::settings() const
     QString returning;
 
     QTextStream out(&returning);
-    out.setCodec("UTF-8");
     out << "{ ";
 
     // chartinfo

--- a/src/Core/APIWebService.cpp
+++ b/src/Core/APIWebService.cpp
@@ -395,7 +395,6 @@ APIWebService::listActivity(QString athlete, QStringList paths, HttpRequest &req
             // read in the whole thing
             out.open(QFile::ReadOnly | QFile::Text);
             QTextStream in(&out);
-            in.setCodec ("UTF-8");
             contents = in.readAll();
             out.close();
 

--- a/src/Core/GcUpgrade.cpp
+++ b/src/Core/GcUpgrade.cpp
@@ -1005,7 +1005,6 @@ GcUpgradeLogDialog::saveAs()
     QFile file(fileName);
     file.resize(0);
     QTextStream out(&file);
-    out.setCodec("UTF-8");
 
     if (file.open(QIODevice::WriteOnly)) {
 

--- a/src/Core/Measures.cpp
+++ b/src/Core/Measures.cpp
@@ -164,7 +164,6 @@ MeasuresGroup::serialize(QString filename, QList<Measure> &data)
     };
     file.resize(0);
     QTextStream out(&file);
-    out.setCodec("UTF-8");
 
     Measure *m = NULL;
     QJsonArray measures;

--- a/src/Core/NamedSearch.cpp
+++ b/src/Core/NamedSearch.cpp
@@ -198,7 +198,6 @@ NamedSearchParser::serialize(QString filename, QList<NamedSearch>NamedSearches)
     };
     file.resize(0);
     QTextStream out(&file);
-    out.setCodec("UTF-8");
 
     // begin document
     out << "<NamedSearches>\n";

--- a/src/Core/RideCache.cpp
+++ b/src/Core/RideCache.cpp
@@ -449,7 +449,6 @@ RideCache::writeAsCSV(QString filename)
     };
     file.resize(0);
     QTextStream out(&file);
-    out.setCodec("UTF-8"); // Metric names can be translated
 
     // write headings
     out<<"date, time, filename";

--- a/src/Core/RideDB.y
+++ b/src/Core/RideDB.y
@@ -334,7 +334,6 @@ RideCache::load()
 
         // ok, lets read it in
         QTextStream stream(&rideDB);
-        stream.setCodec("UTF-8");
 
         // Read the entire file into a QString -- we avoid using fopen since it
         // doesn't handle foreign characters well. Instead we use QFile and parse
@@ -495,7 +494,6 @@ void RideCache::save(bool opendata, QString filename)
 
         // ok, lets write out the cache
         QTextStream stream(&rideDB);
-        stream.setCodec("UTF-8");
 
         // no BOM needed for opendata as it doesn't contain textual data
         if (!opendata) stream.setGenerateByteOrderMark(true);
@@ -993,7 +991,6 @@ APIWebService::listRides(QString athlete, HttpRequest &request, HttpResponse &re
 
             // ok, lets read it in
             QTextStream stream(&rideDB);
-            stream.setCodec("UTF-8");
 
             // Read the entire file into a QString -- we avoid using fopen since it
             // doesn't handle foreign characters well. Instead we use QFile and parse

--- a/src/Core/SeasonParser.cpp
+++ b/src/Core/SeasonParser.cpp
@@ -182,7 +182,6 @@ SeasonParser::serialize(QString filename, QList<Season>Seasons)
     };
     file.resize(0);
     QTextStream out(&file);
-    out.setCodec("UTF-8");
 
     // begin document
     out << "<seasons>\n";

--- a/src/FileIO/FitlogRideFile.cpp
+++ b/src/FileIO/FitlogRideFile.cpp
@@ -239,7 +239,6 @@ FitlogFileReader::writeRideFile(Context *context, const RideFile *ride, QFile &f
     if (!file.open(QIODevice::WriteOnly)) return(false);
     file.resize(0);
     QTextStream out(&file);
-    out.setCodec("UTF-8");
     out.setGenerateByteOrderMark(true);
     out << xml;
     out.flush();

--- a/src/FileIO/GcRideFile.cpp
+++ b/src/FileIO/GcRideFile.cpp
@@ -275,7 +275,6 @@ GcFileReader::writeRideFile(Context *,const RideFile *ride, QFile &file) const
         return false;
     file.resize(0);
     QTextStream out(&file);
-    out.setCodec("UTF-8");
     out.setGenerateByteOrderMark(true);
     out << xml;
     out.flush();

--- a/src/FileIO/GpxRideFile.cpp
+++ b/src/FileIO/GpxRideFile.cpp
@@ -178,7 +178,6 @@ GpxFileReader::writeRideFile(Context *context, const RideFile *ride, QFile &file
     if (!file.open(QIODevice::WriteOnly)) return(false);
     file.resize(0);
     QTextStream out(&file);
-    out.setCodec("UTF-8");
     //out.setGenerateByteOrderMark(true);
     out << xml;
     out.flush();

--- a/src/FileIO/JsonRideFile.y
+++ b/src/FileIO/JsonRideFile.y
@@ -407,7 +407,6 @@ JsonFileReader::openRideFile(QFile &file, QStringList &errors, QList<RideFile*>*
         // read in the whole thing
         QTextStream in(&file);
         // GC .JSON is stored in UTF-8 with BOM(Byte order mark) for identification
-        in.setCodec ("UTF-8");
         contents = in.readAll();
         file.close();
 
@@ -416,7 +415,7 @@ JsonFileReader::openRideFile(QFile &file, QStringList &errors, QList<RideFile*>*
         if (contents.contains(QChar::ReplacementCharacter)) {
            if (file.exists() && file.open(QFile::ReadOnly | QFile::Text)) {
              QTextStream in(&file);
-             in.setCodec ("ISO 8859-1");
+             in.setEncoding ( QStringConverter::Latin1 );
              contents = in.readAll();
              file.close();
            }
@@ -784,7 +783,6 @@ JsonFileReader::writeRideFile(Context *context, const RideFile *ride, QFile &fil
     // setup streamer
     QTextStream out(&file);
     // unified codepage and BOM for identification on all platforms
-    out.setCodec("UTF-8");
     out.setGenerateByteOrderMark(true);
 
     out << xml;

--- a/src/FileIO/PolarRideFile.cpp
+++ b/src/FileIO/PolarRideFile.cpp
@@ -45,7 +45,6 @@ bool ScanPddFile(QFile &file, QString &hrmFile, QString &hrvFile, QString &gpxFi
       // from a QString
       QString contents;
       QTextStream in(&file);
-      in.setCodec("UTF-8");
       contents = in.readAll();
       file.close();
       // check if the text string contains the replacement character for UTF-8 encoding
@@ -59,7 +58,7 @@ bool ScanPddFile(QFile &file, QString &hrmFile, QString &hrvFile, QString &gpxFi
   file.open(QFile::ReadOnly);
   QTextStream is(&file);
   if (useISO8859)
-      is.setCodec ("ISO 8859-1");
+      is.setEncoding ( QStringConverter::Latin1 );
 
   while (!is.atEnd()) {
     // the readLine() method doesn't handle old Macintosh CR line
@@ -189,7 +188,6 @@ void HrmRideFile(RideFile *rideFile, RideFile*gpxresult, bool haveGPX, XDataSeri
       // from a QString
       QString contents;
       QTextStream in(&file);
-      in.setCodec("UTF-8");
       contents = in.readAll();
       file.close();
       // check if the text string contains the replacement character for UTF-8 encoding
@@ -204,7 +202,7 @@ void HrmRideFile(RideFile *rideFile, RideFile*gpxresult, bool haveGPX, XDataSeri
   file.open(QFile::ReadOnly);
   QTextStream is(&file);
   if (useISO8859)
-      is.setCodec ("ISO 8859-1");
+      is.setEncoding ( QStringConverter::Latin1 );
   QString section = NULL;
 
   if (haveGPX)

--- a/src/FileIO/PwxRideFile.cpp
+++ b/src/FileIO/PwxRideFile.cpp
@@ -985,7 +985,6 @@ PwxFileReader::writeRideFile(Context *context, const RideFile *ride, QFile &file
     if (!file.open(QIODevice::WriteOnly)) return(false);
     file.resize(0);
     QTextStream out(&file);
-    out.setCodec("UTF-8");
     out.setGenerateByteOrderMark(true);
     out << xml;
     out.flush();

--- a/src/FileIO/RideAutoImportConfig.cpp
+++ b/src/FileIO/RideAutoImportConfig.cpp
@@ -161,7 +161,6 @@ RideAutoImportConfigParser::serialize(QString filename, QList<RideAutoImportRule
     };
     file.resize(0);
     QTextStream out(&file);
-    out.setCodec("UTF-8");
 
     // begin document
     out << "<autoimportrules>\n";

--- a/src/FileIO/Snippets.cpp
+++ b/src/FileIO/Snippets.cpp
@@ -123,8 +123,6 @@ Snippets::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op=
 
         // setup streamer
         QTextStream out(&outfile);
-        // unified codepage and BOM for identification on all platforms
-        out.setCodec("UTF-8");
         //out.setGenerateByteOrderMark(true); << make it easier to parse with no BOM
 
         out << "{\n\t\"" << op << "\": {\n";

--- a/src/FileIO/TcxRideFile.cpp
+++ b/src/FileIO/TcxRideFile.cpp
@@ -480,7 +480,6 @@ TcxFileReader::writeRideFile(Context *context, const RideFile *ride, QFile &file
     if (!file.open(QIODevice::WriteOnly)) return(false);
     file.resize(0);
     QTextStream out(&file);
-    out.setCodec("UTF-8");
     out.setGenerateByteOrderMark(true);
     out << xml;
     out.flush();

--- a/src/Gui/GcCrashDialog.cpp
+++ b/src/Gui/GcCrashDialog.cpp
@@ -497,7 +497,6 @@ GcCrashDialog::saveAs()
     QFile file(fileName);
     file.resize(0);
     QTextStream out(&file);
-    out.setCodec("UTF-8");
 
     if (file.open(QIODevice::WriteOnly)) {
         // write the texts

--- a/src/Gui/Perspective.cpp
+++ b/src/Gui/Perspective.cpp
@@ -1481,7 +1481,6 @@ Perspective::toFile(QString filename)
     // truncate and use 8bit encoding
     file.resize(0);
     QTextStream out(&file);
-    out.setCodec("UTF-8");
 
     // write to output stream
     toXml(out);

--- a/src/Gui/TabView.cpp
+++ b/src/Gui/TabView.cpp
@@ -291,7 +291,6 @@ TabView::saveState()
     };
     file.resize(0);
     QTextStream out(&file);
-    out.setCodec("UTF-8");
 
     // is just a collection of layout (aka old HomeWindow name-layout.xml)
     out<<"<layouts>\n";

--- a/src/Metrics/HrZones.cpp
+++ b/src/Metrics/HrZones.cpp
@@ -112,7 +112,6 @@ bool HrZones::read(QFile &file)
         return false;
     }
     QTextStream fileStream(&file);
-    fileStream.setCodec("UTF-8");
 
     QRegExp commentrx("\\s*#.*$");
     QRegExp blankrx("^[ \t]*$");
@@ -729,7 +728,6 @@ void HrZones::write(QDir home)
     if (file.open(QFile::WriteOnly))
     {
         QTextStream stream(&file);
-        stream.setCodec("UTF-8");
         stream << strzones;
         file.close();
     } else {

--- a/src/Metrics/PaceZones.cpp
+++ b/src/Metrics/PaceZones.cpp
@@ -145,7 +145,6 @@ bool PaceZones::read(QFile &file)
         return false;
     }
     QTextStream fileStream(&file);
-    fileStream.setCodec("UTF-8");
 
     QRegExp commentrx("\\s*#.*$");
     QRegExp blankrx("^[ \t]*$");
@@ -849,7 +848,6 @@ void PaceZones::write(QDir home)
     QFile file(home.canonicalPath() + "/" + fileName_);
     if (file.open(QFile::WriteOnly)) {
         QTextStream stream(&file);
-        stream.setCodec("UTF-8");
         stream << strzones;
         file.close();
     } else {

--- a/src/Metrics/RideMetadata.cpp
+++ b/src/Metrics/RideMetadata.cpp
@@ -1390,7 +1390,6 @@ RideMetadata::serialize(QString filename, QList<KeywordDefinition>keywordDefinit
     };
     file.resize(0);
     QTextStream out(&file);
-    out.setCodec("UTF-8");
 
     // begin document
     out << "<metadata>\n";

--- a/src/Metrics/UserMetricParser.cpp
+++ b/src/Metrics/UserMetricParser.cpp
@@ -119,8 +119,6 @@ UserMetricParser::serialize(QString filename, QList<UserMetricSettings> metrics)
 void
 UserMetricParser::serializeToQTextStream(QTextStream& out, QList<UserMetricSettings> metrics)
 {
-    out.setCodec("UTF-8");
-
     // begin document
     out << QString("<usermetrics version=\"%1\">\n").arg(USER_METRICS_VERSION_NUMBER);
 

--- a/src/Metrics/Zones.cpp
+++ b/src/Metrics/Zones.cpp
@@ -105,7 +105,6 @@ bool Zones::read(QFile &file)
         return false;
     }
     QTextStream fileStream(&file);
-    fileStream.setCodec("UTF-8");
 
     QRegExp commentrx("\\s*#.*$");
     QRegExp blankrx("^[ \t]*$");
@@ -892,7 +891,6 @@ void Zones::write(QDir home)
     if (file.open(QFile::WriteOnly)) {
 
         QTextStream stream(&file);
-        stream.setCodec("UTF-8");
         stream << strzones;
         file.close();
     } else {

--- a/src/Train/ErgFile.cpp
+++ b/src/Train/ErgFile.cpp
@@ -1207,7 +1207,6 @@ ErgFile::save(QStringList &errors)
 
         // setup output stream to file
         QTextStream out(&f);
-        out.setCodec("UTF-8");
 
         // write the header
         //
@@ -1317,7 +1316,6 @@ ErgFile::save(QStringList &errors)
 
         // setup output stream to file
         QTextStream out(&f);
-        out.setCodec("UTF-8");
 
         // write the header
         //
@@ -1422,7 +1420,6 @@ ErgFile::save(QStringList &errors)
 
         // setup output stream to file
         QTextStream out(&f);
-        out.setCodec("UTF-8");
 
         out << "<workout_file>\n";
 

--- a/src/Train/LibraryParser.cpp
+++ b/src/Train/LibraryParser.cpp
@@ -83,7 +83,6 @@ LibraryParser::serialize(QDir home)
     };
     file.resize(0);
     QTextStream out(&file);
-    out.setCodec("UTF-8");
 
 
     // write out to file


### PR DESCRIPTION
This must not be merged before porting to Qt6.
QTextStream defaults to codecForLocale in Qt5, see
https://doc.qt.io/qt-5/qtextstream.html
and to UTF8 in Qt6, see
https://doc.qt.io/qt-6/qtextstream.html