### PR TITLE
workaround circular dependency for qt6

### DIFF
--- a/src/Charts/GoldenCheetah.h
+++ b/src/Charts/GoldenCheetah.h
@@ -44,8 +44,14 @@ class Perspective;
 
 #include "GcWindowRegistry.h"
 #include "TimeUtils.h"
-
 class RideItem;
+
+#if QT_VERSION >= 0x060000
+// For the RideItem property, this is required.
+// A normal include would lead to a circular dependency here.
+Q_MOC_INCLUDE("RideItem.h");
+#endif
+
 class GcOverlayWidget;
 class Perspective;
 


### PR DESCRIPTION
In Qt6, moc needs to know the types of properties. So one would need to include RideItem.h from GoldenCheetah.h. But we run into a circular dependency there, becasue RideItem.h includes GoldenCheetah.h.
To solve this, add this moc-include.