### PR TITLE
Configurable Themes & Backup Colour Settings

### DIFF
--- a/src/Gui/Colors.cpp
+++ b/src/Gui/Colors.cpp
@@ -25,6 +25,10 @@
 #include <QByteArray>
 #include <QDir>
 #include "Settings.h"
+#include <vector>
+#include <string>
+#include <sstream>
+#include <iostream>
 
 #ifdef Q_OS_WIN
 #include <windows.h>
@@ -87,9 +91,6 @@ static bool initStandardColors()
 }
 static bool init = initStandardColors();
 
-// the standard themes, a global object
-static Themes allThemes;
-
 // Number of configurable metric colors + 1 for sentinel value
 static Colors ColorList[CNUMOFCFGCOLORS+1],
               LightDefaultColorList[CNUMOFCFGCOLORS+1],
@@ -99,6 +100,142 @@ static void copyArray(Colors source[], Colors target[])
 {
     for (int i=0; source[i].name != ""; i++)
         target[i] = source[i];
+}
+
+//
+// theme parser - reads in gcroot/themes.xml
+//
+bool ThemeParser::startDocument() {
+    return true;
+}
+
+bool ThemeParser::endElement(const QString&, const QString&, const QString& qName) {
+
+    if (qName == "theme") {
+
+        themes.push_back(theme);
+    }
+    return true;
+}
+
+bool ThemeParser::startElement(const QString&, const QString&, const QString& name, const QXmlAttributes& attrs) {
+
+    if (name == "themes") {
+    }
+    else if (name == "theme") {
+
+        
+        theme = ColorTheme();
+
+        QString name = "", dark = "", stealth = "";
+
+        // get attributes
+        for (int i = 0; i < attrs.count(); i++) {
+            if (attrs.qName(i) == "name") name = Utils::unprotect(attrs.value(i));
+            if (attrs.qName(i) == "dark") dark = Utils::unprotect(attrs.value(i));
+            if (attrs.qName(i) == "stealth") stealth = Utils::unprotect(attrs.value(i));
+        }
+
+        // Setup theme
+        theme.name = name;
+        theme.dark = (dark == "True" || dark == "true");
+        theme.stealth = (stealth == "True" || stealth == "true");
+    }
+    else if (name == "color") {
+
+        QString index, rgb;
+
+        // get attributes
+        for (int i = 0; i < attrs.count(); i++) {
+            if (attrs.qName(i) == "index") index = Utils::unprotect(attrs.value(i));
+            if (attrs.qName(i) == "rgb") rgb = Utils::unprotect(attrs.value(i));
+        }
+
+        // Setup color
+        if (rgb.contains("Qt::")) {
+            theme.colors.push_back(QColor(rgb.replace("Qt::", "")));
+        } else {
+            std::vector<int> vect;
+            std::stringstream ss(rgb.toStdString());
+
+            for (int i; ss >> i;) {
+                vect.push_back(i);
+                if (ss.peek() == ',')
+                    ss.ignore();
+            }
+            theme.colors.push_back(QColor(vect[0], vect[1], vect[2]));
+        }
+    }
+    return true;
+}
+
+bool ThemeParser::characters(const QString&) {
+    return true;
+}
+
+
+bool ThemeParser::endDocument() {
+    return true;
+}
+
+//
+// ColorBackupParser - reads in gcroot/colors-backup.xml
+//
+bool ColorBackupParser::startDocument() {
+    return true;
+}
+
+bool ColorBackupParser::endElement(const QString&, const QString&, const QString& qName) {
+
+    if (qName == "color") {
+
+        colors.push_back(color);
+    }
+    return true;
+}
+
+bool ColorBackupParser::startElement(const QString&, const QString&, const QString& name, const QXmlAttributes& attrs) {
+
+    if (name == "colors") {
+    }
+    else if (name == "color") {
+
+        QString index, group, name, setting, rgb;
+
+        // get attributes
+        for (int i = 0; i < attrs.count(); i++) {
+            if (attrs.qName(i) == "index") index = Utils::unprotect(attrs.value(i));
+            if (attrs.qName(i) == "group") group = Utils::unprotect(attrs.value(i));
+            if (attrs.qName(i) == "name") name = Utils::unprotect(attrs.value(i));
+            if (attrs.qName(i) == "setting") setting = Utils::unprotect(attrs.value(i));
+            if (attrs.qName(i) == "rgb") rgb = Utils::unprotect(attrs.value(i));
+        }
+
+        std::vector<int> vect;
+        std::stringstream ss(rgb.toStdString());
+
+        for (int i; ss >> i;) {
+            vect.push_back(i);
+            if (ss.peek() == ',')
+                ss.ignore();
+        }
+
+        color.index = atoi(index.toStdString().c_str());
+        color.group = group;
+        color.name = name;
+        color.name = setting;
+        color.color = QColor(vect[0], vect[1], vect[2]);
+    }
+    return true;
+}
+
+bool ColorBackupParser::characters(const QString&) {
+    return true;
+}
+
+
+bool ColorBackupParser::endDocument() {
+    return true;
 }
 
 unsigned long Colors::fingerprint(const Colors *set)
