### PR TITLE
Make GCColor & Themes into Singletons

### DIFF
--- a/deprecated/BingMap.cpp
+++ b/deprecated/BingMap.cpp
@@ -170,7 +170,7 @@ void BingMap::createHtml()
     }
 
     QColor bgColor = GColor(CPLOTBACKGROUND);
-    QColor fgColor = GCColor::invertColor(bgColor);
+    QColor fgColor = GInvertColor(bgColor);
 
     // No GPS data, so sorry no map
     if(!ride || !ride->ride() || ride->ride()->areDataPresent()->lat == false || ride->ride()->areDataPresent()->lon == false) {

--- a/deprecated/GcScopeBar.cpp
+++ b/deprecated/GcScopeBar.cpp
@@ -190,7 +190,7 @@ GcScopeBar::paintBackground(QPaintEvent *)
     QRect all(0,0,width(),height());
 
     // fill with a linear gradient
-    QLinearGradient linearGradient = GCColor::linearGradient(23*dpiYFactor, isActiveWindow());
+    QLinearGradient linearGradient = GCColor::instance()->linearGradient(23*dpiYFactor, isActiveWindow());
     painter.setPen(Qt::NoPen);
     painter.fillRect(all, linearGradient);
 
@@ -380,7 +380,7 @@ GcScopeButton::paintEvent(QPaintEvent *)
     // don't do all that offset nonsense for flat style
     // set fg checked and unchecked colors
     QColor checkedCol(240,240,240), uncheckedCol(30,30,30,200);
-    if (!GCColor::isFlat()) {
+    if (!GCColor::instance()->isFlat()) {
 
         // metal style
         painter.setPen((underMouse() || checked) ? QColor(50,50,50) : Qt::white);
@@ -389,7 +389,7 @@ GcScopeButton::paintEvent(QPaintEvent *)
     } else {
 
         // adjust colors if flat and dark
-        if (GCColor::luminance(GColor(CCHROME)) < 127) {
+        if (GCColor::instance()->luminance(CCHROME) < 127) {
             // dark background so checked is white and unchecked is light gray
             checkedCol = QColor(Qt::white);
             uncheckedCol = QColor(Qt::lightGray);

--- a/deprecated/GoogleMapControl.cpp
+++ b/deprecated/GoogleMapControl.cpp
@@ -206,7 +206,7 @@ void GoogleMapControl::createHtml()
 
     // No GPS data, so sorry no map
     QColor bgColor = GColor(CPLOTBACKGROUND);
-    QColor fgColor = GCColor::invertColor(bgColor);
+    QColor fgColor = GInvertColor(bgColor);
     if(!ride || !ride->ride() || ride->ride()->areDataPresent()->lat == false || ride->ride()->areDataPresent()->lon == false) {
         currentPage = QString("<STYLE>BODY { background-color: %1; color: %2 }</STYLE><center>%3</center>").arg(bgColor.name()).arg(fgColor.name()).arg(tr("No GPS Data Present"));
         setIsBlank(true);

--- a/deprecated/IntervalNavigator.cpp
+++ b/deprecated/IntervalNavigator.cpp
@@ -247,7 +247,7 @@ IntervalNavigator::configChanged(qint32)
                 "QHeaderView::section { background-color: %1; color: %2; "
                 " border: 0px ; }")
                 .arg(GColor(CPLOTBACKGROUND).name())
-                .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name()));
+                .arg(GInvertColor(CPLOTBACKGROUND.name()));
     }
 
 #endif
@@ -1133,7 +1133,7 @@ void IntervalNavigatorCellDelegate::paint(QPainter *painter, const QStyleOptionV
             if (!selected) {
                 // not selected, so invert ride plot color
                 if (hover) painter->setPen(QPen(Qt::black));
-                else painter->setPen(rideBG ? intervalNavigator->reverseColor : GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+                else painter->setPen(rideBG ? intervalNavigator->reverseColor : GInvertColor(CPLOTBACKGROUND);
             }
             painter->drawText(myOption.rect, Qt::AlignLeft | Qt::TextWordWrap, calendarText);
             painter->setPen(isColor);

--- a/deprecated/IntervalSidebar.cpp
+++ b/deprecated/IntervalSidebar.cpp
@@ -137,15 +137,15 @@ IntervalSidebar::close()
 void
 IntervalSidebar::configChanged(qint32)
 {
-    routeNavigator->tableView->viewport()->setPalette(GCColor::palette());
+    routeNavigator->tableView->viewport()->setPalette(GCColor::instance()->palette());
     routeNavigator->tableView->viewport()->setStyleSheet(QString("background: %1;").arg(GColor(CPLOTBACKGROUND).name()));
 
-    bestNavigator->tableView->viewport()->setPalette(GCColor::palette());
+    bestNavigator->tableView->viewport()->setPalette(GCColor::instance()->palette());
     bestNavigator->tableView->viewport()->setStyleSheet(QString("background: %1;").arg(GColor(CPLOTBACKGROUND).name()));
 
     // interval tree
-    context->athlete->intervalWidget->setPalette(GCColor::palette());
-    context->athlete->intervalWidget->setStyleSheet(GCColor::stylesheet());
+    context->athlete->intervalWidget->setPalette(GCColor::instance()->palette());
+    context->athlete->intervalWidget->setStyleSheet(GCColor::instance()->stylesheet());
 
     repaint();
 }

--- a/deprecated/ModelPlot.cpp
+++ b/deprecated/ModelPlot.cpp
@@ -919,7 +919,7 @@ ModelPlot::configChanged(qint32)
     setBackgroundColor(bg);
 
     // labels
-    QColor irgba = GCColor::invertColor(GColor(CPLOTBACKGROUND));
+    QColor irgba = GInvertColor(CPLOTBACKGROUND;
     RGBA fg(irgba.red()/255.0, irgba.green()/255.0, irgba.blue()/255.0, 0);
     coordinates()->setLabelColor(fg);
     coordinates()->setNumberColor(fg);
@@ -1310,7 +1310,7 @@ void Bar::draw(Qwt3D::Triple const& pos)
 
     } else {
         // first bars use max and are see-through
-        QColor irgba = GCColor::invertColor(GColor(CPLOTBACKGROUND));
+        QColor irgba = GInvertColor(CPLOTBACKGROUND;
         RGBA t(irgba.red()/255.0, irgba.green()/255.0, irgba.blue()/255.0, 1);
         RGBA b(irgba.red()/255.0, irgba.green()/255.0, irgba.blue()/255.0, 0);
         rgbat = t;
@@ -1366,7 +1366,7 @@ void Bar::draw(Qwt3D::Triple const& pos)
     }
 
     if (model->intervals_ == 0 || model->intervals_&SHOW_FRAME) {
-        QColor irgba = GCColor::invertColor(GColor(CPLOTBACKGROUND));
+        QColor irgba = GInvertColor(CPLOTBACKGROUND;
         glColor3d(irgba.red()/255.0, irgba.green()/255.0,irgba.blue()/255);
         glBegin(GL_LINES);
         glVertex3d(pos.x-model->diag_,pos.y-model->diag_,gminz); glVertex3d(pos.x+model->diag_,pos.y-model->diag_,gminz);

--- a/deprecated/OverviewWindow.cpp
+++ b/deprecated/OverviewWindow.cpp
@@ -986,7 +986,7 @@ Card::paint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget *) {
     //XXXpainter->drawLine(QLineF(0,ROWHEIGHT*2,geometry().width(),ROWHEIGHT*2));
     //painter->fillRect(QRectF(0,0,geometry().width()+1,geometry().height()+1), brush);
     //titlefont.setWeight(QFont::Bold);
-    if (GCColor::luminance(GColor(CCARDBACKGROUND)) < 127) painter->setPen(QColor(200,200,200));
+    if (GCColor::instance()->luminance(CCARDBACKGROUND) < 127) painter->setPen(QColor(200,200,200));
     else painter->setPen(QColor(70,70,70));
 
     painter->setFont(parent->titlefont);
@@ -2231,7 +2231,7 @@ OverviewWindow::configChanged(qint32)
     if (GColor(COVERVIEWBACKGROUND) != Qt::white)
 #endif
     {
-        //palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CTRAINPLOTBACKGROUND)));
+        //palette.setColor(QPalette::Base, GCColor::instance()->alternateColor(CTRAINPLOTBACKGROUND));
         palette.setColor(QPalette::Base, GColor(COVERVIEWBACKGROUND));
         palette.setColor(QPalette::Window, GColor(COVERVIEWBACKGROUND));
     }
@@ -2240,8 +2240,8 @@ OverviewWindow::configChanged(qint32)
     //code->setStyleSheet(TabView::ourStyleSheet());
 #endif
 
-    palette.setColor(QPalette::WindowText, GCColor::invertColor(GColor(COVERVIEWBACKGROUND)));
-    palette.setColor(QPalette::Text, GCColor::invertColor(GColor(COVERVIEWBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GInvertColor(COVERVIEWBACKGROUND));
+    palette.setColor(QPalette::Text, GInvertColor(COVERVIEWBACKGROUND));
     //code->setPalette(palette);
     repaint();
 }

--- a/deprecated/PerformanceManagerWindow.cpp
+++ b/deprecated/PerformanceManagerWindow.cpp
@@ -154,13 +154,13 @@ void PerformanceManagerWindow::configChanged()
     palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
     palette.setBrush(QPalette::Background, QBrush(GColor(CPLOTBACKGROUND)));
     palette.setBrush(QPalette::Base, QBrush(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::WindowText, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::Normal, QPalette::Window, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GInvertColor(CPLOTBACKGROUND);
+    palette.setColor(QPalette::Text, GInvertColor(CPLOTBACKGROUND);
+    palette.setColor(QPalette::Normal, QPalette::Window, GInvertColor(CPLOTBACKGROUND);
     setPalette(palette);
     setStyleSheet(QString("background-color: %1; color: %2; border: %1")
                     .arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name()));
+                    .arg(GInvertColor(CPLOTBACKGROUND.name()));
 }
 
 void PerformanceManagerWindow::metricChanged()

--- a/deprecated/RideSummaryWindow.cpp
+++ b/deprecated/RideSummaryWindow.cpp
@@ -341,7 +341,7 @@ RideSummaryWindow::refresh()
         // if we're summarising a ride but have no ride to summarise
         if (ridesummary && !myRideItem) {
             setSubTitle(tr("Summary"));
-            rideSummary->page()->setHtml(GCColor::css(ridesummary));
+            rideSummary->page()->setHtml(GCColor::instance()->css(ridesummary));
             return;
         }
 
@@ -408,8 +408,8 @@ RideSummaryWindow::htmlSummary()
 
     QString summary("");
     QColor bgColor = ridesummary ? GColor(CPLOTBACKGROUND) : GColor(CTRENDPLOTBACKGROUND);
-    //QColor fgColor = GCColor::invertColor(bgColor);
-    QColor altColor = GCColor::alternateColor(bgColor);
+    //QColor fgColor = GInvertColor(bgColor);
+    QColor altColor = GCColor::instance()->alternateColor(bgColor);
 
     RideItem *rideItem = myRideItem;
     RideFile *ride;
@@ -437,7 +437,7 @@ RideSummaryWindow::htmlSummary()
     context->athlete->rideCache->getRideTypeCounts(specification, nActivities, nRides, nRuns, nSwims, sport);
 
     // set those colors
-    summary = GCColor::css(ridesummary);
+    summary = GCColor::instance()->css(ridesummary);
     summary += "<center>";
 
     // device summary for ride summary, otherwise how many activities?
@@ -629,8 +629,8 @@ RideSummaryWindow::htmlSummary()
             if (ridesummary) {
 
                 // for rag reporting
-                QColor defaultColor = ridesummary ? GCColor::invertColor(GColor(CPLOTBACKGROUND)) :
-                                                    GCColor::invertColor(GColor(CTRENDPLOTBACKGROUND));
+                QColor defaultColor = ridesummary ? GInvertColor(CPLOTBACKGROUND :
+                                                    GInvertColor(CTRENDPLOTBACKGROUND);
 
                 // get the Coggan PMC and add values for date of ride
                 summary += QString(tr("<tr><td>%3</td><td align=\"right\"><font color=\"%2\">%1</font></td></tr>")
@@ -1714,8 +1714,8 @@ RideSummaryWindow::htmlCompareSummary() const
     QString summary;
 
     QColor bgColor = ridesummary ? GColor(CPLOTBACKGROUND) : GColor(CTRENDPLOTBACKGROUND);
-    //QColor fgColor = GCColor::invertColor(bgColor);
-    QColor altColor = GCColor::alternateColor(bgColor);
+    //QColor fgColor = GInvertColor(bgColor);
+    QColor altColor = GCColor::instance()->alternateColor(bgColor);
 
     // SETUP ALL THE METRICS WE WILL SHOW
 
@@ -1837,7 +1837,7 @@ RideSummaryWindow::htmlCompareSummary() const
             intervalMetrics << context->compareIntervals.at(j).rideItem;
 
         // LETS FORMAT THE HTML
-        summary = GCColor::css(ridesummary);
+        summary = GCColor::instance()->css(ridesummary);
         summary += "<center>";
 
         //
@@ -2200,7 +2200,7 @@ RideSummaryWindow::htmlCompareSummary() const
     } else { // DATE RANGE COMPARE
 
         // LETS FORMAT THE HTML
-        summary = GCColor::css(ridesummary);
+        summary = GCColor::instance()->css(ridesummary);
         summary += "<center>";
 
         //

--- a/src/Charts/AerolabWindow.cpp
+++ b/src/Charts/AerolabWindow.cpp
@@ -332,12 +332,12 @@ AerolabWindow::configChanged(qint32)
   if (GColor(CPLOTBACKGROUND) != Qt::white)
 #endif
   {
-      palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CPLOTBACKGROUND)));
+      palette.setColor(QPalette::Base, GCColor::instance()->alternateColor(CPLOTBACKGROUND));
       palette.setColor(QPalette::Window,  GColor(CPLOTBACKGROUND));
   }
 
-  palette.setColor(QPalette::WindowText, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-  palette.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+  palette.setColor(QPalette::WindowText, GInvertColor(CPLOTBACKGROUND));
+  palette.setColor(QPalette::Text, GInvertColor(CPLOTBACKGROUND));
   setPalette(palette);
   aerolab->setPalette(palette);
   crrLabel->setPalette(palette);

--- a/src/Charts/AllPlot.cpp
+++ b/src/Charts/AllPlot.cpp
@@ -1174,7 +1174,7 @@ AllPlot::configChanged(qint32 what)
         QColor brush_color = GColor(CALTITUDEBRUSH);
         brush_color.setAlpha(200);
         standard->altCurve->setBrush(brush_color);   // fill below the line
-        QPen altSlopePen(GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+        QPen altSlopePen(GInvertColor(CPLOTBACKGROUND));
         altSlopePen.setWidth(width);
         standard->altSlopeCurve->setPen(altSlopePen);
         QPen tempPen = QPen(GColor(CTEMP));

--- a/src/Charts/AllPlotSlopeCurve.cpp
+++ b/src/Charts/AllPlotSlopeCurve.cpp
@@ -271,7 +271,7 @@ void AllPlotSlopeCurve::drawCurve( QPainter *painter, int,
             } else {
                 text.setNum(mperh, 'f', 0);
             }
-            painter->setPen(GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+            painter->setPen(GInvertColor(CPLOTBACKGROUND));
             painter->setFont(QFont("Helvetica",8));
             QwtPainter::drawText(painter, pText, text );
         }

--- a/src/Charts/ChartBar.cpp
+++ b/src/Charts/ChartBar.cpp
@@ -421,7 +421,7 @@ ButtonBar::paintBackground(QPaintEvent *)
     painter.fillRect(all, QColor(Qt::white));
     painter.fillRect(all, GColor(CCHARTBAR));
 
-    if (!GCColor::isFlat()) {
+    if (!GCColor::instance()->isFlat()) {
         QPen black(QColor(100,100,100,200));
         painter.setPen(black);
         painter.drawLine(0,height()-1, width()-1, height()-1);
@@ -466,7 +466,7 @@ ChartBarItem::paintEvent(QPaintEvent *)
     painter.fillRect(body, brush);
 
     // now paint the text
-    QPen pen(GCColor::invertColor(brush.color()));
+    QPen pen(GInvertColor(brush.color()));
     painter.setPen(pen);
     painter.drawText(body, text, Qt::AlignHCenter | Qt::AlignVCenter);
 
@@ -491,7 +491,7 @@ ChartBarItem::paintEvent(QPaintEvent *)
         if (checked) {
 
             // different color if under mouse
-            QBrush brush(GCColor::invertColor(color));
+            QBrush brush(GInvertColor(color));
             if (hotspot.contains(mouse)) brush.setColor(GColor(CPLOTMARKER));
             painter.fillPath (triangle, brush);
         } else {

--- a/src/Charts/CriticalPowerWindow.cpp
+++ b/src/Charts/CriticalPowerWindow.cpp
@@ -661,7 +661,7 @@ CriticalPowerWindow::configChanged(qint32)
     else palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
     palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
     palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CPLOTBACKGROUND)));
+    palette.setColor(QPalette::Base, GCColor::instance()->alternateColor(CPLOTBACKGROUND));
     setPalette(palette);
 
     // inverted palette for data etc
@@ -669,15 +669,15 @@ CriticalPowerWindow::configChanged(qint32)
     if (rangemode) {
         whitepalette.setBrush(QPalette::Window, QBrush(GColor(CTRENDPLOTBACKGROUND)));
         whitepalette.setBrush(QPalette::Background, QBrush(GColor(CTRENDPLOTBACKGROUND)));
-        whitepalette.setColor(QPalette::WindowText, GCColor::invertColor(GColor(CTRENDPLOTBACKGROUND)));
-        whitepalette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CPLOTBACKGROUND)));
-        whitepalette.setColor(QPalette::Text, GCColor::invertColor(GColor(CTRENDPLOTBACKGROUND)));
+        whitepalette.setColor(QPalette::WindowText, GInvertColor(CTRENDPLOTBACKGROUND));
+        whitepalette.setColor(QPalette::Base, GCColor::instance()->alternateColor(CPLOTBACKGROUND));
+        whitepalette.setColor(QPalette::Text, GInvertColor(CTRENDPLOTBACKGROUND));
     } else {
         whitepalette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
         whitepalette.setBrush(QPalette::Background, QBrush(GColor(CPLOTBACKGROUND)));
-        whitepalette.setColor(QPalette::WindowText, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-        whitepalette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CPLOTBACKGROUND)));
-        whitepalette.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+        whitepalette.setColor(QPalette::WindowText, GInvertColor(CPLOTBACKGROUND));
+        whitepalette.setColor(QPalette::Base, GCColor::instance()->alternateColor(CPLOTBACKGROUND));
+        whitepalette.setColor(QPalette::Text, GInvertColor(CPLOTBACKGROUND));
     }
 
     QFont font;
@@ -720,7 +720,7 @@ CriticalPowerWindow::configChanged(qint32)
 
 
 #ifndef Q_OS_MAC
-    QString style = QString("QSpinBox { background: %1; }").arg(GCColor::alternateColor(GColor(CPLOTBACKGROUND)).name());
+    QString style = QString("QSpinBox { background: %1; }").arg(GCColor::instance()->alternateColor(CPLOTBACKGROUND).name());
     CPEdit->setStyleSheet(style);
     //CPLabel->setStyleSheet(style);
     //CPSlider->setStyleSheet(style);

--- a/src/Charts/DiaryWindow.cpp
+++ b/src/Charts/DiaryWindow.cpp
@@ -113,20 +113,20 @@ DiaryWindow::configChanged(qint32)
     palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
     palette.setBrush(QPalette::Background, QBrush(GColor(CPLOTBACKGROUND)));
     palette.setBrush(QPalette::Base, QBrush(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::WindowText, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::Normal, QPalette::Window, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GInvertColor(CPLOTBACKGROUND));
+    palette.setColor(QPalette::Text, GInvertColor(CPLOTBACKGROUND));
+    palette.setColor(QPalette::Normal, QPalette::Window, GInvertColor(CPLOTBACKGROUND));
     setPalette(palette);
     monthlyView->setPalette(palette);
     monthlyView->setStyleSheet(QString("QTableView QTableCornerButton::section { background-color: %1; color: %2; border: %1 }")
                     .arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name()));
+                    .arg(GInvertColor(CPLOTBACKGROUND).name()));
     monthlyView->horizontalHeader()->setStyleSheet(QString("QHeaderView::section { background-color: %1; color: %2; border: 0px }")
                     .arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name()));
+                    .arg(GInvertColor(CPLOTBACKGROUND).name()));
     monthlyView->verticalHeader()->setStyleSheet(QString("QHeaderView::section { background-color: %1; color: %2; border: 0px }")
                     .arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name()));
+                    .arg(GInvertColor(CPLOTBACKGROUND).name()));
 #ifndef Q_OS_MAC
     monthlyView->verticalScrollBar()->setStyleSheet(AbstractView::ourStyleSheet());
     monthlyView->horizontalScrollBar()->setStyleSheet(AbstractView::ourStyleSheet());

--- a/src/Charts/GcOverlayWidget.cpp
+++ b/src/Charts/GcOverlayWidget.cpp
@@ -107,8 +107,8 @@ GcOverlayWidget::GcOverlayWidget(Context *context, QWidget *parent) : QWidget(pa
 void
 GcOverlayWidget::configChanged(qint32)
 {
-    if (GCColor::isFlat()) {
-        titleLabel->setStyleSheet(QString("color: %1;").arg(GCColor::invertColor(GColor(CCHROME)).name()));
+    if (GCColor::instance()->isFlat()) {
+        titleLabel->setStyleSheet(QString("color: %1;").arg(GInvertColor(CCHROME).name()));
     } else {
         titleLabel->setStyleSheet("color: black;");
     }
@@ -216,15 +216,15 @@ GcOverlayWidget::paintBackground(QPaintEvent *)
     painter.drawRect(boundary);
 
     // linear gradients
-    QLinearGradient active = GCColor::linearGradient(23*dpiXFactor, true);
-    QLinearGradient inactive = GCColor::linearGradient(23*dpiYFactor, false);
+    QLinearGradient active = GCColor::instance()->linearGradient(23*dpiXFactor, true);
+    QLinearGradient inactive = GCColor::instance()->linearGradient(23*dpiYFactor, false);
 
     // title
     QRect title(1*dpiXFactor,1*dpiYFactor,width()-(2*dpiXFactor),22*dpiYFactor);
     painter.fillRect(title, QColor(Qt::white));
     painter.fillRect(title, isActiveWindow() ? active : inactive);
 
-    if (!GCColor::isFlat()) {
+    if (!GCColor::instance()->isFlat()) {
         QPen black(QColor(100,100,100,200));
         painter.setPen(black);
         painter.drawLine(0,22*dpiYFactor, width()-(1*dpiXFactor), 22*dpiYFactor);

--- a/src/Charts/GenericLegend.cpp
+++ b/src/Charts/GenericLegend.cpp
@@ -160,7 +160,7 @@ GenericLegendItem::paintEvent(QPaintEvent *)
     if (hasstring)  string=this->string;
 
     // set pen to series color for now
-    if (enabled)  painter.setPen(GCColor::invertColor(legend->plot()->backgroundColor())); // use invert - usually black or white
+    if (enabled)  painter.setPen(GInvertColor(legend->plot()->backgroundColor())); // use invert - usually black or white
     else painter.setPen(Qt::gray);
 
     QFont f;

--- a/src/Charts/GenericPlot.cpp
+++ b/src/Charts/GenericPlot.cpp
@@ -262,7 +262,7 @@ GenericPlot::configChanged(qint32)
     palette.setBrush(QPalette::Window, QBrush(bgcolor_));
     palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
     palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Base, GCColor::alternateColor(bgcolor_));
+    palette.setColor(QPalette::Base, GCColor::instance()->alternateColor(bgcolor_));
     setPalette(palette);
 
     // chart colors

--- a/src/Charts/GenericSelectTool.cpp
+++ b/src/Charts/GenericSelectTool.cpp
@@ -86,7 +86,7 @@ void GenericSelectTool::paint(QPainter*painter, const QStyleOptionGraphicsItem *
             //
             foreach(SeriesPoint p, hoverpoints) {
                 QPointF pos = mapFromScene(host->qchart->mapToPosition(p.xy,p.series));
-                QColor invert = GCColor::invertColor(GColor(CPLOTBACKGROUND));
+                QColor invert = GInvertColor(CPLOTBACKGROUND);
                 painter->setBrush(invert);
                 painter->setPen(invert);
                 QRectF circle(0,0,gl_linemarker*dpiXFactor*host->scale_,gl_linemarker*dpiYFactor*host->scale_);
@@ -114,7 +114,7 @@ void GenericSelectTool::paint(QPainter*painter, const QStyleOptionGraphicsItem *
                     //
                     if (hoverpoint != GPointF()) {
                         // draw a circle using marker color
-                        QColor invert = GCColor::invertColor(GColor(CPLOTBACKGROUND));
+                        QColor invert = GInvertColor(CPLOTBACKGROUND);
                         painter->setBrush(invert);
                         painter->setPen(invert);
                         QRectF circle(0,0,gl_scattermarker*dpiXFactor*host->scale_,gl_scattermarker*dpiYFactor*host->scale_);

--- a/src/Charts/GoldenCheetah.cpp
+++ b/src/Charts/GoldenCheetah.cpp
@@ -290,7 +290,7 @@ GcWindow::paintEvent(QPaintEvent * /*event*/)
         if (showtitle) {
             // pen color needs to contrast to background color
             QColor bgColor = property("color").value<QColor>();
-            QColor fgColor = GCColor::invertColor(bgColor); // return the contrasting color
+            QColor fgColor = GInvertColor(bgColor); // return the contrasting color
 
             painter.setPen(fgColor);
             painter.drawText(bar, heading, Qt::AlignVCenter | Qt::AlignCenter);
@@ -765,7 +765,7 @@ GcChartWindow::GcChartWindow(Context *context) : GcWindow(context), context(cont
 void
 GcChartWindow::colorChanged(QColor z)
 {
-    QColor fgColor = GCColor::invertColor(z);
+    QColor fgColor = GInvertColor(z);
 
     // so z is color for bg and fgColor is for fg
     QString stylesheet = QString("color: rgb(%1, %2, %3); background-color: rgba(%4, %5, %6, 80%)")

--- a/src/Charts/IntervalSummaryWindow.cpp
+++ b/src/Charts/IntervalSummaryWindow.cpp
@@ -50,7 +50,7 @@ IntervalSummaryWindow::IntervalSummaryWindow(Context *context) : context(context
     connect(context, SIGNAL(intervalHover(IntervalItem*)), this, SLOT(intervalHover(IntervalItem*)));
     connect(context, SIGNAL(configChanged(qint32)), this, SLOT(intervalSelected()));
 
-    setHtml(GCColor::css() + "<body></body>");
+    setHtml(GCColor::instance()->css() + "<body></body>");
 }
 
 IntervalSummaryWindow::~IntervalSummaryWindow() {
@@ -63,14 +63,14 @@ void IntervalSummaryWindow::intervalSelected()
 
     if (rideItem == NULL || rideItem->intervalsSelected().count() == 0 || rideItem->ride() == NULL) {
         // no ride just update the colors
-	    QString html = GCColor::css();
+	    QString html = GCColor::instance()->css();
         html += "<body></body>";
 	    setHtml(html);
 	    return;
     }
 
     // summary is html
-	QString html = GCColor::css();
+	QString html = GCColor::instance()->css();
     html += "<body>";
 
     // summarise all the intervals selected - this is painful!
@@ -84,7 +84,7 @@ void IntervalSummaryWindow::intervalSelected()
     // now add the excluding text
     html += notincluding;
 
-    if (html == GCColor::css()+"<body>") html += "<i>" + tr("select an interval for summary info") + "</i>";
+    if (html == GCColor::instance()->css()+"<body>") html += "<i>" + tr("select an interval for summary info") + "</i>";
 
     html += "</body>";
 	setHtml(html);
@@ -104,7 +104,7 @@ IntervalSummaryWindow::intervalHover(IntervalItem* x)
     RideItem *rideItem = const_cast<RideItem*>(context->currentRideItem());
     if (!x && rideItem && rideItem->intervalsSelected().count()) return;
 
-    QString html = GCColor::css();
+    QString html = GCColor::instance()->css();
     html += "<body>";
 
     if (x == NULL) {

--- a/src/Charts/LTMWindow.cpp
+++ b/src/Charts/LTMWindow.cpp
@@ -513,16 +513,16 @@ LTMWindow::configChanged(qint32)
     palette.setBrush(QPalette::Window, QBrush(GColor(CTRENDPLOTBACKGROUND)));
     palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
     palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CPLOTBACKGROUND)));
+    palette.setColor(QPalette::Base, GCColor::instance()->alternateColor(CPLOTBACKGROUND));
     setPalette(palette);
 
     // inverted palette for data etc
     QPalette whitepalette;
     whitepalette.setBrush(QPalette::Window, QBrush(GColor(CTRENDPLOTBACKGROUND)));
     whitepalette.setBrush(QPalette::Background, QBrush(GColor(CTRENDPLOTBACKGROUND)));
-    whitepalette.setColor(QPalette::WindowText, GCColor::invertColor(GColor(CTRENDPLOTBACKGROUND)));
-    whitepalette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CPLOTBACKGROUND)));
-    whitepalette.setColor(QPalette::Text, GCColor::invertColor(GColor(CTRENDPLOTBACKGROUND)));
+    whitepalette.setColor(QPalette::WindowText, GInvertColor(CTRENDPLOTBACKGROUND));
+    whitepalette.setColor(QPalette::Base, GCColor::instance()->alternateColor(CPLOTBACKGROUND));
+    whitepalette.setColor(QPalette::Text, GInvertColor(CTRENDPLOTBACKGROUND));
 
     QFont font;
     font.setPointSize(12); // reasonably big
@@ -1299,12 +1299,12 @@ LTMWindow::dataTable(bool html)
     QString summary;
 
     QColor bgColor = GColor(CTRENDPLOTBACKGROUND);
-    QColor altColor = GCColor::alternateColor(bgColor);
+    QColor altColor = GCColor::instance()->alternateColor(bgColor);
 
     // html page prettified with a title
     if (html) {
 
-        summary = GCColor::css();
+        summary = GCColor::instance()->css();
         summary += "<center>";
 
         // device summary for ride summary, otherwise how many activities?

--- a/src/Charts/MUWidget.cpp
+++ b/src/Charts/MUWidget.cpp
@@ -158,7 +158,7 @@ MUWidget::configChanged(qint32)
     setPalette(palette);
 
     QColor bgColor = GColor(CPLOTBACKGROUND);
-    QColor fgColor = GCColor::invertColor(bgColor);
+    QColor fgColor = GInvertColor(bgColor);
     QColor border = bgColor;
     border = border.darker(300);
 

--- a/src/Charts/OverviewItems.cpp
+++ b/src/Charts/OverviewItems.cpp
@@ -1965,7 +1965,7 @@ DonutOverviewItem::setDateRange(DateRange dr)
     // now do the colors
     double i=1;
     QColor min=GColor(CPLOTMARKER);
-    QColor max=GCColor::invertColor(GColor(CCARDBACKGROUND));
+    QColor max=GInvertColor(CCARDBACKGROUND);
     bool exploded=false;
     foreach(QPieSlice *slice, add->slices()) {
 
@@ -2732,7 +2732,7 @@ KPIOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *, 
             if (!percenttext.startsWith("nan") && !percenttext.startsWith("inf") && percenttext != "0%") {
 
                 // title color, copied code from chartspace.cpp, should really be a cleaner way to get these
-                if (GCColor::luminance(GColor(CCARDBACKGROUND)) < 127) painter->setPen(QColor(200,200,200));
+                if (GCColor::instance()->luminance(CCARDBACKGROUND) < 127) painter->setPen(QColor(200,200,200));
                 else painter->setPen(QColor(70,70,70));
 
                 painter->setFont(parent->midfont);
@@ -2934,7 +2934,7 @@ DataOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *,
     bold.setBold(true);
 
     // normal just grey, we highlight with plot marker
-    QColor cnormal = (GCColor::luminance(GColor(CCARDBACKGROUND)) < 127) ? QColor(200,200,200) : QColor(70,70,70);
+    QColor cnormal = (GCColor::instance()->luminance(CCARDBACKGROUND) < 127) ? QColor(200,200,200) : QColor(70,70,70);
 
 
     // step 2: where is the mouse hovering, paint a background etc ....
@@ -3403,7 +3403,7 @@ TopNOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *,
     QRectF barrect = QRectF(0,10, width, 30);
 
     // text color
-    QColor cnormal = (GCColor::luminance(GColor(CCARDBACKGROUND)) < 127) ? QColor(200,200,200) : QColor(70,70,70);
+    QColor cnormal = (GCColor::instance()->luminance(CCARDBACKGROUND) < 127) ? QColor(200,200,200) : QColor(70,70,70);
 
     // PAINT
     for (int i=0; i<maxrows && i<ranked.count(); i++) {
@@ -5347,7 +5347,7 @@ Button::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
     painter->setRenderHint(QPainter::Antialiasing);
 
     // button background
-    QColor pc = GCColor::invertColor(GColor(CCARDBACKGROUND));
+    QColor pc = GInvertColor(CCARDBACKGROUND);
     pc.setAlpha(64);
     QPen line(pc,gl_border, Qt::SolidLine);
     line.setJoinStyle(Qt::RoundJoin);
@@ -5363,11 +5363,11 @@ Button::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
 
     // text using large font clipped
     if (isUnderMouse()) {
-        QColor tc = GCColor::invertColor(CPLOTMARKER);
+        QColor tc = GInvertColor(CPLOTMARKER);
         tc.setAlpha(200);
         painter->setPen(tc);
     } else {
-        QColor tc = GCColor::invertColor(GColor(CCARDBACKGROUND));
+        QColor tc = GInvertColor(CCARDBACKGROUND);
         tc.setAlpha(200);
         painter->setPen(tc);
     }

--- a/src/Charts/PythonChart.cpp
+++ b/src/Charts/PythonChart.cpp
@@ -47,7 +47,7 @@ PythonConsole::PythonConsole(Context *context, PythonHost *pythonHost, QWidget *
     setAcceptRichText(false);
     document()->setMaximumBlockCount(512); // lets not get carried away!
     putData(GColor(CPLOTMARKER), QString(tr("Python Console (%1)").arg(python->version)));
-    putData(GCColor::invertColor(GColor(CPLOTBACKGROUND)), "\n>>> ");
+    putData(GInvertColor(CPLOTBACKGROUND), "\n>>> ");
 
     connect(context, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));
     connect(context, SIGNAL(rMessage(QString)), this, SLOT(rMessage(QString)));
@@ -68,7 +68,7 @@ PythonConsole::configChanged(qint32)
     setFont(courier);
     QPalette p = palette();
     p.setColor(QPalette::Base, GColor(CPLOTBACKGROUND));
-    p.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+    p.setColor(QPalette::Text, GInvertColor(CPLOTBACKGROUND));
     setPalette(p);
     setStyleSheet(AbstractView::ourStyleSheet());
 }
@@ -157,7 +157,7 @@ void PythonConsole::keyPressEvent(QKeyEvent *e)
 
                 // new prompt
                 putData("\n");
-                putData(GCColor::invertColor(GColor(CPLOTBACKGROUND)), ">>> ");
+                putData(GInvertColor(CPLOTBACKGROUND), ">>> ");
 
             } else {
                 // normal C just do the usual
@@ -234,7 +234,7 @@ void PythonConsole::keyPressEvent(QKeyEvent *e)
         }
 
         // prompt ">"
-        putData(GCColor::invertColor(GColor(CPLOTBACKGROUND)), ">>> ");
+        putData(GInvertColor(CPLOTBACKGROUND), ">>> ");
     }
     break;
 
@@ -254,7 +254,7 @@ PythonConsole::setCurrentLine(QString p)
 
     select.select(QTextCursor::LineUnderCursor);
     select.removeSelectedText();
-    putData(GCColor::invertColor(GColor(CPLOTBACKGROUND)), ">>> ");
+    putData(GInvertColor(CPLOTBACKGROUND), ">>> ");
     putData(p);
 }
 
@@ -327,7 +327,7 @@ PythonChart::PythonChart(Context *context, bool ridesummary) : GcChartWindow(con
         script->setFont(courier);
         QPalette p = palette();
         p.setColor(QPalette::Base, GColor(CPLOTBACKGROUND));
-        p.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+        p.setColor(QPalette::Text, GInvertColor(CPLOTBACKGROUND));
         script->setPalette(p);
         script->setStyleSheet(AbstractView::ourStyleSheet());
 
@@ -513,7 +513,7 @@ PythonChart::configChanged(qint32)
     palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
     palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
     palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CPLOTBACKGROUND)));
+    palette.setColor(QPalette::Base, GCColor::instance()->alternateColor(CPLOTBACKGROUND));
     setPalette(palette);
 
     // refresh

--- a/src/Charts/RCanvas.cpp
+++ b/src/Charts/RCanvas.cpp
@@ -84,7 +84,7 @@ RCanvas::configChanged(qint32)
     // set background etc to the prevailing defaults
     QPalette p = palette();
     p.setColor(QPalette::Base, GColor(CPLOTBACKGROUND));
-    p.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+    p.setColor(QPalette::Text, GInvertColor(CPLOTBACKGROUND));
     setPalette(p);
     setStyleSheet(AbstractView::ourStyleSheet());
 }

--- a/src/Charts/RChart.cpp
+++ b/src/Charts/RChart.cpp
@@ -37,7 +37,7 @@ RConsole::RConsole(Context *context, RChart *parent)
     setAcceptRichText(false);
     document()->setMaximumBlockCount(512); // lets not get carried away!
     putData(GColor(CPLOTMARKER), QString(tr("R Console (%1)").arg(rtool->version)));
-    putData(GCColor::invertColor(GColor(CPLOTBACKGROUND)), "\n> ");
+    putData(GInvertColor(CPLOTBACKGROUND), "\n> ");
 
     connect(context, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));
     connect(context, SIGNAL(rMessage(QString)), this, SLOT(rMessage(QString)));
@@ -58,7 +58,7 @@ RConsole::configChanged(qint32)
     setFont(courier);
     QPalette p = palette();
     p.setColor(QPalette::Base, GColor(CPLOTBACKGROUND));
-    p.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+    p.setColor(QPalette::Text, GInvertColor(CPLOTBACKGROUND));
     setPalette(p);
     setStyleSheet(AbstractView::ourStyleSheet());
 
@@ -149,7 +149,7 @@ void RConsole::keyPressEvent(QKeyEvent *e)
 
                 // new prompt
                 putData("\n");
-                putData(GCColor::invertColor(GColor(CPLOTBACKGROUND)), "> ");
+                putData(GInvertColor(CPLOTBACKGROUND), "> ");
 
             } else {
                 // normal C just do the usual
@@ -227,9 +227,9 @@ void RConsole::keyPressEvent(QKeyEvent *e)
 
         // prompt ">" for new command and ">>" for a continuation line
         if (rtool->R->program.count()==0)
-            putData(GCColor::invertColor(GColor(CPLOTBACKGROUND)), "> ");
+            putData(GInvertColor(CPLOTBACKGROUND), "> ");
         else
-            putData(GCColor::invertColor(GColor(CPLOTBACKGROUND)), ">>");
+            putData(GInvertColor(CPLOTBACKGROUND), ">>");
     }
     break;
 
@@ -249,7 +249,7 @@ RConsole::setCurrentLine(QString p)
 
     select.select(QTextCursor::LineUnderCursor);
     select.removeSelectedText();
-    putData(GCColor::invertColor(GColor(CPLOTBACKGROUND)), "> ");
+    putData(GInvertColor(CPLOTBACKGROUND), "> ");
     putData(p);
 }
 
@@ -317,7 +317,7 @@ RChart::RChart(Context *context, bool ridesummary) : GcChartWindow(context), con
         script->setFont(courier);
         QPalette p = palette();
         p.setColor(QPalette::Base, GColor(CPLOTBACKGROUND));
-        p.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+        p.setColor(QPalette::Text, GInvertColor(CPLOTBACKGROUND));
         script->setPalette(p);
         script->setStyleSheet(AbstractView::ourStyleSheet());
 
@@ -474,7 +474,7 @@ RChart::configChanged(qint32)
     palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
     palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
     palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CPLOTBACKGROUND)));
+    palette.setColor(QPalette::Base, GCColor::instance()->alternateColor(CPLOTBACKGROUND));
     setPalette(palette);
 
     runScript(); // to update

--- a/src/Charts/RideEditor.cpp
+++ b/src/Charts/RideEditor.cpp
@@ -260,17 +260,17 @@ RideEditor::configChanged(qint32)
     palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
     palette.setBrush(QPalette::Background, QBrush(GColor(CPLOTBACKGROUND)));
     palette.setBrush(QPalette::Base, QBrush(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::WindowText, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::Normal, QPalette::Window, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GInvertColor(CPLOTBACKGROUND));
+    palette.setColor(QPalette::Text, GInvertColor(CPLOTBACKGROUND));
+    palette.setColor(QPalette::Normal, QPalette::Window, GInvertColor(CPLOTBACKGROUND));
     setPalette(palette);
     tabbar->setPalette(palette);
-    QColor faded = GCColor::invertColor(GColor(CPLOTBACKGROUND));
+    QColor faded = GInvertColor(CPLOTBACKGROUND);
     tabbar->setStyleSheet(QString("QTabBar::tab { background-color: %1; border: 0.5px solid %1; color: rgba(%3,%4,%5,50%) }"
                                   "QTabBar::tab:selected { background-color: %1; color: %2; border-bottom: %7px solid %1; border-bottom-color: %6 }"
                                   "QTabBar::close-button:!selected { background-color: %1; }")
                     .arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name())
+                    .arg(GInvertColor(CPLOTBACKGROUND).name())
                     .arg(faded.red()).arg(faded.green()).arg(faded.blue())
                     .arg(GColor(CPLOTMARKER).name())
                     .arg(4 * dpiXFactor));
@@ -279,21 +279,21 @@ RideEditor::configChanged(qint32)
                                  "QTableView QTableCornerButton::section { background-color: %1; color: %2; border: %1 }"
                                  "QHeaderView { background-color: %1; color: %2; border: %1 }")
                     .arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name()));
