### PR TITLE
Fix False ANT+ Cadences

### DIFF
--- a/src/ANT/ANTChannel.cpp
+++ b/src/ANT/ANTChannel.cpp
@@ -804,10 +804,13 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                    lastMessageTimestamp = parent->getElapsedTime();
                } else {
                    qint64 ms = parent->getElapsedTime() - lastMessageTimestamp;
-                   rpm = qMin((float)(1000.0*60.0*1.0) / ms, parent->getCadence());
+                   float estimatedRpm = (float)(1000.0*60.0*1.0) / ms;
                    // If we received a message but timestamp remain unchanged then we know that sensor have not detected magnet thus we deduct that rpm cannot be higher than this
-                   if (rpm < last_measured_rpm / 2.0)
+                   if (estimatedRpm < last_measured_rpm / 2.0)
                        rpm = 0.0; // if rpm is less than half previous cadence we consider that we are stopped
+                    else {
+                        rpm = parent->getCadence();
+                    }
                }
                parent->setCadence(rpm);
                value2 = value = rpm;


### PR DESCRIPTION
I was having issues where my cadence readings in training mode were regularly jumping down to 80 rpm when I was pedaling above 80 rpm (see plot of one of my rides below).
<img width="1454" alt="Screen Shot 2021-12-05 at 6 21 16 PM" src="https://user-images.githubusercontent.com/16847359/144770150-ad94cf26-d5ee-47af-bd19-ca1cdf1882c3.png">

I looked through the data in the raw ANT+ cadence messages (in the `antlog.raw` file) and confirmed that this bit of code was artificially setting my cadence to 80 when I was actually pedaling above 80 RPM:
```
rpm = qMin((float)(1000.0*60.0*1.0) / ms, parent->getCadence());
```

Basically, the final message before the data was updated caused `(1000.0*60.0*1.0) / ms` to be 80, which was less than what my previously calculated cadence was (`parent->getCadence()`).

Here are my data files:
- [antlog.raw](https://github.com/GoldenCheetah/GoldenCheetah/files/7657120/antlog.txt) (change the file extension to .raw; github wouldn't accept a .raw, so I changed extension to .txt)
- [2021_12_04_07_17_36.json](https://github.com/GoldenCheetah/GoldenCheetah/files/7657123/2021_12_04_07_17_36.txt) (again, change file extension to .json when you download it) - this is the data file with faulty cadence readings