### PR TITLE
Upgrade Python AppImage version for Linux builds

### DIFF
--- a/travis/linux/after_success.sh
+++ b/travis/linux/after_success.sh
@@ -55,7 +55,7 @@ chmod a+x linuxdeployqt-7-x86_64.AppImage
 ./linuxdeployqt-7-x86_64.AppImage appdir/GoldenCheetah -verbose=2 -bundle-non-qt-libs -exclude-libs=libqsqlmysql,libqsqlpsql,libnss3,libnssutil3,libxcb-dri3.so.0 -unsupported-allow-new-glibc
 
 # Add Python and core modules
-wget --no-verbose https://github.com/niess/python-appimage/releases/download/python3.7/python3.7.16-cp37-cp37m-manylinux1_x86_64.AppImage
+wget --no-verbose https://github.com/niess/python-appimage/releases/download/python3.7/python3.7.17-cp37-cp37m-manylinux1_x86_64.AppImage
 chmod +x python3.7.16-cp37-cp37m-manylinux1_x86_64.AppImage
 ./python3.7.16-cp37-cp37m-manylinux1_x86_64.AppImage --appimage-extract
 rm -f python3.7.16-cp37-cp37m-manylinux1_x86_64.AppImage


### PR DESCRIPTION
Python 3.7.15 AppImage is no longer available, upgrade to 3.7.17