+                    .arg(GInvertColor(CPLOTBACKGROUND).name()));
     table->horizontalHeader()->setStyleSheet(QString("QHeaderView::section { background-color: %1; color: %2; border: 0px; border-bottom: %3px solid %2; }")
                     .arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name())
+                    .arg(GInvertColor(CPLOTBACKGROUND).name())
                     .arg(2 * dpiYFactor));
     table->verticalHeader()->setStyleSheet(QString("QHeaderView::section { background-color: %1; color: %2; border: 0px }")
                     .arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name()));
+                    .arg(GInvertColor(CPLOTBACKGROUND).name()));
     table->horizontalHeader()->setDefaultAlignment(Qt::AlignLeft | Qt::AlignVCenter);
 #ifndef Q_OS_MAC
     table->verticalScrollBar()->setStyleSheet(AbstractView::ourStyleSheet());
     table->horizontalScrollBar()->setStyleSheet(AbstractView::ourStyleSheet());
 #endif
     toolbar->setStyleSheet(QString("::enabled { background: %1; color: %2; border: 0px; } ").arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name()));
+                    .arg(GInvertColor(CPLOTBACKGROUND).name()));
 
     // the xdata editors
     QMapIterator<QString, XDataEditor *>it(xdataEditors);
@@ -1290,7 +1290,7 @@ void CellDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
 
         painter->save();
         painter->translate(option.rect.x(), option.rect.y());
