### PR TITLE
Python import processing working

### DIFF
--- a/src/Core/RideCache.cpp
+++ b/src/Core/RideCache.cpp
@@ -256,14 +256,14 @@ RideCache::itemChanged()
 }
 
 // add a new ride
-void
+RideItem*
 RideCache::addRide(QString name, bool dosignal, bool select, bool useTempActivities, bool planned)
 {
     RideItem *prior = context->ride;
 
     // ignore malformed names
     QDateTime dt;
-    if (!RideFile::parseRideFileName(name, &dt)) return;
+    if (!RideFile::parseRideFileName(name, &dt)) return NULL;
 
     // new ride item
     RideItem *last;
@@ -316,6 +316,8 @@ RideCache::addRide(QString name, bool dosignal, bool select, bool useTempActivit
 
     // model estimates (lazy refresh)
     estimator->refresh();
+
+    return last;
 }
 
 void

--- a/src/Core/RideCache.h
+++ b/src/Core/RideCache.h
@@ -92,7 +92,7 @@ class RideCache : public QObject
 	    QVector<RideItem*>&rides() { return rides_; } 
 
         // add/remove a ride to the list
-        void addRide(QString name, bool dosignal, bool select, bool useTempActivities, bool planned);
+        RideItem* addRide(QString name, bool dosignal, bool select, bool useTempActivities, bool planned);
         void removeCurrentRide();
 
         // export metrics in CSV format


### PR DESCRIPTION
This PR fixes the python import processing, and I have tested this using the following processors set for import:

- The Power Spikes Core data processor

- Python data processor using GC.activityMetrics()

```
if (GC.activityMetrics()['Device'] == "Wahoo fitness 43"):
        GC.setTag("Device", "Elemnt Bolt v2")
```
- Python data processor using GC.activityMetrics() & using GC.activity() to process a data file, removing leading zero distance samples

```
if (GC.activityMetrics()['Device'] == "Wahoo fitness 43"):
	GC.setTag("Device", "Elemnt Bolt v2")

	activity = GC.activity()

	if ('distance' in activity.keys()):

		notFinished = True

		while (notFinished):

			dist = GC.series(GC.SERIES_KM)

			for i in range (0, len(dist)):
				if (dist[i] < 0.001):
					GC.deleteActivitySample(i, activity)
					break
				else:
					notFinished = False
```


This PR has modified the import Wizard processing "Save Step 5" as follows:


**_RideImportWizard.cpp_**
1. Read activity file into RideFile object
2. Setup RideFile objects attributes (filename, etc)
3. Write JSON version of the RideFile object to the /tmpActivities folder
4. Add the RideFile in the /tmpActivities folder in turn creating a RideItem Object
5. If the RideItem was successfully created and its RideFile Object can be accessed (can only fail in unusual corner cases) then
6. Setup the Context's ride attribute to the currently imported RideItem Object, as the Python processors need the ride item object setup in the context as well as the processingRideF, because the python processors can manipulate the raw data sets and the metadata tags, while the builtin core processors only need the ride file (processingRideF) to be setup.
7. **Run the data processors on the ride file**
8. RecalculateDerivedSeries() in the Ride File Object;
9. Refresh the ride Item object
10. Write JSON version of the processed ride file object to disk, overwriting the temporary one created earlier which was just needed to create the Ride Item Object. This PR removes the later step of autoProcess(ride, "Save", "ADD"); as this would just duplicate the work already completed by steps 7, 8, 9 & 10.
11. Move the ride file from /tmpActivities to /Activities
12. Update the ride file location in the ride item object
13. Report all is done "file saved"

**_RideCache.h & cpp_**
Updated the addRide() function to return the pointer to the added rideItem, and this also provides feedback on whether the call was successful or not which is now used in the RideImportWizard.