@@ -133,125 +270,125 @@ void GCColor::setupColors()
     // consider removing when we can guarantee extended initialisation support in gcc
     // (c++0x not supported by Qt currently and not planned for 4.8 or 5.0)
     Colors init[CNUMOFCFGCOLORS+1] = {
-        { tr("Chart"), tr("Plot Background"), "COLORPLOTBACKGROUND", QColor(52,52,52) },
-        { tr("Chart"), tr("Performance Plot Background"), "COLORRIDEPLOTBACKGROUND", QColor(52,52,52) },
-        { tr("Chart"), tr("Trend Plot Background"), "COLORTRENDPLOTBACKGROUND", Qt::black },
-        { tr("Chart"), tr("Train Plot Background"), "COLORTRAINPLOTBACKGROUND", Qt::black },
-        { tr("Chart"), tr("Plot Symbols"), "COLORRIDEPLOTSYMBOLS", Qt::cyan },
-        { tr("Chart"), tr("Performance Plot X Axis"), "COLORRIDEPLOTXAXIS", Qt::blue },
-        { tr("Chart"), tr("Performance Plot Y Axis"), "COLORRIDEPLOTYAXIS", Qt::red },
-        { tr("Chart"), tr("Plot Thumbnail Background"), "COLORPLOTTHUMBNAIL", Qt::gray },
-        { tr("Chart"), tr("Plot Title"), "COLORPLOTTITLE", Qt::gray },
-        { tr("Chart"), tr("Plot Selection Pen"), "COLORPLOTSELECT", Qt::blue },
-        { tr("Chart"), tr("Plot TrackerPen"), "COLORPLOTTRACKER", Qt::blue },
-        { tr("Chart"), tr("Plot Markers"), "COLORPLOTMARKER", Qt::cyan },
-        { tr("Chart"), tr("Plot Grid"), "COLORGRID", QColor(65,65,65) },
-        { tr("Chart"), tr("Interval Highlighter"), "COLORINTERVALHIGHLIGHTER", Qt::blue },
-        { tr("Data"), tr("Heart Rate"), "COLORHEARTRATE", Qt::red },
-        { tr("Data"), tr("Core Temperature"), "COLORCORETEMP", QColor(255, 173, 92) },
-        { tr("Data"), tr("Speed"), "COLORSPEED", Qt::green },
-        { tr("Data"), tr("Acceleration"), "COLORACCEL", Qt::cyan },
-        { tr("Data"), tr("Power"), "COLORPOWER", Qt::yellow },
-        { tr("Data"), tr("Iso Power"), "CNPOWER", Qt::magenta },
-        { tr("Data"), tr("Skiba xPower"), "CXPOWER", Qt::magenta },
-        { tr("Data"), tr("Altitude Power"), "CAPOWER", Qt::magenta },
-        { tr("Data"), tr("Train Target Power"), "CTPOWER", Qt::blue },
-        { tr("Data"), tr("Critical Power"), "COLORCP", Qt::cyan },
-        { tr("Data"), tr("Cadence"), "COLORCADENCE", QColor(0,204,204) },
-        { tr("Data"), tr("Altitude"), "COLORALTITUTDE", QColor(Qt::gray) },
-        { tr("Data"), tr("Altitude Shading"), "COLORALTITUDESHADE", QColor(Qt::lightGray) },
-        { tr("Data"), tr("Wind Speed"), "COLORWINDSPEED", Qt::darkGreen },
-        { tr("Data"), tr("Torque"), "COLORTORQUE", Qt::magenta },
-        { tr("Data"), tr("Slope"), "CSLOPE", Qt::green },
-        { tr("Data"), tr("Gear Ratio"), "COLORGEAR", QColor(0xff, 0x90, 0x00) },
-        { tr("Data"), tr("Run Vertical Oscillation"), "COLORRVERT", QColor(0xff, 0x90, 0x00) }, // same as garmin connect colors
-        { tr("Data"), tr("Run Cadence"), "COLORRCAD", QColor(0xff, 0x90, 0x00) }, // same as garmin connect colors
-        { tr("Data"), tr("Run Ground Contact"), "COLORGCT", QColor(0xff, 0x90, 0x00) }, // same as garmin connect colors
-        { tr("Data"), tr("Muscle Oxygen (SmO2)"), "COLORSMO2", QColor(0x00, 0x89, 0x77) }, // green same as moxy monitor
-        { tr("Data"), tr("Haemoglobin Mass (tHb)"), "COLORTHB", QColor(0xa3,0x44,0x02) },  // brown same as moxy monitor
-        { tr("Data"), tr("Oxygenated Haemoglobin (O2Hb)"), "CO2HB", QColor(0xd1,0x05,0x72) },
-        { tr("Data"), tr("Deoxygenated Haemoglobin (HHb)"), "CHHB", QColor(0x00,0x7f,0xcc) },
-        { tr("Data"), tr("Load"), "COLORLOAD", Qt::yellow },
-        { tr("Data"), tr("BikeStress"), "COLORTSS", Qt::green },
-        { tr("Data"), tr("Short Term Stress"), "COLORSTS", Qt::blue },
-        { tr("Data"), tr("Long Term Stress"), "COLORLTS", Qt::green },
-        { tr("Data"), tr("Stress Balance"), "COLORSB", QColor(180,140,140) },
-        { tr("Data"), tr("Daily Stress"), "COLORDAILYSTRESS", Qt::red },
-        { tr("Data"), "Bike Score (TM)", "COLORBIKESCORE", Qt::gray },
-        { tr("Gui"), tr("Calendar Text"), "COLORCALENDARTEXT", Qt::gray },
-        { tr("Data"), tr("Power Zone 1 Shading"), "COLORZONE1", QColor(255,0,255) },
-        { tr("Data"), tr("Power Zone 2 Shading"), "COLORZONE2", QColor(42,0,255) },
-        { tr("Data"), tr("Power Zone 3 Shading"), "COLORZONE3", QColor(0,170,255) },
-        { tr("Data"), tr("Power Zone 4 Shading"), "COLORZONE4", QColor(0,255,128) },
-        { tr("Data"), tr("Power Zone 5 Shading"), "COLORZONE5", QColor(85,255,0) },
-        { tr("Data"), tr("Power Zone 6 Shading"), "COLORZONE6", QColor(255,213,0) },
-        { tr("Data"), tr("Power Zone 7 Shading"), "COLORZONE7", QColor(255,0,0) },
-        { tr("Data"), tr("Power Zone 8 Shading"), "COLORZONE8", Qt::gray },
-        { tr("Data"), tr("Power Zone 9 Shading"), "COLORZONE9", Qt::gray },
-        { tr("Data"), tr("Power Zone 10 Shading"), "COLORZONE10", Qt::gray },
-        { tr("Data"), tr("HR Zone 1 Shading"), "HRCOLORZONE1", QColor(255,0,255) },
-        { tr("Data"), tr("HR Zone 2 Shading"), "HRCOLORZONE2", QColor(42,0,255) },
-        { tr("Data"), tr("HR Zone 3 Shading"), "HRCOLORZONE3", QColor(0,170,255) },
-        { tr("Data"), tr("HR Zone 4 Shading"), "HRCOLORZONE4", QColor(0,255,128) },
-        { tr("Data"), tr("HR Zone 5 Shading"), "HRCOLORZONE5", QColor(85,255,0) },
-        { tr("Data"), tr("HR Zone 6 Shading"), "HRCOLORZONE6", QColor(255,213,0) },
-        { tr("Data"), tr("HR Zone 7 Shading"), "HRCOLORZONE7", QColor(255,0,0) },
-        { tr("Data"), tr("HR Zone 8 Shading"), "HRCOLORZONE8", Qt::gray },
-        { tr("Data"), tr("HR Zone 9 Shading"), "HRCOLORZONE9", Qt::gray },
-        { tr("Data"), tr("HR Zone 10 Shading"), "HRCOLORZONE10", Qt::gray },
-        { tr("Data"), tr("Aerolab Vrtual Elevation"), "COLORAEROVE", Qt::blue },
-        { tr("Data"), tr("Aerolab Elevation"), "COLORAEROEL", Qt::green },
-        { tr("Gui"), tr("Calendar background"), "CCALCELL", Qt::white },
-        { tr("Gui"), tr("Calendar heading"), "CCALHEAD", QColor(230,230,230) },
-        { tr("Gui"), tr("Calendar Current Selection"), "CCALCURRENT", QColor(255,213,0) },
-        { tr("Gui"), tr("Calendar Actual Workout"), "CCALACTUAL", Qt::green },
-        { tr("Gui"), tr("Calendar Planned Workout"), "CCALPLANNED", Qt::yellow },
-        { tr("Gui"), tr("Calendar Today"), "CCALTODAY", Qt::cyan },
-        { tr("Gui"), tr("Pop Up Windows Background"), "CPOPUP", Qt::lightGray },
-        { tr("Gui"), tr("Pop Up Windows Foreground"), "CPOPUPTEXT", Qt::white },
-        { tr("Gui"), tr("Chart Bar Unselected"), "CTILEBAR", Qt::gray },
-        { tr("Gui"), tr("Chart Bar Selected"), "CTILEBARSELECT", Qt::yellow },
-        { tr("Gui"), tr("ToolBar Background"), "CTOOLBAR", Qt::white },
-        { tr("Gui"), tr("Activity History Group"), "CRIDEGROUP", QColor(236,246,255) },
-        { tr("Data"), tr("SpinScan Left"), "CSPINSCANLEFT", Qt::gray },
-        { tr("Data"), tr("SpinScan Right"), "CSPINSCANRIGHT", Qt::cyan },
-        { tr("Data"), tr("Temperature"), "COLORTEMPERATURE", Qt::yellow },
-        { tr("Data"), tr("Default Dial Color"), "CDIAL", Qt::gray },
-        { tr("Data"), tr("Alternate Power"), "CALTPOWER", Qt::magenta },
-        { tr("Data"), tr("Left Balance"), "CBALANCELEFT", QColor(178,0,0) },
-        { tr("Data"), tr("Right Balance"), "CBALANCERIGHT", QColor(128,0,50) },
-        { tr("Data"), tr("W' Balance"), "CWBAL", Qt::red },
-        { tr("Data"), tr("Mean-maximal Power"), "CRIDECP", Qt::red },
-        { tr("Data"), tr("Aerobic TISS"), "CATISS", Qt::magenta },
-        { tr("Data"), tr("Anaerobic TISS"), "CANTISS", Qt::cyan },
-        { tr("Data"), tr("Left Torque Effectiveness"), "CLTE", Qt::cyan },
-        { tr("Data"), tr("Right Torque Effectiveness"), "CRTE", Qt::magenta },
-        { tr("Data"), tr("Left Pedal Smoothness"), "CLPS", Qt::cyan },
-        { tr("Data"), tr("Right Pedal Smoothness"), "CRPS", Qt::magenta },
+        { CPLOTBACKGROUND, tr("Chart"), tr("Plot Background"), "COLORPLOTBACKGROUND", QColor(52,52,52) },
+        { CRIDEPLOTBACKGROUND, tr("Chart"), tr("Performance Plot Background"), "COLORRIDEPLOTBACKGROUND", QColor(52,52,52) },
+        { CTRENDPLOTBACKGROUND, tr("Chart"), tr("Trend Plot Background"), "COLORTRENDPLOTBACKGROUND", Qt::black },
+        { CTRAINPLOTBACKGROUND, tr("Chart"), tr("Train Plot Background"), "COLORTRAINPLOTBACKGROUND", Qt::black },
+        { CPLOTSYMBOL, tr("Chart"), tr("Plot Symbols"), "COLORRIDEPLOTSYMBOLS", Qt::cyan },
+        { CRIDEPLOTXAXIS, tr("Chart"), tr("Performance Plot X Axis"), "COLORRIDEPLOTXAXIS", Qt::blue },
+        { CRIDEPLOTYAXIS, tr("Chart"), tr("Performance Plot Y Axis"), "COLORRIDEPLOTYAXIS", Qt::red },
+        { CPLOTTHUMBNAIL, tr("Chart"), tr("Plot Thumbnail Background"), "COLORPLOTTHUMBNAIL", Qt::gray },
+        { CPLOTTITLE, tr("Chart"), tr("Plot Title"), "COLORPLOTTITLE", Qt::gray },
+        { CPLOTSELECT, tr("Chart"), tr("Plot Selection Pen"), "COLORPLOTSELECT", Qt::blue },
+        { CPLOTTRACKER, tr("Chart"), tr("Plot TrackerPen"), "COLORPLOTTRACKER", Qt::blue },
+        { CPLOTMARKER, tr("Chart"), tr("Plot Markers"), "COLORPLOTMARKER", Qt::cyan },
+        { CPLOTGRID, tr("Chart"), tr("Plot Grid"), "COLORGRID", QColor(65,65,65) },
+        { CINTERVALHIGHLIGHTER, tr("Chart"), tr("Interval Highlighter"), "COLORINTERVALHIGHLIGHTER", Qt::blue },
+        { CHEARTRATE, tr("Data"), tr("Heart Rate"), "COLORHEARTRATE", Qt::red },
+        { CCORETEMP, tr("Data"), tr("Core Temperature"), "COLORCORETEMP", QColor(255, 173, 92) },
+        { CSPEED, tr("Data"), tr("Speed"), "COLORSPEED", Qt::green },
+        { CACCELERATION, tr("Data"), tr("Acceleration"), "COLORACCEL", Qt::cyan },
+        { CPOWER, tr("Data"), tr("Power"), "COLORPOWER", Qt::yellow },
+        { CNPOWER, tr("Data"), tr("Iso Power"), "CNPOWER", Qt::magenta },
+        { CXPOWER, tr("Data"), tr("Skiba xPower"), "CXPOWER", Qt::magenta },
+        { CAPOWER, tr("Data"), tr("Altitude Power"), "CAPOWER", Qt::magenta },
+        { CTPOWER, tr("Data"), tr("Train Target Power"), "CTPOWER", Qt::blue },
+        { CCP, tr("Data"), tr("Critical Power"), "COLORCP", Qt::cyan },
+        { CCADENCE, tr("Data"), tr("Cadence"), "COLORCADENCE", QColor(0,204,204) },
+        { CALTITUDE, tr("Data"), tr("Altitude"), "COLORALTITUTDE", QColor(Qt::gray) },
+        { CALTITUDEBRUSH, tr("Data"), tr("Altitude Shading"), "COLORALTITUDESHADE", QColor(Qt::lightGray) },
+        { CWINDSPEED, tr("Data"), tr("Wind Speed"), "COLORWINDSPEED", Qt::darkGreen },
+        { CTORQUE, tr("Data"), tr("Torque"), "COLORTORQUE", Qt::magenta },
+        { CSLOPE, tr("Data"), tr("Slope"), "CSLOPE", Qt::green },
+        { CGEAR, tr("Data"), tr("Gear Ratio"), "COLORGEAR", QColor(0xff, 0x90, 0x00) },
+        { CRV, tr("Data"), tr("Run Vertical Oscillation"), "COLORRVERT", QColor(0xff, 0x90, 0x00) }, // same as garmin connect colors
+        { CRCAD, tr("Data"), tr("Run Cadence"), "COLORRCAD", QColor(0xff, 0x90, 0x00) }, // same as garmin connect colors
+        { CRGCT, tr("Data"), tr("Run Ground Contact"), "COLORGCT", QColor(0xff, 0x90, 0x00) }, // same as garmin connect colors
+        { CSMO2, tr("Data"), tr("Muscle Oxygen (SmO2)"), "COLORSMO2", QColor(0x00, 0x89, 0x77) }, // green same as moxy monitor
+        { CTHB, tr("Data"), tr("Haemoglobin Mass (tHb)"), "COLORTHB", QColor(0xa3,0x44,0x02) },  // brown same as moxy monitor
+        { CO2HB, tr("Data"), tr("Oxygenated Haemoglobin (O2Hb)"), "CO2HB", QColor(0xd1,0x05,0x72) },
+        { CHHB, tr("Data"), tr("Deoxygenated Haemoglobin (HHb)"), "CHHB", QColor(0x00,0x7f,0xcc) },
+        { CLOAD, tr("Data"), tr("Load"), "COLORLOAD", Qt::yellow },
+        { CTSS, tr("Data"), tr("BikeStress"), "COLORTSS", Qt::green },
+        { CSTS, tr("Data"), tr("Short Term Stress"), "COLORSTS", Qt::blue },
+        { CLTS, tr("Data"), tr("Long Term Stress"), "COLORLTS", Qt::green },
+        { CSB, tr("Data"), tr("Stress Balance"), "COLORSB", QColor(180,140,140) },
+        { CDAILYSTRESS, tr("Data"), tr("Daily Stress"), "COLORDAILYSTRESS", Qt::red },
+        { CBIKESCORE, tr("Data"), "Bike Score (TM)", "COLORBIKESCORE", Qt::gray },
+        { CCALENDARTEXT, tr("Gui"), tr("Calendar Text"), "COLORCALENDARTEXT", Qt::gray },
+        { CZONE1, tr("Data"), tr("Power Zone 1 Shading"), "COLORZONE1", QColor(255,0,255) },
+        { CZONE2, tr("Data"), tr("Power Zone 2 Shading"), "COLORZONE2", QColor(42,0,255) },
+        { CZONE3, tr("Data"), tr("Power Zone 3 Shading"), "COLORZONE3", QColor(0,170,255) },
+        { CZONE4, tr("Data"), tr("Power Zone 4 Shading"), "COLORZONE4", QColor(0,255,128) },
+        { CZONE5, tr("Data"), tr("Power Zone 5 Shading"), "COLORZONE5", QColor(85,255,0) },
+        { CZONE6, tr("Data"), tr("Power Zone 6 Shading"), "COLORZONE6", QColor(255,213,0) },
+        { CZONE7, tr("Data"), tr("Power Zone 7 Shading"), "COLORZONE7", QColor(255,0,0) },
+        { CZONE8, tr("Data"), tr("Power Zone 8 Shading"), "COLORZONE8", Qt::gray },
+        { CZONE9, tr("Data"), tr("Power Zone 9 Shading"), "COLORZONE9", Qt::gray },
+        { CZONE10, tr("Data"), tr("Power Zone 10 Shading"), "COLORZONE10", Qt::gray },
+        { CHZONE1, tr("Data"), tr("HR Zone 1 Shading"), "HRCOLORZONE1", QColor(255,0,255) },
+        { CHZONE2, tr("Data"), tr("HR Zone 2 Shading"), "HRCOLORZONE2", QColor(42,0,255) },
+        { CHZONE3, tr("Data"), tr("HR Zone 3 Shading"), "HRCOLORZONE3", QColor(0,170,255) },
+        { CHZONE4, tr("Data"), tr("HR Zone 4 Shading"), "HRCOLORZONE4", QColor(0,255,128) },
+        { CHZONE5, tr("Data"), tr("HR Zone 5 Shading"), "HRCOLORZONE5", QColor(85,255,0) },
+        { CHZONE6, tr("Data"), tr("HR Zone 6 Shading"), "HRCOLORZONE6", QColor(255,213,0) },
+        { CHZONE7, tr("Data"), tr("HR Zone 7 Shading"), "HRCOLORZONE7", QColor(255,0,0) },
+        { CHZONE8, tr("Data"), tr("HR Zone 8 Shading"), "HRCOLORZONE8", Qt::gray },
+        { CHZONE9, tr("Data"), tr("HR Zone 9 Shading"), "HRCOLORZONE9", Qt::gray },
+        { CHZONE10, tr("Data"), tr("HR Zone 10 Shading"), "HRCOLORZONE10", Qt::gray },
+        { CAEROVE, tr("Data"), tr("Aerolab Vrtual Elevation"), "COLORAEROVE", Qt::blue },
+        { CAEROEL, tr("Data"), tr("Aerolab Elevation"), "COLORAEROEL", Qt::green },
+        { CCALCELL, tr("Gui"), tr("Calendar background"), "CCALCELL", Qt::white },
+        { CCALHEAD, tr("Gui"), tr("Calendar heading"), "CCALHEAD", QColor(230,230,230) },
+        { CCALCURRENT, tr("Gui"), tr("Calendar Current Selection"), "CCALCURRENT", QColor(255,213,0) },
+        { CCALACTUAL, tr("Gui"), tr("Calendar Actual Workout"), "CCALACTUAL", Qt::green },
+        { CCALPLANNED, tr("Gui"), tr("Calendar Planned Workout"), "CCALPLANNED", Qt::yellow },
+        { CCALTODAY, tr("Gui"), tr("Calendar Today"), "CCALTODAY", Qt::cyan },
+        { CPOPUP, tr("Gui"), tr("Pop Up Windows Background"), "CPOPUP", Qt::lightGray },
+        { CPOPUPTEXT, tr("Gui"), tr("Pop Up Windows Foreground"), "CPOPUPTEXT", Qt::white },
+        { CTILEBAR, tr("Gui"), tr("Chart Bar Unselected"), "CTILEBAR", Qt::gray },
+        { CTILEBARSELECT, tr("Gui"), tr("Chart Bar Selected"), "CTILEBARSELECT", Qt::yellow },
+        { CTOOLBAR, tr("Gui"), tr("ToolBar Background"), "CTOOLBAR", Qt::white },
+        { CRIDEGROUP, tr("Gui"), tr("Activity History Group"), "CRIDEGROUP", QColor(236,246,255) },
+        { CSPINSCANLEFT, tr("Data"), tr("SpinScan Left"), "CSPINSCANLEFT", Qt::gray },
+        { CSPINSCANRIGHT, tr("Data"), tr("SpinScan Right"), "CSPINSCANRIGHT", Qt::cyan },
+        { CTEMP, tr("Data"), tr("Temperature"), "COLORTEMPERATURE", Qt::yellow },
+        { CDIAL, tr("Data"), tr("Default Dial Color"), "CDIAL", Qt::gray },
+        { CALTPOWER, tr("Data"), tr("Alternate Power"), "CALTPOWER", Qt::magenta },
+        { CBALANCELEFT, tr("Data"), tr("Left Balance"), "CBALANCELEFT", QColor(178,0,0) },
+        { CBALANCERIGHT, tr("Data"), tr("Right Balance"), "CBALANCERIGHT", QColor(128,0,50) },
+        { CWBAL, tr("Data"), tr("W' Balance"), "CWBAL", Qt::red },
+        { CRIDECP, tr("Data"), tr("Mean-maximal Power"), "CRIDECP", Qt::red },
+        { CATISS, tr("Data"), tr("Aerobic TISS"), "CATISS", Qt::magenta },
+        { CANTISS, tr("Data"), tr("Anaerobic TISS"), "CANTISS", Qt::cyan },
+        { CRTE, tr("Data"), tr("Left Torque Effectiveness"), "CLTE", Qt::cyan },
+        { CRTE, tr("Data"), tr("Right Torque Effectiveness"), "CRTE", Qt::magenta },
+        { CLPS, tr("Data"), tr("Left Pedal Smoothness"), "CLPS", Qt::cyan },
+        { CRPS, tr("Data"), tr("Right Pedal Smoothness"), "CRPS", Qt::magenta },
 #ifdef GC_HAVE_DWM
-        { tr("Gui"), tr("Toolbar and Sidebar"), "CCHROME", QColor(1,1,1) },
+        { CCHROME, tr("Gui"), tr("Toolbar and Sidebar"), "CCHROME", QColor(1,1,1) },
 #else
 #ifdef Q_OS_MAC
-        { tr("Gui"), tr("Sidebar background"), "CCHROME", QColor(213,213,213) },
+        { CCHROME, tr("Gui"), tr("Sidebar background"), "CCHROME", QColor(213,213,213) },
 #else
-        { tr("Gui"), tr("Sidebar background"), "CCHROME", QColor(0xec,0xec,0xec) },
+        { CCHROME, tr("Gui"), tr("Sidebar background"), "CCHROME", QColor(0xec,0xec,0xec) },
 #endif
 #endif
-        { tr("Gui"), tr("Overview Background"), "COVERVIEWBACKGROUND", QColor(0,0,0) },
-        { tr("Gui"), tr("Overview Tile Background"), "CCARDBACKGROUND", QColor(52,52,52) },
-        { tr("Data"), tr("VO2"), "CVO2", Qt::magenta },
-        { tr("Data"), tr("Ventilation"), "CVENTILATION", Qt::cyan },
-        { tr("Data"), tr("VCO2"), "CVCO2", Qt::green },
-        { tr("Data"), tr("Tidal Volume"), "CTIDALVOLUME", Qt::yellow },
-        { tr("Data"), tr("Respiratory Frequency"), "CRESPFREQUENCY", Qt::yellow },
-        { tr("Data"), tr("FeO2"), "CFEO2", Qt::yellow },
-        { tr("Gui"), tr("Toolbar Hover"), "CHOVER", Qt::lightGray },
-        { tr("Gui"), tr("Chartbar background"), "CCHARTBAR", Qt::lightGray },
-        { tr("Gui"), tr("Overview Tile Background Alternate"), "CCARDBACKGROUND2", QColor(0,0,0) },
-        { tr("Gui"), tr("Overview Tile Background Vibrant"), "CCARDBACKGROUND3", QColor(52,52,52) },
-        { tr("Gui"), tr("Map Route Line"), "MAPROUTELINE", Qt::red },
-        { tr("Data"), tr("Stress Ramp Rate"), "COLORRR", Qt::green },
-        { "", "", "", QColor(0,0,0) },
+        { COVERVIEWBACKGROUND, tr("Gui"), tr("Overview Background"), "COVERVIEWBACKGROUND", QColor(0,0,0) },
+        { CCARDBACKGROUND, tr("Gui"), tr("Overview Tile Background"), "CCARDBACKGROUND", QColor(52,52,52) },
+        { CVO2, tr("Data"), tr("VO2"), "CVO2", Qt::magenta },
+        { CVENTILATION, tr("Data"), tr("Ventilation"), "CVENTILATION", Qt::cyan },
+        { CVCO2, tr("Data"), tr("VCO2"), "CVCO2", Qt::green },
+        { CTIDALVOLUME, tr("Data"), tr("Tidal Volume"), "CTIDALVOLUME", Qt::yellow },
+        { CRESPFREQUENCY, tr("Data"), tr("Respiratory Frequency"), "CRESPFREQUENCY", Qt::yellow },
+        { CFEO2, tr("Data"), tr("FeO2"), "CFEO2", Qt::yellow },
+        { CHOVER, tr("Gui"), tr("Toolbar Hover"), "CHOVER", Qt::lightGray },
+        { CCHARTBAR, tr("Gui"), tr("Chartbar background"), "CCHARTBAR", Qt::lightGray },
+        { CCARDBACKGROUND2, tr("Gui"), tr("Overview Tile Background Alternate"), "CCARDBACKGROUND2", QColor(0,0,0) },
+        { CCARDBACKGROUND3, tr("Gui"), tr("Overview Tile Background Vibrant"), "CCARDBACKGROUND3", QColor(52,52,52) },
+        { MAPROUTELINE, tr("Gui"), tr("Map Route Line"), "MAPROUTELINE", Qt::red },
+        { COLORRR, tr("Data"), tr("Stress Ramp Rate"), "COLORRR", Qt::green },
+        { CNUMOFCFGCOLORS + 1, "", "", "", QColor(0,0,0) },
     };
 
     // set the defaults to system defaults
