### PR TITLE
Honor chart filters in Trends view Histogram and CP charts

### DIFF
--- a/src/Charts/CPPlot.cpp
+++ b/src/Charts/CPPlot.cpp
@@ -1202,12 +1202,12 @@ CPPlot::plotBests(RideItem *rideItem)
     if (bestsCache == NULL) {
         // isFiltered and files are filters from CriticalPowerWindow's filter setting
         // we also need to take into account the perspective filter if on trends so
-        // its easier to just aggregate the filter list here (bit hacky but works ok)
+        // we pass isFiltered and files for filterlist to take care of them,
         // but only if rangemode (aka on trends)
         if (rangemode) {
             bestsCache = new RideFileCache(context, startDate, endDate,
                             isFiltered || (parent->myPerspective && parent->myPerspective->isFiltered()),
-                            files + ((parent->myPerspective && parent->myPerspective->isFiltered()) ? parent->myPerspective->filterlist(DateRange(startDate,endDate)) : QStringList()),
+                            parent->myPerspective ? parent->myPerspective->filterlist(DateRange(startDate,endDate), isFiltered, files) : files,
                             rangemode, rideItem);
         } else {
             bestsCache = new RideFileCache(context, startDate, endDate, isFiltered, files, rangemode, rideItem);

--- a/src/Charts/HistogramWindow.cpp
+++ b/src/Charts/HistogramWindow.cpp
@@ -1032,8 +1032,9 @@ HistogramWindow::updateChart()
                 // plotting a data series, so refresh the ridefilecache
 
                 if (rangemode) {
+                    // filterlist takes care of both chart and perspective filters to generate the file list
                     source = new RideFileCache(context, use.from, use.to, isfiltered || (myPerspective && myPerspective->isFiltered()),
-                                               files + (myPerspective ? myPerspective->filterlist(use) : QStringList()), rangemode);
+                                               myPerspective ? myPerspective->filterlist(use, isfiltered, files) : files, rangemode);
                 } else source = new RideFileCache(context, use.from, use.to, isfiltered, files, rangemode);
 
                 cfrom = use.from;

--- a/src/Gui/Perspective.cpp
+++ b/src/Gui/Perspective.cpp
@@ -1704,13 +1704,14 @@ Perspective::relevant(RideItem *item)
 }
 
 QStringList
-Perspective::filterlist(DateRange dr)
+Perspective::filterlist(DateRange dr, bool isfiltered, QStringList files)
 {
     SSS;
     QStringList returning;
 
     Specification spec;
     spec.setDateRange(dr);
+    spec.setFilterSet(FilterSet(isfiltered, files)); // typically chart level filter
 
     foreach(RideItem *item, context->athlete->rideCache->rides()) {
         if (!spec.pass(item)) continue;

--- a/src/Gui/Perspective.h
+++ b/src/Gui/Perspective.h
@@ -67,9 +67,9 @@ class Perspective : public GcWindow
         // am I relevant? (for switching when ride selected)
         bool relevant(RideItem*);
 
-        // the items I'd choose (for filtering on trends view)
+        // the items I'd choose (for filtering on trends view, optionally refined by chart filter)
         bool isFiltered() const override { return (type_ == VIEW_TRENDS && df != NULL); }
-        QStringList filterlist(DateRange dr);
+        QStringList filterlist(DateRange dr, bool isfiltered=false, QStringList files=QStringList());
 
         // get/set the expression (will compile df)
         QString expression() const;


### PR DESCRIPTION
Just appending the file lists doesn't work like addFilter does, isfiltered and files are added as optional parameters to Pespective:filterlist so they are accounted for when the list of files is generated.
Fixes #4285