### PR TITLE
Fix for DP #4095 - Python Fixes work on auto import (save option)

### DIFF
--- a/src/FileIO/FixPyDataProcessor.cpp
+++ b/src/FileIO/FixPyDataProcessor.cpp
@@ -23,7 +23,7 @@ bool FixPyDataProcessor::postProcess(RideFile *rideFile, DataProcessorConfig *se
 
     QString errText;
     bool useNewThread = op != "PYTHON";
-    Context* context = (op != "DELETE" && rideFile) ? rideFile->context : nullptr;
+    Context* context = (rideFile) ? rideFile->context : nullptr;
     FixPyRunner pyRunner(context, rideFile, useNewThread);
     return pyRunner.run(pyScript->source, pyScript->iniKey, errText) == 0;
 }

--- a/src/FileIO/FixPyDataProcessor.cpp
+++ b/src/FileIO/FixPyDataProcessor.cpp
@@ -23,7 +23,8 @@ bool FixPyDataProcessor::postProcess(RideFile *rideFile, DataProcessorConfig *se
 
     QString errText;
     bool useNewThread = op != "PYTHON";
-    FixPyRunner pyRunner(nullptr, rideFile, useNewThread);
+    Context* context = (op != "DELETE" && rideFile) ? rideFile->context : nullptr;
+    FixPyRunner pyRunner(context, rideFile, useNewThread);
     return pyRunner.run(pyScript->source, pyScript->iniKey, errText) == 0;
 }
 

--- a/src/Gui/Pages.cpp
+++ b/src/Gui/Pages.cpp
@@ -2753,17 +2753,20 @@ ProcessorPage::ProcessorPage(Context *context) : context(context)
         // Auto or Manual run?
         QComboBox *comboButton = new QComboBox(this);
         comboButton->addItem(tr("Manual"));
-        comboButton->addItem(tr("Import"));
-        comboButton->addItem(tr("Save"));
+        comboButton->addItem(tr("Save")); 
+        // The Python data processors only work correctly on manual & save.
+        // Save is executed at the end of auto import process, so has equivalent functionality as "Import"
+        if (i.value()->isCoreProcessor()) comboButton->addItem(tr("Import"));
+
         processorTree->setItemWidget(add, 1, comboButton);
 
         QString configsetting = QString("dp/%1/apply").arg(i.key());
         if (appsettings->value(NULL, GC_QSETTINGS_GLOBAL_GENERAL+configsetting, "Manual").toString() == "Manual")
             comboButton->setCurrentIndex(0);
         else if (appsettings->value(NULL, GC_QSETTINGS_GLOBAL_GENERAL+configsetting, "Save").toString() == "Save")
-            comboButton->setCurrentIndex(2);
-        else
             comboButton->setCurrentIndex(1);
+        else
+            comboButton->setCurrentIndex(2); // auto import
 
         // Get and Set the Config Widget
         DataProcessorConfig *config = i.value()->processorConfig(this);
@@ -2791,8 +2794,8 @@ ProcessorPage::saveClicked()
         switch(((QComboBox*)(processorTree->itemWidget(processorTree->invisibleRootItem()->child(i), 1)))->currentIndex())  {
             default:
             case 0: apply = "Manual"; break;
-            case 1: apply = "Auto"; break;
-            case 2: apply = "Save"; break;
+            case 1: apply = "Save"; break;
+            case 2: apply = "Auto"; break;
         }
 
         appsettings->setValue(GC_QSETTINGS_GLOBAL_GENERAL+configsetting, apply);

--- a/src/Gui/Pages.cpp
+++ b/src/Gui/Pages.cpp
@@ -2753,20 +2753,17 @@ ProcessorPage::ProcessorPage(Context *context) : context(context)
         // Auto or Manual run?
         QComboBox *comboButton = new QComboBox(this);
         comboButton->addItem(tr("Manual"));
-        comboButton->addItem(tr("Save")); 
-        // The Python data processors only work correctly on manual & save.
-        // Save is executed at the end of auto import process, so has equivalent functionality as "Import"
-        if (i.value()->isCoreProcessor()) comboButton->addItem(tr("Import"));
-
+        comboButton->addItem(tr("Import"));
+        comboButton->addItem(tr("Save"));
         processorTree->setItemWidget(add, 1, comboButton);
 
         QString configsetting = QString("dp/%1/apply").arg(i.key());
         if (appsettings->value(NULL, GC_QSETTINGS_GLOBAL_GENERAL+configsetting, "Manual").toString() == "Manual")
             comboButton->setCurrentIndex(0);
         else if (appsettings->value(NULL, GC_QSETTINGS_GLOBAL_GENERAL+configsetting, "Save").toString() == "Save")
-            comboButton->setCurrentIndex(1);
+            comboButton->setCurrentIndex(2);
         else
-            comboButton->setCurrentIndex(2); // auto import
+            comboButton->setCurrentIndex(1);
 
         // Get and Set the Config Widget
         DataProcessorConfig *config = i.value()->processorConfig(this);
@@ -2794,8 +2791,8 @@ ProcessorPage::saveClicked()
         switch(((QComboBox*)(processorTree->itemWidget(processorTree->invisibleRootItem()->child(i), 1)))->currentIndex())  {
             default:
             case 0: apply = "Manual"; break;
-            case 1: apply = "Save"; break;
-            case 2: apply = "Auto"; break;
+            case 1: apply = "Auto"; break;
+            case 2: apply = "Save"; break;
         }
 
         appsettings->setValue(GC_QSETTINGS_GLOBAL_GENERAL+configsetting, apply);


### PR DESCRIPTION
This will allow the Python Fixes scripts to work on auto import (save option), resolving #4095

During Auto import, the Data processors are called twice for each imported activity, once for the "Import" setting and once for the "Save" settings. Unfortunately the "Import" data processing call occurs before the RideFile context is configured (at this point it set to the previous ride if it exists), but when they are called by the "Save" option at the end of the processing the context is correct for the ride being imported, BUT the code didn't pass the context to the Python Data processor.

I don't want to try and restructure the AutoImportWizard to try and fix the "Import" case, when the "Save" option works correctly (when this PR is applied). This PR now passes the context to the Python data processor. 

The resulting auto import functionality for Python Data Processors is:
i) "Import" option: will process all imported activities except the last one  :(
ii) "Save" option: will process all imported activities  :)

I have tested this and it works fine, but there maybe unintended consequences of this approach, so it needs review by GC expert.
