### PR TITLE
Replace deprecated QSignalMapper::mapped signal

### DIFF
--- a/deprecated/IntervalNavigator.cpp
+++ b/deprecated/IntervalNavigator.cpp
@@ -160,7 +160,11 @@ IntervalColumnChooser::IntervalColumnChooser(QList<QString>&logicalHeadings)
     setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint | Qt::Tool);
 
     clicked = new QSignalMapper(this); // maps each button click event
-    connect(clicked, &QSignalMapper::mappedString, this, &IntervalColumnChooser::buttonClicked);
+#if QT_VERSION >= 0x060000
+    connect(clicked, SIGNAL(mappedString(const QString &)), this, SLOT(buttonClicked(const QString &)));
+#else
+    connect(clicked, SIGNAL(mapped(const QString &)), this, SLOT(buttonClicked(const QString &)));
+#endif
 
     buttons = new QGridLayout(this);
     buttons->setSpacing(0);

--- a/deprecated/IntervalNavigator.cpp
+++ b/deprecated/IntervalNavigator.cpp
@@ -160,7 +160,7 @@ IntervalColumnChooser::IntervalColumnChooser(QList<QString>&logicalHeadings)
     setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint | Qt::Tool);
 
     clicked = new QSignalMapper(this); // maps each button click event
-    connect(clicked, SIGNAL(mapped(const QString &)), this, SLOT(buttonClicked(const QString &)));
+    connect(clicked, &QSignalMapper::mappedString, this, &IntervalColumnChooser::buttonClicked);
 
     buttons = new QGridLayout(this);
     buttons->setSpacing(0);

