### PR TITLE
Fix python-version in travis after_success.sh for linux build

### DIFF
--- a/travis/linux/after_success.sh
+++ b/travis/linux/after_success.sh
@@ -46,10 +46,10 @@ chmod a+x linuxdeployqt-7-x86_64.AppImage
 ./linuxdeployqt-7-x86_64.AppImage appdir/GoldenCheetah -verbose=2 -bundle-non-qt-libs -exclude-libs=libqsqlmysql,libqsqlpsql,libnss3,libnssutil3,libxcb-dri3.so.0 -unsupported-allow-new-glibc
 
 # Add Python and core modules
-wget https://github.com/niess/python-appimage/releases/download/python3.7/python3.7.11-cp37-cp37m-manylinux1_x86_64.AppImage
-chmod +x python3.7.11-cp37-cp37m-manylinux1_x86_64.AppImage
-./python3.7.11-cp37-cp37m-manylinux1_x86_64.AppImage --appimage-extract
-rm -f python3.7.11-cp37-cp37m-manylinux1_x86_64.AppImage
+wget https://github.com/niess/python-appimage/releases/download/python3.7/python3.7.12-cp37-cp37m-manylinux1_x86_64.AppImage
+chmod +x python3.7.12-cp37-cp37m-manylinux1_x86_64.AppImage
+./python3.7.12-cp37-cp37m-manylinux1_x86_64.AppImage --appimage-extract
+rm -f python3.7.12-cp37-cp37m-manylinux1_x86_64.AppImage
 export PATH="$(pwd)/squashfs-root/usr/bin:$PATH"
 pip install --upgrade pip
 pip install -r Python/requirements.txt

--- a/travis/linux/after_success.sh
+++ b/travis/linux/after_success.sh
@@ -52,7 +52,7 @@ chmod +x python3.7.12-cp37-cp37m-manylinux1_x86_64.AppImage
 rm -f python3.7.12-cp37-cp37m-manylinux1_x86_64.AppImage
 export PATH="$(pwd)/squashfs-root/usr/bin:$PATH"
 pip install --upgrade pip
-pip install -r Python/requirements.txt
+pip install -q -r Python/requirements.txt
 mv squashfs-root/usr appdir/usr
 mv squashfs-root/opt appdir/opt
 rm -rf squashfs-root

--- a/travis/linux/after_success.sh
+++ b/travis/linux/after_success.sh
@@ -46,7 +46,7 @@ chmod a+x linuxdeployqt-7-x86_64.AppImage
 ./linuxdeployqt-7-x86_64.AppImage appdir/GoldenCheetah -verbose=2 -bundle-non-qt-libs -exclude-libs=libqsqlmysql,libqsqlpsql,libnss3,libnssutil3,libxcb-dri3.so.0 -unsupported-allow-new-glibc
 
 # Add Python and core modules
-wget https://github.com/niess/python-appimage/releases/download/python3.7/python3.7.12-cp37-cp37m-manylinux1_x86_64.AppImage
+wget --no-verbose https://github.com/niess/python-appimage/releases/download/python3.7/python3.7.12-cp37-cp37m-manylinux1_x86_64.AppImage
 chmod +x python3.7.12-cp37-cp37m-manylinux1_x86_64.AppImage
 ./python3.7.12-cp37-cp37m-manylinux1_x86_64.AppImage --appimage-extract
 rm -f python3.7.12-cp37-cp37m-manylinux1_x86_64.AppImage
@@ -58,7 +58,7 @@ mv squashfs-root/opt appdir/opt
 rm -rf squashfs-root
 
 # Generate AppImage
-wget "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
+wget --no-verbose "https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage"
 chmod a+x appimagetool-x86_64.AppImage
 ./appimagetool-x86_64.AppImage appdir
 

--- a/travis/linux/before_install.sh
+++ b/travis/linux/before_install.sh
@@ -63,7 +63,7 @@ sudo apt-get -qq install libgsl-dev
 
 # AWS S3 client to upload binaries
 curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip"
-unzip awscliv2.zip
+unzip -qq awscliv2.zip
 sudo ./aws/install
 aws --version
 

--- a/travis/linux/before_install.sh
+++ b/travis/linux/before_install.sh
@@ -28,12 +28,12 @@ R --version
 
 # D2XX - refresh cache if folder is empty
 if [ -z "$(ls -A D2XX)" ]; then
-    wget http://www.ftdichip.com/Drivers/D2XX/Linux/libftd2xx-x86_64-1.3.6.tgz
+    wget --no-verbose http://www.ftdichip.com/Drivers/D2XX/Linux/libftd2xx-x86_64-1.3.6.tgz
     tar xf libftd2xx-x86_64-1.3.6.tgz -C D2XX
 fi
 
 # SRMIO
-wget https://github.com/rclasen/srmio/archive/v0.1.1git1.tar.gz
+wget --no-verbose https://github.com/rclasen/srmio/archive/v0.1.1git1.tar.gz
 tar xf v0.1.1git1.tar.gz
 cd srmio-0.1.1git1
 sh genautomake.sh
@@ -50,7 +50,7 @@ sudo add-apt-repository -y ppa:deadsnakes/ppa
 sudo apt-get update -qq
 sudo apt-get install -qq python3.7-dev
 python3.7 --version
-wget https://sourceforge.net/projects/pyqt/files/sip/sip-4.19.8/sip-4.19.8.tar.gz
+wget --no-verbose https://sourceforge.net/projects/pyqt/files/sip/sip-4.19.8/sip-4.19.8.tar.gz
 tar xf sip-4.19.8.tar.gz
 cd sip-4.19.8
 python3.7 configure.py

--- a/travis/linux/deploy.sh
+++ b/travis/linux/deploy.sh
@@ -29,7 +29,7 @@ cp /usr/lib/x86_64-linux-gnu/libssl.so appdir/lib
 cp /usr/lib/x86_64-linux-gnu/libcrypto.so appdir/lib
 
 ### Download current version of linuxdeployqt
-wget -c https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
+wget --no-verbose -c https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
 chmod a+x linuxdeployqt-continuous-x86_64.AppImage
 
 ### Deploy to appdir and generate AppImage


### PR DESCRIPTION
The upstream AppImage for python3.7.x got upgraded from 3.7.11 to
3.7.12, causing the script to fail.

I'm still waiting for a build with this fix included to finish in my own fork with travis-ci enabled: https://app.travis-ci.com/github/erikboto/GoldenCheetah/jobs/541072491 , if that works as intended I guess it can be considered tested ok.