### PR TITLE
User selectable map route line color and switchable route line out & back opacity

### DIFF
--- a/src/Charts/RideMapWindow.h
+++ b/src/Charts/RideMapWindow.h
@@ -111,6 +111,7 @@ class RideMapWindow : public GcChartWindow
     Q_PROPERTY(bool showintervals READ showIntervals WRITE setShowIntervals USER true)
     Q_PROPERTY(bool hideShadedZones READ hideShadedZones WRITE setHideShadedZones USER true)
     Q_PROPERTY(bool hideYellowLine READ hideYellowLine WRITE setHideYellowLine USER true)
+    Q_PROPERTY(bool hideRouteLineOpacity READ hideRouteLineOpacity WRITE setRouteLineOpacity USER true)
     Q_PROPERTY(int osmts READ osmTS WRITE setOsmTS USER true)
     Q_PROPERTY(QString googleKey READ googleKey WRITE setGoogleKey USER true)
 
@@ -138,6 +139,9 @@ class RideMapWindow : public GcChartWindow
         bool hideYellowLine() const { return hideYellowLineCk->isChecked(); }
         void setHideYellowLine(bool x) { hideYellowLineCk->setChecked(x); }
 
+        bool hideRouteLineOpacity() const { return hideRouteLineOpacityCk->isChecked(); }
+        void setRouteLineOpacity(bool x) { hideRouteLineOpacityCk->setChecked(x); }
+
         bool showMarkers() const { return ( showMarkersCk->checkState() == Qt::Checked); }
         void setShowMarkers(bool x) { if (x) showMarkersCk->setCheckState(Qt::Checked); else showMarkersCk->setCheckState(Qt::Unchecked) ;}
 
@@ -161,6 +165,7 @@ class RideMapWindow : public GcChartWindow
         void showFullPlotChanged(int value);
         void hideShadedZonesChanged(int value);
         void hideYellowLineChanged(int value);
+        void hideRouteLineOpacityChanged(int value);
         void showIntervalsChanged(int value);
         void osmCustomTSURLEditingFinished();
 
@@ -181,7 +186,7 @@ class RideMapWindow : public GcChartWindow
 
         QComboBox *mapCombo, *tileCombo;
         QCheckBox *showMarkersCk, *showFullPlotCk, *showInt;
-        QCheckBox* hideShadedZonesCk, * hideYellowLineCk;
+        QCheckBox* hideShadedZonesCk, * hideYellowLineCk, * hideRouteLineOpacityCk;
         QLabel *osmTSTitle, *osmTSLabel, *osmTSUrlLabel;
         QLineEdit *osmTSUrl;
 

--- a/src/Gui/Colors.cpp
+++ b/src/Gui/Colors.cpp
@@ -249,6 +249,7 @@ void GCColor::setupColors()
         { tr("Gui"), tr("Chartbar background"), "CCHARTBAR", Qt::lightGray },
         { tr("Gui"), tr("Overview Tile Background Alternate"), "CCARDBACKGROUND2", QColor(0,0,0) },
         { tr("Gui"), tr("Overview Tile Background Vibrant"), "CCARDBACKGROUND3", QColor(52,52,52) },
+        { tr("Map Route Line"), "MAPROUTECOLOR", Qt::red },
         { "", "", "", QColor(0,0,0) },
     };
 
@@ -376,8 +377,11 @@ void GCColor::setupColors()
     LightDefaultColorList[101].color = QColor(101,44,45); // 101:Tidal Volume
     LightDefaultColorList[102].color = QColor(134,74,255); // 102:Respiratory Frequency
     LightDefaultColorList[103].color = QColor(255,46,46); // 103:FeO2
+    LightDefaultColorList[104].color = QColor(180, 180, 180); // 104:CHOVER
+    LightDefaultColorList[105].color = QColor(0xee, 0xf8, 0xff); // 105:CCHARTBAR
     LightDefaultColorList[106].color = QColor(180,180,180); // 106:Tile Alternate
     LightDefaultColorList[107].color = QColor(0xee,0xf8,0xff); // 107:Tile Vibrant
+    LightDefaultColorList[104].color = QColor(255, 0, 0); // 104:MapRouteLine
 }
 
 // default settings for fonts etc

