### PR TITLE
mention QMAKE_MOVE requirement for bison > 3.7 in INSTALL-LINUX

### DIFF
--- a/INSTALL-LINUX
+++ b/INSTALL-LINUX
@@ -104,6 +104,9 @@ win32 {
   QMAKE_DEL_FILE = rm -f
 }
 
+And if you are using bison 3.7 or higher, make sure to also add:
+QMAKE_MOVE = cp
+
 To compile translation you need the QT tool lrelease
 If it is not found using the defaults in src/src.pro then set the full path and
 filename in gcconfig.pri, s.t.


### PR DESCRIPTION
I was following the `INSTALL-LINUX` instructions and stumbled over this problem.

And 2 open questions regarding the installation instructions:
- I skipped the below because it was referencing `win32`, is this needed in the Linux install instructions? 
https://github.com/GoldenCheetah/GoldenCheetah/blob/996ee63cd5935012fb80761af04e6984a79737ab/INSTALL-LINUX#L101-L105

- Is there an easy way to determine if I need `-lz`? My `QtCore` lib is definitely linked against `libz.so` but I still had to specify `-lz` here. 
https://github.com/GoldenCheetah/GoldenCheetah/blob/996ee63cd5935012fb80761af04e6984a79737ab/INSTALL-LINUX#L112-L115 