### PR TITLE
Qt6: Remove call to qRegisterMetaTypeStreamOperators

### DIFF
--- a/src/Charts/LTMSettings.h
+++ b/src/Charts/LTMSettings.h
@@ -221,6 +221,10 @@ class LTMSettings {
     public:
 
         LTMSettings() {
+#if QT_VERSION < 0x060000
+            // we need to register the stream operators
+            qRegisterMetaTypeStreamOperators<LTMSettings>("LTMSettings");
+#endif
             bests = NULL;
             ltmTool = NULL;
         }

--- a/src/Charts/LTMSettings.h
+++ b/src/Charts/LTMSettings.h
@@ -221,8 +221,6 @@ class LTMSettings {
     public:
 
         LTMSettings() {
-            // we need to register the stream operators
-            qRegisterMetaTypeStreamOperators<LTMSettings>("LTMSettings");
             bests = NULL;
             ltmTool = NULL;
         }


### PR DESCRIPTION
Stream operator registration is now automatic, see
https://doc.qt.io/qt-6/qtcore-changes-qt6.html

Not to be merged before going to Qt6