### PR TITLE
Corrected problems with LRBalance Import

### DIFF
--- a/src/FileIO/FitRideFile.cpp
+++ b/src/FileIO/FitRideFile.cpp
@@ -1895,10 +1895,10 @@ struct FitFileReaderState
                              break;
                     case 30: //LEFT_RIGHT_BALANCE
                              // When bit 7 is 1 value are right power contribution
-                             // not '1' the location of the contribution is undefined
-                             if (value & 0x80)
-                                lrbalance = 100 - (value & 0x7F);
-                             else
+                             //  some manufacturers use left power contribution
+                             lrbalance = (value & 0x80 ? 100 - (value & 0x7F) : value & 0x7F);
+                             // exclude invalid data 
+                             if ( (lrbalance > 100) || (lrbalance < 0) )
                                 lrbalance = RideFile::NA;
                              break;
                     case 31: // GPS Accuracy
@@ -2209,7 +2209,7 @@ struct FitFileReaderState
             double deltaLat = lat - prevPoint->lat;
             // double deltaHeadwind = headwind - prevPoint->headwind;
             double deltaSlope = slope - prevPoint->slope;
-            double deltaLeftRightBalance = (lrbalance>=0?lrbalance:50.0) - (prevPoint->lrbalance?prevPoint->lrbalance:50.0);
+            double deltaLeftRightBalance = lrbalance - prevPoint->lrbalance;
             double deltaLeftTE = leftTorqueEff - prevPoint->lte;
             double deltaRightTE = rightTorqueEff - prevPoint->rte;
             double deltaLeftPS = leftPedalSmooth - prevPoint->lps;
@@ -2250,7 +2250,7 @@ struct FitFileReaderState
                         0.0, // headwind
                         prevPoint->slope + (deltaSlope * weight),
                         temperature,
-                        prevPoint->lrbalance + (deltaLeftRightBalance * weight),
+                        (lrbalance!=RideFile::NA && prevPoint->lrbalance!=RideFile::NA) ? prevPoint->lrbalance + (deltaLeftRightBalance * weight) : RideFile::NA,
                         prevPoint->lte + (deltaLeftTE * weight),
                         prevPoint->rte + (deltaRightTE * weight),
                         prevPoint->lps + (deltaLeftPS * weight),


### PR DESCRIPTION
I've made two corrections to the import of FIT files to correct problems with LRBalance-Data.

First, the formula for interpolation of data was wrong. It would count up from -255 when prevPoint->lrbalance is an RideFile::NA-value. 
I did change the algorithm not to interpolate values when prevPoint->lrbalance or lrbalance is RideFile::NA, but just to set all the intermediate values to RideFile::NA, too. IMHO it doesn't make sense to interpolate this value as LRBalance usually is not monotonic and changes within a few seconds.

Second I reverted the change which excluded all LRBalance-data without right-bit set.
I checked all the issues and I found no technical reason which made this change necessary. There were only two reasons for this change:
1) A concern by Alejandro in issue 3819 "Obviously it is easy to revert that change, but my concern is we loose the ability to detect LR balance marked as invalid."
2) The ANT-specification

The concern was never confirmed by any issue, nor any complaint from an user. The specification is a proprietary specification controlled by one manufacturer. Other manufacturers are using left-based values with right bit not set, it would not be ok to exclude these manufacturers.