-        meh->drawContents(painter, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+        meh->drawContents(painter, GInvertColor(CPLOTBACKGROUND));
         painter->restore();
         delete meh;
 
@@ -1644,7 +1644,7 @@ RideEditor::setTabBar(bool force)
         tb->setAutoRaise(true);
         tb->setStyleSheet(QString("QToolButton { background: %1; color: %2; border: 0px; } ")
                           .arg(GColor(CPLOTBACKGROUND).name())
-                          .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name()));
+                          .arg(GInvertColor(CPLOTBACKGROUND).name()));
 
         tabbar->setTabButton(tabbar->count()-1, QTabBar::LeftSide, tb);
         tabbar->setTabButton(tabbar->count()-1, QTabBar::RightSide, 0);
@@ -3051,27 +3051,27 @@ void XDataEditor::configChanged()
     QPalette palette;
     palette.setColor(QPalette::Active, QPalette::Background, GColor(CPLOTBACKGROUND));
     palette.setColor(QPalette::Active, QPalette::Base, GColor(CPLOTBACKGROUND));
-    palette.setColor(QPalette::Active, QPalette::WindowText, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::Active, QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::Active, QPalette::Window, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+    palette.setColor(QPalette::Active, QPalette::WindowText, GInvertColor(CPLOTBACKGROUND));
+    palette.setColor(QPalette::Active, QPalette::Text, GInvertColor(CPLOTBACKGROUND));
+    palette.setColor(QPalette::Active, QPalette::Window, GInvertColor(CPLOTBACKGROUND));
     palette.setColor(QPalette::Inactive, QPalette::Background, GColor(CPLOTBACKGROUND));
     palette.setColor(QPalette::Inactive, QPalette::Base, GColor(CPLOTBACKGROUND));
-    palette.setColor(QPalette::Inactive, QPalette::WindowText, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::Inactive, QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::Inactive, QPalette::Window, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+    palette.setColor(QPalette::Inactive, QPalette::WindowText, GInvertColor(CPLOTBACKGROUND));
+    palette.setColor(QPalette::Inactive, QPalette::Text, GInvertColor(CPLOTBACKGROUND));
+    palette.setColor(QPalette::Inactive, QPalette::Window, GInvertColor(CPLOTBACKGROUND));
     setPalette(palette);
     setFrameStyle(QFrame::NoFrame);
     setStyleSheet(QString("QTableView QTableCornerButton::section { background-color: %1; color: %2; border: %1 }"
                                   "QHeaderView { background-color: %1; color: %2; border: %1 }")
                     .arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name()));
+                    .arg(GInvertColor(CPLOTBACKGROUND).name()));
     horizontalHeader()->setStyleSheet(QString("QHeaderView::section { background-color: %1; color: %2; border: 0px; border-bottom: %3px solid %2; }")
                     .arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name())
