### PR TITLE
Estimate Power: corrected adjustment of CdA when not set

### DIFF
--- a/src/FileIO/FixDerivePower.cpp
+++ b/src/FileIO/FixDerivePower.cpp
@@ -230,6 +230,7 @@ FixDerivePower::postProcess(RideFile *ride, DataProcessorConfig *config=0, QStri
         windSpeed = ((FixDerivePowerConfig*)(config))->windSpeed->value();                // kph
         windHeading = ((FixDerivePowerConfig*)(config))->windHeading->value() / 180 * MATHCONST_PI; // rad
     }
+    bool CdANotSet = (CdA == 0.0);
 
     // Do nothing for swims and runs
     if (ride->isSwim() || ride->isRun()) return false;
@@ -307,7 +308,7 @@ FixDerivePower::postProcess(RideFile *ride, DataProcessorConfig *config=0, QStri
 
                 double vw=V+W; // Wind speed against cyclist = cyclist speed + wind speed
 
-                if (CdA == 0) {
+                if (CdANotSet) {
                     double CwaRider = (1 + cad * cCad) * afCd * adipos * (((hRider - adipos) * afSin) + adipos);
                     CdA = CwaRider + CwaBike;
                 }


### PR DESCRIPTION
When CdA is not set, it is estimated at every sample, using cadence
If CdA is left blank (0), it is supposed to be computedd at every timestep, as it depends on the cadence.
there is a bug in the code: in the first timestep, CdA is computed, and for the rest of the timesteps, CdA is not equal to 0, so, it is not computed anymore, keeping the value for the first timestep.
This pull request corrects that