### PR TITLE
Estimates and Performances - Generalize to any sport with power data

### DIFF
--- a/src/Charts/LTMPlot.cpp
+++ b/src/Charts/LTMPlot.cpp
@@ -3055,14 +3055,14 @@ void
 LTMPlot::createEstimateData(Context *context, LTMSettings *settings, MetricDetail metricDetail,
                                               QVector<double>&x,QVector<double>&y,int&n, bool)
 {
-    // curve specific filter, used to figure out if all activities are runs
+    // curve specific filter, used to figure out if all activities are from the same sport
     Specification spec = settings->specification;
     if (!SearchFilterBox::isNull(metricDetail.datafilter))
         spec.addMatches(SearchFilterBox::matches(context, metricDetail.datafilter));
     int nActivities, nRides, nRuns, nSwims;
     QString sport;
     context->athlete->rideCache->getRideTypeCounts(spec, nActivities, nRides, nRuns, nSwims, sport);
-    metricDetail.run = (nRuns > 0 && nActivities == nRuns);
+    if (sport.isEmpty()) sport = "Bike"; // Mixed sports use Bike estimates for backward compatibility
 
     // resize the curve array to maximum possible size (even if we don't need it)
     int maxdays = groupForDate(settings->end.date(), settings->groupBy)
@@ -3089,7 +3089,7 @@ LTMPlot::createEstimateData(Context *context, LTMSettings *settings, MetricDetai
     foreach(PDEstimate est, context->athlete->getPDEstimates()) {
 
         // skip if not the requested sport
-        if (est.run != metricDetail.run) continue;
+        if (est.sport != sport) continue;
 
         // wpk skip for now
         if (est.wpk != metricDetail.wpk) continue;
@@ -3751,14 +3751,14 @@ LTMPlot::createMeasureData(Context *context, LTMSettings *settings, MetricDetail
 void
 LTMPlot::createPerformanceData(Context *context, LTMSettings *settings, MetricDetail metricDetail, QVector<double>&x,QVector<double>&y,int&n, bool)
 {
-    // curve specific filter, used to figure out if all activities are runs
+    // curve specific filter, used to figure out if all activities are from the same sport
     Specification spec = settings->specification;
     if (!SearchFilterBox::isNull(metricDetail.datafilter))
         spec.addMatches(SearchFilterBox::matches(context, metricDetail.datafilter));
     int nActivities, nRides, nRuns, nSwims;
     QString sport;
     context->athlete->rideCache->getRideTypeCounts(spec, nActivities, nRides, nRuns, nSwims, sport);
-    metricDetail.run = (nRuns > 0 && nActivities == nRuns);
+    if (sport.isEmpty()) sport = "Bike"; // Mixed sports use Bike performances for backward compatibility
 
     int maxdays = groupForDate(settings->end.date(), settings->groupBy)
                   - groupForDate(settings->start.date(), settings->groupBy) + 1;
@@ -3820,12 +3820,12 @@ LTMPlot::createPerformanceData(Context *context, LTMSettings *settings, MetricDe
         }
         if (metricDetail.perfs && value <= 0) {
             // is there a weekly performance today?
-            Performance p = context->athlete->rideCache->estimator->getPerformanceForDate(date, metricDetail.run);
+            Performance p = context->athlete->rideCache->estimator->getPerformanceForDate(date, sport);
             if (!p.submaximal) value = p.powerIndex;
         }
         if (metricDetail.submax && value <= 0) {
             // is there a submax weekly performance today?
-            Performance p = context->athlete->rideCache->estimator->getPerformanceForDate(date, metricDetail.run);
+            Performance p = context->athlete->rideCache->estimator->getPerformanceForDate(date, sport);
             if (p.submaximal) value = p.powerIndex;
         }
 

--- a/src/Core/Athlete.cpp
+++ b/src/Core/Athlete.cpp
@@ -587,11 +587,11 @@ Athlete::getPMCFor(Leaf *expr, DataFilterRuntime *df, int stsdays, int ltsdays)
 }
 
 PDEstimate
-Athlete::getPDEstimateFor(QDate date, QString model, bool wpk, bool run)
+Athlete::getPDEstimateFor(QDate date, QString model, bool wpk, QString sport)
 {
     // whats the estimate for this date
     foreach(PDEstimate est, getPDEstimates()) {
-        if (est.model == model && est.wpk == wpk && est.run == run && est.from <= date && est.to >= date)
+        if (est.model == model && est.wpk == wpk && est.sport == sport && est.from <= date && est.to >= date)
             return est;
     }
     return PDEstimate();

--- a/src/Core/Athlete.h
+++ b/src/Core/Athlete.h
@@ -100,7 +100,7 @@ class Athlete : public QObject
         CloudServiceAutoDownload *cloudAutoDownload;
 
         // Estimates
-        PDEstimate getPDEstimateFor(QDate, QString model, bool wpk, bool run);
+        PDEstimate getPDEstimateFor(QDate, QString model, bool wpk, QString sport);
         QList<PDEstimate> getPDEstimates();
 
         // PMC Data

--- a/src/FileIO/RideFileCache.cpp
+++ b/src/FileIO/RideFileCache.cpp
@@ -315,7 +315,7 @@ static long countForMeanMax(RideFileCacheHeader head, RideFile::SeriesType serie
     return 0;
 }
 
-QVector<float> RideFileCache::meanMaxPowerFor(Context *context, QVector<float> &wpk, QDate from, QDate to, QVector<QDate>*dates, bool wantruns)
+QVector<float> RideFileCache::meanMaxPowerFor(Context *context, QVector<float> &wpk, QDate from, QDate to, QVector<QDate>*dates, QString sport)
 {
     QVector<float> returning;
     QVector<float> returningwpk;
@@ -326,7 +326,7 @@ QVector<float> RideFileCache::meanMaxPowerFor(Context *context, QVector<float> &
 
         if (item->dateTime.date() < from || item->dateTime.date() > to) continue; // not one we want
 
-        if (item->isRun != wantruns) continue; // they don't want these
+        if (item->sport != sport) continue; // they don't want these
 
         // get the power data
         if (first == true) {

--- a/src/FileIO/RideFileCache.h
+++ b/src/FileIO/RideFileCache.h
@@ -170,7 +170,7 @@ class RideFileCache
         static bool checkStale(Context *context, RideItem*item);
 
         // Just get mean max values for power & wpk for a ride
-        static QVector<float> meanMaxPowerFor(Context *context, QVector<float>&wpk, QDate from, QDate to, QVector<QDate> *dates, bool wantruns=true);
+        static QVector<float> meanMaxPowerFor(Context *context, QVector<float>&wpk, QDate from, QDate to, QVector<QDate> *dates, QString sport="Bike");
         static QVector<float> meanMaxPowerFor(Context *context, QVector<float>&wpk, QString filename);
 
         // Fast standalone search reads input and outputs into ride_bests

--- a/src/Metrics/Banister.cpp
+++ b/src/Metrics/Banister.cpp
@@ -307,7 +307,7 @@ Banister::refresh()
             // is a weekly performance already identified
             // This applies only when performance metric is power_index
             if (!(todaybest > 0) && perf_symbol == "power_index") {
-                Performance p = context->athlete->rideCache->estimator->getPerformanceForDate(item->dateTime.date(), item->isRun);
+                Performance p = context->athlete->rideCache->estimator->getPerformanceForDate(item->dateTime.date(), item->sport);
                 if (!p.submaximal && p.powerIndex > 0) {
 
                     // its not submax
@@ -567,9 +567,9 @@ void Banister::fit()
 //
 
 // power index metric
-double powerIndex(double averagepower, double duration, bool isRun)
+double powerIndex(double averagepower, double duration, QString sport)
 {
-    if (isRun) return RideFile::NIL; // TODO: different parameters for Running
+    Q_UNUSED(sport) // TODO: different parameters for other sports?
 
     // so now lets work out what the 3p model says the
     // typical athlete would do for the same duration
@@ -638,7 +638,7 @@ class PowerIndex : public RideMetric {
         }
 
         // calculate power index, 0=out of bounds
-        double pix = powerIndex(averagepower, duration, item->isRun);
+        double pix = powerIndex(averagepower, duration, item->sport);
 
         // we could convert to linear work time model before
         // indexing, but they cancel out so no value in doing so
@@ -689,7 +689,7 @@ class PeakPowerIndex : public RideMetric {
 
             // calculate peak power index, starting from 3 mins, 0=out of bounds
             for (int secs=180; secs<vector.count(); secs++) {
-                double pix = powerIndex(vector[secs], secs, item->isRun);
+                double pix = powerIndex(vector[secs], secs, item->sport);
                 if (pix > peakpix) {
                     peakpix=pix;
                 }

--- a/src/Metrics/Banister.h
+++ b/src/Metrics/Banister.h
@@ -32,7 +32,7 @@
 extern const double typical_CP, typical_WPrime, typical_Pmax;
 
 // calculate power index, used to model in cp plot too
-extern double powerIndex(double averagepower, double duration, bool isRun=false);
+extern double powerIndex(double averagepower, double duration, QString sport="Bike");
 
 // gap with no training that constitutes break in seasons
 extern const int typical_SeasonBreak;

--- a/src/Metrics/Estimator.h
+++ b/src/Metrics/Estimator.h
@@ -35,12 +35,12 @@ class Performance {
 
     public:
         Performance(QDate wc, double power, double duration, double powerIndex) :
-            weekcommencing(wc), power(power), duration(duration), powerIndex(powerIndex), submaximal(false) {}
+            weekcommencing(wc), power(power), duration(duration), powerIndex(powerIndex), submaximal(false), sport("Bike") {}
 
         QDate when, weekcommencing;
         double power, duration, powerIndex;
         bool submaximal; // set by the filter, user can choose to include.
-        bool run; // indicates a Running with power performance
+        QString sport;
 
         double x; // different units, but basically when as a julian day
 };
@@ -73,7 +73,7 @@ class Estimator : public QThread {
         void calculate();
 
         // get a performance for a given day
-        Performance getPerformanceForDate(QDate date, bool wantrun);
+        Performance getPerformanceForDate(QDate date, QString sport);
         QList<Performance> &allPerformances() { return performances; }
 
     protected:

--- a/src/Metrics/PDModel.h
+++ b/src/Metrics/PDModel.h
@@ -186,7 +186,7 @@ extern double calllmfitf(double t, const double *p);
 class PDEstimate
 {
     public:
-        PDEstimate() : WPrime(0), CP(0), FTP(0), PMax(0), EI(0), wpk(false), run(false) {}
+        PDEstimate() : WPrime(0), CP(0), FTP(0), PMax(0), EI(0), wpk(false), sport("Bike") {}
 
         QDate from, to;
         QString model;
@@ -197,7 +197,7 @@ class PDEstimate
             EI;
 
         bool wpk;
-        bool run;
+        QString sport;
 
         QList<double> parameters; // parameters are stored/retrieved from here
                                   // so we can run the model using pre-computed


### PR DESCRIPTION
Weekly estimates and performances are precomputed for any sport with power data, not just Bike and Run.
In Trends view both LTM charts and DataFilter select sport based on applied filters: when all activities are from the same sport, that is used to select estimates and performances, otherwise Bike estimates and performances are used for backward compatibility. This reverts 1a285d105096c53409889b3e4ec305d7ac1b6047