@@ -274,6 +411,7 @@ void GCColor::setupColors()
     // were all selected on the basis of a dark background
     // note: we don't update them all so old standard charts
     // aren't affected to badly, but may do so in the future
+<<<<<<< HEAD
     LightDefaultColorList[0].color = QColor(255,255,255); // 0:Plot Background
     LightDefaultColorList[1].color = QColor(255,255,255); // 1:Performance Plot Background
     LightDefaultColorList[2].color = QColor(255,255,255); // 2:Trend Plot Background
@@ -382,6 +520,117 @@ void GCColor::setupColors()
     LightDefaultColorList[107].color = QColor(238,248,255); // 107:Tile Vibrant
     LightDefaultColorList[108].color = QColor(255, 0, 0); // 105:MapRouteLine
     LightDefaultColorList[109].color = QColor(0,102,0); // 109:Stress Ramp Rate
+=======
+    LightDefaultColorList[CPLOTBACKGROUND].color = QColor(255,255,255); // 0:Plot Background
+    LightDefaultColorList[CRIDEPLOTBACKGROUND].color = QColor(255,255,255); // 1:Performance Plot Background
+    LightDefaultColorList[CTRENDPLOTBACKGROUND].color = QColor(255,255,255); // 2:Trend Plot Background
+    LightDefaultColorList[CTRAINPLOTBACKGROUND].color = QColor(255,255,255); // 3:Train Plot Background
+    LightDefaultColorList[CPLOTSYMBOL].color = QColor(101,105,165); // 4:Plot Symbols
+    LightDefaultColorList[CRIDEPLOTXAXIS].color = QColor(101,105,165); // 5:Performance Plot X Axis
+    LightDefaultColorList[CRIDEPLOTYAXIS].color = QColor(101,105,165); // 6:Performance Plot Y Axis
+    LightDefaultColorList[CPLOTTHUMBNAIL].color = QColor(160,160,164); // 7:Plot Thumbnail Background
+    LightDefaultColorList[CPLOTTITLE].color = QColor(0,0,0); // 8:Plot Title
+    LightDefaultColorList[CPLOTSELECT].color = QColor(194,194,194); // 9:Plot Selection Pen
+    LightDefaultColorList[CPLOTTRACKER].color = QColor(194,194,194); // 10:Plot TrackerPen
+    LightDefaultColorList[CPLOTMARKER].color = QColor(101,105,165); // 11:Plot Markers
+    LightDefaultColorList[CPLOTGRID].color = QColor(232,232,232); // 12:Plot Grid
+    LightDefaultColorList[CINTERVALHIGHLIGHTER].color = QColor(194,194,194); // 13:Interval Highlighter
+    LightDefaultColorList[CHEARTRATE].color = QColor(255,0,0); // 14:Heart Rate
+    LightDefaultColorList[CCORETEMP].color = QColor(131,8,255); // 15:Core Temperature
+    LightDefaultColorList[CSPEED].color = QColor(0, 102, 0); // 16:Speed
+    LightDefaultColorList[CACCELERATION].color = QColor(0, 146, 146); // 17:Acceleration
+    LightDefaultColorList[CPOWER].color = QColor(255, 170, 0); // 18:Power
+    LightDefaultColorList[CNPOWER].color = QColor(255, 0, 255); // 19:Iso Power
+    LightDefaultColorList[CXPOWER].color = QColor(158, 0, 158); // 20:Skiba xPower
+    LightDefaultColorList[CAPOWER].color = QColor(255, 0, 255); // 21:Altitude Power
+    LightDefaultColorList[CTPOWER].color = QColor(0, 0, 255); // 22:Train Target Power
+    LightDefaultColorList[CCP].color = QColor(167, 0, 109); // 23:Critical Power
+    LightDefaultColorList[CCADENCE].color = QColor(0, 126, 126); // 24:Cadence
+    LightDefaultColorList[CALTITUDE].color = QColor(119, 119, 122); // 25:Altitude
+    LightDefaultColorList[CALTITUDEBRUSH].color = QColor(114, 114, 114); // 26:Altitude Shading
+    LightDefaultColorList[CWINDSPEED].color = QColor(0, 128, 0); // 27:Wind Speed
+    LightDefaultColorList[CTORQUE].color = QColor(111, 0, 111); // 28:Torque
+    LightDefaultColorList[CSLOPE].color = QColor(0, 127, 0); // 29:Slope
+    LightDefaultColorList[CGEAR].color = QColor(255, 144, 0); // 30:Gear Ratio
+    LightDefaultColorList[CRV].color = QColor(255, 144, 0); // 31:Run Vertical Oscillation
+    LightDefaultColorList[CRCAD].color = QColor(255, 144, 0); // 32:Run Cadence
+    LightDefaultColorList[CRGCT].color = QColor(255, 144, 0); // 33:Run Ground Contact
+    LightDefaultColorList[CSMO2].color = QColor(0, 137, 119); // 34:Muscle Oxygen (SmO2)
+    LightDefaultColorList[CTHB].color = QColor(163, 68, 2); // 35:Haemoglobin Mass (tHb)
+    LightDefaultColorList[CO2HB].color = QColor(209, 5, 114); // 36:Oxygenated Haemoglobin (O2Hb)
+    LightDefaultColorList[CHHB].color = QColor(0, 127, 204); // 37:Deoxygenated Haemoglobin (HHb)
+    LightDefaultColorList[CLOAD].color = QColor(127, 127, 0); // 38:Load
+    LightDefaultColorList[CTSS].color = QColor(0, 81, 0); // 39:BikeStress
+    LightDefaultColorList[CSTS].color = QColor(227, 12, 255); // 40:Short Term Stress
+    LightDefaultColorList[CLTS].color = QColor(16, 0, 195); // 41:Long Term Stress
+    LightDefaultColorList[CSB].color = QColor(209, 193, 23); // 42:Stress Balance
+    LightDefaultColorList[CDAILYSTRESS].color = QColor(255, 0, 0); // 43:Daily Stress
+    LightDefaultColorList[CBIKESCORE].color = QColor(160, 160, 164); // 44:Bike Score (TM)
+    LightDefaultColorList[CCALENDARTEXT].color = QColor(0, 0, 0); // 45:Calendar Text
+    LightDefaultColorList[CZONE1].color = QColor(255, 0, 255); // 46:Power Zone 1 Shading
+    LightDefaultColorList[CZONE2].color = QColor(42, 0, 255); // 47:Power Zone 2 Shading
+    LightDefaultColorList[CZONE3].color = QColor(0, 170, 255); // 48:Power Zone 3 Shading
+    LightDefaultColorList[CZONE4].color = QColor(0, 255, 128); // 49:Power Zone 4 Shading
+    LightDefaultColorList[CZONE5].color = QColor(85, 255, 0); // 50:Power Zone 5 Shading
+    LightDefaultColorList[CZONE6].color = QColor(255, 213, 0); // 51:Power Zone 6 Shading
+    LightDefaultColorList[CZONE7].color = QColor(255, 0, 0); // 52:Power Zone 7 Shading
+    LightDefaultColorList[CZONE8].color = QColor(160, 160, 164); // 53:Power Zone 8 Shading
+    LightDefaultColorList[CZONE9].color = QColor(160, 160, 164); // 54:Power Zone 9 Shading
+    LightDefaultColorList[CZONE10].color = QColor(160, 160, 164); // 55:Power Zone 10 Shading
+    LightDefaultColorList[CHZONE1].color = QColor(255, 0, 255); // 56:HR Zone 1 Shading
+    LightDefaultColorList[CHZONE2].color = QColor(42, 0, 255); // 57:HR Zone 2 Shading
+    LightDefaultColorList[CHZONE3].color = QColor(0, 170, 255); // 58:HR Zone 3 Shading
+    LightDefaultColorList[CHZONE4].color = QColor(0, 255, 128); // 59:HR Zone 4 Shading
+    LightDefaultColorList[CHZONE5].color = QColor(85, 255, 0); // 60:HR Zone 5 Shading
+    LightDefaultColorList[CHZONE6].color = QColor(255, 213, 0); // 61:HR Zone 6 Shading
+    LightDefaultColorList[CHZONE7].color = QColor(255, 0, 0); // 62:HR Zone 7 Shading
+    LightDefaultColorList[CHZONE8].color = QColor(160, 160, 164); // 63:HR Zone 8 Shading
+    LightDefaultColorList[CHZONE9].color = QColor(160, 160, 164); // 64:HR Zone 9 Shading
+    LightDefaultColorList[CHZONE10].color = QColor(160, 160, 164); // 65:HR Zone 10 Shading
+    LightDefaultColorList[CAEROVE].color = QColor(0, 0, 255); // 66:Aerolab VE
+    LightDefaultColorList[CAEROEL].color = QColor(0, 255, 0); // 67:Aerolab Elevation
+    LightDefaultColorList[CCALCELL].color = QColor(255, 255, 255); // 68:Calendar background
+    LightDefaultColorList[CCALHEAD].color = QColor(230, 230, 230); // 69:Calendar heading
+    LightDefaultColorList[CCALCURRENT].color = QColor(48, 140, 198); // 70:Calendar Current Selection
+    LightDefaultColorList[CCALACTUAL].color = QColor(0, 255, 0); // 71:Calendar Actual Workout
+    LightDefaultColorList[CCALPLANNED].color = QColor(255, 177, 21); // 72:Calendar Planned Workout
+    LightDefaultColorList[CCALTODAY].color = QColor(0, 255, 255); // 73:Calendar Today
+    LightDefaultColorList[CPOPUP].color = QColor(255, 255, 255); // 74:Pop Up Windows Background
+    LightDefaultColorList[CPOPUPTEXT].color = QColor(119, 119, 119); // 75:Pop Up Windows Foreground
+    LightDefaultColorList[CTILEBAR].color = QColor(160, 160, 164); // 76:Chart Bar Unselected
+    LightDefaultColorList[CTILEBARSELECT].color = QColor(255, 255, 0); // 77:Chart Bar Selected
+    LightDefaultColorList[CTOOLBAR].color = QColor(239, 239, 239); // 78:ToolBar Background
+    LightDefaultColorList[CRIDEGROUP].color = QColor(236, 246, 255); // 79:Activity History Group
+    LightDefaultColorList[CSPINSCANLEFT].color = QColor(0, 164, 101); // 80:SpinScan Left
+    LightDefaultColorList[CSPINSCANRIGHT].color = QColor(0, 130, 130); // 81:SpinScan Right
+    LightDefaultColorList[CTEMP].color = QColor(0, 107, 188); // 82:Temperature
+    LightDefaultColorList[CDIAL].color = QColor(160, 160, 164); // 83:Default Dial Color
+    LightDefaultColorList[CALTPOWER].color = QColor(255, 0, 255); // 84:Alternate Power
+    LightDefaultColorList[CBALANCELEFT].color = QColor(178, 0, 0); // 85:Left Balance
+    LightDefaultColorList[CBALANCERIGHT].color = QColor(128, 0, 50); // 86:Right Balance
+    LightDefaultColorList[CWBAL].color = QColor(186, 57, 59); // 87:W' Balance
+    LightDefaultColorList[CRIDECP].color = QColor(255, 85, 255); // 88:CP Curve
+    LightDefaultColorList[CATISS].color = QColor(146, 0, 146); // 89:Aerobic TISS
+    LightDefaultColorList[CANTISS].color = QColor(0, 130, 130); // 90:Anaerobic TISS
+    LightDefaultColorList[CLTE].color = QColor(0, 137, 137); // 91:Left Torque Effectiveness
+    LightDefaultColorList[CRTE].color = QColor(145, 0, 145); // 92:Right Torque Effectiveness
+    LightDefaultColorList[CLPS].color = QColor(0, 146, 146); // 93:Left Pedal Smoothness
+    LightDefaultColorList[CRPS].color = QColor(117, 0, 117); // 94:Right Pedal Smoothness
+    LightDefaultColorList[CCHROME].color = QColor(54, 55, 75); // 95:Toolbar and Sidebar
+    LightDefaultColorList[COVERVIEWBACKGROUND].color = QColor(227, 224, 232); // 96:Overview Background
+    LightDefaultColorList[CCARDBACKGROUND].color = QColor(255, 255, 255); // 97:Overview Tile Background
+    LightDefaultColorList[CVO2].color = QColor(255, 25, 167); // 98:VO2
+    LightDefaultColorList[CVENTILATION].color = QColor(27, 203, 177); // 99:Ventilation
+    LightDefaultColorList[CVCO2].color = QColor(0, 121, 0); // 100:VCO2
+    LightDefaultColorList[CTIDALVOLUME].color = QColor(101, 44, 45); // 101:Tidal Volume
+    LightDefaultColorList[CRESPFREQUENCY].color = QColor(134, 74, 255); // 102:Respiratory Frequency
+    LightDefaultColorList[CFEO2].color = QColor(255, 46, 46); // 103:FeO2
+     // Definition for CHOVER missing
+     // Definition for CCHARTBAR missing
+    LightDefaultColorList[CCARDBACKGROUND2].color = QColor(180, 180, 180); // 106:Tile Alternate
+    LightDefaultColorList[CCARDBACKGROUND3].color = QColor(238, 248, 255); // 107:Tile Vibrant
+    LightDefaultColorList[MAPROUTELINE].color = QColor(255, 0, 0); // 105:MapRouteLine
+>>>>>>> b3634a389 (Themes & color backup functionality)
 }
 
 // default settings for fonts etc
