### PR TITLE
Fix font issue under Windows 10.

### DIFF
--- a/src/Gui/ChartSpace.cpp
+++ b/src/Gui/ChartSpace.cpp
@@ -1,4 +1,4 @@
-﻿/*
+/*
  * Copyright (c) 2020 Mark Liversedge (liversedge@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it
@@ -609,10 +609,15 @@ ChartSpace::configChanged(qint32 why)
 
     // set fonts
     bigfont.setPixelSize(pixelSizeForFont(bigfont, ROWHEIGHT *2.5f));
+    bigfont.setHintingPreference(QFont::HintingPreference::PreferNoHinting);
     titlefont.setPixelSize(pixelSizeForFont(titlefont, ROWHEIGHT)); // need a bit of space
+    titlefont.setHintingPreference(QFont::HintingPreference::PreferNoHinting);
     midfont.setPixelSize(pixelSizeForFont(midfont, ROWHEIGHT *0.8f));
+    midfont.setHintingPreference(QFont::HintingPreference::PreferNoHinting);
     smallfont.setPixelSize(pixelSizeForFont(smallfont, ROWHEIGHT*0.7f));
+    smallfont.setHintingPreference(QFont::HintingPreference::PreferNoHinting);
     tinyfont.setPixelSize(pixelSizeForFont(smallfont, ROWHEIGHT*0.5f));
+    tinyfont.setHintingPreference(QFont::HintingPreference::PreferNoHinting);
 
     setProperty("color", GColor(COVERVIEWBACKGROUND));
     view->setBackgroundBrush(QBrush(GColor(COVERVIEWBACKGROUND)));


### PR DESCRIPTION
Under Windows 10 the fonts of the tiles in the new overview page are not nice and a bit unreadable. 
![Screenshot 2021-11-17 124127](https://user-images.githubusercontent.com/514609/142198963-945b0690-69bf-4379-810e-53de7e690a66.png)

QT documentation about HintingPreference:
https://doc.qt.io/qt-5/qfont.html#HintingPreference-enum

With HintingPreference set to PreferNoHinting fonts are looking ok:
![Screenshot 2021-11-17 131144](https://user-images.githubusercontent.com/514609/142198966-11606c8a-79e0-4403-b25b-3ff5bc849a86.png)
