### PR TITLE
adapt SSL protocol name

### DIFF
--- a/contrib/httpserver/httpconnectionhandlerpool.cpp
+++ b/contrib/httpserver/httpconnectionhandlerpool.cpp
@@ -123,7 +123,7 @@ void HttpConnectionHandlerPool::loadSslConfig() {
             sslConfiguration->setLocalCertificate(certificate);
             sslConfiguration->setPrivateKey(sslKey);
             sslConfiguration->setPeerVerifyMode(QSslSocket::VerifyNone);
-            sslConfiguration->setProtocol(QSsl::TlsV1SslV3);
+            sslConfiguration->setProtocol(QSsl::TlsV1_0);
 
             wDebug("HttpConnectionHandlerPool: SSL settings loaded");
          #endif


### PR DESCRIPTION
QSsl::TlsV1SslV3 has been renamed to TlsV1_0.
See
https://doc.qt.io/qt-5/qssl.html#SslProtocol-enum

This might be merged at any time.