+                    .arg(GInvertColor(CPLOTBACKGROUND).name())
                     .arg(2 * dpiYFactor));
     verticalHeader()->setStyleSheet(QString("QHeaderView::section { background-color: %1; color: %2; border: 0px }")
                     .arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name()));
+                    .arg(GInvertColor(CPLOTBACKGROUND).name()));
 #ifndef Q_OS_MAC
     verticalScrollBar()->setStyleSheet(AbstractView::ourStyleSheet());
     horizontalScrollBar()->setStyleSheet(AbstractView::ourStyleSheet());

--- a/src/Charts/RideMapWindow.cpp
+++ b/src/Charts/RideMapWindow.cpp
@@ -415,7 +415,7 @@ void RideMapWindow::createHtml()
 
     // No GPS data, so sorry no map
     QColor bgColor = GColor(CPLOTBACKGROUND);
-    QColor fgColor = GCColor::invertColor(bgColor);
+    QColor fgColor = GInvertColor(bgColor);
     if(!ride || !ride->ride() || ride->ride()->areDataPresent()->lat == false || ride->ride()->areDataPresent()->lon == false) {
         currentPage = QString("<STYLE>BODY { background-color: %1; color: %2 }</STYLE><center>%3</center>").arg(bgColor.name()).arg(fgColor.name()).arg(tr("No GPS Data Present"));
         setIsBlank(true);

--- a/src/Charts/UserChart.cpp
+++ b/src/Charts/UserChart.cpp
@@ -90,7 +90,7 @@ UserChart::configChanged(qint32)
     palette.setBrush(QPalette::Background, RGBColor(chartinfo.bgcolor));
     palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
     palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Base, RGBColor(chartinfo.bgcolor) /*GCColor::alternateColor(bgcolor)*/);
+    palette.setColor(QPalette::Base, RGBColor(chartinfo.bgcolor) /*GCColor::instance()->alternateColor(bgcolor)*/);
     setPalette(palette);
 
     setAutoFillBackground(true);
@@ -288,7 +288,7 @@ UserChart::refresh()
             }
             series.colors.clear();
             QColor min=QColor(series.color);