--- a/src/Charts/ChartBar.cpp
+++ b/src/Charts/ChartBar.cpp
@@ -113,10 +113,10 @@ ChartBar::ChartBar(Context *context) : QWidget(context->mainWindow), context(con
     //connect(p, SIGNAL(clicked()), action, SLOT(trigger()));
 
     signalMapper = new QSignalMapper(this); // maps each option
-    connect(signalMapper, SIGNAL(mapped(int)), this, SLOT(clicked(int)));
+    connect(signalMapper, &QSignalMapper::mappedInt, this, &ChartBar::clicked);
 
     menuMapper = new QSignalMapper(this); // maps each option
-    connect(menuMapper, SIGNAL(mapped(int)), this, SLOT(triggerContextMenu(int)));
+    connect(menuMapper, &QSignalMapper::mappedInt, this, &ChartBar::triggerContextMenu);
 
     barMenu = new QMenu("Add");
     chartMenu = barMenu->addMenu(tr("New Chart"));

--- a/src/Charts/ChartBar.cpp
+++ b/src/Charts/ChartBar.cpp
@@ -113,10 +113,18 @@ ChartBar::ChartBar(Context *context) : QWidget(context->mainWindow), context(con
     //connect(p, SIGNAL(clicked()), action, SLOT(trigger()));
 
     signalMapper = new QSignalMapper(this); // maps each option
-    connect(signalMapper, &QSignalMapper::mappedInt, this, &ChartBar::clicked);
+#if QT_VERSION >= 0x060000
+    connect(signalMapper, SIGNAL(mappedInt(int)), this, SLOT(clicked(int)));
+#else
+    connect(signalMapper, SIGNAL(mapped(int)), this, SLOT(clicked(int)));
+#endif
 
     menuMapper = new QSignalMapper(this); // maps each option
-    connect(menuMapper, &QSignalMapper::mappedInt, this, &ChartBar::triggerContextMenu);
+#if QT_VERSION >= 0x060000
+    connect(menuMapper, SIGNAL(mappedInt(int)), this, SLOT(triggerContextMenu(int)));
+#else
+    connect(menuMapper, SIGNAL(mapped(int)), this, SLOT(triggerContextMenu(int)));
+#endif
 
     barMenu = new QMenu("Add");
     chartMenu = barMenu->addMenu(tr("New Chart"));

--- a/src/Charts/RideEditor.cpp
+++ b/src/Charts/RideEditor.cpp
@@ -862,7 +862,7 @@ RideEditor::borderMenu(const QPoint &pos)
         // add menu options for each column
         if (colMapper) delete colMapper;
         colMapper = new QSignalMapper(this);
-        connect(colMapper, SIGNAL(mapped(const QString &)), this, SLOT(insColumn(const QString &)));
+        connect(colMapper, &QSignalMapper::mappedString, this, &RideEditor::insColumn);
 
         foreach(QString heading, whatColumns()) {
             QAction *insColAct = new QAction(heading, table);

--- a/src/Charts/RideEditor.cpp
+++ b/src/Charts/RideEditor.cpp
@@ -862,7 +862,11 @@ RideEditor::borderMenu(const QPoint &pos)
         // add menu options for each column
         if (colMapper) delete colMapper;
         colMapper = new QSignalMapper(this);
-        connect(colMapper, &QSignalMapper::mappedString, this, &RideEditor::insColumn);
+#if QT_VERSION >= 0x060000
+        connect(colMapper, SIGNAL(mappedString(const QString &)), this, SLOT(insColumn(const QString &)));
+#else
+        connect(colMapper, SIGNAL(mapped(const QString &)), this, SLOT(insColumn(const QString &)));
+#endif
 
         foreach(QString heading, whatColumns()) {
             QAction *insColAct = new QAction(heading, table);

--- a/src/Cloud/AddCloudWizard.cpp
+++ b/src/Cloud/AddCloudWizard.cpp
@@ -93,7 +93,11 @@ AddClass::AddClass(AddCloudWizard *parent) : QWizardPage(parent), wizard(parent)
     setLayout(layout);
 
     mapper = new QSignalMapper(this);
-    connect(mapper, &QSignalMapper::mappedInt, this, &AddClass::clicked);
+#if QT_VERSION >= 0x060000
+    connect(mapper, SIGNAL(mappedInt(int)), this, SLOT(clicked(int)));
+#else
+    connect(mapper, SIGNAL(mapped(int)), this, SLOT(clicked(int)));
+#endif
 
     // Activities
     QFont font;
@@ -147,7 +151,11 @@ AddService::AddService(AddCloudWizard *parent) : QWizardPage(parent), wizard(par
     scrollarea->setWidget(buttons);
 
     mapper = new QSignalMapper(this);
-    connect(mapper, &QSignalMapper::mappedString, this, &AddService::clicked);
+#if QT_VERSION >= 0x060000
+    connect(mapper, SIGNAL(mappedString(QString)), this, SLOT(clicked(QString)));
+#else
+    connect(mapper, SIGNAL(mapped(QString)), this, SLOT(clicked(QString)));
+#endif
 
     layout->addWidget(scrollarea);
 
@@ -472,7 +480,11 @@ AddAthlete::AddAthlete(AddCloudWizard *parent) : QWizardPage(parent), wizard(par
     scrollarea->setWidget(buttons);
 
     mapper = new QSignalMapper(this);
-    connect(mapper, &QSignalMapper::mappedInt, this, &AddAthlete::clicked);
+#if QT_VERSION >= 0x060000
+    connect(mapper, SIGNAL(mappedInt(int)), this, SLOT(clicked(int)));
+#else
+    connect(mapper, SIGNAL(mapped(int)), this, SLOT(clicked(int)));
+#endif
 
     layout->addWidget(scrollarea);
 

--- a/src/Cloud/AddCloudWizard.cpp
+++ b/src/Cloud/AddCloudWizard.cpp
@@ -93,7 +93,7 @@ AddClass::AddClass(AddCloudWizard *parent) : QWizardPage(parent), wizard(parent)
     setLayout(layout);
 
     mapper = new QSignalMapper(this);
-    connect(mapper, SIGNAL(mapped(int)), this, SLOT(clicked(int)));
+    connect(mapper, &QSignalMapper::mappedInt, this, &AddClass::clicked);
 
     // Activities
     QFont font;
@@ -147,7 +147,7 @@ AddService::AddService(AddCloudWizard *parent) : QWizardPage(parent), wizard(par
     scrollarea->setWidget(buttons);
 
     mapper = new QSignalMapper(this);
-    connect(mapper, SIGNAL(mapped(QString)), this, SLOT(clicked(QString)));
+    connect(mapper, &QSignalMapper::mappedString, this, &AddService::clicked);
 
     layout->addWidget(scrollarea);
 
@@ -472,7 +472,7 @@ AddAthlete::AddAthlete(AddCloudWizard *parent) : QWizardPage(parent), wizard(par
     scrollarea->setWidget(buttons);
 
     mapper = new QSignalMapper(this);
-    connect(mapper, SIGNAL(mapped(int)), this, SLOT(clicked(int)));
+    connect(mapper, &QSignalMapper::mappedInt, this, &AddAthlete::clicked);
 
     layout->addWidget(scrollarea);
 

--- a/src/Gui/AddChartWizard.cpp
+++ b/src/Gui/AddChartWizard.cpp
@@ -80,7 +80,11 @@ AddChartType::AddChartType(AddChartWizard *parent) : QWizardPage(parent), wizard
     scrollarea->setWidget(buttons);
 
     mapper = new QSignalMapper(this);
-    connect(mapper, &QSignalMapper::mappedInt, this, &AddChartType::clicked);
+#if QT_VERSION >= 0x060000
+    connect(mapper, SIGNAL(mappedInt(int)), this, SLOT(clicked(int)));
+#else
+    connect(mapper, SIGNAL(mapped(int)), this, SLOT(clicked(int)));
+#endif
 
     layout->addWidget(scrollarea);
 

--- a/src/Gui/AddChartWizard.cpp
+++ b/src/Gui/AddChartWizard.cpp
@@ -80,7 +80,7 @@ AddChartType::AddChartType(AddChartWizard *parent) : QWizardPage(parent), wizard
     scrollarea->setWidget(buttons);
 
     mapper = new QSignalMapper(this);
-    connect(mapper, SIGNAL(mapped(int)), this, SLOT(clicked(int)));
+    connect(mapper, &QSignalMapper::mappedInt, this, &AddChartType::clicked);
 
     layout->addWidget(scrollarea);
 

--- a/src/Gui/AnalysisSidebar.cpp
+++ b/src/Gui/AnalysisSidebar.cpp
@@ -431,7 +431,11 @@ AnalysisSidebar::showActivityMenu(const QPoint &pos)
             // add menu options for each column
             if (groupByMapper) delete groupByMapper;
             groupByMapper = new QSignalMapper(this);
-            connect(groupByMapper, &QSignalMapper::mappedString, rideNavigator, &RideNavigator::setGroupByColumnName);
+#if QT_VERSION >= 0x060000
+            connect(groupByMapper, SIGNAL(mappedString(const QString &)), rideNavigator, SLOT(setGroupByColumnName(QString)));
+#else
+            connect(groupByMapper, SIGNAL(mapped(const QString &)), rideNavigator, SLOT(setGroupByColumnName(QString)));
+#endif
 
             foreach(QString heading, rideNavigator->columnNames()) {
                 if (heading == "*") continue; // special hidden column

--- a/src/Gui/AnalysisSidebar.cpp
+++ b/src/Gui/AnalysisSidebar.cpp
@@ -431,7 +431,7 @@ AnalysisSidebar::showActivityMenu(const QPoint &pos)
             // add menu options for each column
             if (groupByMapper) delete groupByMapper;
             groupByMapper = new QSignalMapper(this);
-            connect(groupByMapper, SIGNAL(mapped(const QString &)), rideNavigator, SLOT(setGroupByColumnName(QString)));
+            connect(groupByMapper, &QSignalMapper::mappedString, rideNavigator, &RideNavigator::setGroupByColumnName);
 
             foreach(QString heading, rideNavigator->columnNames()) {
                 if (heading == "*") continue; // special hidden column

--- a/src/Gui/ColorButton.cpp
+++ b/src/Gui/ColorButton.cpp
@@ -123,7 +123,7 @@ GColorDialog::GColorDialog(QColor selected, QWidget *parent) : QDialog(parent), 
 
     // map button signals
     mapper = new QSignalMapper(this);
-    connect(mapper, SIGNAL(mappedInt(int)), this, SLOT(gcClicked(int)));
+    connect(mapper, &QSignalMapper::mappedInt, this, &GColorDialog::gcClicked);
 
     // now add all the colours to select
     colorSet = GCColor::colorSet();

--- a/src/Gui/ColorButton.cpp
+++ b/src/Gui/ColorButton.cpp
@@ -123,7 +123,11 @@ GColorDialog::GColorDialog(QColor selected, QWidget *parent) : QDialog(parent), 
 
     // map button signals
     mapper = new QSignalMapper(this);
-    connect(mapper, &QSignalMapper::mappedInt, this, &GColorDialog::gcClicked);
+#if QT_VERSION >= 0x060000
+    connect(mapper, SIGNAL(mappedInt(int)), this, SLOT(gcClicked(int)));
+#else
+    connect(mapper, SIGNAL(mapped(int)), this, SLOT(gcClicked(int)));
+#endif
 
     // now add all the colours to select
     colorSet = GCColor::colorSet();

--- a/src/Gui/ConfigDialog.cpp
+++ b/src/Gui/ConfigDialog.cpp
@@ -73,7 +73,7 @@ ConfigDialog::ConfigDialog(QDir _home, Context *context) :
     // Setup the signal mapping so the right config
     // widget is displayed when the icon is clicked
     QSignalMapper *iconMapper = new QSignalMapper(this); // maps each option
-    connect(iconMapper, SIGNAL(mapped(int)), this, SLOT(changePage(int)));
+    connect(iconMapper, &QSignalMapper::mappedInt, this, &ConfigDialog::changePage);
     head->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
     head->setIconSize(QSize(32*dpiXFactor,32*dpiXFactor)); // use XFactor for both to ensure aspect ratio maintained
 

--- a/src/Gui/ConfigDialog.cpp
+++ b/src/Gui/ConfigDialog.cpp
@@ -73,7 +73,11 @@ ConfigDialog::ConfigDialog(QDir _home, Context *context) :
     // Setup the signal mapping so the right config
     // widget is displayed when the icon is clicked
     QSignalMapper *iconMapper = new QSignalMapper(this); // maps each option
-    connect(iconMapper, &QSignalMapper::mappedInt, this, &ConfigDialog::changePage);
+#if QT_VERSION >= 0x060000
+    connect(iconMapper, SIGNAL(mappedInt(int)), this, SLOT(changePage(int)));
+#else
+    connect(iconMapper, SIGNAL(mapped(int)), this, SLOT(changePage(int)));
+#endif
     head->setToolButtonStyle(Qt::ToolButtonTextUnderIcon);
     head->setIconSize(QSize(32*dpiXFactor,32*dpiXFactor)); // use XFactor for both to ensure aspect ratio maintained
 

--- a/src/Gui/DiarySidebar.cpp
+++ b/src/Gui/DiarySidebar.cpp
@@ -377,7 +377,7 @@ GcMiniCalendar::GcMiniCalendar(Context *context, bool master) : context(context)
     layout->addStretch();
 
     // day clicked
-    connect(signalMapper, SIGNAL(mapped(int)), this, SLOT(dayClicked(int)));
+    connect(signalMapper, &QSignalMapper::mappedInt, this, &GcMiniCalendar::dayClicked);
 
     // set up for current selections - and watch for future changes
     connect(context, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));

--- a/src/Gui/DiarySidebar.cpp
+++ b/src/Gui/DiarySidebar.cpp
@@ -377,7 +377,11 @@ GcMiniCalendar::GcMiniCalendar(Context *context, bool master) : context(context)
     layout->addStretch();
 
     // day clicked
-    connect(signalMapper, &QSignalMapper::mappedInt, this, &GcMiniCalendar::dayClicked);
+#if QT_VERSION >= 0x060000
+    connect(signalMapper, SIGNAL(mappedInt(int)), this, SLOT(dayClicked(int)));
+#else
+    connect(signalMapper, SIGNAL(mapped(int)), this, SLOT(dayClicked(int)));
+#endif
 
     // set up for current selections - and watch for future changes
     connect(context, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -482,19 +482,31 @@ MainWindow::MainWindow(const QDir &home)
     connect(openTabMenu, SIGNAL(aboutToShow()), this, SLOT(setOpenTabMenu()));
 
     tabMapper = new QSignalMapper(this); // maps each option
-    connect(tabMapper, &QSignalMapper::mappedString, this, &MainWindow::openTab);
+#if QT_VERSION >= 0x060000
+    connect(tabMapper, SIGNAL(mappedString(const QString &)), this, SLOT(openTab(const QString &)));
+#else
+    connect(tabMapper, SIGNAL(mapped(const QString &)), this, SLOT(openTab(const QString &)));
+#endif
 
     fileMenu->addSeparator();
     backupAthleteMenu = fileMenu->addMenu(tr("Backup..."));
     connect(backupAthleteMenu, SIGNAL(aboutToShow()), this, SLOT(setBackupAthleteMenu()));
     backupMapper = new QSignalMapper(this); // maps each option
-    connect(backupMapper, &QSignalMapper::mappedString, this, &MainWindow::backupAthlete);
+#if QT_VERSION >= 0x060000
+    connect(backupMapper, SIGNAL(mappedString(const QString &)), this, SLOT(backupAthlete(const QString &)));
+#else
+    connect(backupMapper, SIGNAL(mapped(const QString &)), this, SLOT(backupAthlete(const QString &)));
+#endif
 
     fileMenu->addSeparator();
     deleteAthleteMenu = fileMenu->addMenu(tr("Delete..."));
     connect(deleteAthleteMenu, SIGNAL(aboutToShow()), this, SLOT(setDeleteAthleteMenu()));
     deleteMapper = new QSignalMapper(this); // maps each option
-    connect(deleteMapper, &QSignalMapper::mappedString, this, &MainWindow::deleteAthlete);
+#if QT_VERSION >= 0x060000
+    connect(deleteMapper, SIGNAL(mappedString(const QString &)), this, SLOT(deleteAthlete(const QString &)));
+#else
+    connect(deleteMapper, SIGNAL(mapped(const QString &)), this, SLOT(deleteAthlete(const QString &)));
+#endif
 
     fileMenu->addSeparator();
     fileMenu->addAction(tr("Save all modified activities"), this, SLOT(saveAllUnsavedRides()));
@@ -610,7 +622,11 @@ MainWindow::MainWindow(const QDir &home)
 
         toolMapper = new QSignalMapper(this); // maps each option
         QMapIterator<QString, DataProcessor*> i(processors);
-        connect(toolMapper, &QSignalMapper::mappedString, this, &MainWindow::manualProcess);
+#if QT_VERSION >= 0x060000
+        connect(toolMapper, SIGNAL(mappedString(const QString &)), this, SLOT(manualProcess(const QString &)));
+#else
+        connect(toolMapper, SIGNAL(mapped(const QString &)), this, SLOT(manualProcess(const QString &)));
+#endif
 
         i.toFront();
         while (i.hasNext()) {

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -482,19 +482,19 @@ MainWindow::MainWindow(const QDir &home)
     connect(openTabMenu, SIGNAL(aboutToShow()), this, SLOT(setOpenTabMenu()));
 
     tabMapper = new QSignalMapper(this); // maps each option
-    connect(tabMapper, SIGNAL(mapped(const QString &)), this, SLOT(openTab(const QString &)));
+    connect(tabMapper, &QSignalMapper::mappedString, this, &MainWindow::openTab);
 
     fileMenu->addSeparator();
     backupAthleteMenu = fileMenu->addMenu(tr("Backup..."));
     connect(backupAthleteMenu, SIGNAL(aboutToShow()), this, SLOT(setBackupAthleteMenu()));
     backupMapper = new QSignalMapper(this); // maps each option
-    connect(backupMapper, SIGNAL(mapped(const QString &)), this, SLOT(backupAthlete(const QString &)));
+    connect(backupMapper, &QSignalMapper::mappedString, this, &MainWindow::backupAthlete);
 
     fileMenu->addSeparator();
     deleteAthleteMenu = fileMenu->addMenu(tr("Delete..."));
     connect(deleteAthleteMenu, SIGNAL(aboutToShow()), this, SLOT(setDeleteAthleteMenu()));
     deleteMapper = new QSignalMapper(this); // maps each option
-    connect(deleteMapper, SIGNAL(mapped(const QString &)), this, SLOT(deleteAthlete(const QString &)));
+    connect(deleteMapper, &QSignalMapper::mappedString, this, &MainWindow::deleteAthlete);
 
     fileMenu->addSeparator();
     fileMenu->addAction(tr("Save all modified activities"), this, SLOT(saveAllUnsavedRides()));
@@ -610,7 +610,7 @@ MainWindow::MainWindow(const QDir &home)
 
         toolMapper = new QSignalMapper(this); // maps each option
         QMapIterator<QString, DataProcessor*> i(processors);
-        connect(toolMapper, SIGNAL(mapped(const QString &)), this, SLOT(manualProcess(const QString &)));
+        connect(toolMapper, &QSignalMapper::mappedString, this, &MainWindow::manualProcess);
 
         i.toFront();
         while (i.hasNext()) {

--- a/src/Gui/MergeActivityWizard.cpp
+++ b/src/Gui/MergeActivityWizard.cpp
@@ -623,7 +623,7 @@ MergeSource::MergeSource(MergeActivityWizard *parent) : QWizardPage(parent), wiz
     setLayout(layout);
 
     mapper = new QSignalMapper(this);
-    connect(mapper, SIGNAL(mapped(QString)), this, SLOT(clicked(QString)));
+    connect(mapper, &QSignalMapper::mappedString, this, &MergeSource::clicked);
 
     // select a file
     QCommandLinkButton *p = new QCommandLinkButton(tr("Import from a File"), 
@@ -930,7 +930,7 @@ MergeMode::MergeMode(MergeActivityWizard *parent) : QWizardPage(parent), wizard(
     setLayout(layout);
 
     mapper = new QSignalMapper(this);
-    connect(mapper, SIGNAL(mapped(QString)), this, SLOT(clicked(QString)));
+    connect(mapper, &QSignalMapper::mappedString, this, &MergeMode::clicked);
 
     // merge
     QCommandLinkButton *p = new QCommandLinkButton(tr("Merge Data to add another data series"), 
@@ -992,7 +992,7 @@ MergeStrategy::MergeStrategy(MergeActivityWizard *parent) : QWizardPage(parent),
     setLayout(layout);
 
     mapper = new QSignalMapper(this);
-    connect(mapper, SIGNAL(mapped(QString)), this, SLOT(clicked(QString)));
+    connect(mapper, &QSignalMapper::mappedString, this, &MergeStrategy::clicked);
 
     // time
     QCommandLinkButton *p = new QCommandLinkButton(tr("Align using start time"), 

--- a/src/Gui/MergeActivityWizard.cpp
+++ b/src/Gui/MergeActivityWizard.cpp
@@ -623,7 +623,11 @@ MergeSource::MergeSource(MergeActivityWizard *parent) : QWizardPage(parent), wiz
     setLayout(layout);
 
     mapper = new QSignalMapper(this);
-    connect(mapper, &QSignalMapper::mappedString, this, &MergeSource::clicked);
+#if QT_VERSION >= 0x060000
+    connect(mapper, SIGNAL(mappedString(QString)), this, SLOT(clicked(QString)));
+#else
+    connect(mapper, SIGNAL(mapped(QString)), this, SLOT(clicked(QString)));
+#endif
 
     // select a file
     QCommandLinkButton *p = new QCommandLinkButton(tr("Import from a File"), 
@@ -930,7 +934,11 @@ MergeMode::MergeMode(MergeActivityWizard *parent) : QWizardPage(parent), wizard(
     setLayout(layout);
 
     mapper = new QSignalMapper(this);
-    connect(mapper, &QSignalMapper::mappedString, this, &MergeMode::clicked);
+#if QT_VERSION >= 0x060000
+    connect(mapper, SIGNAL(mappedString(QString)), this, SLOT(clicked(QString)));
+#else
+    connect(mapper, SIGNAL(mapped(QString)), this, SLOT(clicked(QString)));
+#endif
 
     // merge
     QCommandLinkButton *p = new QCommandLinkButton(tr("Merge Data to add another data series"), 
@@ -992,7 +1000,11 @@ MergeStrategy::MergeStrategy(MergeActivityWizard *parent) : QWizardPage(parent),
     setLayout(layout);
 
     mapper = new QSignalMapper(this);
-    connect(mapper, &QSignalMapper::mappedString, this, &MergeStrategy::clicked);
+#if QT_VERSION >= 0x060000
+    connect(mapper, SIGNAL(mappedString(QString)), this, SLOT(clicked(QString)));
+#else
+    connect(mapper, SIGNAL(mapped(QString)), this, SLOT(clicked(QString)));
+#endif
 
     // time
     QCommandLinkButton *p = new QCommandLinkButton(tr("Align using start time"), 

--- a/src/Gui/RideNavigator.cpp
+++ b/src/Gui/RideNavigator.cpp
@@ -1289,7 +1289,7 @@ ColumnChooser::ColumnChooser(QList<QString>&logicalHeadings)
     setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint | Qt::Tool);
 
     clicked = new QSignalMapper(this); // maps each button click event
-    connect(clicked, SIGNAL(mapped(const QString &)), this, SLOT(buttonClicked(const QString &)));
+    connect(clicked, &QSignalMapper::mappedString, this, &ColumnChooser::buttonClicked);
 
     QVBoxLayout *us = new QVBoxLayout(this);
     us->setSpacing(0);

--- a/src/Gui/RideNavigator.cpp
+++ b/src/Gui/RideNavigator.cpp
@@ -1289,7 +1289,11 @@ ColumnChooser::ColumnChooser(QList<QString>&logicalHeadings)
     setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint | Qt::Tool);
 
     clicked = new QSignalMapper(this); // maps each button click event
-    connect(clicked, &QSignalMapper::mappedString, this, &ColumnChooser::buttonClicked);
+#if QT_VERSION >= 0x060000
+    connect(clicked, SIGNAL(mappedString(const QString &)), this, SLOT(buttonClicked(const QString &)));
+#else
+    connect(clicked, SIGNAL(mapped(const QString &)), this, SLOT(buttonClicked(const QString &)));
+#endif
 
     QVBoxLayout *us = new QVBoxLayout(this);
     us->setSpacing(0);

--- a/src/Train/AddDeviceWizard.cpp
+++ b/src/Train/AddDeviceWizard.cpp
@@ -102,7 +102,11 @@ AddType::AddType(AddDeviceWizard *parent) : QWizardPage(parent), wizard(parent)
     buttons->setLayout(layout);
 
     mapper = new QSignalMapper(this);
-    connect(mapper, &QSignalMapper::mappedString, this, &AddType::clicked);
+#if QT_VERSION >= 0x060000
+    connect(mapper, SIGNAL(mappedString(QString)), this, SLOT(clicked(QString)));
+#else
+    connect(mapper, SIGNAL(mapped(QString)), this, SLOT(clicked(QString)));
+#endif
 
     foreach(DeviceType t, wizard->deviceTypes.Supported) {
         if (t.type) {
@@ -837,7 +841,11 @@ AddPair::initializePage()
     enableDisable(channelWidget);
 
     updateValues.start(200); // 5hz
-    connect(signalMapper, &QSignalMapper::mappedInt, this, &AddPair::sensorChanged);
+#if QT_VERSION >= 0x060000
+    connect(signalMapper, SIGNAL(mappedInt(int)), this, SLOT(sensorChanged(int)));
+#else
+    connect(signalMapper, SIGNAL(mapped(int)), this, SLOT(sensorChanged(int)));
+#endif
     connect(&updateValues, SIGNAL(timeout()), this, SLOT(getChannelValues()));
     connect(wizard->controller, SIGNAL(foundDevice(int,int,int)), this, SLOT(channelInfo(int,int,int)));
     connect(wizard->controller, SIGNAL(searchTimeout(int)), this, SLOT(searchTimeout(int)));

--- a/src/Train/AddDeviceWizard.cpp
+++ b/src/Train/AddDeviceWizard.cpp
@@ -102,7 +102,7 @@ AddType::AddType(AddDeviceWizard *parent) : QWizardPage(parent), wizard(parent)
     buttons->setLayout(layout);
 
     mapper = new QSignalMapper(this);
-    connect(mapper, SIGNAL(mapped(QString)), this, SLOT(clicked(QString)));
+    connect(mapper, &QSignalMapper::mappedString, this, &AddType::clicked);
 
     foreach(DeviceType t, wizard->deviceTypes.Supported) {
         if (t.type) {
@@ -837,7 +837,7 @@ AddPair::initializePage()
     enableDisable(channelWidget);
 
     updateValues.start(200); // 5hz
-    connect(signalMapper, SIGNAL(mapped(int)), this, SLOT(sensorChanged(int)));
+    connect(signalMapper, &QSignalMapper::mappedInt, this, &AddPair::sensorChanged);
     connect(&updateValues, SIGNAL(timeout()), this, SLOT(getChannelValues()));
     connect(wizard->controller, SIGNAL(foundDevice(int,int,int)), this, SLOT(channelInfo(int,int,int)));
     connect(wizard->controller, SIGNAL(searchTimeout(int)), this, SLOT(searchTimeout(int)));


### PR DESCRIPTION
The QSignalMapper::mapped signal does not exist any more and
was replaced by mappedString, mappedInt, and mappedObject.
This patch adapts its usages and only transitions to
new style signal-slot connection syntax.

This is required for porting to Qt 6.
The new signals were introduced in Qt 5.15. If you need only compatibility with Qt 5.15 and Qt6, this is fine as-is. If you want to continue supporting older Qt versions, this needs to be modified and ifdef-ed on Qt version.