### PR TITLE
Allows optional cloud service sync on auto import

### DIFF
--- a/src/Core/Athlete.cpp
+++ b/src/Core/Athlete.cpp
@@ -366,6 +366,11 @@ Athlete::configChanged(qint32 state)
 void
 Athlete::importFilesWhenOpeningAthlete() {
 
+    if (autoImportConfig->importCloudSyncEnabled()) {
+        // sync with cloud
+        cloudAutoDownload->checkDownload();
+    }
+
     autoImport = NULL;
     // just do it if something is configured
     if (autoImportConfig->hasRules()) {

--- a/src/FileIO/RideAutoImportConfig.h
+++ b/src/FileIO/RideAutoImportConfig.h
@@ -63,6 +63,7 @@ class RideAutoImportConfig : public QObject {
         void writeConfig();
         QList<RideAutoImportRule> getConfig() { return _configList; }
         bool hasRules() { return (_configList.count() > 0); }
+        bool importCloudSyncEnabled() { return cloudSync; }
 
     signals:
         void changedConfig();
@@ -70,6 +71,7 @@ class RideAutoImportConfig : public QObject {
     private:
         QDir config;
         QList<RideAutoImportRule> _configList;
+        bool cloudSync;
 };
 
 
@@ -78,7 +80,7 @@ class RideAutoImportConfigParser : public QXmlDefaultHandler
 
 public:
     // marshall
-    static bool serialize(QString, QList<RideAutoImportRule> rules);
+    static bool serialize(QString filename, bool cloudSync, QList<RideAutoImportRule> rules);
 
     // unmarshall
     bool startDocument();
@@ -87,11 +89,13 @@ public:
     bool startElement(const QString&, const QString&, const QString &name, const QXmlAttributes& );
     bool characters( const QString& str );
     QList<RideAutoImportRule> getRules();
+    bool importCloudSyncEnabled() { return cloudSync; }
 
 private:
     QString buffer;
     RideAutoImportRule rule;
     QList<RideAutoImportRule> rules;
+    bool cloudSync;
     static QString EncodeXML ( const QString& );
     static QString DecodeXML ( const QString& );
 

--- a/src/Gui/AthletePages.cpp
+++ b/src/Gui/AthletePages.cpp
@@ -2025,7 +2025,6 @@ LTPage::LTPage(Context *context, HrZones *hrZones, HrSchemePage *schemePage) :
     addLayout->addWidget(dateEdit);
     addLayout->addStretch();
 
-    QHBoxLayout *addLayout2 = new QHBoxLayout;
     QLabel *ltLabel = new QLabel(tr("Lactate Threshold"));
     QLabel *aetLabel = new QLabel(tr("Aerobic Threshold"));
     QLabel *restHrLabel = new QLabel(tr("Rest HR"));
@@ -3488,10 +3487,16 @@ AutoImportPage::AutoImportPage(Context *context) : context(context)
 
     fields->setCurrentItem(fields->invisibleRootItem()->child(0));
 
-    mainLayout->addWidget(fields, 0,0);
-    mainLayout->addLayout(actionButtons, 1,0);
-
     context->athlete->autoImportConfig->readConfig();
+ 
+    cloudSyncChkBox = new QCheckBox(tr("Enable Cloud Sync On Import"), this);
+    bool enabled = context->athlete->autoImportConfig->importCloudSyncEnabled();
+    cloudSyncChkBox->setChecked(enabled);
+
+    mainLayout->addWidget(cloudSyncChkBox, 0, 0);
+    mainLayout->addWidget(fields, 1,0);
+    mainLayout->addLayout(actionButtons, 2,0);
+
     QList<RideAutoImportRule> rules = context->athlete->autoImportConfig->getConfig();
     int index = 0;
     foreach (RideAutoImportRule rule, rules) {
@@ -3606,7 +3611,7 @@ AutoImportPage::saveClicked()
 
     // write to disk
     QString file = QString(context->athlete->home->config().canonicalPath() + "/autoimport.xml");
-    RideAutoImportConfigParser::serialize(file, rules);
+    RideAutoImportConfigParser::serialize(file, cloudSyncChkBox->isChecked(), rules);
 
     // re-read
     context->athlete->autoImportConfig->readConfig();

--- a/src/Gui/AthletePages.h
+++ b/src/Gui/AthletePages.h
@@ -592,6 +592,7 @@ class AutoImportPage : public QWidget
         QList<RideAutoImportRule> rules;
 
         QTreeWidget *fields;
+        QCheckBox* cloudSyncChkBox;
 
 #ifndef Q_OS_MAC
         QToolButton *upButton, *downButton;


### PR DESCRIPTION
This PR aims to resolve #2710 by adding an option in the auto import dialog to incude the configured cloud services.

Note: Due to the secret key cloud service key, I cannot test it locally so hopefully I can use the version built by the GC build process.

![cloudSync](https://user-images.githubusercontent.com/46629337/235118947-a562c154-f1d8-429e-978e-956fb0f526c9.JPG)
