### PR TITLE
travis/linux: set QTWEBENGINE_DISABLE_SANDBOX=1

### DIFF
--- a/travis/linux/after_success.sh
+++ b/travis/linux/after_success.sh
@@ -18,6 +18,15 @@ mkdir -p appdir
 # Executable
 cp GoldenCheetah appdir
 
+# AppRun file
+cat >appdir/AppRun <<EOF
+#!/bin/bash
+HERE="\$(dirname "\$(readlink -f "\${0}")")"
+export QTWEBENGINE_DISABLE_SANDBOX=1
+exec "\${HERE}/GoldenCheetah" "\$@"
+EOF
+chmod a+x appdir/AppRun
+
 # Desktop file
 cat >appdir/GoldenCheetah.desktop <<EOF
 [Desktop Entry]


### PR DESCRIPTION
There is an issue with qtwebengine (chromium) and glibc 2.34

See: https://codereview.qt-project.org/c/qt/qtwebengine-chromium/+/374204
Fixes: https://github.com/GoldenCheetah/GoldenCheetah/issues/4196