### PR TITLE
CP Chart - restate access to Delta Compare

### DIFF
--- a/src/Charts/CriticalPowerWindow.cpp
+++ b/src/Charts/CriticalPowerWindow.cpp
@@ -73,22 +73,15 @@ CriticalPowerWindow::CriticalPowerWindow(Context *context, bool rangemode) :
     rDeltaPercent->setText(tr("as percentage"));
     rDeltaPercent->hide();
 
-    QVBoxLayout *checks = new QVBoxLayout;
-    checks->addStretch();
-    checks->addWidget(rPercent);
-    checks->addWidget(rHeat);
-    checks->addWidget(rDelta);
-    checks->addWidget(rDeltaPercent);
-    checks->addStretch();
-
     revealLayout->addStretch();
     revealLayout->addWidget(rSeriesLabel);
     revealLayout->addWidget(rSeriesSelector);
     revealLayout->addSpacing(20);
-    revealLayout->addLayout(checks);
+    revealLayout->addWidget(rPercent);
+    revealLayout->addWidget(rHeat);
+    revealLayout->addWidget(rDelta);
+    revealLayout->addWidget(rDeltaPercent);
     revealLayout->addStretch();
-
-    setRevealLayout(revealLayout);
 
     //
     // main plot area
@@ -97,6 +90,7 @@ CriticalPowerWindow::CriticalPowerWindow(Context *context, bool rangemode) :
     setChartLayout(mainLayout);
 
     cpPlot = new CPPlot(this, context, rangemode);
+    mainLayout->addLayout(revealLayout);
     mainLayout->addWidget(cpPlot);
     HelpWhatsThis *help = new HelpWhatsThis(cpPlot);
     if (rangemode) cpPlot->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::ChartTrends_Critical_MM));


### PR DESCRIPTION
Reveal controls were disabled by 53081eb to avoid UX interferences, but Delta Compare options are not available as standard chart settings, since they are specific to Compare Mode we could keep them always visible at the top of the chart instead of moving them to standard settings.

This is how the top of the chart looks like in compare mode:
![image](https://user-images.githubusercontent.com/1444784/216089422-6232647b-1f4e-4f08-b698-2e05e4fd97e7.png)

and in normal mode:
![image](https://user-images.githubusercontent.com/1444784/216089205-e47734de-a3ed-4e52-9b6a-c7db420daf60.png)

It uses some vertical space, but it is similar to User Charts in that respect, and it makes the UI simpler and more intuitive, not all users are aware of reveal controls, IMHO.