### PR TITLE
Determine virtual activity sub-sport based on gps trace

### DIFF
--- a/src/Core/Units.h
+++ b/src/Core/Units.h
@@ -39,6 +39,7 @@
 #define KG_FORCE_PER_METER 9.80665f
 #define MS_IN_ONE_HOUR 3600000
 #define MS_IN_WKO_HOURS 360000 // yes this number of ms is required to match for WKO
+#define DEG_TO_RAD(deg) (deg * M_PI / 180)
 
 #include <QString>
 extern QString kphToPace(double kph, bool metric, bool isSwim=false);

--- a/src/FileIO/CsvRideFile.cpp
+++ b/src/FileIO/CsvRideFile.cpp
@@ -1266,9 +1266,9 @@ RideFile *CsvFileReader::openRideFile(QFile &file, QStringList &errors, QList<Ri
     file.close();
 
     // here we were capturing data on hometrainer with GoldenCheetah
-    if (csvType == gc) {
-        // add Sport Tag
-        rideFile->setTag("Sport", "Bike");
+    if ((csvType == gc) && rideFile->isBike()) {
+        // add Sport Tag when not already there
+        rideFile->setTag("Sport", rideFile->sport());
 
         // default mode is not virtual activity but home-trainer
         rideFile->setTag("SubSport", "home trainer");


### PR DESCRIPTION
Segregate indoor cycling activities by detecting

- virtual activities: when GPS trace follows workout fake trace
- hometrainer workout when GPS signal ramain whthin the same area range

Then populate sub_sport tag accordingly.