### PR TITLE
after_success.sh script does not fail in case of executing in a non clean environment

### DIFF
--- a/travis/linux/after_success.sh
+++ b/travis/linux/after_success.sh
@@ -82,6 +82,7 @@ fi
 
 echo "Renaming AppImage file to branch and build number ready for deploy"
 export FINAL_NAME=GoldenCheetah_v3.6-DEV_x64.AppImage
+[[ -f ./$FINAL_NAME ]] && rm $FINAL_NAME
 mv GoldenCheetah*.AppImage $FINAL_NAME
 ls -l $FINAL_NAME
 


### PR DESCRIPTION
in case AppImage file already exists from a previous execution, the scrip will fail, as it can not move the generated file to another file that already exists, using wildcards in the move operation

If the file is previously deleted, the problem is gone