### PR TITLE
show/hide interval settings based on selection

### DIFF
--- a/src/Charts/CriticalPowerWindow.cpp
+++ b/src/Charts/CriticalPowerWindow.cpp
@@ -751,6 +751,120 @@ CriticalPowerWindow::fitChanged()
 }
 
 void
+CriticalPowerWindow::showAnaerobicIntervals(bool show)
+{
+    if (show) {
+        anLabel->show();
+        anI1SpinBox->show();
+        anI2SpinBox->show();
+    } else {
+        anLabel->hide();
+        anI1SpinBox->hide();
+        anI2SpinBox->hide();
+    }
+}
+
+void
+CriticalPowerWindow::showAerobicIntervals(bool show)
+{
+    if (show) {
+        aeLabel->show();
+        aeI1SpinBox->show();
+        aeI2SpinBox->show();
+    } else {
+        aeLabel->hide();
+        aeI1SpinBox->hide();
+        aeI2SpinBox->hide();
+    }
+}
+void
+CriticalPowerWindow::showShortAnaerobicIntervals(bool show)
+{
+    if (show) {
+        sanLabel->show();
+        sanI1SpinBox->show();
+        sanI2SpinBox->show();
+    } else {
+        sanLabel->hide();
+        sanI1SpinBox->hide();
+        sanI2SpinBox->hide();
+    }
+}
+
+void
+CriticalPowerWindow::showLongAerobicIntervals(bool show)
+{
+    if (show) {
+        laeLabel->show();
+        laeI1SpinBox->show();
+        laeI2SpinBox->show();
+    } else {
+        laeLabel->hide();
+        laeI1SpinBox->hide();
+        laeI2SpinBox->hide();
+    }
+}
+
+/** 
+ * Shows or hides the interval spinboxes relevant for the current selection.
+ *
+ * The decision depends on both, the model and the fitting method.
+ */
+void
+CriticalPowerWindow::showRelevantIntervals()
+{
+    // interval selection has no effect for fits other than envelope. In this
+    // case hide them all.
+    if (fitCombo->currentIndex() != 0) {
+        intervalLabel->hide();
+        secondsLabel->hide();
+        showShortAnaerobicIntervals(false);
+        showAnaerobicIntervals(false);
+        showAerobicIntervals(false);
+        showLongAerobicIntervals(false);
+        return;
+    }
+    // if we have come here, we have envelope fits and the required
+    // intervals depend on the chosen model.
+    intervalLabel->show();
+    secondsLabel->show();
+    switch(modelCombo->currentIndex()) {
+    // no model
+    case 0:
+        intervalLabel->hide();
+        secondsLabel->hide();
+        showShortAnaerobicIntervals(false);
+        showAnaerobicIntervals(false);
+        showAerobicIntervals(false);
+        showLongAerobicIntervals(false);
+        break;
+    // 2 parameter model
+    case 1:
+    // 3 parameter model
+    case 2:
+    // WS-model
+    case 5:
+        showShortAnaerobicIntervals(false);
+        showAnaerobicIntervals(true);
+        showAerobicIntervals(true);
+        showLongAerobicIntervals(false);
+        break;
+    case 3:
+        showShortAnaerobicIntervals(true);
+        showAnaerobicIntervals(true);
+        showAerobicIntervals(true);
+        showLongAerobicIntervals(true);
+        break;
+    default:
+        // we should not reach this point, since models >= 3 have been handled
+        // before.
+        break;
+
+
+    }
+}
+
+void
 CriticalPowerWindow::modelChanged()
 {
     // we changed from/to a 2 or 3 parameter model
@@ -789,21 +903,6 @@ CriticalPowerWindow::modelChanged()
     switch (modelCombo->currentIndex()) {
 
     case 0 : // None
-
-            intervalLabel->hide();
-            secondsLabel->hide();
-            sanLabel->hide();
-            sanI1SpinBox->hide();
-            sanI2SpinBox->hide();
-            anLabel->hide();
-            anI1SpinBox->hide();
-            anI2SpinBox->hide();
-            aeLabel->hide();
-            aeI1SpinBox->hide();
-            aeI2SpinBox->hide();
-            laeLabel->hide();
-            laeI1SpinBox->hide();
-            laeI2SpinBox->hide();
             modelDecayCheck->hide();
             modelDecayLabel->hide();
 
@@ -823,22 +922,6 @@ CriticalPowerWindow::modelChanged()
             // and drop through into case 1 below ...
 
     case 1 : // Classic 2 param model 2-20 default (per literature)
-
-            intervalLabel->show();
-            secondsLabel->show();
-            anLabel->show();
-            sanLabel->hide();
-            sanI1SpinBox->hide();
-            sanI2SpinBox->hide();
-            anLabel->show();
-            anI1SpinBox->show();
-            anI2SpinBox->show();
-            aeLabel->show();
-            aeI1SpinBox->show();
-            aeI2SpinBox->show();
-            laeLabel->hide();
-            laeI1SpinBox->hide();
-            laeI2SpinBox->hide();
             modelDecayCheck->hide();
             modelDecayLabel->hide();
 
@@ -852,21 +935,6 @@ CriticalPowerWindow::modelChanged()
 
     case 2 : // 3 param model: 30-60 model
     case 5 : // WS model: 30-60 model
-
-            intervalLabel->show();
-            secondsLabel->show();
-            sanLabel->hide();
-            sanI1SpinBox->hide();
-            sanI2SpinBox->hide();
-            anLabel->show();
-            anI1SpinBox->show();
-            anI2SpinBox->show();
-            aeLabel->show();
-            aeI1SpinBox->show();
-            aeI2SpinBox->show();
-            laeLabel->hide();
-            laeI1SpinBox->hide();
-            laeI2SpinBox->hide();
             modelDecayLabel->show();
             modelDecayCheck->show();
 
@@ -879,21 +947,6 @@ CriticalPowerWindow::modelChanged()
             break;
 
     case 3 : // ExtendedCP
-
-            intervalLabel->show();
-            secondsLabel->show();
-            sanLabel->show();
-            sanI1SpinBox->show();
-            sanI2SpinBox->show();
-            anLabel->show();
-            anI1SpinBox->show();
-            anI2SpinBox->show();
-            aeLabel->show();
-            aeI1SpinBox->show();
-            aeI2SpinBox->show();
-            laeLabel->show();
-            laeI1SpinBox->show();
-            laeI2SpinBox->show();
             modelDecayCheck->hide();
             modelDecayLabel->hide();
 
@@ -965,6 +1018,14 @@ CriticalPowerWindow::modelParametersChanged()
     // and apply
     if (amVisible() && myRideItem != NULL) {
         cpPlot->setRide(myRideItem);
+    }
+    showRelevantIntervals();
+    // disable data selection for envelope fits, since it has no effect for
+    // these.
+    if (fitCombo->currentIndex() == 0) {
+        fitdataCombo->setEnabled(false);
+    } else {
+        fitdataCombo->setEnabled(true);
     }
 }
 

--- a/src/Charts/CriticalPowerWindow.h
+++ b/src/Charts/CriticalPowerWindow.h
@@ -299,6 +299,11 @@ class CriticalPowerWindow : public GcChartWindow
         void exportData();
 
     private:
+        void showRelevantIntervals();
+        void showAnaerobicIntervals(bool);
+        void showAerobicIntervals(bool);
+        void showShortAnaerobicIntervals(bool);
+        void showLongAerobicIntervals(bool);
         void updateCpint(double minutes);
         void hideIntervalCurve(int index);
         void showIntervalCurve(IntervalItem *current, int index);


### PR DESCRIPTION
## Problem 
The CriticalPowerWindow always shows the interval selection in the model tab even though it has only effect for certain model/fit-method combinations. This was already mentioned in #4333. In the current implementation it is not apparent to the user that the interval selection is not effective for any fitting method but the envelope-fit.

## Suggested Solution
- show/hide the spinboxes for the interval selection according to the current model configuration.
- disable the fitdataCombobox for the envelope-fit, since it is not considered for this fitting method.

## Alternative Solution
Maybe disabling the interval spinboxes instead of hiding them would provide a better user experience. I have no strong feelings about that. If prefered, I would change my PR accordingly.