### PR TITLE
Use configured bicycle weight for training in Simulated Speed

### DIFF
--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -1990,7 +1990,7 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
             displayLongitude = rtData.getLongitude();
             displayAltitude = rtData.getAltitude();
 
-            double weightKG = context->athlete->getWeight(QDate::currentDate()) + 10; // 10kg bike
+            double weightKG = bicycle.MassKG();
             double vs = computeInstantSpeed(weightKG, rtData.getSlope(), rtData.getAltitude(), rtData.getWatts());
 
             rtData.setVirtualSpeed(vs);


### PR DESCRIPTION
When computing simulated speed based on slope, altitude, etc, total weight (athlete + bicycle) is relevant, specially in up and down hills

Currently, It is using 10kg plus the athlete weight. Now, it considers configured bicycle weigth. Not very relevant, but consistent with the data GH has for training