### PR TITLE
src/Charts/PythonChart.cpp: allow LocalContentCanAccessRemoteUrls

### DIFF
--- a/src/Charts/PythonChart.cpp
+++ b/src/Charts/PythonChart.cpp
@@ -448,6 +448,7 @@ PythonChart::setWeb(bool x)
         canvas->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));
         // stop stealing focus!
         canvas->settings()->setAttribute(QWebEngineSettings::FocusOnNavigationEnabled, false);
+        canvas->settings()->setAttribute(QWebEngineSettings::LocalContentCanAccessRemoteUrls, true);
         renderlayout->insertWidget(0, canvas);
     }
 


### PR DESCRIPTION
new versions of qtwebengine block those requests by default

fix "Access to fetch at *** from origin 'file://' has been blocked by CORS policy:
   Cross origin requests are only supported for protocol schemes: http, data, chrome, chrome-extension, chrome-untrusted, https."

see https://forum.qt.io/topic/132956/qwebengineview-javascript-fetch-cors-error-but-works-on-chrome-desktop