### PR TITLE
Cloud: include "Secrets.h" in Nolio.cpp

### DIFF
--- a/src/Cloud/Nolio.cpp
+++ b/src/Cloud/Nolio.cpp
@@ -19,6 +19,7 @@
 #include "MainWindow.h"
 #include "JsonRideFile.h"
 #include "Athlete.h"
+#include "Secrets.h"
 #include "Settings.h"
 #include <QByteArray>
 #include <QHttpMultiPart>


### PR DESCRIPTION
Otherwise, build fails with:
error: ‘GC_NOLIO_CLIENT_ID’ was not declared in this scope
error: ‘GC_NOLIO_CLIENT_SECRET’ was not declared in this scope