@@ -512,7 +761,7 @@ GCColor::setColor(int colornum, QColor color)
 Themes &
 GCColor::themes()
 {
-    return allThemes;
+    return *(Themes::instance());
 }
 
 ColorEngine::ColorEngine(GlobalContext *gc) : defaultColor(QColor(Qt::white)), gc(gc)
@@ -738,253 +987,49 @@ GCColor::getConfigKeys() {
 // Themes
 //
 
-Themes::Themes()
-{
+Themes::Themes() {
     // initialise the array of themes, lets just start with a compiled in list
-    QList<QColor> colors;
-    ColorTheme add("", true, QList<QColor>());
+    //QList<QColor> colors;
+    //ColorTheme add("", true, QList<QColor>());
 
-    //
-    // Add all the standard themes
-    //
+    // load themes from config file
+    QString content = "";
+    QString filename = QDir(gcroot).canonicalPath() + "/themes.xml"; 
+    QFile file(filename);
+    if (file.open(QIODevice::ReadOnly)) {
+        content = file.readAll();
+        file.close();
+    }
+    else {
+        QMessageBox msgBox;
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.setText(tr("Problem loading the themes.xml GUI configuration file."));
+        msgBox.setInformativeText(tr("File: %1 cannot be located or opened for 'Reading'.").arg(filename));
+        msgBox.exec();
+        return;
+    }
 
-    // MODERN DARK (Sublime Editor inspired)
-    add.name = tr("Modern Dark");
-    add.dark = true;
-    add.stealth = false;
-    colors << QColor(19,19,19) // Plot Background
-           << QColor(32,32,32) // Toolbar and Sidebar Chrome
-           << QColor(85,170,255) // Accent color (markers)
-           << QColor(194,194,194) // Selection color
-           << QColor(Qt::yellow) // Critical Power and W'Bal
-           << QColor(Qt::red) // Heartrate
-           << QColor(Qt::green) // Speed
-           << QColor(255,170,0) // Power
-           << QColor(0,204,204) // Cadence
-           << QColor(Qt::magenta) // Torque
-           << QColor(19,19,19) // Overview Background
-           << QColor(39,39,39) // Overview Tile Background
-           << QColor(60,60,60) // Overview Tile Background 2
-           << QColor(84,84,84);// Overview Tile Background 3
-    add.colors = colors;
-    themes << add;
-    colors.clear();
+    if (content != "") {
 
+        // setup the handler
+        QXmlInputSource source;
+        source.setData(content);
+        QXmlSimpleReader xmlReader;
+        ThemeParser handler;
+        xmlReader.setContentHandler(&handler);
+        xmlReader.setErrorHandler(&handler);
 
-    // MODERN LIGHT (SAP Fiori Belize inspired)
-    add.name = tr("Modern Light");
-    add.dark = false;
-    add.stealth = false;
-    colors << QColor(Qt::white)  // Plot Background
-           << QColor(0xef,0xf4,0xf9) // Toolbar and Sidebar Chrome
-           << QColor(0x26,0x84,0xf6) // Accent color (markers)
-           << QColor(Qt::blue) // Selection color
-           << QColor(Qt::darkMagenta) // Critical Power and W'Bal
-           << QColor(Qt::red) // Heartrate
-           << QColor(85,170,0) // Speed
-           << QColor(255,170,0) // Power
-           << QColor(0,204,204) // Cadence
-           << QColor(Qt::magenta) // Torque
-           << QColor(0xcb,0xdc,0xea) // Overview Background
-           << QColor(255,255,255) // Overview Tile Background
-           << QColor(247,252,255) // Overview Tile Background 2
-           << QColor(231,241,250);// Overview Tile Background 3
-    add.colors = colors;
-    themes << add;
-    colors.clear();
-
-    // STEALTH DARK (tab placement and mostly black)
-    add.name = tr("Modern Stealth Dark");
-    add.dark = true;
-    add.stealth = true;
-    colors << QColor(19,19,19) // Plot Background
-           << QColor(19,19,19) // Toolbar and Sidebar Chrome
-           << QColor(85,170,255) // Accent color (markers)
-           << QColor(194,194,194) // Selection color
-           << QColor(Qt::yellow) // Critical Power and W'Bal
-           << QColor(Qt::red) // Heartrate
-           << QColor(Qt::green) // Speed
-           << QColor(255,170,0) // Power
-           << QColor(0,204,204) // Cadence
-           << QColor(Qt::magenta) // Torque
-           << QColor(19,19,19) // Overview Background
-           << QColor(30,30,30) // Overview Tile Background
-           << QColor(38,38,38) // Overview Tile Background 2
-           << QColor(88,88,88);// Overview Tile Background 3
-    add.colors = colors;
-    themes << add;
-    colors.clear();
-
-    // STEALTH LIGHT (tab placement and mostly white)
-    add.name = tr("Modern Stealth Light");
-    add.dark = false;
-    add.stealth = true;
-    colors << QColor(255,255,255) // Plot Background
-           << QColor(255,255,255) // Toolbar and Sidebar Chrome
-           << QColor(52,99,255) // Accent color (markers)
-           << QColor(Qt::blue) // Selection color
-           << QColor(Qt::darkMagenta) // Critical Power and W'Bal
-           << QColor(Qt::red) // Heartrate
-           << QColor(85,170,0) // Speed
-           << QColor(255,170,0) // Power
-           << QColor(0,204,204) // Cadence
-           << QColor(Qt::magenta) // Torque
-           << QColor(255,255,255) // Overview Background
-           << QColor(245,245,245) // Overview Tile Background
-           << QColor(227,227,227) // Overview Tile Background 2
-           << QColor(202,202,202);// Overview Tile Background 3
-    add.colors = colors;
-    themes << add;
-    colors.clear();
-
-    add.name = tr("Gnome Adwaita Dark");
-    add.dark = true;
-    add.stealth = false;
-    colors << QColor(19,19,19)  // Plot Background
-           << QColor(44,49,51) // Toolbar and Sidebar Chrome
-           << QColor(85,170,255) // Accent color (markers)
-           << QColor(194,194,194) // Selection color
-           << QColor(Qt::yellow) // Critical Power and W'Bal
-           << QColor(Qt::red) // Heartrate
-           << QColor(Qt::green) // Speed
-           << QColor(255,170,0) // Power
-           << QColor(0,204,204) // Cadence
-           << QColor(Qt::magenta) // Torque
-           << QColor(19,19,19) // Overview Background
-           << QColor(44,49,51) // Overview Tile Background
-           << QColor(57,63,66) // Overview Tile Background 2
-           << QColor(73,81,91);// Overview Tile Background 3
-    add.colors = colors;
-    themes  << add;
-    colors.clear();
-
-    add.name = tr("Team Colours (light)");
-    add.dark = false;
-    add.stealth = false;
-    colors << QColor(Qt::white)  // Plot Background
-           << QColor(0x36,0x37,0x4b) // Toolbar and Sidebar Chrome
-           << QColor(0x65,0x69,0xa5) // Accent color (markers)
-           << QColor(194,194,194) // Selection color
-           << QColor(Qt::darkMagenta) // Critical Power and W'Bal
-           << QColor(Qt::red) // Heartrate
-           << QColor(Qt::darkGreen) // Speed
-           << QColor(255,170,0) // Power
-           << QColor(0,204,204) // Cadence
-           << QColor(Qt::magenta) // Torque
-           << QColor(0xe3,0xe0,0xe8) // Overview Background
-           << QColor(Qt::white) // Overview Tile Background
-           << QColor(252,249,255) // Overview Tile Background 2
-           << QColor(235,235,250);// Overview Tile Background 3
-    add.colors = colors;
-    themes  << add;
-    colors.clear();
-
-    add.name = tr("Ollie's Oatmeal (light)");
-    add.dark = false;
-    add.stealth = false;
-    colors << QColor(255,255,255)  // Plot Background
-           << QColor(63,69,58) // Toolbar and Sidebar Chrome
-           << QColor(0x8d,0x57,0x30) // Accent color (markers)
-           << QColor(194,194,194) // Selection color
-           << QColor(Qt::darkMagenta) // Critical Power and W'Bal
-           << QColor(Qt::red) // Heartrate
-           << QColor(Qt::green) // Speed
-           << QColor(255,170,0) // Power
-           << QColor(0,204,204) // Cadence
-           << QColor(Qt::magenta) // Torque
-           << QColor(192,201,197) // Overview Background
-           << QColor(235,241,234) // Overview Tile Background
-           << QColor(250,255,247) // Overview Tile Background 2
-           << QColor(83,93,82);// Overview Tile Background 3
-    add.colors = colors;
-    themes  << add;
-    colors.clear();
-
-    add.name = tr("Mustang (dark)"); // ** DARK **
-    add.dark = true;
-    add.stealth = false;
-    colors << QColor(0,0,0)  // Plot Background
-           << QColor(35,35,35) // Toolbar and Sidebar Chrome
-           << QColor(255,152,0) // Accent color (markers)
-           << QColor(Qt::white) // Selection color
-           << QColor(126,138,162) // Critical Power and W'Bal
-           << QColor(Qt::red) // Heartrate
-           << QColor(Qt::green) // Speed
-           << QColor(Qt::yellow) // Power
-           << QColor(0,204,204) // Cadence
-           << QColor(Qt::magenta) // Torque
-           << QColor(0,0,0) // Overview Background
-           << QColor(42,42,42) // Overview Tile Background
-           << QColor(30,30,30) // Overview Tile Background 2
-           << QColor(80,80,80);// Overview Tile Background 3
-    add.colors = colors;
-    themes  << add;
-    colors.clear();
-
-    add.name = tr("Mono (dark)"); // New v3.1 default colors // ** DARK **
-    add.dark = true;
-    add.stealth = false;
-    colors << QColor(Qt::black)  // Plot Background
-           << QColor(Qt::black) // Toolbar and Sidebar Chrome
-           << QColor(Qt::white) // Accent color (markers)
-           << QColor(Qt::white) // Selection color
-           << QColor(Qt::white) // Critical Power and W'Bal
-           << QColor(Qt::red) // Heartrate
-           << QColor(Qt::green) // Speed
-           << QColor(Qt::yellow) // Power
-           << QColor(0,204,204) // Cadence
-           << QColor(Qt::magenta) // Torque
-           << QColor(0,0,0) // Overview Background
-           << QColor(42,42,42) // Overview Tile Background
-           << QColor(42,42,42) // Overview Tile Background 2
-           << QColor(42,42,42);// Overview Tile Background 3
-    add.colors = colors;
-    themes  << add;
-    colors.clear();
-
-    add.name = tr("Mono (light)"); // New v3.1 default colors // ** LIGHT **
-    add.dark = false;
-    add.stealth = false;
-    colors  << QColor(Qt::white)  // Plot Background
-           << QColor(Qt::white) // Toolbar and Sidebar Chrome
-           << QColor(Qt::black) // Accent color (markers)
-           << QColor(Qt::black) // Selection color
-           << QColor(Qt::black) // Critical Power and W'Bal
-           << QColor(Qt::red) // Heartrate
-           << QColor(Qt::green) // Speed
-           << QColor(Qt::black) // Power
-           << QColor(0,204,204) // Cadence
-           << QColor(Qt::magenta) // Torque
-           << QColor(255,255,255) // Overview Background
-           << QColor(245,245,245) // Overview Tile Background
-           << QColor(245,245,245) // Overview Tile Background 2
-           << QColor(245,245,245);// Overview Tile Background 3
-    add.colors = colors;
-    themes  << add;
-    colors.clear();
-
-    // we can add more later ....
-    add.name = tr("Schoberer (light)"); // Old GoldenCheetah colors // ** LIGHT **
-    add.dark = false;
-    add.stealth = false;
-    colors << QColor(Qt::white)  // Plot Background
-           << QColor(0xec,0xec,0xec) // Toolbar and Sidebar Chrome
-           << QColor(Qt::black) // Accent color (markers)
-           << QColor(Qt::green) // Selection color
-           << QColor(Qt::red) // Critical Power and W'Bal
-           << QColor(Qt::red) // Heartrate
-           << QColor(Qt::magenta) // Speed
-           << QColor(Qt::green) // Power
-           << QColor(Qt::blue) // Cadence
-           << QColor(Qt::darkGreen) // Torque
-           << QColor(255,255,255) // Overview Background
-           << QColor(245,245,245) // Overview Tile Background
-           << QColor(245,245,245) // Overview Tile Background 2
-           << QColor(245,245,245);// Overview Tile Background 3
-    add.colors = colors;
-    themes  << add;
-    colors.clear();
-
+        // parse and instantiate the charts
+        xmlReader.parse(source);
+        themes = handler.themes;
+    }
+    else {
+        QMessageBox msgBox;
+        msgBox.setIcon(QMessageBox::Critical);
+        msgBox.setText(tr("File: %1 is empty !").arg(filename));
+        msgBox.exec();
+        return;
+    }
 }
 
 // NOTE: this is duplicated in Pages.cpp:1407:ColorsPage::applyThemeClicked()
@@ -1127,7 +1172,7 @@ GCColor::applyTheme(int index)
 }
 
 //
-// ColorLabel - just paints a swatch of the first 5 colors
+// ColorLabel - just paints a swatch of the colors
 //
 void
 ColorLabel::paintEvent(QPaintEvent *)
@@ -1141,11 +1186,11 @@ ColorLabel::paintEvent(QPaintEvent *)
     QRectF allF(0,0,width(),height());
     QRect all(0,0,width(),height());
 
-    const double x = width() / 5; 
+    const double x = width() / theme.colors.size();
     const double y = height();
 
     // now do all the color blocks
-    for (int i=0; i<5; i++) {
+    for (int i=0; i<theme.colors.size(); i++) {
 
         QRectF block (i*x,0,x,y);
         painter.fillRect(block, theme.colors[i]);

--- a/src/Gui/Colors.h
+++ b/src/Gui/Colors.h
@@ -26,7 +26,8 @@
 #include <QLabel>
 #include <QGradient>
 #include <QLinearGradient>
-
+#include <QXmlDefaultHandler>
+#include <QTextStream>
 
 // A selection of distinct colours, user can adjust also
 extern QList<QColor> standardColors;
@@ -75,6 +76,9 @@ class Colors
 {
 public:
         static unsigned long fingerprint(const Colors*set);
+
+        // all public
+        unsigned int index;
         QString group,
                 name,
                 setting;
@@ -84,6 +88,7 @@ public:
 class ColorTheme
 {
     public:
+        ColorTheme() : name(""), dark(false), stealth(false) {};
         ColorTheme(QString name, bool dark, QList<QColor>colors) : name(name), dark(dark), colors(colors) {}
 
         // all public
@@ -99,9 +104,61 @@ class Themes
     Q_DECLARE_TR_FUNCTIONS(Themes);
 
     public:
-        Themes(); // will init the array of themes
+       
+        Themes(Themes const&) = delete;
+        Themes& operator=(Themes const&) = delete;
 
         QList<ColorTheme> themes;
+
+        static Themes* instance() {
+            static Themes* s{ new Themes };
+            return s;
+        }
+
+    private:
+        Themes();
+ };
+
+// reads in themes
+class ThemeParser : public QXmlDefaultHandler {
+
+public:
+    ThemeParser() {};
+
+    // the themes!
+    ColorTheme theme;
+    QList<ColorTheme> themes;
+
+    // unmarshall
+    bool startDocument();
+    bool endDocument();
+    bool endElement(const QString&, const QString&, const QString& qName);
+    bool startElement(const QString&, const QString&, const QString& name, const QXmlAttributes& attrs);
+    bool characters(const QString& str);
+
+protected:
+
+};
+
+// reads in backup colors
+class ColorBackupParser : public QXmlDefaultHandler {
+
+public:
+    ColorBackupParser() {};
+
+    // the themes!
+    Colors color;
+    QList<Colors> colors;
+
+    // unmarshall
+    bool startDocument();
+    bool endDocument();
+    bool endElement(const QString&, const QString&, const QString& qName);
+    bool startElement(const QString&, const QString&, const QString& name, const QXmlAttributes& attrs);
+    bool characters(const QString& str);
+
+protected:
+
 };
 
 class ColorLabel : public QLabel

--- a/src/Gui/Pages.h
+++ b/src/Gui/Pages.h
@@ -454,6 +454,9 @@ class ColorsPage : public QWidget
         void scaleFont();
         void searchFilter(QString);
 
+        void backupColorsToXML();
+        void restoreColorsFromXML();
+
     private:
 
         // General stuff


### PR DESCRIPTION
**Configurable Themes**

This PR moves the original eight defined Themes that are hardcoded into GC into a configuration file stored in the GCRoot directory. This will enable new themes to be easily created, and corrections to existing themes to be made. This only replaces the themes definition aspect, GC has internal code which defines how the themes are applied and there are some platform dependent override cases, these are not altered by this PR.

The new themes configuration file which needs to be in GCRoot is:
https://drive.google.com/drive/folders/17bL9G6DMg-T8JfGvd1FnvRMmyhtXrQlk?usp=sharing

I have expanded the themes swatch to display all 13 colors in the theme color definitions, which makes it easier to compare the differences between the themes before applying them:

![Capture1](https://user-images.githubusercontent.com/46629337/177506719-f726d40d-6f23-4b77-b6b1-091a7d0736f5.PNG)



**Backup Colors**

When experimenting with the 109 possible colors in the Appearance->Colors tab there is no way to return to initial settings once "save" has been pressed, this is especially true if a theme was applied and then further modifications have been made in the Colors tab. So this PR introduces two buttons into the Colors tab which allow the current Color settings to be written to a "color-backup.xml" file in the GCRoot directory, and for the backup color settings to be imported.

Note1: The backup exports the colors currently defined in the Color tab, these maybe different to what GC is displaying if they haven't been applied by pressing "save".
Note2: Importing the color backup requires the user to press "save" to make them permanent within GC.

This change will also support copying Colors from one GC installation to another, the colors just need to be backed up, the color-backup.xml file copied to the same location in another GC installation, and then imported, and "save" pressed on the appearance dialog.

An example of the color-backup file created by the backup process (and written to GCRoot) can be found in:
https://drive.google.com/drive/folders/17bL9G6DMg-T8JfGvd1FnvRMmyhtXrQlk?usp=sharing


![Capture2](https://user-images.githubusercontent.com/46629337/177507304-6133b33c-4cc7-4b2d-b049-6f3deff7c231.PNG)


Should one element of this PR be considered unacceptable, let me know and I can separate them, but I think they are both useful additions to support the user configurability of GC.