### PR TITLE
QWebEnginePage::view was removed

### DIFF
--- a/src/Charts/LTMWindow.cpp
+++ b/src/Charts/LTMWindow.cpp
@@ -151,7 +151,6 @@ LTMWindow::LTMWindow(Context *context) :
     }
     dataSummary->settings()->setFontFamily(QWebEngineSettings::StandardFont, defaultFont.family());
     dataSummary->setContentsMargins(0,0,0,0);
-    dataSummary->page()->view()->setContentsMargins(0,0,0,0);
     dataSummary->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     dataSummary->setAcceptDrops(false);
 

--- a/src/Charts/PythonChart.cpp
+++ b/src/Charts/PythonChart.cpp
@@ -443,7 +443,6 @@ PythonChart::setWeb(bool x)
         // setup the canvas
         canvas = new QWebEngineView(this);
         canvas->setContentsMargins(0,0,0,0);
-        canvas->page()->view()->setContentsMargins(0,0,0,0);
         canvas->setZoomFactor(dpiXFactor);
         canvas->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));
         // stop stealing focus!

--- a/src/Charts/RideMapWindow.cpp
+++ b/src/Charts/RideMapWindow.cpp
@@ -131,7 +131,6 @@ RideMapWindow::RideMapWindow(Context *context, int mapType) : GcChartWindow(cont
     view->settings()->setAttribute(QWebEngineSettings::FocusOnNavigationEnabled, false);
     view->setPage(new mapWebPage());
     view->setContentsMargins(0,0,0,0);
-    view->page()->view()->setContentsMargins(0,0,0,0);
     view->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     view->setAcceptDrops(false);
     layout->addWidget(view);

--- a/src/Cloud/OAuthDialog.cpp
+++ b/src/Cloud/OAuthDialog.cpp
@@ -82,7 +82,6 @@ OAuthDialog::OAuthDialog(Context *context, OAuthSite site, CloudService *service
     view->page()->profile()->setHttpUserAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.79 Safari/537.36 Edge/14.14393");
 
     view->setContentsMargins(0,0,0,0);
-    view->page()->view()->setContentsMargins(0,0,0,0);
     view->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     view->setAcceptDrops(false);
     layout->addWidget(view);

--- a/src/Core/GcUpgrade.cpp
+++ b/src/Core/GcUpgrade.cpp
@@ -955,7 +955,6 @@ GcUpgradeLogDialog::GcUpgradeLogDialog(QDir homeDir) : QDialog(NULL, Qt::Dialog)
 
     report = new QWebEngineView(this);
     report->setContentsMargins(0,0,0,0);
-    report->page()->view()->setContentsMargins(0,0,0,0);
     report->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     //XXX WEBENGINE report->page()->setLinkDelegationPolicy(QWebPage::DelegateAllLinks);
     report->setContextMenuPolicy(Qt::NoContextMenu);

--- a/src/Gui/GcCrashDialog.cpp
+++ b/src/Gui/GcCrashDialog.cpp
@@ -132,7 +132,6 @@ GcCrashDialog::GcCrashDialog(QDir homeDir) : QDialog(NULL, Qt::Dialog), home(hom
 
     report = new QWebEngineView(this);
     report->setContentsMargins(0,0,0,0);
-    report->page()->view()->setContentsMargins(0,0,0,0);
     report->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     report->setAcceptDrops(false);
     report->settings()->setFontSize(QWebEngineSettings::DefaultFontSize, defaultFont.pointSize()+1);

--- a/src/Train/LiveMapWebPageWindow.cpp
+++ b/src/Train/LiveMapWebPageWindow.cpp
@@ -111,8 +111,7 @@ LiveMapWebPageWindow::LiveMapWebPageWindow(Context *context) : GcChartWindow(con
     webPage = view->page();
     view->setPage(webPage);
 
-    view->setContentsMargins(0,0,0,0);
-    view->page()->view()->setContentsMargins(0,10,0,0);
+    view->setContentsMargins(0,10,0,0);
     view->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     view->setAcceptDrops(false);
     layout->addWidget(view);

--- a/src/Train/WebPageWindow.cpp
+++ b/src/Train/WebPageWindow.cpp
@@ -160,7 +160,6 @@ WebPageWindow::WebPageWindow(Context *context) : GcChartWindow(context), context
 
     view->setPage(new simpleWebPage());
     view->setContentsMargins(0,0,0,0);
-    view->page()->view()->setContentsMargins(0,0,0,0);
     view->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     view->setAcceptDrops(false);
     layout->addWidget(view);


### PR DESCRIPTION
The view() method of the page does not exist any more in Qt 6.2.
I think it is redundant with the preceding call anyway, isn't it?