### PR TITLE
Accept gpx as videosynch source during scan

### DIFF
--- a/src/Train/VideoSyncFile.cpp
+++ b/src/Train/VideoSyncFile.cpp
@@ -31,6 +31,7 @@ static bool setSupported()
     ::supported << ".rlv";
     ::supported << ".tts";
     ::supported << ".json";
+    ::supported << ".gpx";
 
     return true;
 }


### PR DESCRIPTION
GPX, RLV, GC JSON and TTS files are part of VideoSynch.cpp code (line 59) but GPX is not included in supported format when scanning for videosynch files.
This patch just includes GPX as files to be included in the scan.