-            QColor max=GCColor::invertColor(GColor(CPLOTBACKGROUND));
+            QColor max=GInvertColor(CPLOTBACKGROUND);
             for(int i=0; i<series.labels.count(); i++) {
                 QColor color = QColor(min.red() + (double(max.red()-min.red()) * (i/double(series.labels.count()))),
                               min.green() + (double(max.green()-min.green()) * (i/double(series.labels.count()))),

--- a/src/Cloud/CloudService.cpp
+++ b/src/Cloud/CloudService.cpp
@@ -2035,7 +2035,7 @@ CloudServiceAutoDownloadWidget::paintEvent(QPaintEvent*)
     QFont font;
     QFontMetrics fm(font);
     painter.setFont(font);
-    painter.setPen(GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+    painter.setPen(GInvertColor(CPLOTBACKGROUND));
     QRectF textbox = QRectF(0,0, fm.width(statusstring), height() / 2.0f);
     painter.drawText(textbox, Qt::AlignVCenter | Qt::AlignCenter, statusstring);
 

--- a/src/Core/DataFilter.cpp
+++ b/src/Core/DataFilter.cpp
@@ -5093,7 +5093,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, const Result &x, long it, R
                         // apply item color, remembering that 1,1,1 means use default (reverse in this case)
                         if (ii->color == QColor(1,1,1,1)) {
                             // use the inverted color, not plot marker as that hideous
-                            QColor col =GCColor::invertColor(GColor(CPLOTBACKGROUND));
+                            QColor col =GInvertColor(CPLOTBACKGROUND);
                             // white is jarring on a dark background!
                             if (col==QColor(Qt::white)) col=QColor(127,127,127);
                             asstring = col.name();

--- a/src/Core/GcCalendarModel.h
+++ b/src/Core/GcCalendarModel.h
@@ -485,7 +485,7 @@ class GcCalendarDelegate : public QItemDelegate
         // date...
         QString datestring = index.data(GcCalendarModel::DateStringRole).toString();
         QTextOption textOption(Qt::AlignRight);
-        painter->setPen(GCColor::invertColor(hg));
+        painter->setPen(GInvertColor(hg));
         painter->drawText(hd, datestring, textOption);
 
         // text

--- a/src/Core/GcUpgrade.cpp
+++ b/src/Core/GcUpgrade.cpp
@@ -202,7 +202,7 @@ GcUpgrade::upgrade(const QDir &home)
         if (charts.exists()) charts.remove();
 
         // 3. Reset colour defaults **
-        GCColor::applyTheme(0); // set to default theme
+        GCColor::instance()->applyTheme(0); // set to default theme
 
         // 4. Theme and Chrome Color
         QString theme = "Flat";
@@ -223,7 +223,7 @@ GcUpgrade::upgrade(const QDir &home)
                                                  .arg(chromeColor.green())
                                                  .arg(chromeColor.blue());
         appsettings->setValue("CCHROME", colorstring);
-        GCColor::setColor(CCHROME, chromeColor);
+        GCColor::instance()->setColor(CCHROME, chromeColor);
 
         // 5. Metrics and Notes keywords
         QString filename = home.canonicalPath()+"/metadata.xml";
@@ -392,8 +392,8 @@ GcUpgrade::upgrade(const QDir &home)
         }
 
         // reset themes on basis of plot background (first 2 themes are default dark and light themes
-        if (GCColor::luminance(GColor(CPLOTBACKGROUND)) < 127)  GCColor::applyTheme(0);
-        else GCColor::applyTheme(1);
+        if (GCColor::instance()->luminance(GColor(CPLOTBACKGROUND)) < 127)  GCColor::instance()->applyTheme(0);
+        else GCColor::instance()->applyTheme(1);
 
     }
 
@@ -591,8 +591,8 @@ GcUpgrade::upgrade(const QDir &home)
 
         // trend plot matches ride plot, as newly introduced
         // just do for first time we run 3.2 and set to ride plot
-        QColor color = GCColor::getColor(CRIDEPLOTBACKGROUND);
-        GCColor::setColor(CTRENDPLOTBACKGROUND, color);
+        QColor color = GCColor::instance()->getColor(CRIDEPLOTBACKGROUND);
+        GCColor::instance()->setColor(CTRENDPLOTBACKGROUND, color);
 
         // and update config
         QString colorstring = QString("%1:%2:%3").arg(color.red())

--- a/src/Core/RideItem.cpp
+++ b/src/Core/RideItem.cpp
@@ -328,7 +328,7 @@ IntervalItem *
 RideItem::newInterval(QString name, double start, double stop, double startKM, double stopKM, QColor color, bool test)
 {
     // add a new interval to the end of the list
-    color = color == Qt::black ? standardColor(intervals(RideFileInterval::USER).count()) : color;
+    color = color == Qt::black ? GCColor::instance()->standardColor(intervals(RideFileInterval::USER).count()) : color;
 
     IntervalItem *add = new IntervalItem(this, name, start, stop, startKM, stopKM, 1,
                                          color, test, RideFileInterval::USER);
@@ -937,7 +937,7 @@ RideItem::updateIntervals()
                                                       f->timeToDistance(interval->start),
                                                       f->timeToDistance(interval->stop),
                                                       seq,
-                                                      (interval->color == Qt::black) ? standardColor(count) : interval->color,
+                                                      (interval->color == Qt::black) ? GCColor::instance()->standardColor(count) : interval->color,
                                                       interval->test,
                                                       RideFileInterval::USER);
 

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -550,7 +550,7 @@ GSettings::upgradeSystem() {
     //DEPRECATED IN V3.5 migrateValue(GC_FONT_CHARTMARKERS_SIZE);
     //DEPRECATED IN V3.5 migrateValue(GC_FONT_CALENDAR_SIZE);
 
-    QStringList colorProperties = GCColor::getConfigKeys();
+    QStringList colorProperties = GCColor::instance()->getConfigKeys();
     QStringListIterator colorIterator(colorProperties);
     while (colorIterator.hasNext()) {
         QString key = QString(colorIterator.next().data());

--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -634,11 +634,11 @@ main(int argc, char *argv[])
         application->installTranslator(&gcTranslator);
 
         // Now the translator is installed, set default colors with translated names
-        GCColor::setupColors();
+        GCColor::instance()->setupColors();
 
         // migration
         appsettings->migrateQSettingsSystem(); // colors must be setup before migration can take place, but reading has to be from the migrated ones
-        GCColor::readConfig();
+        GCColor::instance()->readConfig();
 
         // Initialize metrics once the translator is installed
         RideMetricFactory::instance().initialize();

--- a/src/FileIO/FixPyScriptsDialog.cpp
+++ b/src/FileIO/FixPyScriptsDialog.cpp
@@ -138,7 +138,7 @@ EditFixPyScriptDialog::EditFixPyScriptDialog(Context *context, FixPyScript *fix,
     script->setFont(courier);
     QPalette p = palette();
     p.setColor(QPalette::Base, GColor(CPLOTBACKGROUND));
-    p.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+    p.setColor(QPalette::Text, GInvertColor(CPLOTBACKGROUND));
     script->setPalette(p);
     script->setStyleSheet(AbstractView::ourStyleSheet());
     scriptLayout->addWidget(script);

--- a/src/Gui/AbstractView.cpp
+++ b/src/Gui/AbstractView.cpp
@@ -240,7 +240,7 @@ AbstractView::ourStyleSheet()
            "QTreeView::item:hover { color: black; background: lightGray; }"
            "").arg(GColor(CPLOTBACKGROUND).name())
             .arg(GColor(CPLOTGRID).name())
-            .arg(GCColor::alternateColor(GColor(CPLOTBACKGROUND)).name())
+            .arg(GCColor::instance()->alternateColor(CPLOTBACKGROUND).name())
             .arg(8 * dpiXFactor) // width
             .arg(4 * dpiXFactor) // border radius
             .arg(GColor(CPLOTMARKER).name())

--- a/src/Gui/AnalysisSidebar.cpp
+++ b/src/Gui/AnalysisSidebar.cpp
@@ -321,18 +321,18 @@ AnalysisSidebar::close()
 void
 AnalysisSidebar::configChanged(qint32)
 {
-    //calendarWidget->setPalette(GCColor::palette());
-    //intervalSummaryWindow->setPalette(GCColor::palette());
-    //intervalSummaryWindow->setStyleSheet(GCColor::stylesheet());
+    //calendarWidget->setPalette(GCColor::instance()->palette());
+    //intervalSummaryWindow->setPalette(GCColor::instance()->palette());
+    //intervalSummaryWindow->setStyleSheet(GCColor::instance()->stylesheet());
 
-    splitter->setPalette(GCColor::palette());
+    splitter->setPalette(GCColor::instance()->palette());
     activityHistory->setStyleSheet(QString("background: %1;").arg(GColor(CPLOTBACKGROUND).name()));
-    rideNavigator->tableView->viewport()->setPalette(GCColor::palette());
+    rideNavigator->tableView->viewport()->setPalette(GCColor::instance()->palette());
     rideNavigator->tableView->viewport()->setStyleSheet(QString("background: %1;").arg(GColor(CPLOTBACKGROUND).name()));
 
     // interval tree
-    intervalTree->setPalette(GCColor::palette());
-    intervalTree->setStyleSheet(GCColor::stylesheet());
+    intervalTree->setPalette(GCColor::instance()->palette());
+    intervalTree->setStyleSheet(GCColor::instance()->stylesheet());
     QMapIterator<RideFileInterval::intervaltype, QTreeWidgetItem*> i(trees);
     i.toFront();
     while(i.hasNext()) {

--- a/src/Gui/ChartSpace.cpp
+++ b/src/Gui/ChartSpace.cpp
@@ -319,7 +319,7 @@ ChartSpaceItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *opt, QW
     //XXXpainter->drawLine(QLineF(0,ROWHEIGHT*2,geometry().width(),ROWHEIGHT*2));
     //painter->fillRect(QRectF(0,0,geometry().width()+1,geometry().height()+1), brush);
     //titlefont.setWeight(QFont::Bold);
-    if (GCColor::luminance(RGBColor(color())) < 127) painter->setPen(QColor(200,200,200));
+    if (GCColor::instance()->luminance(RGBColor(color())) < 127) painter->setPen(QColor(200,200,200));
     else painter->setPen(QColor(70,70,70));
 
     painter->setFont(parent->titlefont);
@@ -650,7 +650,7 @@ ChartSpace::configChanged(qint32 why)
     if (GColor(COVERVIEWBACKGROUND) != Qt::white)
 #endif
     {
-        //palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CTRAINPLOTBACKGROUND)));
+        //palette.setColor(QPalette::Base, GCColor::instance()->alternateColor(CTRAINPLOTBACKGROUND));
         palette.setColor(QPalette::Base, GColor(COVERVIEWBACKGROUND));
         palette.setColor(QPalette::Window, GColor(COVERVIEWBACKGROUND));
     }
@@ -659,8 +659,8 @@ ChartSpace::configChanged(qint32 why)
     //code->setStyleSheet(TabView::ourStyleSheet());
 #endif
 
-    palette.setColor(QPalette::WindowText, GCColor::invertColor(GColor(COVERVIEWBACKGROUND)));
-    palette.setColor(QPalette::Text, GCColor::invertColor(GColor(COVERVIEWBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GInvertColor(COVERVIEWBACKGROUND));
+    palette.setColor(QPalette::Text, GInvertColor(COVERVIEWBACKGROUND));
     //code->setPalette(palette);
 
     foreach(ChartSpaceItem *item, items) item->configChanged(why);

--- a/src/Gui/ColorButton.cpp
+++ b/src/Gui/ColorButton.cpp
@@ -126,7 +126,7 @@ GColorDialog::GColorDialog(QColor selected, QWidget *parent, bool all) : QDialog
     connect(mapper, SIGNAL(mappedInt(int)), this, SLOT(gcClicked(int)));
 
     // now add all the colours to select
-    colorSet = GCColor::colorSet();
+    colorSet = GCColor::instance()->colorSet();
     for (int i=0; colorSet[i].name != ""; i++) {
 
         if (!all && colorSet[i].group != tr("Data")) continue;

--- a/src/Gui/Colors.h
+++ b/src/Gui/Colors.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010 Mark Liversedge (liversedge@gmail.com)
+ * GCColor & Themes Singletons - Copyright (c) 2022 Paul Johnson (paul49457@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -27,167 +28,7 @@
 #include <QGradient>
 #include <QLinearGradient>
 
-
-// A selection of distinct colours, user can adjust also
-extern QList<QColor> standardColors;
-extern QIcon colouredIconFromPNG(QString filename, QColor color);
-extern QPixmap colouredPixmapFromPNG(QString filename, QColor color);
-
-// dialog scaling
-extern double dpiXFactor, dpiYFactor;
-extern QFont baseFont;
-
-// turn color to rgb, checks if a named color
-#define StandardColor(x) (QColor(1,1,x))
-#define NamedColor(x) (x.red()==1 && x.green()==1)
-#define RGBColor(x) (NamedColor(x) ? GColor(x.blue()) : x)
-
-// get the pixel size for a font that is no taller
-// than height in pixels (let QT adapt for device ratios)
-int pixelSizeForFont(QFont &font, int height);
-
-class Context;
-
-// set appearace defaults based upon screen size
-struct SizeSettings {
-
-    // this applies up to the following geometry
-    int maxheight,
-        maxwidth;
-
-    // font size
-    int defaultFont,
-        titleFont,
-        markerFont,
-        labelFont,
-        calendarFont;
-
-    // screen dimension
-    int width,
-        height;
-};
-
-extern SizeSettings defaultAppearance[];
-extern float GCDPIScale; // font scaling for display
-extern QColor standardColor(int num);
-
-class Colors
-{
-public:
-        static unsigned long fingerprint(const Colors*set);
-        QString group,
-                name,
-                setting;
-        QColor  color;
-};
-
-class ColorTheme
-{
-    public:
-        ColorTheme(QString name, bool dark, QList<QColor>colors) : name(name), dark(dark), colors(colors) {}
-
-        // all public
-        QString name;
-        bool dark;
-        bool stealth;
-        QList<QColor> colors;
-};
-
-class Themes
-{
-
-    Q_DECLARE_TR_FUNCTIONS(Themes);
-
-    public:
-        Themes(); // will init the array of themes
-
-        QList<ColorTheme> themes;
-};
-
-class ColorLabel : public QLabel
-{
-    Q_OBJECT
-
-    public:
-        ColorLabel(ColorTheme theme) : theme(theme) {}
-
-        void paintEvent(QPaintEvent *);
-
-        ColorTheme theme;
-};
-
-class GCColor : public QObject
-{
-    Q_OBJECT
-
-    public:
-        static QColor getColor(int);
-        static void setColor(int,QColor);
-        static const Colors *colorSet();
-        static const Colors *defaultColorSet(bool dark);
-        static void resetColors();
-        static struct SizeSettings defaultSizes(int width, int height);
-        static double luminance(QColor color); // return the relative luminance
-        static QColor invertColor(QColor); // return the contrasting color
-        static QColor alternateColor(QColor); // return the alternate background
-        static QColor htmlCode(QColor x) { return x.name(); } // return the alternate background
-        static Themes &themes(); 
-        static void applyTheme(int index);
-
-        // for styling things with current preferences
-        static bool isFlat();
-        static QLinearGradient linearGradient(int size, bool active, bool alternate=false);
-        static QString css(bool ridesummary=true);
-        static QPalette palette();
-        static QString stylesheet(bool train=false);
-        static void readConfig();
-        static void setupColors();
-        static void dumpColors();
-
-        // for upgrade/migration of Config
-        static QStringList getConfigKeys();
-
-};
-
-// color chooser that also supports the standard colors (CPLOTMARKER, CPOWER)
-// and returns them as a QColor(1,1,1,<int>) where <int> is the color number
-// .e.g CPOWER is 18, see below for full list
-#if 0
-class GColorDialog : public QDialog
-{
-    GColorDialog(QWidget *parent);
-
-};
-#endif
-
-// return a color for a ride file
-class GlobalContext;
-class ColorEngine : public QObject
-{
-    Q_OBJECT
-    G_OBJECT
-
-    public:
-        ColorEngine(GlobalContext *);
-
-        QColor colorFor(QString);
-        QColor defaultColor, reverseColor;
-
-    public slots:
-        void configChanged(qint32);
-
-    private:
-        QMap<QString, QColor> workoutCodes;
-        GlobalContext *gc; // bootstrapping
-};
-
-
-// shorthand
-#define GColor(x) GCColor::getColor(x)
-
-// Define how many cconfigurable metric colors are available
-#define CNUMOFCFGCOLORS       110
-
+ // Define how many configurable metric colors are available
 #define CPLOTBACKGROUND       0
 #define CRIDEPLOTBACKGROUND   1
 #define CTRENDPLOTBACKGROUND  2
@@ -298,4 +139,182 @@ class ColorEngine : public QObject
 #define CCARDBACKGROUND3      107
 #define MAPROUTELINE          108
 #define COLORRR               109
+#define CNUMOFCFGCOLORS       110
+
+// The color returned when color functions are accessed with an out of range value
+#define OUTOFRANGECOLOR       CINTERVALHIGHLIGHTER
+
+// A selection of distinct colours, user can adjust also
+extern QIcon colouredIconFromPNG(QString filename, QColor color);
+extern QPixmap colouredPixmapFromPNG(QString filename, QColor color);
+
+// dialog scaling
+extern double dpiXFactor, dpiYFactor;
+extern QFont baseFont;
+
+// turn color to rgb, checks if a named color
+#define StandardColor(x) (QColor(1,1,x))
+#define NamedColor(x) (x.red()==1 && x.green()==1)
+#define RGBColor(x) (NamedColor(x) ? GColor(x.blue()) : x)
+
+// get the pixel size for a font that is no taller
+// than height in pixels (let QT adapt for device ratios)
+int pixelSizeForFont(QFont &font, int height);
+
+class Context;
+
+// set appearace defaults based upon screen size
+struct SizeSettings {
+
+    // this applies up to the following geometry
+    int maxheight,
+        maxwidth;
+
+    // font size
+    int defaultFont,
+        titleFont,
+        markerFont,
+        labelFont,
+        calendarFont;
+
+    // screen dimension
+    int width,
+        height;
+};
+
+class Colors
+{
+public:
+        static unsigned long fingerprint(const Colors*set);
+        QString group,
+                name,
+                setting;
+        QColor  color;
+};
+
+class ColorTheme
+{
+    public:
+        ColorTheme(QString name, bool dark, QList<QColor>colors) : name(name), dark(dark), colors(colors) {}
+
+        // all public
+        QString name;
+        bool dark;
+        bool stealth;
+        QList<QColor> colors;
+};
+
+class Themes
+{
+    Q_DECLARE_TR_FUNCTIONS(Themes);
+
+    public:
+
+        QList<ColorTheme> themes;
+
+        static Themes* instance() {
+            static Themes* s{ new Themes };
+            return s;
+        }
+
+    private:
+        Themes();
+ };
+
+class ColorLabel : public QLabel
+{
+    Q_OBJECT
+
+    public:
+        ColorLabel(ColorTheme theme) : theme(theme) {}
+
+        void paintEvent(QPaintEvent *);
+
+        ColorTheme theme;
+};
+
+class GCColor : public QObject
+{
+    Q_OBJECT
+
+    public:
+
+        GCColor(GCColor const&) = delete;
+        GCColor& operator=(GCColor const&) = delete;
+
+        static GCColor* instance() {
+            static GCColor* s{ new GCColor };
+            return s;
+        }
+
+        QColor getColor(int);
+        bool setColor(int, QColor);
+        void resetColors();
+        const Colors* colorSet();
+        const Colors* defaultColorSet(bool dark);
+        struct SizeSettings defaultSizes(int width, int height);
+        double luminance(int); // return the relative luminance
+        double luminance(QColor); // return the relative luminance
+        QColor invertColor(int); // return the contrasting color
+        QColor invertColor(QColor); // return the contrasting color
+        QColor alternateColor(int); // return the alternate background
+        QColor alternateColor(QColor); // return the alternate background
+        QColor htmlCode(QColor x) { return x.name(); } // return the alternate background
+        void applyTheme(int index);
+
+
+        // for styling things with current preferences
+        bool isFlat();
+        QLinearGradient linearGradient(int size, bool active, bool alternate = false);
+        QString css(bool ridesummary = true);
+        QPalette palette();
+        QString stylesheet(bool train = false);
+        QColor standardColor(int num);
+        void readConfig();
+        void setupColors();
+        void dumpColors();
+
+        // for upgrade/migration of Config
+        QStringList getConfigKeys();
+
+    private:
+        GCColor();
+
+        void copyArray(Colors source[], Colors target[]);
+
+        // Number of configurable metric colors + 1 for sentinel value
+        Colors ColorList[CNUMOFCFGCOLORS + 1];
+        Colors LightDefaultColorList[CNUMOFCFGCOLORS + 1];
+        Colors DarkDefaultColorList[CNUMOFCFGCOLORS + 1];
+
+        QList<QColor> standardColors;
+        QList<struct SizeSettings> defaultAppearance;
+
+};
+
+// return a color for a ride file
+class GlobalContext;
+class ColorEngine : public QObject
+{
+    Q_OBJECT
+    G_OBJECT
+
+    public:
+        ColorEngine(GlobalContext *);
+
+        QColor colorFor(QString);
+        QColor defaultColor, reverseColor;
+
+    public slots:
+        void configChanged(qint32);
+
+    private:
+        QMap<QString, QColor> workoutCodes;
+        GlobalContext *gc; // bootstrapping
+};
+
+// shorthand macros due to number of instances
+#define GColor(x) GCColor::instance()->getColor(x)              // 869 instances
+#define GInvertColor(x) GCColor::instance()->invertColor(x)     // 124 instances
+
 #endif

--- a/src/Gui/ComparePane.cpp
+++ b/src/Gui/ComparePane.cpp
@@ -38,11 +38,6 @@
 #include <QTextEdit>
 
 
-QColor standardColor(int num)
-{
-   return standardColors.at(num % standardColors.count());
-}
-
 // we need to fix the sort order! (fixed for time fields)
 class CTableWidgetItem : public QTableWidgetItem
 {
@@ -161,7 +156,7 @@ void
 ComparePane::configChanged(qint32)
 {
     // via standard style sheet
-    table->setStyleSheet(GCColor::stylesheet());
+    table->setStyleSheet(GCColor::instance()->stylesheet());
 
     // refresh table...
     refreshTable();
@@ -780,7 +775,7 @@ ComparePane::dropEvent(QDropEvent *event)
             // just use standard colors and cycle round
             // we will of course repeat, but the user can
             // just edit them using the button
-            add.color = standardColors.at((i + context->compareIntervals.count()) % standardColors.count());
+            add.color = GCColor::instance()->standardColor(i + context->compareIntervals.count());
 
             // construct a fake RideItem, slightly hacky need to fix this later XXX fixme
             //                            mostly cut and paste from RideItem::refresh
@@ -962,7 +957,7 @@ ComparePane::dropEvent(QDropEvent *event)
                             // just use standard colors and cycle round
                             // we will of course repeat, but the user can
                             // just edit them using the button
-                            add.color = standardColors.at((newOnes.count()) % standardColors.count());
+                            add.color = GCColor::instance()->standardColor(newOnes.count());
 
                             // now add but only if not empty
                             if (!add.data->dataPoints().empty()) newOnes << add;
@@ -1015,7 +1010,7 @@ ComparePane::dropEvent(QDropEvent *event)
             // just use standard colors and cycle round
             // we will of course repeat, but the user can
             // just edit them using the button
-            add.color = standardColors.at((i + context->compareDateRanges.count()) % standardColors.count());
+            add.color = GCColor::instance()->standardColor(i + context->compareDateRanges.count());
 
             // even empty date ranges are valid
             newOnes << add;

--- a/src/Gui/DiarySidebar.cpp
+++ b/src/Gui/DiarySidebar.cpp
@@ -157,7 +157,7 @@ GcLabel::paintEvent(QPaintEvent *)
     if (text() != "<" && text() != ">") {
         painter.setFont(this->font());
 
-        if (!GCColor::isFlat() && (xoff || yoff)) {
+        if (!GCColor::instance()->isFlat() && (xoff || yoff)) {
 
             // draw text in white behind...
             QRectF off(xoff,yoff,width(),height());
@@ -168,9 +168,9 @@ GcLabel::paintEvent(QPaintEvent *)
         if (filtered && !selected && !underMouse()) painter.setPen(GColor(CCALCURRENT));
         else {
 
-            if (isChrome && GCColor::isFlat()) {
+            if (isChrome && GCColor::instance()->isFlat()) {
 
-                if (GCColor::luminance(GColor(CCHROME)) < 127)
+                if (GCColor::instance()->luminance(GColor(CCHROME)) < 127)
                     painter.setPen(QColor(Qt::white));
                 else
                     painter.setPen(QColor(30,30,30,200));
@@ -388,7 +388,7 @@ void
 GcMiniCalendar::configChanged(qint32)
 {
     QColor bgColor = GColor(CPLOTBACKGROUND);
-    QColor fgColor = GCColor::invertColor(bgColor);
+    QColor fgColor = GInvertColor(bgColor);
     //XXX setStyleSheet(QString("color: %1; background: %2;").arg(fgColor.name()).arg(bgColor.name())); // clear any shit left behind from parents (Larkin ?)
     tint.setColor(QPalette::Window, bgColor);
     tint.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
@@ -706,7 +706,7 @@ void
 GcMultiCalendar::configChanged(qint32)
 {
     QColor bgColor = GColor(CPLOTBACKGROUND);
-    QColor fgColor = GCColor::invertColor(bgColor);
+    QColor fgColor = GInvertColor(bgColor);
 
     QPalette pal;
     pal.setColor(QPalette::Window, bgColor);

--- a/src/Gui/GProgressDialog.cpp
+++ b/src/Gui/GProgressDialog.cpp
@@ -64,7 +64,7 @@ void GProgressDialog::paintEvent(QPaintEvent *)
     translucentGray.setAlpha(240);
     QColor translucentWhite = GColor(CPLOTBACKGROUND);
     translucentWhite.setAlpha(240);
-    QColor black = GCColor::invertColor(translucentWhite);
+    QColor black = GInvertColor(translucentWhite);
 
     // setup a painter and the area to paint
     QPainter painter(this);
@@ -84,7 +84,7 @@ void GProgressDialog::paintEvent(QPaintEvent *)
 
     // heading background and text
     QRectF titlebox(0,0,width(),25);
-    QLinearGradient active = GCColor::linearGradient(25, true, false);
+    QLinearGradient active = GCColor::instance()->linearGradient(25, true, false);
     painter.fillRect(titlebox, QBrush(Qt::white));
     painter.fillRect(titlebox, active);
 

--- a/src/Gui/GcSideBarItem.cpp
+++ b/src/Gui/GcSideBarItem.cpp
@@ -374,12 +374,12 @@ GcSplitterHandle::paintBackground(QPaintEvent *)
     painter.setPen(Qt::NoPen);
     painter.fillRect(all, QColor(Qt::white));
 
-    QLinearGradient active = GCColor::linearGradient(height(), true, !metal);
-    QLinearGradient inactive = GCColor::linearGradient(height(), false, !metal);
+    QLinearGradient active = GCColor::instance()->linearGradient(height(), true, !metal);
+    QLinearGradient inactive = GCColor::instance()->linearGradient(height(), false, !metal);
 
     painter.fillRect(all, isActiveWindow() ? active : inactive);
 
-    if (!GCColor::isFlat()) {
+    if (!GCColor::instance()->isFlat()) {
         QPen black(QColor(100,100,100,200));
         painter.setPen(black);
         painter.drawLine(0,height()-1, width()-1, height()-1);
@@ -426,14 +426,14 @@ GcSplitterControl::paintBackground(QPaintEvent *)
     // setup a painter and the area to paint
     QPainter painter(this);
 
-    QLinearGradient active = GCColor::linearGradient(22 *dpiYFactor, true);
-    QLinearGradient inactive = GCColor::linearGradient(22 *dpiYFactor, false);
+    QLinearGradient active = GCColor::instance()->linearGradient(22 *dpiYFactor, true);
+    QLinearGradient inactive = GCColor::instance()->linearGradient(22 *dpiYFactor, false);
 
     // fill with a linear gradient
     painter.setPen(Qt::NoPen);
     painter.fillRect(all, isActiveWindow() ? active : inactive);
 
-    if (!GCColor::isFlat()) {
+    if (!GCColor::instance()->isFlat()) {
         QPen gray(QColor(230,230,230));
         painter.setPen(gray);
         painter.drawLine(0,0, width()-1, 0);

--- a/src/Gui/GcToolBar.cpp
+++ b/src/Gui/GcToolBar.cpp
@@ -60,7 +60,7 @@ GcToolBar::paintBackground(QPaintEvent *)
     painter.setPen(Qt::NoPen);
     painter.fillRect(all, GColor(CTOOLBAR));
 
-    if (!GCColor::isFlat()) {
+    if (!GCColor::instance()->isFlat()) {
         // paint the bottom lines
         QPen black(QColor(100,100,100));
         painter.setPen(black);

--- a/src/Gui/LTMSidebar.cpp
+++ b/src/Gui/LTMSidebar.cpp
@@ -301,10 +301,10 @@ LTMSidebar::presetSelectionChanged()
 void
 LTMSidebar::configChanged(qint32)
 {
-    seasonsWidget->setStyleSheet(GCColor::stylesheet());
-    eventsWidget->setStyleSheet(GCColor::stylesheet());
-    chartsWidget->setStyleSheet(GCColor::stylesheet());
-    filtersWidget->setStyleSheet(GCColor::stylesheet());
+    seasonsWidget->setStyleSheet(GCColor::instance()->stylesheet());
+    eventsWidget->setStyleSheet(GCColor::instance()->stylesheet());
+    chartsWidget->setStyleSheet(GCColor::instance()->stylesheet());
+    filtersWidget->setStyleSheet(GCColor::instance()->stylesheet());
     setAutoFilterMenu();
 
     // set or reset the autofilter widgets

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -191,7 +191,7 @@ MainWindow::MainWindow(const QDir &home)
          // first run -- lets set some sensible defaults...
          // lets put it in the middle of screen 1
         QRect screenSize = desktop->availableGeometry();
-         struct SizeSettings app = GCColor::defaultSizes(screenSize.height(), screenSize.width());
+         struct SizeSettings app = GCColor::instance()->defaultSizes(screenSize.height(), screenSize.width());
 
          // center on the available screen (minus toolbar/sidebar)
          move((screenSize.width()-screenSize.x())/2 - app.width/2,
@@ -460,7 +460,7 @@ MainWindow::MainWindow(const QDir &home)
      * Application Menus
      *--------------------------------------------------------------------*/
 #ifdef WIN32
-    QString menuColorString = (GCColor::isFlat() ? GColor(CTOOLBAR).name() : "rgba(225,225,225)");
+    QString menuColorString = (GCColor::instance()->isFlat() ? GColor(CTOOLBAR).name() : "rgba(225,225,225)");
     menuBar()->setStyleSheet(QString("QMenuBar { color: black; background: %1; }"
                              "QMenuBar::item { color: black; background: %1; }").arg(menuColorString));
     menuBar()->setContentsMargins(0,0,0,0);
@@ -2504,21 +2504,21 @@ MainWindow::configChanged(qint32)
 {
     // Windows and Linux menu bar should match chrome
     QColor textCol(Qt::black);
-    if (GCColor::luminance(GColor(CTOOLBAR)) < 127)  textCol = QColor(Qt::white);
-    QString menuColorString = (GCColor::isFlat() ? GColor(CTOOLBAR).name() : "rgba(225,225,225)");
+    if (GCColor::instance()->luminance(GColor(CTOOLBAR)) < 127)  textCol = QColor(Qt::white);
+    QString menuColorString = (GCColor::instance()->isFlat() ? GColor(CTOOLBAR).name() : "rgba(225,225,225)");
     menuBar()->setStyleSheet(QString("QMenuBar { color: %1; background: %2; }"
                              "QMenuBar::item { color: %1; background: %2; }")
                              .arg(textCol.name()).arg(menuColorString));
     // search filter box match chrome color
-    searchBox->setStyleSheet(QString("QLineEdit { background: %1; color: %2; }").arg(GColor(CTOOLBAR).name()).arg(GCColor::invertColor(GColor(CTOOLBAR)).name()));
+    searchBox->setStyleSheet(QString("QLineEdit { background: %1; color: %2; }").arg(GColor(CTOOLBAR).name()).arg(GInvertColor(CTOOLBAR).name()));
 
     // perspective selector mimics sidebar colors
     QColor selected;
-    if (GCColor::invertColor(GColor(CTOOLBAR)).name() == Qt::white) selected = QColor(Qt::lightGray);
+    if (GInvertColor(CTOOLBAR).name() == Qt::white) selected = QColor(Qt::lightGray);
     else selected = QColor(Qt::darkGray);
     perspectiveSelector->setStyleSheet(QString("QComboBox { background: %1; color: %2; }"
                                                "QComboBox::item { background: %1; color: %2; }"
-                                               "QComboBox::item::selected { background: %3; color: %1; }").arg(GColor(CTOOLBAR).name()).arg(GCColor::invertColor(GColor(CTOOLBAR)).name()).arg(selected.name()));
+                                               "QComboBox::item::selected { background: %3; color: %1; }").arg(GColor(CTOOLBAR).name()).arg(GInvertColor(CTOOLBAR).name()).arg(selected.name()));
 
     QString buttonstyle = QString("QPushButton { border: none; border-radius: %2px; background-color: %1; "
                                                 "padding-left: 0px; padding-right: 0px; "
@@ -2541,7 +2541,7 @@ MainWindow::configChanged(qint32)
     tabbar->setDrawBase(false);
 
     tabbarPalette.setBrush(backgroundRole(), GColor(CTOOLBAR));
-    tabbarPalette.setBrush(foregroundRole(), GCColor::invertColor(GColor(CTOOLBAR)));
+    tabbarPalette.setBrush(foregroundRole(), GInvertColor(CTOOLBAR));
     tabbar->setPalette(tabbarPalette);
     athleteView->setPalette(tabbarPalette);
 

--- a/src/Gui/NewSideBar.cpp
+++ b/src/Gui/NewSideBar.cpp
@@ -223,7 +223,7 @@ NewSideBarItem::configChanged(qint32)
     setStyleSheet(style);
 
     // set foreground colors
-    fg_normal = GCColor::invertColor(GColor(CCHROME));
+    fg_normal = GInvertColor(CCHROME);
 
     // if foreground is white then we're "dark" if its
     // black the we're "light" so this controls palette
@@ -242,7 +242,7 @@ NewSideBarItem::configChanged(qint32)
     if (dark) bg_select = bg_select.lighter(200);
     else bg_select = bg_select.darker(200);
     if (isblack) bg_select = QColor(30,30,30);
-    fg_select = GCColor::invertColor(bg_select);
+    fg_select = GInvertColor(bg_select);
 
     // on hover
     bg_hover =GColor(CHOVER);

--- a/src/Gui/Pages.cpp
+++ b/src/Gui/Pages.cpp
@@ -1315,7 +1315,7 @@ ColorsPage::ColorsPage(QWidget *parent) : QWidget(parent)
 
     mainLayout->addWidget(colorTab);
 
-    colorSet = GCColor::colorSet();
+    colorSet = GCColor::instance()->colorSet();
     for (int i=0; colorSet[i].name != ""; i++) {
 
         QTreeWidgetItem *add;
@@ -1333,7 +1333,7 @@ ColorsPage::ColorsPage(QWidget *parent) : QWidget(parent)
 
     connect(applyTheme, SIGNAL(clicked()), this, SLOT(applyThemeClicked()));
 
-    foreach(ColorTheme theme, GCColor::themes().themes) {
+    foreach(ColorTheme theme, Themes::instance()->themes) {
 
         QTreeWidgetItem *add;
         ColorLabel *swatch = new ColorLabel(theme);
@@ -1408,10 +1408,10 @@ ColorsPage::applyThemeClicked()
     if (themes->currentItem() && (index=themes->invisibleRootItem()->indexOfChild(themes->currentItem())) >= 0) {
 
         // now get the theme selected
-        ColorTheme theme = GCColor::themes().themes[index];
+        ColorTheme theme = Themes::instance()->themes[index];
 
         // reset to base
-        colorSet = GCColor::defaultColorSet(theme.dark);
+        colorSet = GCColor::instance()->defaultColorSet(theme.dark);
 
         // reset the color selection tools
         colors->clear();
@@ -1577,7 +1577,7 @@ ColorsPage::saveClicked()
     appsettings->setValue(GC_FONT_CHARTLABELS_SIZE, font.pointSizeF() * 0.8);
 
     // reread into colorset so we can check for changes
-    GCColor::readConfig();
+    GCColor::instance()->readConfig();
 
     // did we change anything ?
     if(b4.alias != antiAliased->isChecked() ||

--- a/src/Gui/RideNavigator.cpp
+++ b/src/Gui/RideNavigator.cpp
@@ -189,7 +189,7 @@ RideNavigator::configChanged(qint32 state)
                 "QHeaderView::section { background-color: %1; color: %2; "
                 " border: 0px ; }")
                 .arg(GColor(CPLOTBACKGROUND).name())
-                .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name()));
+                .arg(GInvertColor(CPLOTBACKGROUND).name()));
     }
 
 #endif
@@ -1234,7 +1234,7 @@ void NavigatorCellDelegate::paint(QPainter *painter, const QStyleOptionViewItem 
             if (!selected) {
                 // not selected, so invert ride plot color
                 if (hover) painter->setPen(QPen(Qt::black));
-                else painter->setPen(rideBG ? rideNavigator->reverseColor : GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+                else painter->setPen(rideBG ? rideNavigator->reverseColor : GInvertColor(CPLOTBACKGROUND));
             }
             painter->drawText(myOption.rect, Qt::AlignLeft | Qt::TextWordWrap, calendarText);
             painter->setPen(isColor);

--- a/src/Gui/SearchBox.cpp
+++ b/src/Gui/SearchBox.cpp
@@ -106,7 +106,7 @@ SearchBox::configChanged(qint32)
     QColor color = QPalette().color(QPalette::Highlight);
 
     // flat mode has square corners
-    if (GCColor::isFlat()) {
+    if (GCColor::instance()->isFlat()) {
 
         setStyleSheet(QString( //"QLineEdit { padding-right: %1px; } "
                           "QLineEdit#SearchBox {"

--- a/src/Metrics/RideMetadata.cpp
+++ b/src/Metrics/RideMetadata.cpp
@@ -350,12 +350,12 @@ RideMetadata::configChanged(qint32)
         if (GColor(CPLOTBACKGROUND) != Qt::white)
 #endif
         {
-            palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CPLOTBACKGROUND)));
+            palette.setColor(QPalette::Base, GCColor::instance()->alternateColor(CPLOTBACKGROUND));
             palette.setColor(QPalette::Window,  GColor(CPLOTBACKGROUND));
         }
 
-        palette.setColor(QPalette::WindowText, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-        palette.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+        palette.setColor(QPalette::WindowText, GInvertColor(CPLOTBACKGROUND));
+        palette.setColor(QPalette::Text, GInvertColor(CPLOTBACKGROUND));
         setPalette(palette);
         tabs->setPalette(palette);
 
@@ -432,9 +432,9 @@ RideMetadata::configChanged(qint32)
                               .arg(4*dpiYFactor)                                          // 3 selected bar width
                               .arg(2*dpiXFactor)                                          // 4 padding
                               .arg(75*dpiXFactor)                                         // 5 tab minimum width
-                              .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name())     // 6 tab text color
+                              .arg(GInvertColor(CPLOTBACKGROUND).name())     // 6 tab text color
 #ifdef Q_OS_MAC
-                              .arg( GCColor::alternateColor(GColor(CPLOTBACKGROUND)).name()) // 7 lineedit background
+                              .arg( GCColor::instance()->alternateColor(CPLOTBACKGROUND).name()) // 7 lineedit background
 #endif
                             ;
         tabs->setStyleSheet(styling);

--- a/src/Planning/PlanningWindow.cpp
+++ b/src/Planning/PlanningWindow.cpp
@@ -58,7 +58,7 @@ PlanningWindow::configChanged(qint32)
     if (GColor(CTRENDPLOTBACKGROUND) != Qt::white)
 #endif
     {
-        //palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CTRAINPLOTBACKGROUND)));
+        //palette.setColor(QPalette::Base, GCColor::instance()->alternateColor(CTRAINPLOTBACKGROUND));
         palette.setColor(QPalette::Base, GColor(CTRAINPLOTBACKGROUND));
         palette.setColor(QPalette::Window, GColor(CTRAINPLOTBACKGROUND));
     }
@@ -67,8 +67,8 @@ PlanningWindow::configChanged(qint32)
     //code->setStyleSheet(TabView::ourStyleSheet());
 #endif
 
-    palette.setColor(QPalette::WindowText, GCColor::invertColor(GColor(CTRAINPLOTBACKGROUND)));
-    palette.setColor(QPalette::Text, GCColor::invertColor(GColor(CTRAINPLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GInvertColor(CTRAINPLOTBACKGROUND));
+    palette.setColor(QPalette::Text, GInvertColor(CTRAINPLOTBACKGROUND));
     //code->setPalette(palette);
     repaint();
 }

--- a/src/Python/SIP/Bindings.cpp
+++ b/src/Python/SIP/Bindings.cpp
@@ -1012,7 +1012,7 @@ Bindings::activityMetrics(RideItem* item) const
     if (item->color == QColor(1,1,1,1)) {
 
         // use the inverted color, not plot marker as that hideous
-        QColor col =GCColor::invertColor(GColor(CPLOTBACKGROUND));
+        QColor col =GInvertColor(CPLOTBACKGROUND);
 
         // white is jarring on a dark background!
         if (col==QColor(Qt::white)) col=QColor(127,127,127);
@@ -1149,7 +1149,7 @@ Bindings::seasonMetrics(bool all, DateRange range, QString filter) const
             if (ride->color == QColor(1,1,1,1)) {
 
                 // use the inverted color, not plot marker as that hideous
-                QColor col =GCColor::invertColor(GColor(CPLOTBACKGROUND));
+                QColor col =GInvertColor(CPLOTBACKGROUND);
 
                 // white is jarring on a dark background!
                 if (col==QColor(Qt::white)) col=QColor(127,127,127);
@@ -1354,7 +1354,7 @@ Bindings::seasonIntervals(DateRange range, QString type) const
                     QString color;
                     if (item->color == QColor(1,1,1,1)) {
                         // use the inverted color, not plot marker as that hideous
-                        QColor col =GCColor::invertColor(GColor(CPLOTBACKGROUND));
+                        QColor col =GInvertColor(CPLOTBACKGROUND);
                         // white is jarring on a dark background!
                         if (col==QColor(Qt::white)) col=QColor(127,127,127);
                         color = col.name();
@@ -1470,7 +1470,7 @@ Bindings::activityIntervals(QString type, PyObject* activity) const
             QString color;
             if (item->color == QColor(1,1,1,1)) {
                 // use the inverted color, not plot marker as that hideous
-                QColor col =GCColor::invertColor(GColor(CPLOTBACKGROUND));
+                QColor col =GInvertColor(CPLOTBACKGROUND);
                 // white is jarring on a dark background!
                 if (col==QColor(Qt::white)) col=QColor(127,127,127);
                 color = col.name();

--- a/src/R/RGraphicsDevice.cpp
+++ b/src/R/RGraphicsDevice.cpp
@@ -539,7 +539,7 @@ void RGraphicsDevice::setDeviceAttributes(pDevDesc pDev)
     pDev->startlty = 0;
 
     QColor bg=GColor(CPLOTBACKGROUND);
-    QColor fg=GCColor::invertColor(GColor(CPLOTBACKGROUND));
+    QColor fg=GInvertColor(CPLOTBACKGROUND);
 
     pDev->startfill = R_RGB(bg.red(),bg.green(),bg.blue());
     pDev->startcol = R_RGB(fg.red(),fg.green(),fg.blue());

--- a/src/R/RTool.cpp
+++ b/src/R/RTool.cpp
@@ -425,7 +425,7 @@ RTool::configChanged()
                                "    col.axis=\"%3\")\n"
                                "par.gc <- par()\n"
                             ).arg(GColor(CPLOTBACKGROUND).name())
-                             .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name())
+                             .arg(GInvertColor(CPLOTBACKGROUND).name())
                              .arg(GColor(CPLOTMARKER).name());
 
     // fire and forget, don't care if it fails or not !!
@@ -1095,7 +1095,7 @@ RTool::dfForRideItem(const RideItem *ri)
     if (item->color == QColor(1,1,1,1)) {
 
         // use the inverted color, not plot marker as that hideous
-        QColor col =GCColor::invertColor(GColor(CPLOTBACKGROUND));
+        QColor col = GInvertColor(CPLOTBACKGROUND);
 
         // white is jarring on a dark background!
         if (col==QColor(Qt::white)) col=QColor(127,127,127);
@@ -1330,7 +1330,7 @@ RTool::dfForDateRange(bool all, DateRange range, SEXP filter)
             if (item->color == QColor(1,1,1,1)) {
 
                 // use the inverted color, not plot marker as that hideous
-                QColor col =GCColor::invertColor(GColor(CPLOTBACKGROUND));
+                QColor col = GInvertColor(CPLOTBACKGROUND);
 
                 // white is jarring on a dark background!
                 if (col==QColor(Qt::white)) col=QColor(127,127,127);
@@ -1561,7 +1561,7 @@ RTool::dfForDateRangeIntervals(DateRange range, QStringList types)
             if (interval->color == QColor(1,1,1,1)) {
 
                 // use the inverted color, not plot marker as that hideous
-                QColor col =GCColor::invertColor(GColor(CPLOTBACKGROUND));
+                QColor col = GInvertColor(CPLOTBACKGROUND);
 
                 // white is jarring on a dark background!
                 if (col==QColor(Qt::white)) col=QColor(127,127,127);
@@ -1989,7 +1989,7 @@ RTool::activityIntervals(SEXP pTypes, SEXP datetime)
         if (interval->color == QColor(1,1,1,1)) {
 
             // use the inverted color, not plot marker as that hideous
-            QColor col =GCColor::invertColor(GColor(CPLOTBACKGROUND));
+            QColor col = GInvertColor(CPLOTBACKGROUND);
 
             // white is jarring on a dark background!
             if (col==QColor(Qt::white)) col=QColor(127,127,127);

--- a/src/Train/LiveMapWebPageWindow.cpp
+++ b/src/Train/LiveMapWebPageWindow.cpp
@@ -218,7 +218,7 @@ void LiveMapWebPageWindow::configChanged(qint32)
     palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
     palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
     palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CPLOTBACKGROUND)));
+    palette.setColor(QPalette::Base, GCColor::instance()->alternateColor(CPLOTBACKGROUND));
     setPalette(palette);
 
 }

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -624,13 +624,13 @@ TrainSidebar::configChanged(qint32)
 
     setProperty("color", GColor(CTRAINPLOTBACKGROUND));
 #if !defined GC_VIDEO_NONE
-    mediaTree->setStyleSheet(GCColor::stylesheet(true));
+    mediaTree->setStyleSheet(GCColor::instance()->stylesheet(true));
 #ifdef GC_HAVE_VLC  // RLV currently only support for VLC
-    videosyncTree->setStyleSheet(GCColor::stylesheet(true));
+    videosyncTree->setStyleSheet(GCColor::instance()->stylesheet(true));
 #endif
 #endif
-    workoutTree->setStyleSheet(GCColor::stylesheet(true));
-    deviceTree->setStyleSheet(GCColor::stylesheet(true));
+    workoutTree->setStyleSheet(GCColor::instance()->stylesheet(true));
+    deviceTree->setStyleSheet(GCColor::instance()->stylesheet(true));
 
     // DEVICES
 

--- a/src/Train/WebPageWindow.cpp
+++ b/src/Train/WebPageWindow.cpp
@@ -193,7 +193,7 @@ WebPageWindow::configChanged(qint32)
     palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
     palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
     palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CPLOTBACKGROUND)));
+    palette.setColor(QPalette::Base, GCColor::instance()->alternateColor(CPLOTBACKGROUND));
     setPalette(palette);
 }
 

--- a/src/Train/WorkoutWindow.cpp
+++ b/src/Train/WorkoutWindow.cpp
@@ -365,7 +365,7 @@ WorkoutWindow::configChanged(qint32)
     scroll->setStyleSheet(AbstractView::ourStyleSheet());
     toolbar->setStyleSheet(QString("::enabled { background: %1; color: %2; border: 0px; } ")
                            .arg(GColor(CTRAINPLOTBACKGROUND).name())
-                           .arg(GCColor::invertColor(GColor(CTRAINPLOTBACKGROUND)).name()));
+                           .arg(GInvertColor(CTRAINPLOTBACKGROUND).name()));
 
     xlabel->setStyleSheet("color: darkGray;");
     ylabel->setStyleSheet("color: darkGray;");
@@ -388,7 +388,7 @@ WorkoutWindow::configChanged(qint32)
     if (GColor(CTRAINPLOTBACKGROUND) != Qt::white)
 #endif
     {
-        //palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CTRAINPLOTBACKGROUND)));
+        //palette.setColor(QPalette::Base, GCColor::instance()->alternateColor(CTRAINPLOTBACKGROUND));
         palette.setColor(QPalette::Base, GColor(CTRAINPLOTBACKGROUND));
         palette.setColor(QPalette::Window, GColor(CTRAINPLOTBACKGROUND));
     }
@@ -397,8 +397,8 @@ WorkoutWindow::configChanged(qint32)
     code->setStyleSheet(AbstractView::ourStyleSheet());
 #endif
 
-    palette.setColor(QPalette::WindowText, GCColor::invertColor(GColor(CTRAINPLOTBACKGROUND)));
-    palette.setColor(QPalette::Text, GCColor::invertColor(GColor(CTRAINPLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GInvertColor(CTRAINPLOTBACKGROUND));
+    palette.setColor(QPalette::Text, GInvertColor(CTRAINPLOTBACKGROUND));
     code->setPalette(palette);
     repaint();
 }


### PR DESCRIPTION
GCColor has been defined with many static functions and accesses entirely static data, so is really a prime candidate for a Singleton pattern within the GC code. Therefore I have updated it to be a singleton, added defensive code, and additional overloaded function access so GColor macro doesn't always have to be used when accessing luminance, alternateColor, etc.

Themes is another candidate for a Singleton pattern, and its access is now independent of GCColor, as this was just providing a pass through access, and I have removed GCColor's unused Themes list to tidy the code.

This PR does NOT change any GCColor or Themes functionality in normal operation, although it does now defend against out of range colornum values in access functions, returning a defined out of range color.

This PR does impact numerous files accessing GCColor (and there are many!), but the changes are simple word replacements, so it looks far worse than it actually is, GCColor.[h & cpp] are where the changes have been made.

**NOTE:**
 I noticed two color definitions are missing from the LightDefaultColorList, I'm not sure whether this was intentional, but I've added a comment in the code to highlight this possible issue, but I've no idea what sensible values should be for these.

    LightDefaultColorList[102].color = QColor(134,74,255); // 102:Respiratory Frequency
    LightDefaultColorList[103].color = QColor(255,46,46); // 103:FeO2
    // CHOVER (104) are missing definitions !
    // CCHARTBAR (105) are missing definitions !
    LightDefaultColorList[106].color = QColor(180,180,180); // 106:Tile Alternate
    LightDefaultColorList[107].color = QColor(238,248,255); // 107:Tile Vibrant