--- a/src/Gui/Colors.cpp
+++ b/src/Gui/Colors.cpp
@@ -249,7 +249,7 @@ void GCColor::setupColors()
         { tr("Gui"), tr("Chartbar background"), "CCHARTBAR", Qt::lightGray },
         { tr("Gui"), tr("Overview Tile Background Alternate"), "CCARDBACKGROUND2", QColor(0,0,0) },
         { tr("Gui"), tr("Overview Tile Background Vibrant"), "CCARDBACKGROUND3", QColor(52,52,52) },
-        { tr("Map Route Line"), "MAPROUTECOLOR", Qt::red },
+        { tr("Gui"), tr("Map Route Line"), "MAPROUTELINE", Qt::red },
         { "", "", "", QColor(0,0,0) },
     };
 
@@ -377,11 +377,9 @@ void GCColor::setupColors()
     LightDefaultColorList[101].color = QColor(101,44,45); // 101:Tidal Volume
     LightDefaultColorList[102].color = QColor(134,74,255); // 102:Respiratory Frequency
     LightDefaultColorList[103].color = QColor(255,46,46); // 103:FeO2
-    LightDefaultColorList[104].color = QColor(180, 180, 180); // 104:CHOVER
-    LightDefaultColorList[105].color = QColor(0xee, 0xf8, 0xff); // 105:CCHARTBAR
     LightDefaultColorList[106].color = QColor(180,180,180); // 106:Tile Alternate
-    LightDefaultColorList[107].color = QColor(0xee,0xf8,0xff); // 107:Tile Vibrant
-    LightDefaultColorList[104].color = QColor(255, 0, 0); // 104:MapRouteLine
+    LightDefaultColorList[107].color = QColor(238,248,255); // 107:Tile Vibrant
+    LightDefaultColorList[108].color = QColor(255, 0, 0); // 105:MapRouteLine
 }
 
 // default settings for fonts etc

--- a/src/Gui/Colors.h
+++ b/src/Gui/Colors.h
@@ -186,7 +186,7 @@ class ColorEngine : public QObject
 #define GColor(x) GCColor::getColor(x)
 
 // Define how many cconfigurable metric colors are available
-#define CNUMOFCFGCOLORS       108
+#define CNUMOFCFGCOLORS       109
 
 #define CPLOTBACKGROUND       0
 #define CRIDEPLOTBACKGROUND   1
@@ -296,4 +296,5 @@ class ColorEngine : public QObject
 #define CCHARTBAR             105
 #define CCARDBACKGROUND2      106
 #define CCARDBACKGROUND3      107
+#define MAPROUTELINE          108
 #endif


### PR DESCRIPTION
To try and address comments 1&2 raised in : https://groups.google.com/g/golden-cheetah-users/c/LQ1bq3zGTeE/m/5AvoGKX6AQAJ

_1) Map tiles layer should be able to be dimmed or desaturated to make the ride's path more visible - The map details are great, but often visually overpower and make it hard to see the ride's path (map details have many colours and saturated colours).. especially if multicoloured "shaded zone" (which I find useful is on)
2) The colour and width of yellow outline of ride path should be configurable - depending on map tiles other colours might be preferable (don't overlap colours of map tile details).. increasing width (if highlight colour is transparent) make path more visible_

Trying to keep things simple and hopefully provide sufficient configurability I have proposed:

1) the option to switch off the out & back route line opacity, this can improve the visibility of the route line, the default is the standard GC 50% opacity display.

![Capture1](https://user-images.githubusercontent.com/46629337/131373009-0b03dc5a-348f-4818-9ca8-0a59529b4abf.PNG)

2) and I have also added the option to change the route line colour (see below), note: this is only displayed for activities with no power information or when the hide shaded zones is selected (checkbox ticked), and again defaults to the standard GC red:

![Capture2](https://user-images.githubusercontent.com/46629337/131373063-29527e9c-d74a-411b-bff5-1cbd65fbf1e3.PNG)

Note the power zone line colours are already configurable, the difficulty is trying to choose them so they appear clear on some tile server displays :

![Capture3](https://user-images.githubusercontent.com/46629337/131373120-2d8fc205-b889-4a61-868d-78f3b6bc546b.PNG)
