### PR TITLE
Qt6: Remove usage of QHashIterator

### DIFF
--- a/src/Charts/LTMPlot.cpp
+++ b/src/Charts/LTMPlot.cpp
@@ -281,7 +281,11 @@ LTMPlot::setData(LTMSettings *set)
     setAxisVisible(QwtAxis::xTop, false);
 
     // wipe existing curves/axes details
+#if QT_VERSION >= 0x060000
+    QMultiHashIterator<QString, QwtPlotCurve*> c(curves);
+#else
     QHashIterator<QString, QwtPlotCurve*> c(curves);
+#endif
     while (c.hasNext()) {
         c.next();
         QString symbol = c.key();
@@ -1352,7 +1356,11 @@ LTMPlot::setData(LTMSettings *set)
         refreshZoneLabels(QwtAxisId(-1,-1)); // turn em off
     }
 
+#if QT_VERSION >= 0x060000
+    QMultiHashIterator<QString, QwtPlotCurve*> p(curves);
+#else
     QHashIterator<QString, QwtPlotCurve*> p(curves);
+#endif
     while (p.hasNext()) {
         p.next();
 
@@ -1403,7 +1411,11 @@ LTMPlot::setCompareData(LTMSettings *set)
     //qDebug()<<"Starting.."<<timer.elapsed();
 
     // wipe existing curves/axes details
+#if QT_VERSION >= 0x060000
+    QMultiHashIterator<QString, QwtPlotCurve*> c(curves);
+#else
     QHashIterator<QString, QwtPlotCurve*> c(curves);
+#endif
     while (c.hasNext()) {
         c.next();
         QString symbol = c.key();
@@ -2481,7 +2493,11 @@ LTMPlot::setCompareData(LTMSettings *set)
     if (settings->legend == false) this->legend()->hide();
     else this->legend()->show();
 
+#if QT_VERSION >= 0x060000
+    QMultiHashIterator<QString, QwtPlotCurve*> p(curves);
+#else
     QHashIterator<QString, QwtPlotCurve*> p(curves);
+#endif
     while (p.hasNext()) {
         p.next();
 
@@ -4037,7 +4053,11 @@ LTMPlot::pointHover(QwtPlotCurve *curve, int index)
 
         // we reference the metric definitions of name and
         // units to decide on the level of precision required
+#if QT_VERSION >= 0x060000
+        QMultiHashIterator<QString, QwtPlotCurve*> c(curves);
+#else
         QHashIterator<QString, QwtPlotCurve*> c(curves);
+#endif
         while (c.hasNext()) {
             c.next();
             if (c.value() == curve) {


### PR DESCRIPTION
QHashIterator is no longer able to iterate over QMultiHash, even
though it is documented to be.

This patch removes usages of QHashIterator on QMultiHash.

An alternative solution would be to use QMultiHashIterator, but that is only available in Qt 6 and thus would require an ifdef on the Qt version. This solution works with both Qt6 and Qt5.