### PR TITLE
Corrections to travis/linux/deploy.sh to make it work

### DIFF
--- a/travis/linux/deploy.sh
+++ b/travis/linux/deploy.sh
@@ -1,6 +1,9 @@
 #!/bin/sh
 
 ### This script should be run from GoldenCheetah root directory after build
+
+export PATH=/opt/qt514/bin:$PATH
+
 if [ ! -x src/GoldenCheetah ]
 then echo "Build GoldenCheetah and execute from distribution root"; exit 1
 fi
@@ -41,9 +44,13 @@ chmod a+x linuxdeployqt-continuous-x86_64.AppImage
 rm linuxdeployqt-continuous-x86_64.AppImage
 rm -rf appdir
 
+
+export FINAL_NAME=GoldenCheetah_v3.6-DEV_x64.AppImage
+mv GoldenCheetah*.AppImage $FINAL_NAME
+
 ### Minimum Test - Result is ./GoldenCheetah-x86_64.AppImage
-if [ ! -x ./GoldenCheetah-x86_64.AppImage ]
+if [ ! -x ./$FINAL_NAME ]
 then echo "AppImage not generated, check the errors"; exit 1
 fi
-./GoldenCheetah-x86_64.AppImage --version
+./$FINAL_NAME --version
 exit


### PR DESCRIPTION
travis/linux/deploy.sh script does not work standalone on the development environment.
It is necessary to add a search path. Also, AppImage filename has embedded the commit. Then, the script tries to execute the Appimage, but not considering the real filename, so it fails.
Copying the procedure followed in travis/linux/after_success.sh, the solution consists on renaming the Appimage file beforehand.

Maybe this script is not used yet; it seems a simplified proccedure of after_succcess.sh; but, anyway, if it exists in the repository, it is better if it works.
I have found it useful to pack the binary once it has been generated in the devel environment, so it works in the execution environnment without the need of modifying paths, or having trouble with vlc