### PR TITLE
Python automated processors fix, working as in manual mode

### DIFF
--- a/src/FileIO/FixPyDataProcessor.cpp
+++ b/src/FileIO/FixPyDataProcessor.cpp
@@ -37,6 +37,9 @@ bool FixPyDataProcessor::postProcess(RideFile *rideFile, DataProcessorConfig *se
     FixPyRunner pyRunner(rideFile->context, rideFile, useNewThread);
     bool result = pyRunner.run(pyScript->source, pyScript->iniKey, errText) == 0;
     rideFile->context->ride = prior;
+    ride->context = NULL;
+    ride->setRide((RideFile*)NULL);
+    delete ride;
     return result;
 }
 

--- a/src/FileIO/FixPyDataProcessor.cpp
+++ b/src/FileIO/FixPyDataProcessor.cpp
@@ -23,8 +23,21 @@ bool FixPyDataProcessor::postProcess(RideFile *rideFile, DataProcessorConfig *se
 
     QString errText;
     bool useNewThread = op != "PYTHON";
-    FixPyRunner pyRunner(nullptr, rideFile, useNewThread);
-    return pyRunner.run(pyScript->source, pyScript->iniKey, errText) == 0;
+
+
+    // Creating a RideItem object from rideFile, to substitute the current one in context object,
+    // so that activityMetrics() can access its data
+
+    QDateTime dt = rideFile->startTime();
+    RideItem *ride = new RideItem(rideFile, dt, rideFile->context);
+    RideItem *prior = rideFile->context->ride;
+    // It must be refreshed to have metadata, etc updated and accesible from within python code
+    ride->refresh();
+    rideFile->context->ride = ride;
+    FixPyRunner pyRunner(rideFile->context, rideFile, useNewThread);
+    bool result = pyRunner.run(pyScript->source, pyScript->iniKey, errText) == 0;
+    rideFile->context->ride = prior;
+    return result;
 }
 
 DataProcessorConfig *FixPyDataProcessor::processorConfig(QWidget *parent, const RideFile* ride)


### PR DESCRIPTION
Python automated processors cannot execute setTag/delTag/hasTag correctly, as well as meny other features, as the activity being processed is not the RideItem object in the context variable; in fact, it is set with the currently selected activity in the activities list.
This commit changes that, and allows python processors behave as manual processors.
This commit should be verified by some expert, as there can be side effects unknown by me. The most straightfoorward one is: a RideItem is created but not destroyed. The reason is that it cannot be deleted calling its destructor, as it would close and delete the file it has as a property, that was created beforehand. Maybe a trick would be to set to null its ride_ property before deleting it.
But thee correct solution, I think, would be to avoid the need of creating a RideItem object (reuse one if it is already created, or created but inserted in some list wherever it is taken into account,...)
Perhaps this code is not the correcct one, but can give a clue to deveelop a better solution.

Anyway, its behavior is correct, processors run and can read and modify metada, for example.

Resolves #4095