### PR TITLE
Qt6: QSettings defaults to UTF-8, no setIniCodec necessary

### DIFF
--- a/src/Core/Measures.cpp
+++ b/src/Core/Measures.cpp
@@ -355,7 +355,6 @@ Measures::Measures(QDir dir, bool withData) : dir(dir), withData(withData)
     }
 
     QSettings config(filename, QSettings::IniFormat);
-    config.setIniCodec("UTF-8"); // to allow translated names
 
     foreach (QString group, config.value("Measures", "").toStringList()) {
 
@@ -423,7 +422,6 @@ Measures::saveConfig()
     // save measures configuration to measures.ini
     QString filename = QDir(gcroot).canonicalPath() + "/measures.ini";
     QSettings config(filename, QSettings::IniFormat);
-    config.setIniCodec("UTF-8"); // to allow translated names
     config.clear();
 
     config.setValue("Measures", getGroupSymbols());

--- a/src/Core/Measures.cpp
+++ b/src/Core/Measures.cpp
@@ -356,6 +356,10 @@ Measures::Measures(QDir dir, bool withData) : dir(dir), withData(withData)
 
     QSettings config(filename, QSettings::IniFormat);
 
+#if QT_VERSION < 0x060000
+    config.setIniCodec("UTF-8"); // to allow translated names
+#endif
+
     foreach (QString group, config.value("Measures", "").toStringList()) {
 
         if (getGroupSymbols().contains(group)) continue;
@@ -422,6 +426,11 @@ Measures::saveConfig()
     // save measures configuration to measures.ini
     QString filename = QDir(gcroot).canonicalPath() + "/measures.ini";
     QSettings config(filename, QSettings::IniFormat);
+
+#if QT_VERSION < 0x060000
+    config.setIniCodec("UTF-8"); // to allow translated names
+#endif
+
     config.clear();
 
     config.setValue("Measures", getGroupSymbols());


### PR DESCRIPTION
QSettings now always uses UTF-8, no codec necessary.

This is incompatible with Qt 5.15 as-is, we still need a solution which works for both.