### PR TITLE
clearFilter - release memory avoiding crashes

### DIFF
--- a/src/Core/DataFilter.cpp
+++ b/src/Core/DataFilter.cpp
@@ -1662,10 +1662,10 @@ void Leaf::clear(Leaf *leaf)
                            delete leaf->lvalue.l;
                            clear(leaf->series);
                            delete leaf->series;
-                           foreach (Leaf* l, leaf->fparms) clear(l);
+                           foreach (Leaf* l, leaf->fparms) { clear(l); delete l; }
                            leaf->fparms.clear();
                            break;
-    case Leaf::Compound :  foreach (Leaf* l, *(leaf->lvalue.b)) clear(l);
+    case Leaf::Compound :  foreach (Leaf* l, *(leaf->lvalue.b)) { clear(l); delete l; }
                            delete leaf->lvalue.b;
                            break;
     case Leaf::Conditional : clear(leaf->lvalue.l);
@@ -1678,7 +1678,7 @@ void Leaf::clear(Leaf *leaf)
     case Leaf::Index :
     case Leaf::Select :    clear(leaf->lvalue.l);
                            delete leaf->lvalue.l;
-                           foreach (Leaf* l, leaf->fparms) clear(l);
+                           foreach (Leaf* l, leaf->fparms) { clear(l); delete l; }
                            leaf->fparms.clear();
                            break;
     case Leaf::Float :

--- a/src/Core/DataFilter.h
+++ b/src/Core/DataFilter.h
@@ -219,6 +219,7 @@ class DataFilter : public QObject
     public:
         DataFilter(QObject *parent, Context *context);
         DataFilter(QObject *parent, Context *context, QString formula);
+        ~DataFilter() { clearFilter(); }
 
         // runtime passed by datafilter
         DataFilterRuntime rt;

--- a/src/Core/DataFilter.h
+++ b/src/Core/DataFilter.h
@@ -114,7 +114,7 @@ class Leaf {
 
     public:
 
-        Leaf(int loc, int leng) : type(none),op(0),series(NULL),dynamic(false),loc(loc),leng(leng),inerror(false) { }
+        Leaf(int loc, int leng) : type(none),lvalue(),rvalue(),cond(),op(0),series(NULL),dynamic(false),loc(loc),leng(leng),inerror(false) { }
 
         // evaluate against a RideItem using its context
         //
@@ -145,6 +145,7 @@ class Leaf {
                Compound, Script } type;
 
         union value {
+            value() { l = NULL; };
             float f;
             int i;
             QString *s;

--- a/src/Core/DataFilter.y
+++ b/src/Core/DataFilter.y
@@ -458,6 +458,8 @@ expr:
                                                   $1->type = Leaf::Function;
                                                   $1->series = NULL; // not tiz/best
                                                   $1->function = *($1->lvalue.n);
+                                                  delete $1->lvalue.n; // not used anymore
+                                                  $1->lvalue.l = NULL; // avoid double deletion
                                                   $1->fparms.clear(); // no parameters!
                                                 }
         | '(' expr ')'                          { $$ = new Leaf(@2.first_column, @2.last_column);


### PR DESCRIPTION
clearFilter - delete root Leaf
Leaf constructor: initialize left,right and cond to null pointers Leaf::clear avoid crashes when called with a null pointer parameter, and release memory in all cases allocated in the parser
TODO: still crashes if called from DataFilter destructor, see #4249