### PR TITLE
Colour definitions as enumeration classes

### DIFF
--- a/src/Charts/Aerolab.cpp
+++ b/src/Charts/Aerolab.cpp
@@ -250,29 +250,29 @@ Aerolab::configChanged(qint32)
 {
 
   // set colors
-  setCanvasBackground(GColor(CPLOTBACKGROUND));
-  QPen vePen = QPen(GColor(CAEROVE));
+  setCanvasBackground(GColor(GCol::PLOTBACKGROUND));
+  QPen vePen = QPen(GColor(GCol::AEROVE));
   vePen.setWidth(appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble());
   veCurve->setPen(vePen);
-  QPen altPen = QPen(GColor(CAEROEL));
+  QPen altPen = QPen(GColor(GCol::AEROEL));
   altPen.setWidth(appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble());
   altCurve->setPen(altPen);
-  QPen gridPen(GColor(CPLOTGRID));
+  QPen gridPen(GColor(GCol::PLOTGRID));
   gridPen.setStyle(Qt::DotLine);
   grid->setPen(gridPen);
 
-  QPen ihlPen = QPen( GColor( CINTERVALHIGHLIGHTER ) );
+  QPen ihlPen = QPen( GColor( GCol::INTERVALHIGHLIGHTER ) );
   ihlPen.setWidth(1);
   intervalHighlighterCurve->setPen( ihlPen );
 
-  QColor ihlbrush = QColor(GColor(CINTERVALHIGHLIGHTER));
+  QColor ihlbrush = QColor(GColor(GCol::INTERVALHIGHLIGHTER));
   ihlbrush.setAlpha(40);
   intervalHighlighterCurve->setBrush(ihlbrush);   // fill below the line
 
   //XXX broken this->legend()->remove( intervalHighlighterCurve ); // don't show in legend
   QPalette palette;
-  palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
-  palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
+  palette.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
+  palette.setColor(QPalette::Text, GColor(GCol::PLOTMARKER));
   axisWidget(QwtAxis::XBottom)->setPalette(palette);
   axisWidget(QwtAxis::YLeft)->setPalette(palette);
 }
@@ -746,10 +746,10 @@ void Aerolab::refreshIntervalMarkers()
             mrk->attach(this);
             mrk->setLineStyle(QwtPlotMarker::VLine);
             mrk->setLabelAlignment(Qt::AlignRight | Qt::AlignTop);
-            mrk->setLinePen(QPen(GColor(CPLOTMARKER), 0, Qt::DashDotLine));
+            mrk->setLinePen(QPen(GColor(GCol::PLOTMARKER), 0, Qt::DashDotLine));
             QwtText text(interval->name);
             text.setFont(QFont("Helvetica", 10, QFont::Bold));
-            text.setColor(GColor(CPLOTMARKER));
+            text.setColor(GColor(GCol::PLOTMARKER));
             if (!bydist)
                 mrk->setValue(interval->start / 60.0, 0.0);
             else

--- a/src/Charts/AerolabWindow.cpp
+++ b/src/Charts/AerolabWindow.cpp
@@ -318,25 +318,25 @@ AerolabWindow::zoomChanged()
 void
 AerolabWindow::configChanged(qint32)
 {
-  allZoomer->setRubberBandPen(GColor(CPLOTSELECT));
-  setProperty("color", GColor(CPLOTBACKGROUND));
+  allZoomer->setRubberBandPen(GColor(GCol::PLOTSELECT));
+  setProperty("color", GColor(GCol::PLOTBACKGROUND));
 
   QPalette palette;
 
-  palette.setColor(QPalette::Window, GColor(CPLOTBACKGROUND));
+  palette.setColor(QPalette::Window, GColor(GCol::PLOTBACKGROUND));
 
   // only change base if moved away from white plots
   // which is a Mac thing
 #ifndef Q_OS_MAC
-  if (GColor(CPLOTBACKGROUND) != Qt::white)
+  if (GColor(GCol::PLOTBACKGROUND) != Qt::white)
 #endif
   {
-      palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CPLOTBACKGROUND)));
-      palette.setColor(QPalette::Window,  GColor(CPLOTBACKGROUND));
+      palette.setColor(QPalette::Base, GAlternateColor(GCol::PLOTBACKGROUND));
+      palette.setColor(QPalette::Window,  GColor(GCol::PLOTBACKGROUND));
   }
 
-  palette.setColor(QPalette::WindowText, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-  palette.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+  palette.setColor(QPalette::WindowText, GInvertColor(GCol::PLOTBACKGROUND));
+  palette.setColor(QPalette::Text, GInvertColor(GCol::PLOTBACKGROUND));
   setPalette(palette);
   aerolab->setPalette(palette);
   crrLabel->setPalette(palette);

--- a/src/Charts/AllPlot.cpp
+++ b/src/Charts/AllPlot.cpp
@@ -969,7 +969,7 @@ AllPlot::AllPlot(QWidget *parent, AllPlotWindow *window, Context *context, RideF
     bg->attach(this);
 
     //insertLegend(new QwtLegend(), QwtPlot::BottomLegend);
-    setCanvasBackground(GColor(CRIDEPLOTBACKGROUND));
+    setCanvasBackground(GColor(GCol::RIDEPLOTBACKGROUND));
     static_cast<QwtPlotCanvas*>(canvas())->setFrameStyle(QFrame::NoFrame);
 
     // set the axes that we use.. YLeft 3 is ALWAYS the highlighter axes and never visible
@@ -997,7 +997,7 @@ AllPlot::AllPlot(QWidget *parent, AllPlotWindow *window, Context *context, RideF
     setAxisScaleDraw(QwtAxisId(QwtAxis::YLeft, 2), sd);
 
     QPalette pal = palette();
-    pal.setBrush(QPalette::Window, QBrush(GColor(CRIDEPLOTBACKGROUND)));
+    pal.setBrush(QPalette::Window, QBrush(GColor(GCol::RIDEPLOTBACKGROUND)));
     pal.setColor(QPalette::WindowText, QColor(Qt::gray));
     pal.setColor(QPalette::Text, QColor(Qt::gray));
     axisWidget(QwtAxisId(QwtAxis::YLeft, 2))->setPalette(pal);
@@ -1103,136 +1103,136 @@ AllPlot::configChanged(qint32 what)
 
         setAltSlopePlotStyle(standard->altSlopeCurve);
 
-        setCanvasBackground(GColor(CRIDEPLOTBACKGROUND));
-        QPen wattsPen = QPen(GColor(CPOWER));
+        setCanvasBackground(GColor(GCol::RIDEPLOTBACKGROUND));
+        QPen wattsPen = QPen(GColor(GCol::POWER));
         wattsPen.setWidth(width);
         standard->wattsCurve->setPen(wattsPen);
         standard->wattsDCurve->setPen(wattsPen);
-        QPen npPen = QPen(GColor(CNPOWER));
+        QPen npPen = QPen(GColor(GCol::NPOWER));
         npPen.setWidth(width);
         standard->npCurve->setPen(npPen);
-        QPen rvPen = QPen(GColor(CRV));
+        QPen rvPen = QPen(GColor(GCol::RV));
         rvPen.setWidth(width);
         standard->rvCurve->setPen(rvPen);
-        QPen rcadPen = QPen(GColor(CRCAD));
+        QPen rcadPen = QPen(GColor(GCol::RCAD));
         rcadPen.setWidth(width);
         standard->rcadCurve->setPen(rcadPen);
-        QPen rgctPen = QPen(GColor(CRGCT));
+        QPen rgctPen = QPen(GColor(GCol::RGCT));
         rgctPen.setWidth(width);
         standard->rgctCurve->setPen(rgctPen);
-        QPen gearPen = QPen(GColor(CGEAR));
+        QPen gearPen = QPen(GColor(GCol::GEAR));
         gearPen.setWidth(width);
         standard->gearCurve->setPen(gearPen);
-        QPen smo2Pen = QPen(GColor(CSMO2));
+        QPen smo2Pen = QPen(GColor(GCol::SMO2));
         smo2Pen.setWidth(width);
         standard->smo2Curve->setPen(smo2Pen);
-        QPen thbPen = QPen(GColor(CTHB));
+        QPen thbPen = QPen(GColor(GCol::THB));
         thbPen.setWidth(width);
         standard->thbCurve->setPen(thbPen);
-        QPen o2hbPen = QPen(GColor(CO2HB));
+        QPen o2hbPen = QPen(GColor(GCol::O2HB));
         o2hbPen.setWidth(width);
         standard->o2hbCurve->setPen(o2hbPen);
-        QPen hhbPen = QPen(GColor(CHHB));
+        QPen hhbPen = QPen(GColor(GCol::HHB));
         hhbPen.setWidth(width);
         standard->hhbCurve->setPen(hhbPen);
 
-        QPen antissPen = QPen(GColor(CANTISS));
+        QPen antissPen = QPen(GColor(GCol::ANTISS));
         antissPen.setWidth(width);
         standard->antissCurve->setPen(antissPen);
-        QPen atissPen = QPen(GColor(CATISS));
+        QPen atissPen = QPen(GColor(GCol::ATISS));
         atissPen.setWidth(width);
         standard->atissCurve->setPen(atissPen);
-        QPen xpPen = QPen(GColor(CXPOWER));
+        QPen xpPen = QPen(GColor(GCol::XPOWER));
         xpPen.setWidth(width);
         standard->xpCurve->setPen(xpPen);
-        QPen apPen = QPen(GColor(CAPOWER));
+        QPen apPen = QPen(GColor(GCol::APOWER));
         apPen.setWidth(width);
         standard->apCurve->setPen(apPen);
-        QPen hrPen = QPen(GColor(CHEARTRATE));
+        QPen hrPen = QPen(GColor(GCol::HEARTRATE));
         hrPen.setWidth(width);
         standard->hrCurve->setPen(hrPen);
-        QPen tcorePen = QPen(GColor(CCORETEMP));
+        QPen tcorePen = QPen(GColor(GCol::CORETEMP));
         tcorePen.setWidth(width);
         standard->tcoreCurve->setPen(tcorePen);
         standard->hrDCurve->setPen(hrPen);
-        QPen speedPen = QPen(GColor(CSPEED));
+        QPen speedPen = QPen(GColor(GCol::SPEED));
         speedPen.setWidth(width);
         standard->speedCurve->setPen(speedPen);
-        QPen accelPen = QPen(GColor(CACCELERATION));
+        QPen accelPen = QPen(GColor(GCol::ACCELERATION));
         accelPen.setWidth(width);
         standard->accelCurve->setPen(accelPen);
-        QPen cadPen = QPen(GColor(CCADENCE));
+        QPen cadPen = QPen(GColor(GCol::CADENCE));
         cadPen.setWidth(width);
         standard->cadCurve->setPen(cadPen);
         standard->cadDCurve->setPen(cadPen);
-        QPen slopePen(GColor(CSLOPE));
+        QPen slopePen(GColor(GCol::SLOPE));
         slopePen.setWidth(width);
         standard->slopeCurve->setPen(slopePen);
-        QPen altPen(GColor(CALTITUDE));
+        QPen altPen(GColor(GCol::ALTITUDE));
         altPen.setWidth(width);
         standard->altCurve->setPen(altPen);
-        QColor brush_color = GColor(CALTITUDEBRUSH);
+        QColor brush_color = GColor(GCol::ALTITUDEBRUSH);
         brush_color.setAlpha(200);
         standard->altCurve->setBrush(brush_color);   // fill below the line
-        QPen altSlopePen(GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+        QPen altSlopePen(GInvertColor(GCol::PLOTBACKGROUND));
         altSlopePen.setWidth(width);
         standard->altSlopeCurve->setPen(altSlopePen);
-        QPen tempPen = QPen(GColor(CTEMP));
+        QPen tempPen = QPen(GColor(GCol::TEMP));
         tempPen.setWidth(width);
         standard->tempCurve->setPen(tempPen);
-        //QPen windPen = QPen(GColor(CWINDSPEED));
+        //QPen windPen = QPen(GColor(GCol::WINDSPEED));
         //windPen.setWidth(width);
         standard->windCurve->setPen(QPen(Qt::NoPen));
-        QColor wbrush_color = GColor(CWINDSPEED);
+        QColor wbrush_color = GColor(GCol::WINDSPEED);
         wbrush_color.setAlpha(200);
         standard->windCurve->setBrush(wbrush_color);   // fill below the line
-        QPen torquePen = QPen(GColor(CTORQUE));
+        QPen torquePen = QPen(GColor(GCol::TORQUE));
         torquePen.setWidth(width);
         standard->torqueCurve->setPen(torquePen);
         standard->nmDCurve->setPen(torquePen);
-        QPen balanceLPen = QPen(GColor(CBALANCERIGHT));
+        QPen balanceLPen = QPen(GColor(GCol::BALANCERIGHT));
         balanceLPen.setWidth(width);
         standard->balanceLCurve->setPen(balanceLPen);
-        QColor brbrush_color = GColor(CBALANCERIGHT);
+        QColor brbrush_color = GColor(GCol::BALANCERIGHT);
         brbrush_color.setAlpha(200);
         standard->balanceLCurve->setBrush(brbrush_color);   // fill below the line
-        QPen balanceRPen = QPen(GColor(CBALANCELEFT));
+        QPen balanceRPen = QPen(GColor(GCol::BALANCELEFT));
         balanceRPen.setWidth(width);
         standard->balanceRCurve->setPen(balanceRPen);
-        QColor blbrush_color = GColor(CBALANCELEFT);
+        QColor blbrush_color = GColor(GCol::BALANCELEFT);
         blbrush_color.setAlpha(200);
         standard->balanceRCurve->setBrush(blbrush_color);   // fill below the line
-        QPen ltePen = QPen(GColor(CLTE));
+        QPen ltePen = QPen(GColor(GCol::LTE));
         ltePen.setWidth(width);
         standard->lteCurve->setPen(ltePen);
-        QPen rtePen = QPen(GColor(CRTE));
+        QPen rtePen = QPen(GColor(GCol::RTE));
         rtePen.setWidth(width);
         standard->rteCurve->setPen(rtePen);
-        QPen lpsPen = QPen(GColor(CLPS));
+        QPen lpsPen = QPen(GColor(GCol::LPS));
         lpsPen.setWidth(width);
         standard->lpsCurve->setPen(lpsPen);
-        QPen rpsPen = QPen(GColor(CRPS));
+        QPen rpsPen = QPen(GColor(GCol::RPS));
         rpsPen.setWidth(width);
         standard->rpsCurve->setPen(rpsPen);
-        QPen lpcoPen = QPen(GColor(CLPS));
+        QPen lpcoPen = QPen(GColor(GCol::LPS));
         lpcoPen.setWidth(width);
         standard->lpcoCurve->setPen(lpcoPen);
-        QPen rpcoPen = QPen(GColor(CRPS));
+        QPen rpcoPen = QPen(GColor(GCol::RPS));
         rpcoPen.setWidth(width);
         standard->rpcoCurve->setPen(rpcoPen);
-        QPen ldcPen = QPen(GColor(CLPS));
+        QPen ldcPen = QPen(GColor(GCol::LPS));
         ldcPen.setWidth(width);
         standard->lppCurve->setPen(ldcPen);
-        QPen rdcPen = QPen(GColor(CRPS));
+        QPen rdcPen = QPen(GColor(GCol::RPS));
         rdcPen.setWidth(width);
         standard->rppCurve->setPen(rdcPen);
-        QPen lpppPen = QPen(GColor(CLPS));
+        QPen lpppPen = QPen(GColor(GCol::LPS));
         lpppPen.setWidth(width);
         standard->lpppCurve->setPen(lpppPen);
-        QPen rpppPen = QPen(GColor(CRPS));
+        QPen rpppPen = QPen(GColor(GCol::RPS));
         rpppPen.setWidth(width);
         standard->rpppCurve->setPen(rpppPen);
-        QPen wPen = QPen(GColor(CWBAL)); 
+        QPen wPen = QPen(GColor(GCol::WBAL)); 
         wPen.setWidth(width); // don't thicken
         standard->wCurve->setPen(wPen);
         QwtSymbol *sym = new QwtSymbol;
@@ -1240,18 +1240,18 @@ AllPlot::configChanged(qint32 what)
         sym->setPen(QPen(QColor(255,127,0))); // orange like a match, will make configurable later
         sym->setSize(4 *dpiXFactor);
         standard->mCurve->setSymbol(sym);
-        QPen ihlPen = QPen(GColor(CINTERVALHIGHLIGHTER));
+        QPen ihlPen = QPen(GColor(GCol::INTERVALHIGHLIGHTER));
         ihlPen.setWidth(width);
         standard->intervalHighlighterCurve->setPen(QPen(Qt::NoPen));
         standard->intervalHoverCurve->setPen(QPen(Qt::NoPen));
-        QColor ihlbrush = QColor(GColor(CINTERVALHIGHLIGHTER));
+        QColor ihlbrush = QColor(GColor(GCol::INTERVALHIGHLIGHTER));
         ihlbrush.setAlpha(128);
         standard->intervalHighlighterCurve->setBrush(ihlbrush);   // fill below the line
         QColor hbrush = QColor(Qt::lightGray);
         hbrush.setAlpha(gl_alpha);
         standard->intervalHoverCurve->setBrush(hbrush);   // fill below the line
         //this->legend()->remove(intervalHighlighterCurve); // don't show in legend
-        QPen gridPen(GColor(CPLOTGRID));
+        QPen gridPen(GColor(GCol::PLOTGRID));
         //gridPen.setStyle(Qt::DotLine); // solid line is nicer
         standard->grid->setPen(gridPen);
 
@@ -1471,15 +1471,15 @@ AllPlot::configChanged(qint32 what)
         }
 
         QPalette pal = palette();
-        pal.setBrush(QPalette::Window, QBrush(GColor(CRIDEPLOTBACKGROUND)));
+        pal.setBrush(QPalette::Window, QBrush(GColor(GCol::RIDEPLOTBACKGROUND)));
         setPalette(pal);
 
         // tick draw
         TimeScaleDraw *tsd = new TimeScaleDraw(&this->bydist, &timeoffset) ;
         tsd->setTickLength(QwtScaleDiv::MajorTick, 3);
         setAxisScaleDraw(QwtAxis::XBottom, tsd);
-        pal.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
-        pal.setColor(QPalette::Text, GColor(CPLOTMARKER));
+        pal.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
+        pal.setColor(QPalette::Text, GColor(GCol::PLOTMARKER));
         axisWidget(QwtAxis::XBottom)->setPalette(pal);
         setAxisVisible(QwtAxis::XBottom, true);
 
@@ -1488,8 +1488,8 @@ AllPlot::configChanged(qint32 what)
         sd->enableComponent(ScaleScaleDraw::Ticks, false);
         sd->enableComponent(ScaleScaleDraw::Backbone, false);
         setAxisScaleDraw(QwtAxis::YLeft, sd);
-        pal.setColor(QPalette::WindowText, GColor(CPOWER));
-        pal.setColor(QPalette::Text, GColor(CPOWER));
+        pal.setColor(QPalette::WindowText, GColor(GCol::POWER));
+        pal.setColor(QPalette::Text, GColor(GCol::POWER));
         axisWidget(QwtAxis::YLeft)->setPalette(pal);
 
         // some axis show multiple things so color them 
@@ -1506,8 +1506,8 @@ AllPlot::configChanged(qint32 what)
         sd->enableComponent(ScaleScaleDraw::Ticks, false);
         sd->enableComponent(ScaleScaleDraw::Backbone, false);
         setAxisScaleDraw(QwtAxisId(QwtAxis::YLeft, 3), sd);
-        pal.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
-        pal.setColor(QPalette::Text, GColor(CPLOTMARKER));
+        pal.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
+        pal.setColor(QPalette::Text, GColor(GCol::PLOTMARKER));
         axisWidget(QwtAxisId(QwtAxis::YLeft, 3))->setPalette(pal);
 
         sd = new ScaleScaleDraw;
@@ -1515,8 +1515,8 @@ AllPlot::configChanged(qint32 what)
         sd->enableComponent(ScaleScaleDraw::Ticks, false);
         sd->enableComponent(ScaleScaleDraw::Backbone, false);
         setAxisScaleDraw(QwtAxisId(QwtAxis::YRight, 1), sd);
-        pal.setColor(QPalette::WindowText, GColor(CALTITUDE));
-        pal.setColor(QPalette::Text, GColor(CALTITUDE));
+        pal.setColor(QPalette::WindowText, GColor(GCol::ALTITUDE));
+        pal.setColor(QPalette::Text, GColor(GCol::ALTITUDE));
         axisWidget(QwtAxisId(QwtAxis::YRight, 1))->setPalette(pal);
 
         sd = new ScaleScaleDraw;
@@ -1525,8 +1525,8 @@ AllPlot::configChanged(qint32 what)
         sd->setTickLength(QwtScaleDiv::MajorTick, 3);
         sd->setFactor(0.001f); // in kJ
         setAxisScaleDraw(QwtAxisId(QwtAxis::YRight, 2), sd);
-        pal.setColor(QPalette::WindowText, GColor(CWBAL));
-        pal.setColor(QPalette::Text, GColor(CWBAL));
+        pal.setColor(QPalette::WindowText, GColor(GCol::WBAL));
+        pal.setColor(QPalette::Text, GColor(GCol::WBAL));
         axisWidget(QwtAxisId(QwtAxis::YRight, 2))->setPalette(pal);
 
         sd = new ScaleScaleDraw;
@@ -1534,8 +1534,8 @@ AllPlot::configChanged(qint32 what)
         sd->enableComponent(ScaleScaleDraw::Backbone, false);
         sd->setTickLength(QwtScaleDiv::MajorTick, 3);
         setAxisScaleDraw(QwtAxisId(QwtAxis::YRight, 3), sd);
-        pal.setColor(QPalette::WindowText, GColor(CATISS));
-        pal.setColor(QPalette::Text, GColor(CATISS));
+        pal.setColor(QPalette::WindowText, GColor(GCol::ATISS));
+        pal.setColor(QPalette::Text, GColor(GCol::ATISS));
         axisWidget(QwtAxisId(QwtAxis::YRight, 3))->setPalette(pal);
 
         curveColors->saveState();
@@ -1550,20 +1550,20 @@ AllPlot::setLeftOnePalette()
     // Cadence then Temp then SmO2 ...
     QColor single = QColor(Qt::red);
     if (standard->smo2Curve->isVisible()) {
-        single = GColor(CSMO2);
+        single = GColor(GCol::SMO2);
     }
     if (standard->tempCurve->isVisible() && !GlobalContext::context()->useMetricUnits) {
-        single = GColor(CTEMP);
+        single = GColor(GCol::TEMP);
     }
     if (standard->cadCurve->isVisible()) {
-        single = GColor(CCADENCE);
+        single = GColor(GCol::CADENCE);
     }
     if (standard->hrCurve->isVisible()) {
-        single = GColor(CHEARTRATE);
+        single = GColor(GCol::HEARTRATE);
     }
 
     if (standard->tcoreCurve->isVisible()) {
-        single = GColor(CCORETEMP);
+        single = GColor(GCol::CORETEMP);
     }
 
     // lets go
@@ -1574,7 +1574,7 @@ AllPlot::setLeftOnePalette()
     setAxisScaleDraw(QwtAxisId(QwtAxis::YLeft, 1), sd);
 
     QPalette pal = palette();
-    pal.setBrush(QPalette::Window, QBrush(GColor(CRIDEPLOTBACKGROUND)));
+    pal.setBrush(QPalette::Window, QBrush(GColor(GCol::RIDEPLOTBACKGROUND)));
     pal.setColor(QPalette::WindowText, single);
     pal.setColor(QPalette::Text, single);
 
@@ -1589,22 +1589,22 @@ AllPlot::setRightPalette()
     // Cadence then Temp then SmO2 ...
     QColor single = QColor(Qt::green);
     if (standard->speedCurve->isVisible()) {
-        single = GColor(CSPEED);
+        single = GColor(GCol::SPEED);
     }
     if (standard->tempCurve->isVisible() && GlobalContext::context()->useMetricUnits) {
-        single = GColor(CTEMP);
+        single = GColor(GCol::TEMP);
     }
     if (standard->o2hbCurve->isVisible()) {
-        single = GColor(CO2HB);
+        single = GColor(GCol::O2HB);
     }
     if (standard->hhbCurve->isVisible()) {
-        single = GColor(CHHB);
+        single = GColor(GCol::HHB);
     }
     if (standard->thbCurve->isVisible()) {
-        single = GColor(CTHB);
+        single = GColor(GCol::THB);
     }
     if (standard->torqueCurve->isVisible()) {
-        single = GColor(CTORQUE);
+        single = GColor(GCol::TORQUE);
     }
 
     // lets go
@@ -1616,7 +1616,7 @@ AllPlot::setRightPalette()
     setAxisScaleDraw(QwtAxisId(QwtAxis::YRight, 0), sd);
 
     QPalette pal = palette();
-    pal.setBrush(QPalette::Window, QBrush(GColor(CRIDEPLOTBACKGROUND)));
+    pal.setBrush(QPalette::Window, QBrush(GColor(GCol::RIDEPLOTBACKGROUND)));
     pal.setColor(QPalette::WindowText, single);
     pal.setColor(QPalette::Text, single);
 
@@ -2567,7 +2567,7 @@ AllPlot::refreshIntervalMarkers()
             mrk->setLabelAlignment(Qt::AlignRight | Qt::AlignTop);
 
             if (nolabel) mrk->setLinePen(QPen(QColor(127,127,127,65), 0, Qt::DashLine));
-            else mrk->setLinePen(QPen(GColor(CPLOTMARKER), 0, Qt::DashLine));
+            else mrk->setLinePen(QPen(GColor(GCol::PLOTMARKER), 0, Qt::DashLine));
 
             // put matches on second line down
             QString name(interval->name);
@@ -2578,9 +2578,9 @@ AllPlot::refreshIntervalMarkers()
             if (!nolabel) {
                 text.setFont(QFont("Helvetica", 10, QFont::Bold));
                 if (interval->name.startsWith(tr("Match"))) 
-                    text.setColor(GColor(CWBAL));
+                    text.setColor(GColor(GCol::WBAL));
                 else
-                    text.setColor(GColor(CPLOTMARKER));
+                    text.setColor(GColor(GCol::PLOTMARKER));
             }
 
             if (!bydist) {
@@ -2606,7 +2606,7 @@ AllPlot::refreshCalibrationMarkers()
     if (scope != RideFile::none && scope != RideFile::watts && scope != RideFile::aTISS && scope != RideFile::anTISS &&
         scope != RideFile::IsoPower && scope != RideFile::aPower && scope != RideFile::xPower) return;
 
-    QColor color = GColor(CPOWER);
+    QColor color = GColor(GCol::POWER);
     color.setAlpha(15); // almost invisible !
 
     if (rideItem && rideItem->ride()) {
@@ -2703,7 +2703,7 @@ AllPlot::plotReferenceLine(const RideFilePoint *referencePoint)
     if (referencePoint->watts != 0)  {
         referenceLine = new QwtPlotCurve(tr("Power Ref"));
         referenceLine->setYAxis(QwtAxis::YLeft);
-        QPen wattsPen = QPen(GColor(CPOWER));
+        QPen wattsPen = QPen(GColor(GCol::POWER));
         wattsPen.setWidth(1);
         wattsPen.setStyle(Qt::DashLine);
         referenceLine->setPen(wattsPen);
@@ -2714,7 +2714,7 @@ AllPlot::plotReferenceLine(const RideFilePoint *referencePoint)
         referenceLine = new QwtPlotCurve(tr("Heart Rate Ref"));
         if (scope == RideFile::none) referenceLine->setYAxis(QwtAxisId(QwtAxis::YLeft,1));
         else if (scope == RideFile::hr) referenceLine->setYAxis(QwtAxisId(QwtAxis::YLeft));
-        QPen hrPen = QPen(GColor(CHEARTRATE));
+        QPen hrPen = QPen(GColor(GCol::HEARTRATE));
         hrPen.setWidth(1);
         hrPen.setStyle(Qt::DashLine);
         referenceLine->setPen(hrPen);
@@ -2724,7 +2724,7 @@ AllPlot::plotReferenceLine(const RideFilePoint *referencePoint)
     } else if (referencePoint->cad != 0)  {
         referenceLine = new QwtPlotCurve(tr("Cadence Ref"));
         referenceLine->setYAxis(QwtAxis::YLeft);
-        QPen cadPen = QPen(GColor(CCADENCE));
+        QPen cadPen = QPen(GColor(GCol::CADENCE));
         cadPen.setWidth(1);
         cadPen.setStyle(Qt::DashLine);
         referenceLine->setPen(cadPen);
@@ -3108,7 +3108,7 @@ AllPlot::setXTitle()
 static void setSymbol(QwtPlotCurve *curve, int points)
 {
     QwtSymbol *sym = new QwtSymbol;
-    sym->setPen(QPen(GColor(CPLOTMARKER)));
+    sym->setPen(QPen(GColor(GCol::PLOTMARKER)));
     if (points < 150) {
         sym->setStyle(QwtSymbol::Ellipse);
         sym->setSize(3 *dpiXFactor);
@@ -3254,7 +3254,7 @@ AllPlot::setDataFromPlot(AllPlot *plot, int startidx, int stopidx)
         QFont font; // default;
         font.setWeight(QFont::Bold);
         text.setFont(font);
-        text.setColor(GColor(CWBAL));
+        text.setColor(GColor(GCol::WBAL));
         standard->curveTitle.setLabel(text);
     } else {
         standard->curveTitle.setLabel(QwtText(""));
@@ -4091,7 +4091,7 @@ AllPlot::setDataFromPlot(AllPlot *plot)
             // symbol when zoomed in super close
             if (array.size() < 150) {
                 QwtSymbol *sym = new QwtSymbol;
-                sym->setPen(QPen(GColor(CPLOTMARKER)));
+                sym->setPen(QPen(GColor(GCol::PLOTMARKER)));
                 sym->setStyle(QwtSymbol::Ellipse);
                 sym->setSize(3 *dpiXFactor);
                 ourCurve->setSymbol(sym);
@@ -4119,7 +4119,7 @@ AllPlot::setDataFromPlot(AllPlot *plot)
             // symbol when zoomed in super close
             if (array.size() < 150) {
                 QwtSymbol *sym = new QwtSymbol;
-                sym->setPen(QPen(GColor(CPLOTMARKER)));
+                sym->setPen(QPen(GColor(GCol::PLOTMARKER)));
                 sym->setStyle(QwtSymbol::Ellipse);
                 sym->setSize(3 *dpiXFactor);
                 ourCurve2->setSymbol(sym);
@@ -4846,7 +4846,7 @@ AllPlot::setDataFromPlots(QList<AllPlot *> plots)
                     // symbol when zoomed in super close
                     if (x.size() < 150) {
                         QwtSymbol *sym = new QwtSymbol;
-                        sym->setPen(QPen(GColor(CPLOTMARKER)));
+                        sym->setPen(QPen(GColor(GCol::PLOTMARKER)));
                         sym->setStyle(QwtSymbol::Ellipse);
                         sym->setSize(3 *dpiXFactor);
                         ourCurve->setSymbol(sym);
@@ -4884,7 +4884,7 @@ AllPlot::setDataFromPlots(QList<AllPlot *> plots)
                     // symbol when zoomed in super close
                     if (array.size() < 150) {
                         QwtSymbol *sym = new QwtSymbol;
-                        sym->setPen(QPen(GColor(CPLOTMARKER)));
+                        sym->setPen(QPen(GColor(GCol::PLOTMARKER)));
                         sym->setStyle(QwtSymbol::Ellipse);
                         sym->setSize(3 *dpiXFactor);
                         ourCurve2->setSymbol(sym);
@@ -7448,7 +7448,7 @@ AllPlot::plotExhaustionLine(double secs)
     if (secs <= 0 || context->isCompareIntervals) return NULL;
 
     QwtPlotMarker *marker = new QwtPlotMarker(""); //name is TODO
-    marker->setLinePen(QPen(GColor(CWBAL),5.0f));
+    marker->setLinePen(QPen(GColor(GCol::WBAL),5.0f));
     marker->setLineStyle(QwtPlotMarker::VLine);
     marker->setXValue(bydist ? rideItem->ride()->timeToDistance(secs) : secs/60.0f);
     marker->setZ(-15); // to the back

--- a/src/Charts/AllPlotInterval.cpp
+++ b/src/Charts/AllPlotInterval.cpp
@@ -95,8 +95,8 @@ AllPlotInterval::AllPlotInterval(QWidget *parent, Context *context):
     //TimeScaleDraw *tsd = new TimeScaleDraw(&this->bydist) ;
     //tsd->setTickLength(QwtScaleDiv::MajorTick, 3);
     //setAxisScaleDraw(QwtAxis::XBottom, tsd);
-    //pal.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
-    //pal.setColor(QPalette::Text, GColor(CPLOTMARKER));
+    //pal.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
+    //pal.setColor(QPalette::Text, GColor(GCol::PLOTMARKER));
     //axisWidget(QwtAxis::XBottom)->setPalette(pal);
 
     setAxisVisible(QwtAxis::XBottom, false);
@@ -123,9 +123,9 @@ void
 AllPlotInterval::configChanged(qint32)
 {
     QPalette pal = palette();
-    pal.setBrush(QPalette::Window, QBrush(GColor(CRIDEPLOTBACKGROUND)));
+    pal.setBrush(QPalette::Window, QBrush(GColor(GCol::RIDEPLOTBACKGROUND)));
     setPalette(pal);
-    setCanvasBackground(GColor(CRIDEPLOTBACKGROUND));
+    setCanvasBackground(GColor(GCol::RIDEPLOTBACKGROUND));
     static_cast<QwtPlotCanvas*>(canvas())->setFrameStyle(QFrame::NoFrame);
     update();
     replot();

--- a/src/Charts/AllPlotSlopeCurve.cpp
+++ b/src/Charts/AllPlotSlopeCurve.cpp
@@ -272,7 +272,7 @@ void AllPlotSlopeCurve::drawCurve( QPainter *painter, int,
             } else {
                 text.setNum(mperh, 'f', 0);
             }
-            painter->setPen(GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+            painter->setPen(GInvertColor(GCol::PLOTBACKGROUND));
             painter->setFont(QFont("Helvetica",8));
             QwtPainter::drawText(painter, pText, text );
         }

--- a/src/Charts/AllPlotWindow.cpp
+++ b/src/Charts/AllPlotWindow.cpp
@@ -459,7 +459,7 @@ AllPlotWindow::AllPlotWindow(Context *context) :
     mainControls->addRow(smoothLabel, smoothLayout);
 
     QPalette palette;
-    palette.setBrush(QPalette::Window, QBrush(GColor(CRIDEPLOTBACKGROUND)));
+    palette.setBrush(QPalette::Window, QBrush(GColor(GCol::RIDEPLOTBACKGROUND)));
 
     allPlot = new AllPlot(this, this, context);
     allPlot->setContentsMargins(0,0,0,0);
@@ -482,7 +482,7 @@ AllPlotWindow::AllPlotWindow(Context *context) :
 
     allZoomer = new QwtPlotZoomer(allPlot->canvas());
     allZoomer->setRubberBand(QwtPicker::RectRubberBand);
-    allZoomer->setRubberBandPen(GColor(CPLOTSELECT));
+    allZoomer->setRubberBandPen(GColor(GCol::PLOTSELECT));
     allZoomer->setTrackerMode(QwtPicker::AlwaysOff);
     allZoomer->setEnabled(true);
 
@@ -662,7 +662,7 @@ AllPlotWindow::AllPlotWindow(Context *context) :
     fullPlot = new AllPlot(this, this, context);
     fullPlot->standard->grid->enableY(false);
     fullPlot->setFixedHeight(100 *dpiYFactor);
-    fullPlot->setCanvasBackground(GColor(CRIDEPLOTBACKGROUND));
+    fullPlot->setCanvasBackground(GColor(GCol::RIDEPLOTBACKGROUND));
     fullPlot->setHighlightIntervals(false);
     fullPlot->setPaintBrush(0);
     static_cast<QwtPlotCanvas*>(fullPlot->canvas())->setBorderRadius(0);
@@ -674,7 +674,7 @@ AllPlotWindow::AllPlotWindow(Context *context) :
 
     intervalPlot = new AllPlotInterval(this, context);
     intervalPlot->setFixedHeight(100 *dpiYFactor);
-    intervalPlot->setCanvasBackground(GColor(CRIDEPLOTBACKGROUND));
+    intervalPlot->setCanvasBackground(GColor(GCol::RIDEPLOTBACKGROUND));
     static_cast<QwtPlotCanvas*>(intervalPlot->canvas())->setBorderRadius(0);
     intervalPlot->setContentsMargins(0,0,0,0);
 
@@ -838,14 +838,14 @@ AllPlotWindow::configChanged(qint32 state)
 {
     setUpdatesEnabled(false);
 
-    setProperty("color", GColor(CRIDEPLOTBACKGROUND));
+    setProperty("color", GColor(GCol::RIDEPLOTBACKGROUND));
 
     // Container widgets should not paint
     // since they tend to use naff defaults and
     // 'complicate' or 'make busy' the general
     // look and feel
     QPalette palette;
-    palette.setBrush(QPalette::Window, QBrush(GColor(CRIDEPLOTBACKGROUND)));
+    palette.setBrush(QPalette::Window, QBrush(GColor(GCol::RIDEPLOTBACKGROUND)));
     setPalette(palette); // propagates to children
 
     // set style sheets
@@ -874,25 +874,25 @@ AllPlotWindow::configChanged(qint32 state)
     scrollRight->setPalette(palette);
 
 
-    fullPlot->setCanvasBackground(GColor(CRIDEPLOTBACKGROUND));
+    fullPlot->setCanvasBackground(GColor(GCol::RIDEPLOTBACKGROUND));
     fullPlot->setPalette(palette);
     fullPlot->configChanged(state);
     fullPlot->update();
 
-    intervalPlot->setCanvasBackground(GColor(CRIDEPLOTBACKGROUND));
+    intervalPlot->setCanvasBackground(GColor(GCol::RIDEPLOTBACKGROUND));
     intervalPlot->setPalette(palette);
     intervalPlot->configChanged(state);
     intervalPlot->update();
 
     // allPlot of course
-    allPlot->setCanvasBackground(GColor(CRIDEPLOTBACKGROUND));
+    allPlot->setCanvasBackground(GColor(GCol::RIDEPLOTBACKGROUND));
     allPlot->setPalette(palette);
     allPlot->configChanged(state);
     allPlot->update();
 
     // and then the stacked plot
     foreach (AllPlot *plot, allPlots) {
-        plot->setCanvasBackground(GColor(CRIDEPLOTBACKGROUND));
+        plot->setCanvasBackground(GColor(GCol::RIDEPLOTBACKGROUND));
         plot->setPalette(palette);
         plot->configChanged(state);
         plot->update();
@@ -900,7 +900,7 @@ AllPlotWindow::configChanged(qint32 state)
 
     // and then the series plots
     foreach (AllPlot *plot, seriesPlots) {
-        plot->setCanvasBackground(GColor(CRIDEPLOTBACKGROUND));
+        plot->setCanvasBackground(GColor(GCol::RIDEPLOTBACKGROUND));
         plot->setPalette(palette);
         plot->configChanged(state);
         plot->update();
@@ -908,7 +908,7 @@ AllPlotWindow::configChanged(qint32 state)
 
     // and then the compaer plots
     foreach (AllPlot *plot, allComparePlots) {
-        plot->setCanvasBackground(GColor(CRIDEPLOTBACKGROUND));
+        plot->setCanvasBackground(GColor(GCol::RIDEPLOTBACKGROUND));
         plot->setPalette(palette);
         plot->configChanged(state);
         plot->update();
@@ -1650,7 +1650,7 @@ AllPlotWindow::redrawFullPlot()
     // hide the usual plot decorations etc
     fullPlot->setShowPower(1);
     //We now use the window background color
-    //fullPlot->setCanvasBackground(GColor(CPLOTTHUMBNAIL));
+    //fullPlot->setCanvasBackground(GColor(GCol::PLOTTHUMBNAIL));
     static_cast<QwtPlotCanvas*>(fullPlot->canvas())->setBorderRadius(0);
     fullPlot->standard->grid->enableY(false);
 

--- a/src/Charts/CPPlot.cpp
+++ b/src/Charts/CPPlot.cpp
@@ -124,18 +124,18 @@ void
 CPPlot::configChanged(qint32)
 {
     QPalette palette;
-    if (rangemode) palette.setBrush(QPalette::Window, QBrush(GColor(CTRENDPLOTBACKGROUND)));
-    else palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
+    if (rangemode) palette.setBrush(QPalette::Window, QBrush(GColor(GCol::TRENDPLOTBACKGROUND)));
+    else palette.setBrush(QPalette::Window, QBrush(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Text, GColor(GCol::PLOTMARKER));
     setPalette(palette);
 
     axisWidget(QwtAxis::XBottom)->setPalette(palette);
     axisWidget(QwtAxis::YLeft)->setPalette(palette);
     axisWidget(QwtAxis::YRight)->setPalette(palette);
 
-    if (rangemode) setCanvasBackground(GColor(CTRENDPLOTBACKGROUND));
-    else setCanvasBackground(GColor(CPLOTBACKGROUND));
+    if (rangemode) setCanvasBackground(GColor(GCol::TRENDPLOTBACKGROUND));
+    else setCanvasBackground(GColor(GCol::PLOTBACKGROUND));
 }
 
 // get the fonts and colors right for the axis scales
@@ -148,7 +148,7 @@ CPPlot::setAxisTitle(int axis, QString label)
     stGiles.setPointSize(appsettings->value(NULL, GC_FONT_CHARTLABELS_SIZE, 8).toInt());
 
     QwtText title(label);
-    title.setColor(GColor(CPLOTMARKER));
+    title.setColor(GColor(GCol::PLOTMARKER));
     title.setFont(stGiles);
     QwtPlot::setAxisFont(axis, stGiles);
     QwtPlot::setAxisTitle(axis, title);
@@ -533,7 +533,7 @@ CPPlot::plotLinearWorkModel()
         workModelCurve->setSamples(x.constData(), work.constData(), 2);
 
         // curve cosmetics
-        QPen pen(GColor(CCP));
+        QPen pen(GColor(GCol::CP));
         double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
         pen.setWidth(width);
         if (showBest) pen.setStyle(Qt::DashLine);
@@ -617,8 +617,8 @@ CPPlot::plotModel()
             // plot cherries if there are any
             foreach(QPointF cherry, pdModel->cherries()) {
                 QwtSymbol *sym = new QwtSymbol;
-                sym->setBrush(QBrush(GColor(CPLOTMARKER)));
-                sym->setPen(QPen(GColor(CPLOTMARKER)));
+                sym->setBrush(QBrush(GColor(GCol::PLOTMARKER)));
+                sym->setPen(QPen(GColor(GCol::PLOTMARKER)));
                 sym->setStyle(QwtSymbol::XCross);
                 sym->setSize(10 *dpiXFactor);
 
@@ -632,7 +632,7 @@ CPPlot::plotModel()
             }
 
             // curve cosmetics
-            QPen pen(GColor(CCP));
+            QPen pen(GColor(GCol::CP));
             double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
             pen.setWidth(width);
             if (showBest) pen.setStyle(Qt::DashLine);
@@ -651,7 +651,7 @@ CPPlot::plotModel()
 
         if (appsettings->value(this, GC_ANTIALIAS, true).toBool() == true) heatCurve->setRenderHint(QwtPlotItem::RenderAntialiased);
 
-        heatCurve->setBrush(QBrush(GColor(CCP).darker(200)));
+        heatCurve->setBrush(QBrush(GColor(GCol::CP).darker(200)));
         heatCurve->setPen(QPen(Qt::NoPen));
         heatCurve->setZ(-1);
 
@@ -1170,12 +1170,12 @@ CPPlot::plotPowerProfile()
         curve->setStyle(QwtPlotCurve::Lines);
 
         QColor color;
-        if (percentile > 95 || percentile < 5) color = GColor(CPLOTGRID);
+        if (percentile > 95 || percentile < 5) color = GColor(GCol::PLOTGRID);
         else if (percentile < 51 && percentile > 49) {
-            color = GColor(CPLOTGRID);
+            color = GColor(GCol::PLOTGRID);
             color.setRed(150);
         } else {
-            color = GColor(CPLOTGRID);
+            color = GColor(GCol::PLOTGRID);
             color.setBlue(150);
         }
 
@@ -1285,48 +1285,48 @@ CPPlot::plotBests(RideItem *rideItem)
             switch (rideSeries) {
 
             case RideFile::kphd:
-                line.setColor(GColor(CACCELERATION).darker(200));
-                fill = (GColor(CACCELERATION));
+                line.setColor(GColor(GCol::ACCELERATION).darker(200));
+                fill = (GColor(GCol::ACCELERATION));
                 break;
 
             case RideFile::kph:
-                line.setColor(GColor(CSPEED).darker(200));
-                fill = (GColor(CSPEED));
+                line.setColor(GColor(GCol::SPEED).darker(200));
+                fill = (GColor(GCol::SPEED));
                 break;
 
             case RideFile::cad:
             case RideFile::cadd:
-                line.setColor(GColor(CCADENCE).darker(200));
-                fill = (GColor(CCADENCE));
+                line.setColor(GColor(GCol::CADENCE).darker(200));
+                fill = (GColor(GCol::CADENCE));
                 break;
 
             case RideFile::nm:
             case RideFile::nmd:
-                line.setColor(GColor(CTORQUE).darker(200));
-                fill = (GColor(CTORQUE));
+                line.setColor(GColor(GCol::TORQUE).darker(200));
+                fill = (GColor(GCol::TORQUE));
                 break;
 
             case RideFile::hr:
             case RideFile::hrd:
-                line.setColor(GColor(CHEARTRATE).darker(200));
-                fill = (GColor(CHEARTRATE));
+                line.setColor(GColor(GCol::HEARTRATE).darker(200));
+                fill = (GColor(GCol::HEARTRATE));
                 break;
 
             case RideFile::vam:
-                line.setColor(GColor(CALTITUDE).darker(200));
-                fill = (GColor(CALTITUDE));
+                line.setColor(GColor(GCol::ALTITUDE).darker(200));
+                fill = (GColor(GCol::ALTITUDE));
                 break;
 
             default:
             case RideFile::watts:
-                line.setColor(GColor(CCP));
-                fill = (GColor(CCP));
+                line.setColor(GColor(GCol::CP));
+                fill = (GColor(GCol::CP));
                 break;
             case RideFile::wattsd:
             case RideFile::IsoPower:
             case RideFile::xPower:
-                line.setColor(GColor(CPOWER).darker(200));
-                fill = (GColor(CPOWER));
+                line.setColor(GColor(GCol::POWER).darker(200));
+                fill = (GColor(GCol::POWER));
                 break;
             }
 
@@ -1526,7 +1526,7 @@ CPPlot::plotBests(RideItem *rideItem)
                 if (appsettings->value(this, GC_ANTIALIAS, true).toBool() == true)
                     curve->setRenderHint(QwtPlotItem::RenderAntialiased);
                 QPen pen(color.darker(200));
-                pen.setColor(GColor(CCP)); //XXX color ?
+                pen.setColor(GColor(GCol::CP)); //XXX color ?
                 double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
                 pen.setWidth(width);
                 curve->setPen(pen);
@@ -1614,7 +1614,7 @@ CPPlot::plotBests(RideItem *rideItem)
                 if (appsettings->value(this, GC_ANTIALIAS, true).toBool() == true)
                     curve->setRenderHint(QwtPlotItem::RenderAntialiased);
                 QPen pen(color.darker(200));
-                pen.setColor(GColor(CCP)); //XXX color ?
+                pen.setColor(GColor(GCol::CP)); //XXX color ?
                 double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
                 pen.setWidth(width);
                 curve->setPen(pen);
@@ -1750,7 +1750,7 @@ CPPlot::plotEfforts()
     QwtSymbol *sym = new QwtSymbol;
     sym->setStyle(QwtSymbol::Ellipse);
     sym->setSize(dpiXFactor * (rangemode ? 4 : 6));
-    QColor col= GColor(CPOWER);
+    QColor col= GColor(GCol::POWER);
     col.setAlpha(128);
     sym->setBrush(col);
     sym->setPen(QPen(Qt::NoPen));
@@ -1880,7 +1880,7 @@ CPPlot::plotRide(RideItem *rideItem)
     // the CP plot, regardless of the series. Its only the bests
     // curve that gets any special colour treatment.
     QPen ridePen;
-    ridePen.setColor(GColor(CRIDECP));
+    ridePen.setColor(GColor(GCol::RIDECP));
     double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
     ridePen.setWidth(width);
     rideCurve->setPen(ridePen);
@@ -2463,7 +2463,7 @@ CPPlot::refreshReferenceLines(RideItem *rideItem)
                 if (referencePoint->watts != 0) {
                     QwtPlotMarker *referenceLine = new QwtPlotMarker;
                     QPen p;
-                    p.setColor(GColor(CPLOTMARKER));
+                    p.setColor(GColor(GCol::PLOTMARKER));
                     double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
                     p.setWidth(width);
                     p.setStyle(Qt::DashLine);
@@ -2723,7 +2723,7 @@ CPPlot::plotCentile(RideItem *rideItem)
             rideCurve->setRenderHint(QwtPlotItem::RenderAntialiased);
 
             // red hue to cp curve color
-            QColor std = GColor(CRIDECP);
+            QColor std = GColor(GCol::RIDECP);
             QPen pen(QColor(250-(i*20),std.green(),std.blue()));
             pen.setStyle(Qt::DashLine); // Qt::SolidLine
             double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();

--- a/src/Charts/ChartBar.cpp
+++ b/src/Charts/ChartBar.cpp
@@ -149,7 +149,7 @@ ChartBar::configChanged(qint32)
     scrollArea->setFixedHeight(height);
     buttonBar->setFixedHeight(height);
 
-    QColor col=GColor(CCHARTBAR);
+    QColor col=GColor(GCol::CHARTBAR);
     scrollArea->setStyleSheet(QString("QScrollArea { background: rgb(%1,%2,%3); }").arg(col.red()).arg(col.green()).arg(col.blue()));
 
     foreach(ChartBarItem *b, buttons) {
@@ -165,7 +165,7 @@ ChartBar::configChanged(qint32)
                                                 "padding-top:  0px; padding-bottom: 0px; }"
                                   "QPushButton:hover { background-color: %3; }"
                                   "QPushButton:hover:pressed { background-color: %3; }"
-                                ).arg(GColor(CCHARTBAR).name()).arg(3 * dpiXFactor).arg(GColor(CHOVER).name());
+                                ).arg(GColor(GCol::CHARTBAR).name()).arg(3 * dpiXFactor).arg(GColor(GCol::HOVER).name());
     menuButton->setStyleSheet(buttonstyle);
     left->setStyleSheet(buttonstyle);
     right->setStyleSheet(buttonstyle);
@@ -393,7 +393,7 @@ ChartBar::paintBackground(QPaintEvent *)
     painter.save();
     QRect all(0,0,width(),height());
 
-    painter.fillRect(all, GColor(CCHARTBAR));
+    painter.fillRect(all, GColor(GCol::CHARTBAR));
 
     painter.restore();
 }
@@ -419,7 +419,7 @@ ButtonBar::paintBackground(QPaintEvent *)
     // fill with a linear gradient
     painter.setPen(Qt::NoPen);
     painter.fillRect(all, QColor(Qt::white));
-    painter.fillRect(all, GColor(CCHARTBAR));
+    painter.fillRect(all, GColor(GCol::CHARTBAR));
 
     painter.restore();
 }
@@ -450,25 +450,25 @@ ChartBarItem::paintEvent(QPaintEvent *)
     painter.setPen(Qt::NoPen);
 
     // background - chrome or slected colour
-    QBrush brush(GColor(CCHARTBAR));
-    if (underMouse() && !checked) brush = GColor(CHOVER);
+    QBrush brush(GColor(GCol::CHARTBAR));
+    if (underMouse() && !checked) brush = GColor(GCol::HOVER);
     if (checked) brush = color;
     painter.fillRect(body, brush);
 
     // now paint the text
-    QPen pen(GCColor::invertColor(brush.color()));
+    QPen pen(GInvertColor(brush.color()));
     painter.setPen(pen);
     painter.drawText(body, text, Qt::AlignHCenter | Qt::AlignVCenter);
 
     // draw the bar
     if (checked) {
         // at the top if the chartbar background is different to the plot background
-        if (GColor(CCHARTBAR) != color) painter.fillRect(QRect(0,0,geometry().width(), 3*dpiXFactor), QBrush(GColor(CPLOTMARKER)));
+        if (GColor(GCol::CHARTBAR) != color) painter.fillRect(QRect(0,0,geometry().width(), 3*dpiXFactor), QBrush(GColor(GCol::PLOTMARKER)));
         else {
             // only underline the text with a little extra (why adding "XXX" below)
             QFontMetrics fm(font());
             double width = fm.boundingRect(text+"XXX").width();
-            painter.fillRect(QRect((geometry().width()-width)/2.0,geometry().height()-(3*dpiXFactor),width, 3*dpiXFactor), QBrush(GColor(CPLOTMARKER)));
+            painter.fillRect(QRect((geometry().width()-width)/2.0,geometry().height()-(3*dpiXFactor),width, 3*dpiXFactor), QBrush(GColor(GCol::PLOTMARKER)));
         }
     }
 
@@ -481,13 +481,13 @@ ChartBarItem::paintEvent(QPaintEvent *)
         if (checked) {
 
             // different color if under mouse
-            QBrush brush(GCColor::invertColor(color));
-            if (hotspot.contains(mouse)) brush.setColor(GColor(CPLOTMARKER));
+            QBrush brush(GInvertColor(color));
+            if (hotspot.contains(mouse)) brush.setColor(GColor(GCol::PLOTMARKER));
             painter.fillPath (triangle, brush);
         } else {
 
             // visual clue there is a menu option when tab selected
-            QBrush brush(GColor(CHOVER));
+            QBrush brush(GColor(GCol::HOVER));
             painter.fillPath (triangle, brush);
         }
     }

--- a/src/Charts/CriticalPowerWindow.cpp
+++ b/src/Charts/CriticalPowerWindow.cpp
@@ -651,30 +651,30 @@ CriticalPowerWindow::setEditFromSlider()
 void
 CriticalPowerWindow::configChanged(qint32)
 {
-    if (rangemode) setProperty("color", GColor(CTRENDPLOTBACKGROUND));
-    else setProperty("color", GColor(CPLOTBACKGROUND));
+    if (rangemode) setProperty("color", GColor(GCol::TRENDPLOTBACKGROUND));
+    else setProperty("color", GColor(GCol::PLOTBACKGROUND));
 
     // tinted palette for headings etc
     QPalette palette;
-    if (rangemode) palette.setBrush(QPalette::Window, QBrush(GColor(CTRENDPLOTBACKGROUND)));
-    else palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CPLOTBACKGROUND)));
+    if (rangemode) palette.setBrush(QPalette::Window, QBrush(GColor(GCol::TRENDPLOTBACKGROUND)));
+    else palette.setBrush(QPalette::Window, QBrush(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Text, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Base, GAlternateColor(GCol::PLOTBACKGROUND));
     setPalette(palette);
 
     // inverted palette for data etc
     QPalette whitepalette;
     if (rangemode) {
-        whitepalette.setBrush(QPalette::Window, QBrush(GColor(CTRENDPLOTBACKGROUND)));
-        whitepalette.setColor(QPalette::WindowText, GCColor::invertColor(GColor(CTRENDPLOTBACKGROUND)));
-        whitepalette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CPLOTBACKGROUND)));
-        whitepalette.setColor(QPalette::Text, GCColor::invertColor(GColor(CTRENDPLOTBACKGROUND)));
+        whitepalette.setBrush(QPalette::Window, QBrush(GColor(GCol::TRENDPLOTBACKGROUND)));
+        whitepalette.setColor(QPalette::WindowText, GInvertColor(GColor(GCol::TRENDPLOTBACKGROUND)));
+        whitepalette.setColor(QPalette::Base, GAlternateColor(GColor(GCol::PLOTBACKGROUND)));
+        whitepalette.setColor(QPalette::Text, GInvertColor(GColor(GCol::TRENDPLOTBACKGROUND)));
     } else {
-        whitepalette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
-        whitepalette.setColor(QPalette::WindowText, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-        whitepalette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CPLOTBACKGROUND)));
-        whitepalette.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+        whitepalette.setBrush(QPalette::Window, QBrush(GColor(GCol::PLOTBACKGROUND)));
+        whitepalette.setColor(QPalette::WindowText, GInvertColor(GColor(GCol::PLOTBACKGROUND)));
+        whitepalette.setColor(QPalette::Base, GAlternateColor(GColor(GCol::PLOTBACKGROUND)));
+        whitepalette.setColor(QPalette::Text, GInvertColor(GColor(GCol::PLOTBACKGROUND)));
     }
 
     QFont font;
@@ -717,21 +717,21 @@ CriticalPowerWindow::configChanged(qint32)
 
 
 #ifndef Q_OS_MAC
-    QString style = QString("QSpinBox { background: %1; }").arg(GCColor::alternateColor(GColor(CPLOTBACKGROUND)).name());
+    QString style = QString("QSpinBox { background: %1; }").arg(GAlternateColor(GCol::PLOTBACKGROUND).name());
     CPEdit->setStyleSheet(style);
     //CPLabel->setStyleSheet(style);
     //CPSlider->setStyleSheet(style);
     if (dpiXFactor > 1) {
-        helper->setStyleSheet(QString("background: %1; color: %2;").arg(GColor(CPLOTBACKGROUND).name())
-                                                                      .arg(GColor(CPLOTMARKER).name()));
+        helper->setStyleSheet(QString("background: %1; color: %2;").arg(GColor(GCol::PLOTBACKGROUND).name())
+                                                                      .arg(GColor(GCol::PLOTMARKER).name()));
     }
 
     // do after cascade above
-    summary->setStyleSheet(QString("background-color: %1; color: %2;").arg(GColor(CPLOTBACKGROUND).name()).arg(QColor(Qt::gray).name()));
+    summary->setStyleSheet(QString("background-color: %1; color: %2;").arg(GColor(GCol::PLOTBACKGROUND).name()).arg(QColor(Qt::gray).name()));
 #endif
 
 
-    QPen gridPen(GColor(CPLOTGRID));
+    QPen gridPen(GColor(GCol::PLOTGRID));
     grid->setPen(gridPen);
 
     // set ride

--- a/src/Charts/DiaryWindow.cpp
+++ b/src/Charts/DiaryWindow.cpp
@@ -107,31 +107,31 @@ DiaryWindow::configChanged(qint32)
     fieldDefinitions = GlobalContext::context()->rideMetadata->getFields();
 
     // change colors to reflect preferences
-    setProperty("color", GColor(CPLOTBACKGROUND));
+    setProperty("color", GColor(GCol::PLOTBACKGROUND));
 
     QPalette palette;
-    palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
-    palette.setBrush(QPalette::Base, QBrush(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::WindowText, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::Normal, QPalette::Window, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+    palette.setBrush(QPalette::Window, QBrush(GColor(GCol::PLOTBACKGROUND)));
+    palette.setBrush(QPalette::Base, QBrush(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GInvertColor(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::Text, GInvertColor(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::Normal, QPalette::Window, GInvertColor(GColor(GCol::PLOTBACKGROUND)));
     setPalette(palette);
     monthlyView->setPalette(palette);
     monthlyView->setStyleSheet(QString("QTableView QTableCornerButton::section { background-color: %1; color: %2; border: %1 }")
-                    .arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name()));
+                    .arg(GColor(GCol::PLOTBACKGROUND).name())
+                    .arg(GInvertColor(GCol::PLOTBACKGROUND).name()));
     monthlyView->horizontalHeader()->setStyleSheet(QString("QHeaderView::section { background-color: %1; color: %2; border: 0px }")
-                    .arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name()));
+                    .arg(GColor(GCol::PLOTBACKGROUND).name())
+                    .arg(GInvertColor(GCol::PLOTBACKGROUND).name()));
     monthlyView->verticalHeader()->setStyleSheet(QString("QHeaderView::section { background-color: %1; color: %2; border: 0px }")
-                    .arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name()));
+                    .arg(GColor(GCol::PLOTBACKGROUND).name())
+                    .arg(GInvertColor(GCol::PLOTBACKGROUND).name()));
 #ifndef Q_OS_MAC
     monthlyView->verticalScrollBar()->setStyleSheet(AbstractView::ourStyleSheet());
     monthlyView->horizontalScrollBar()->setStyleSheet(AbstractView::ourStyleSheet());
 #endif
-    title->setStyleSheet(QString("background: %1; color: %2;").arg(GColor(CPLOTBACKGROUND).name())
-                                                              .arg(GColor(CPLOTMARKER).name()));
+    title->setStyleSheet(QString("background: %1; color: %2;").arg(GColor(GCol::PLOTBACKGROUND).name())
+                                                              .arg(GColor(GCol::PLOTMARKER).name()));
 }
 
 void

--- a/src/Charts/GcOverlayWidget.cpp
+++ b/src/Charts/GcOverlayWidget.cpp
@@ -107,7 +107,7 @@ GcOverlayWidget::GcOverlayWidget(Context *context, QWidget *parent) : QWidget(pa
 void
 GcOverlayWidget::configChanged(qint32)
 {
-    titleLabel->setStyleSheet(QString("color: %1;").arg(GCColor::invertColor(GColor(CCHROME)).name()));
+    titleLabel->setStyleSheet(QString("color: %1;").arg(GInvertColor(GCol::CHROME).name()));
 }
 
 void
@@ -207,13 +207,13 @@ GcOverlayWidget::paintBackground(QPaintEvent *)
     QRect all(0,0,width(),height());
     QRect boundary(0,0,width()-1,height()-1);
 
-    painter.fillRect(all, GColor(CPLOTBACKGROUND));
+    painter.fillRect(all, GColor(GCol::PLOTBACKGROUND));
     painter.setPen(QPen(Qt::darkGray));
     painter.drawRect(boundary);
 
     // linear gradients
-    QLinearGradient active = GCColor::linearGradient(23*dpiXFactor, true);
-    QLinearGradient inactive = GCColor::linearGradient(23*dpiYFactor, false);
+    QLinearGradient active = GCColor::inst()->linearGradient(23*dpiXFactor);
+    QLinearGradient inactive = GCColor::inst()->linearGradient(23*dpiYFactor);
 
     // title
     QRect title(1*dpiXFactor,1*dpiYFactor,width()-(2*dpiXFactor),22*dpiYFactor);

--- a/src/Charts/GcPane.cpp
+++ b/src/Charts/GcPane.cpp
@@ -99,7 +99,7 @@ GcPane::paintEvent(QPaintEvent *)
     // Init paint settings
     QPainter painter(this);
     //painter.setRenderHint(QPainter::Antialiasing);
-    QColor color = Qt::black; //GColor(CPOPUP);
+    QColor color = Qt::black; //GColor(GCol::POPUP);
     QPen pen(color);
 
     // border color

--- a/src/Charts/GenericAnnotations.cpp
+++ b/src/Charts/GenericAnnotations.cpp
@@ -105,7 +105,7 @@ StraightLine::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*
     double scale = controller->plot->scale();
 
     QPen pen(Qt::lightGray);
-    pen.setColor(GColor(CPLOTMARKER));
+    pen.setColor(GColor(GCol::PLOTMARKER));
     pen.setStyle(style);
     pen.setWidth(pen.width() * scale);
     painter->setPen(pen);

--- a/src/Charts/GenericChart.cpp
+++ b/src/Charts/GenericChart.cpp
@@ -46,7 +46,7 @@ GenericChart::GenericChart(QWidget *parent, Context *context) : QWidget(parent),
 {
     // for scrollarea, since we see a little of it.
     QPalette palette;
-    palette.setBrush(QPalette::Window, QBrush(GColor(CRIDEPLOTBACKGROUND)));
+    palette.setBrush(QPalette::Window, QBrush(GColor(GCol::RIDEPLOTBACKGROUND)));
 
     // main layout for widget
     QVBoxLayout *main=new QVBoxLayout(this);
@@ -84,7 +84,7 @@ GenericChart::GenericChart(QWidget *parent, Context *context) : QWidget(parent),
     connect(context, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));
 
     // default bgcolor
-    bgcolor = GColor(CPLOTBACKGROUND);
+    bgcolor = GColor(GCol::PLOTBACKGROUND);
     configChanged(0);
 }
 

--- a/src/Charts/GenericChart.h
+++ b/src/Charts/GenericChart.h
@@ -183,8 +183,8 @@ class GenericAxisInfo {
 
         GenericAxisInfo() : type(AxisInfoType::CONTINUOUS), orientation(Qt::Vertical), align(Qt::AlignLeft),
                             miny(0), maxy(0), minx(0), maxx(0), visible (true), fixed(false), log(false),
-                            minorgrid(false), majorgrid(true), labelcolor(GColor(CPLOTMARKER)),
-                            axiscolor(GColor(CPLOTMARKER)), smooth(0), groupby(NONE) {}
+                            minorgrid(false), majorgrid(true), labelcolor(GColor(GCol::PLOTMARKER)),
+                            axiscolor(GColor(GCol::PLOTMARKER)), smooth(0), groupby(NONE) {}
 
         static int findAxis(QList<GenericAxisInfo>infos, QString name) {
             for (int i=0; i<infos.count(); i++)
@@ -200,7 +200,7 @@ class GenericAxisInfo {
             type=CONTINUOUS;
             smooth=0;
             groupby=NONE;
-            axiscolor=labelcolor=GColor(CPLOTMARKER);
+            axiscolor=labelcolor=GColor(GCol::PLOTMARKER);
         }
 
         void point(double x, double y) {

--- a/src/Charts/GenericLegend.cpp
+++ b/src/Charts/GenericLegend.cpp
@@ -133,7 +133,7 @@ GenericLegendItem::paintEvent(QPaintEvent *)
 
     // under mouse show
     if (clickable && underMouse()) {
-        QColor color = GColor(CPLOTMARKER);
+        QColor color = GColor(GCol::PLOTMARKER);
         color.setAlphaF(0.2); // same as plotarea
         painter.setBrush(color);
         painter.setPen(Qt::NoPen);
@@ -160,7 +160,7 @@ GenericLegendItem::paintEvent(QPaintEvent *)
     if (hasstring)  string=this->string;
 
     // set pen to series color for now
-    if (enabled)  painter.setPen(GCColor::invertColor(legend->plot()->backgroundColor())); // use invert - usually black or white
+    if (enabled)  painter.setPen(GInvertColor(legend->plot()->backgroundColor())); // use invert - usually black or white
     else painter.setPen(Qt::gray);
 
     QFont f;
@@ -250,7 +250,7 @@ GenericLegend::addX(QString name, bool datetime, QString datetimeformat)
     // if it already exists remove it
     if (items.value(name,NULL) != NULL) removeSeries(name);
 
-    GenericLegendItem *add = new GenericLegendItem(context, this, name, GColor(CPLOTMARKER));
+    GenericLegendItem *add = new GenericLegendItem(context, this, name, GColor(GCol::PLOTMARKER));
     add->setClickable(false);
     add->setDateTime(datetime, datetimeformat);
     layout->insertWidget(0, add);

--- a/src/Charts/GenericPlot.cpp
+++ b/src/Charts/GenericPlot.cpp
@@ -260,15 +260,15 @@ GenericPlot::configChanged(qint32)
     // tinted palette for headings etc
     QPalette palette;
     palette.setBrush(QPalette::Window, QBrush(bgcolor_));
-    palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Base, GCColor::alternateColor(bgcolor_));
+    palette.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Text, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Base, GAlternateColor(bgcolor_));
     setPalette(palette);
 
     // chart colors
     chartview->setBackgroundBrush(QBrush(bgcolor_));
     qchart->setBackgroundBrush(QBrush(bgcolor_));
-    qchart->setBackgroundPen(QPen(GColor(CPLOTMARKER)));
+    qchart->setBackgroundPen(QPen(GColor(GCol::PLOTMARKER)));
 }
 
 void
@@ -527,7 +527,7 @@ GenericPlot::addCurve(QString name, QVector<double> xseries, QVector<double> yse
     QString dname = QString("d_%1").arg(name);
 
     // standard colors are encoded 1,1,x - where x is the index into the colorset
-    QColor applyColor = RGBColor(QColor(color));
+    QColor applyColor = GRGBColorToQColor(QColor(color));
 
     // labels font
     QFont labelsfont;
@@ -565,7 +565,7 @@ GenericPlot::addCurve(QString name, QVector<double> xseries, QVector<double> yse
         bottom = !bottom;
 
         // use marker color for x axes
-        xaxis->labelcolor = xaxis->axiscolor = GColor(CPLOTMARKER);
+        xaxis->labelcolor = xaxis->axiscolor = GColor(GCol::PLOTMARKER);
 
         // add to list
         axisinfos.insert(xname, xaxis);
@@ -871,7 +871,7 @@ GenericPlot::addCurve(QString name, QVector<double> xseries, QVector<double> yse
 
                 slice->setExploded();
                 slice->setLabelVisible();
-                slice->setLabelBrush(QBrush(GColor(CPLOTMARKER)));
+                slice->setLabelBrush(QBrush(GColor(GCol::PLOTMARKER)));
                 slice->setPen(Qt::NoPen);
                 if (i <colors.size()) slice->setBrush(QColor(colors.at(i)));
                 else slice->setBrush(Qt::red);
@@ -1115,7 +1115,7 @@ GenericPlot::finaliseChart()
                 add->setTitleBrush(QBrush(axisinfo->labelcolor));
 
                 // grid lines, just color for now xxx todo: ticks (sigh)
-                add->setGridLineColor(GColor(CPLOTGRID));
+                add->setGridLineColor(GColor(GCol::PLOTGRID));
                 if (charttype != GC_CHART_SCATTER && add->orientation()==Qt::Horizontal) // no x grids unless a scatter
                     add->setGridLineVisible(false);
 
@@ -1160,7 +1160,7 @@ GenericPlot::finaliseChart()
     }
 
     if (charttype== GC_CHART_PIE) {
-        foreach(QString name, havelegend)  legend->addSeries(name, GColor(CPLOTMARKER));
+        foreach(QString name, havelegend)  legend->addSeries(name, GColor(GCol::PLOTMARKER));
         legend->setClickable(false);
     }
 
@@ -1325,8 +1325,8 @@ GenericPlot::configureAxis(QString name, bool visible, int align, double min, do
     }
 
     // color
-    if (labelcolor != "") axis->labelcolor=RGBColor(QColor(labelcolor));
-    if (color != "") axis->axiscolor=RGBColor(QColor(color));
+    if (labelcolor != "") axis->labelcolor=GRGBColorToQColor(QColor(labelcolor));
+    if (color != "") axis->axiscolor=GRGBColorToQColor(QColor(color));
 
     // log ..
     axis->log = log;
@@ -1346,7 +1346,7 @@ GenericPlot::seriesColor(QAbstractSeries* series)
     case QAbstractSeries::SeriesTypeScatter: return static_cast<QScatterSeries*>(series)->color(); break;
     case QAbstractSeries::SeriesTypeLine: return static_cast<QLineSeries*>(series)->color(); break;
     case QAbstractSeries::SeriesTypeArea: return static_cast<QAreaSeries*>(series)->color(); break;
-    default: return GColor(CPLOTMARKER);
+    default: return GColor(GCol::PLOTMARKER);
     }
 }
 
@@ -1369,7 +1369,7 @@ GenericPlot::plotAnnotations(GenericSeriesInfo &seriesinfo)
             QString string = annotation.labels.join(" ");
             add->setFont(std);
             add->setText(string);
-            add->setStyleSheet(QString("color: %1").arg(RGBColor(QColor(seriesinfo.color)).name()));
+            add->setStyleSheet(QString("color: %1").arg(GRGBColorToQColor(QColor(seriesinfo.color)).name()));
             add->setFixedWidth(fm.boundingRect(string).width() + (25*dpiXFactor));
             add->setAlignment(Qt::AlignCenter);
             legend->addLabel(add);
@@ -1444,7 +1444,7 @@ GenericPlot::plotAnnotations(GenericSeriesInfo &seriesinfo)
             QLabel *add = new QLabel(this);
             add->setFont(std);
             add->setText(lr->text());
-            add->setStyleSheet(QString("color: %1").arg(RGBColor(QColor(seriesinfo.color)).name()));
+            add->setStyleSheet(QString("color: %1").arg(GRGBColorToQColor(QColor(seriesinfo.color)).name()));
             add->setFixedWidth(fm.boundingRect(lr->text()).width() + (25*dpiXFactor));
             add->setAlignment(Qt::AlignCenter);
             legend->addLabel(add);

--- a/src/Charts/GenericSelectTool.cpp
+++ b/src/Charts/GenericSelectTool.cpp
@@ -59,7 +59,7 @@ void GenericSelectTool::paint(QPainter*painter, const QStyleOptionGraphicsItem *
     if (hoveraxis) {
         QRectF fr = host->axisRect.value(hoveraxis, QRectF());
         if (fr != QRectF()) {
-            QColor color = GColor(CPLOTMARKER);
+            QColor color = GColor(GCol::PLOTMARKER);
             color.setAlphaF(0.2); // almost hidden if not moving/sizing
             painter->fillRect(mapRectFromScene(fr),QBrush(color));
         }
@@ -86,7 +86,7 @@ void GenericSelectTool::paint(QPainter*painter, const QStyleOptionGraphicsItem *
             //
             foreach(SeriesPoint p, hoverpoints) {
                 QPointF pos = mapFromScene(host->qchart->mapToPosition(p.xy,p.series));
-                QColor invert = GCColor::invertColor(GColor(CPLOTBACKGROUND));
+                QColor invert = GInvertColor(GCol::PLOTBACKGROUND);
                 painter->setBrush(invert);
                 painter->setPen(invert);
                 QRectF circle(0,0,gl_linemarker*dpiXFactor*host->scale_,gl_linemarker*dpiYFactor*host->scale_);
@@ -114,7 +114,7 @@ void GenericSelectTool::paint(QPainter*painter, const QStyleOptionGraphicsItem *
                     //
                     if (hoverpoint != GPointF()) {
                         // draw a circle using marker color
-                        QColor invert = GCColor::invertColor(GColor(CPLOTBACKGROUND));
+                        QColor invert = GInvertColor(GCol::PLOTBACKGROUND);
                         painter->setBrush(invert);
                         painter->setPen(invert);
                         QRectF circle(0,0,gl_scattermarker*dpiXFactor*host->scale_,gl_scattermarker*dpiYFactor*host->scale_);
@@ -187,7 +187,7 @@ void GenericSelectTool::paint(QPainter*painter, const QStyleOptionGraphicsItem *
                         posxp.setY(mapFromScene(host->qchart->plotArea().bottomLeft()).y()); // bottom of plot, 0 is not always origin
 
                         // x value
-                        painter->setPen(QPen(GColor(CPLOTMARKER)));
+                        painter->setPen(QPen(GColor(GCol::PLOTMARKER)));
                         // datetime?
                         if (xaxis && xaxis->type() == QAbstractAxis::AxisTypeDateTime)
                             label=QDateTime::fromMSecsSinceEpoch(v.x()).toString(static_cast<QDateTimeAxis*>(xaxis)->format());
@@ -209,7 +209,7 @@ void GenericSelectTool::paint(QPainter*painter, const QStyleOptionGraphicsItem *
 
                 // there is a rectangle to draw on the screen
                 QRectF r=QRectF(4,4,rect.width()-8,rect.height()-8);
-                QColor color = GColor(CPLOTMARKER);
+                QColor color = GColor(GCol::PLOTMARKER);
                 color.setAlphaF((state == ACTIVE && !isUnderMouse()) ? 0.05 : 0.2); // almost hidden if not moving/sizing
                 painter->fillRect(r,QBrush(color));
 
@@ -261,7 +261,7 @@ void GenericSelectTool::paint(QPainter*painter, const QStyleOptionGraphicsItem *
                             }
 
                             // draw slope line
-                            QColor col=GColor(CPLOTMARKER);
+                            QColor col=GColor(GCol::PLOTMARKER);
                             col.setAlphaF(1);
                             QPen line(col);
                             line.setStyle(Qt::SolidLine);
@@ -291,7 +291,7 @@ void GenericSelectTool::paint(QPainter*painter, const QStyleOptionGraphicsItem *
                         if (host->charttype == GC_CHART_SCATTER) avgxp.setY(mapFromScene(host->qchart->plotArea().bottomLeft()).y()-4);
                         else avgxp.setY(mapFromScene(host->qchart->plotArea().topLeft()).y()+fm.tightBoundingRect("XXX").height()+4);
 
-                        QColor linecol=GColor(CPLOTMARKER);
+                        QColor linecol=GColor(GCol::PLOTMARKER);
                         linecol.setAlphaF(0.25);
                         QPen gridpen(linecol);
                         gridpen.setStyle(Qt::DashLine);
@@ -304,7 +304,7 @@ void GenericSelectTool::paint(QPainter*painter, const QStyleOptionGraphicsItem *
                         stGiles.setPointSizeF(appsettings->value(NULL, GC_FONT_CHARTLABELS_SIZE, 8).toInt()*host->scale_);
                         painter->setFont(stGiles);
 
-                        QPen markerpen(GColor(CPLOTMARKER));
+                        QPen markerpen(GColor(GCol::PLOTMARKER));
                         painter->setPen(markerpen);
                         QString label;
                         QString datetimeformat;

--- a/src/Charts/GoldenCheetah.cpp
+++ b/src/Charts/GoldenCheetah.cpp
@@ -208,7 +208,7 @@ GcWindow::GcWindow(Context *context) : QFrame(context->mainWindow), dragState(No
     setContentsMargins(0,0,0,0);
     setResizable(false);
     setMouseTracking(true);
-    setProperty("color", GColor(CPLOTBACKGROUND));
+    setProperty("color", GColor(GCol::PLOTBACKGROUND));
     menu = NULL;
 
     // make sure its underneath the toggle button
@@ -290,7 +290,7 @@ GcWindow::paintEvent(QPaintEvent * /*event*/)
         if (showtitle) {
             // pen color needs to contrast to background color
             QColor bgColor = property("color").value<QColor>();
-            QColor fgColor = GCColor::invertColor(bgColor); // return the contrasting color
+            QColor fgColor = GInvertColor(bgColor); // return the contrasting color
 
             painter.setPen(fgColor);
             painter.drawText(bar, heading, Qt::AlignVCenter | Qt::AlignCenter);
@@ -305,7 +305,7 @@ GcWindow::paintEvent(QPaintEvent * /*event*/)
 
             if (isFiltered()) {
                 // overlay in highlight color
-                QColor over = GColor(CCALCURRENT);
+                QColor over = GColor(GCol::CALCURRENT);
                 over.setAlpha(220);
                 painter.setPen(over);
                 painter.drawText(bar, heading, Qt::AlignVCenter | Qt::AlignCenter);
@@ -319,7 +319,7 @@ GcWindow::paintEvent(QPaintEvent * /*event*/)
             QPixmap sized = closeImage.scaled(QSize(contentsMargins().top()-6,
                                                     contentsMargins().top()-6));
             QRect all(0,0,width()-1,height()-1);
-            QPen pen(GColor(CPLOTMARKER));
+            QPen pen(GColor(GCol::PLOTMARKER));
             pen.setWidth(1);
             painter.setPen(pen);
             painter.drawRect(all);
@@ -333,7 +333,7 @@ GcWindow::paintEvent(QPaintEvent * /*event*/)
         QRect all(0,0,width(),height());
         if (property("isManager").toBool() == true) {
             //painter.fillRect(all, QColor("#B3B4BA"));
-            painter.fillRect(all, GColor(CPLOTBACKGROUND));
+            painter.fillRect(all, GColor(GCol::PLOTBACKGROUND));
         }
     }
 }
@@ -765,7 +765,7 @@ GcChartWindow::GcChartWindow(Context *context) : GcWindow(context), context(cont
 void
 GcChartWindow::colorChanged(QColor z)
 {
-    QColor fgColor = GCColor::invertColor(z);
+    QColor fgColor = GInvertColor(z);
 
     // so z is color for bg and fgColor is for fg
     QString stylesheet = QString("color: rgb(%1, %2, %3); background-color: rgba(%4, %5, %6, 80%)")

--- a/src/Charts/HistogramWindow.cpp
+++ b/src/Charts/HistogramWindow.cpp
@@ -373,8 +373,8 @@ HistogramWindow::HistogramWindow(Context *context, bool rangemode) : GcChartWind
 void
 HistogramWindow::configChanged(qint32 state)
 {
-    if (!rangemode) setProperty("color", GColor(CPLOTBACKGROUND)); // called on config change
-    else setProperty("color", GColor(CTRENDPLOTBACKGROUND)); // called on config change
+    if (!rangemode) setProperty("color", GColor(GCol::PLOTBACKGROUND)); // called on config change
+    else setProperty("color", GColor(GCol::TRENDPLOTBACKGROUND)); // called on config change
     powerHist->configChanged(state);
 }
 

--- a/src/Charts/HrPwPlot.cpp
+++ b/src/Charts/HrPwPlot.cpp
@@ -54,7 +54,7 @@ HrPwPlot::HrPwPlot(Context *context, HrPwWindow *hrPwWindow) :
 
     // Linear Regression Curve
     regCurve = new QwtPlotCurve("reg");
-    regCurve->setPen(QPen(GColor(CPLOTMARKER)));
+    regCurve->setPen(QPen(GColor(GCol::PLOTMARKER)));
     regCurve->attach(this);
 
     // Power distribution
@@ -118,12 +118,12 @@ void
 HrPwPlot::configChanged(qint32)
 {
     // setColors bg
-    setCanvasBackground(GColor(CPLOTBACKGROUND));
+    setCanvasBackground(GColor(GCol::PLOTBACKGROUND));
 
     QPalette palette;
-    palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
+    palette.setBrush(QPalette::Window, QBrush(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Text, GColor(GCol::PLOTMARKER));
     setPalette(palette);
 
     // tick draw
@@ -141,7 +141,7 @@ HrPwPlot::configChanged(qint32)
     axisWidget(QwtAxis::YLeft)->setPalette(palette);
 
     QPen gridPen;
-    gridPen.setColor(GColor(CPLOTGRID));
+    gridPen.setColor(GColor(GCol::PLOTGRID));
     grid->setPen(gridPen);
 }
 
@@ -323,12 +323,12 @@ HrPwPlot::recalc()
 
     QwtText textr = QwtText(labelp+"*x+"+labelo+" : R "+labelr+" ("+labeldelay+") \n Power@150:"+labelpower150+"W");
     textr.setFont(QFont("Helvetica", 10, QFont::Bold));
-    textr.setColor(GColor(CPLOTMARKER));
+    textr.setColor(GColor(GCol::PLOTMARKER));
 
     r_mrk1->setValue(0,0);
     r_mrk1->setLineStyle(QwtPlotMarker::VLine);
     r_mrk1->setLabelAlignment(Qt::AlignRight | Qt::AlignBottom);
-    r_mrk1->setLinePen(QPen(GColor(CPLOTMARKER), 0, Qt::DashDotLine));
+    r_mrk1->setLinePen(QPen(GColor(GCol::PLOTMARKER), 0, Qt::DashDotLine));
     double averagewatt = hrPwWindow->average(clipWatts, clipWatts.size());
     r_mrk1->setValue(averagewatt, 0.0);
     r_mrk1->setLabel(textr);
@@ -336,7 +336,7 @@ HrPwPlot::recalc()
     r_mrk2->setValue(0,0);
     r_mrk2->setLineStyle(QwtPlotMarker::HLine);
     r_mrk2->setLabelAlignment(Qt::AlignRight | Qt::AlignTop);
-    r_mrk2->setLinePen(QPen(GColor(CPLOTMARKER), 0, Qt::DashDotLine));
+    r_mrk2->setLinePen(QPen(GColor(GCol::PLOTMARKER), 0, Qt::DashDotLine));
     double averagehr = hrPwWindow->average(clipHr,  clipHr.size());
     r_mrk2->setValue(0.0,averagehr);
 

--- a/src/Charts/HrPwWindow.cpp
+++ b/src/Charts/HrPwWindow.cpp
@@ -204,7 +204,7 @@ HrPwWindow::HrPwWindow(Context *context) :
 void
 HrPwWindow::configChanged(qint32)
 {
-    setProperty("color", GColor(CPLOTBACKGROUND));
+    setProperty("color", GColor(GCol::PLOTBACKGROUND));
 }
 
 void

--- a/src/Charts/IntervalSummaryWindow.cpp
+++ b/src/Charts/IntervalSummaryWindow.cpp
@@ -50,7 +50,7 @@ IntervalSummaryWindow::IntervalSummaryWindow(Context *context) : context(context
     connect(context, SIGNAL(intervalHover(IntervalItem*)), this, SLOT(intervalHover(IntervalItem*)));
     connect(context, SIGNAL(configChanged(qint32)), this, SLOT(intervalSelected()));
 
-    setHtml(GCColor::css() + "<body></body>");
+    setHtml(GCColor::inst()->css() + "<body></body>");
 }
 
 IntervalSummaryWindow::~IntervalSummaryWindow() {
@@ -63,14 +63,14 @@ void IntervalSummaryWindow::intervalSelected()
 
     if (rideItem == NULL || rideItem->intervalsSelected().count() == 0 || rideItem->ride() == NULL) {
         // no ride just update the colors
-	    QString html = GCColor::css();
+	    QString html = GCColor::inst()->css();
         html += "<body></body>";
 	    setHtml(html);
 	    return;
     }
 
     // summary is html
-	QString html = GCColor::css();
+	QString html = GCColor::inst()->css();
     html += "<body>";
 
     // summarise all the intervals selected - this is painful!
@@ -84,7 +84,7 @@ void IntervalSummaryWindow::intervalSelected()
     // now add the excluding text
     html += notincluding;
 
-    if (html == GCColor::css()+"<body>") html += "<i>" + tr("select an interval for summary info") + "</i>";
+    if (html == GCColor::inst()->css()+"<body>") html += "<i>" + tr("select an interval for summary info") + "</i>";
 
     html += "</body>";
 	setHtml(html);
@@ -104,7 +104,7 @@ IntervalSummaryWindow::intervalHover(IntervalItem* x)
     RideItem *rideItem = const_cast<RideItem*>(context->currentRideItem());
     if (!x && rideItem && rideItem->intervalsSelected().count()) return;
 
-    QString html = GCColor::css();
+    QString html = GCColor::inst()->css();
     html += "<body>";
 
     if (x == NULL) {

--- a/src/Charts/LTMPlot.cpp
+++ b/src/Charts/LTMPlot.cpp
@@ -153,15 +153,15 @@ void
 LTMPlot::configChanged(qint32)
 {
     // set basic plot colors
-    setCanvasBackground(GColor(CTRENDPLOTBACKGROUND));
-    QPen gridPen(GColor(CPLOTGRID));
+    setCanvasBackground(GColor(GCol::TRENDPLOTBACKGROUND));
+    QPen gridPen(GColor(GCol::PLOTGRID));
     //gridPen.setStyle(Qt::DotLine);
     grid->setPen(gridPen);
 
     QPalette palette;
-    palette.setBrush(QPalette::Window, QBrush(GColor(CTRENDPLOTBACKGROUND)));
-    palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
+    palette.setBrush(QPalette::Window, QBrush(GColor(GCol::TRENDPLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Text, GColor(GCol::PLOTMARKER));
     setPalette(palette);
 
     QPalette gray = palette; // same but with gray text for hidden curves
@@ -340,7 +340,7 @@ LTMPlot::setData(LTMSettings *set)
         refreshZoneLabels(QwtAxisId(-1,-1)); // turn em off
 
         // remove the old markers
-        refreshMarkers(settings, settings->start.date(), settings->end.date(), settings->groupBy, GColor(CPLOTMARKER));
+        refreshMarkers(settings, settings->start.date(), settings->end.date(), settings->groupBy, GColor(GCol::PLOTMARKER));
 
         replot();
         return;
@@ -462,7 +462,7 @@ LTMPlot::setData(LTMSettings *set)
         stacks.insert(current, stackcounter+1);
         if (appsettings->value(this, GC_ANTIALIAS, true).toBool() == true)
             current->setRenderHint(QwtPlotItem::RenderAntialiased);
-        QPen cpen = QPen(RGBColor(metricDetail.penColor));
+        QPen cpen = QPen(GRGBColorToQColor(metricDetail.penColor));
         cpen.setWidth(width);
         current->setPen(cpen);
         current->setStyle(metricDetail.curveStyle);
@@ -494,7 +494,7 @@ LTMPlot::setData(LTMSettings *set)
         if (metricDetail.curveStyle == QwtPlotCurve::Steps) {
             
             // fill the bars
-            QColor brushColor = RGBColor(metricDetail.penColor);
+            QColor brushColor = GRGBColorToQColor(metricDetail.penColor);
             if (metricDetail.stack == true) {
                 brushColor.setAlpha(255);
                 QBrush brush = QBrush(brushColor);
@@ -616,7 +616,7 @@ LTMPlot::setData(LTMSettings *set)
             curves.insert(metricDetail.symbol, current);
         if (appsettings->value(this, GC_ANTIALIAS, true).toBool() == true)
             current->setRenderHint(QwtPlotItem::RenderAntialiased);
-        QPen cpen = QPen(RGBColor(metricDetail.penColor));
+        QPen cpen = QPen(GRGBColorToQColor(metricDetail.penColor));
         cpen.setWidth(width);
         current->setPen(cpen);
         current->setStyle(metricDetail.curveStyle);
@@ -668,7 +668,7 @@ LTMPlot::setData(LTMSettings *set)
                 trend->setVisible(!metricDetail.hidden);
 
                 // cosmetics
-                QPen cpen = QPen(RGBColor(metricDetail.penColor).darker(200));
+                QPen cpen = QPen(GRGBColorToQColor(metricDetail.penColor).darker(200));
                 cpen.setWidth(2); // double thickness for trend lines
                 cpen.setStyle(Qt::SolidLine);
                 trend->setPen(cpen);
@@ -706,7 +706,7 @@ LTMPlot::setData(LTMSettings *set)
                 trend->setVisible(!metricDetail.hidden);
 
                 // cosmetics
-                QPen cpen = QPen(RGBColor(metricDetail.penColor).darker(200));
+                QPen cpen = QPen(GRGBColorToQColor(metricDetail.penColor).darker(200));
                 cpen.setWidth(2); // double thickness for trend lines
                 cpen.setStyle(Qt::SolidLine);
                 trend->setPen(cpen);
@@ -748,7 +748,7 @@ LTMPlot::setData(LTMSettings *set)
                 trend->setVisible(!metricDetail.hidden);
 
                 // cosmetics
-                QPen cpen = QPen(RGBColor(metricDetail.penColor).darker(200));
+                QPen cpen = QPen(GRGBColorToQColor(metricDetail.penColor).darker(200));
                 cpen.setWidth(2); // double thickness for trend lines
                 cpen.setStyle(Qt::SolidLine);
                 trend->setPen(cpen);
@@ -828,7 +828,7 @@ LTMPlot::setData(LTMSettings *set)
                 trend->setVisible(!metricDetail.hidden);
 
                 // cosmetics
-                QPen cpen = QPen(RGBColor(metricDetail.penColor).darker(200));
+                QPen cpen = QPen(GRGBColorToQColor(metricDetail.penColor).darker(200));
                 cpen.setWidth(2); // double thickness for trend lines
                 cpen.setStyle(Qt::SolidLine);
                 trend->setPen(cpen);
@@ -902,9 +902,9 @@ LTMPlot::setData(LTMSettings *set)
                 sym->setStyle(metricDetail.symbolStyle);
                 sym->setSize(20*dpiXFactor);
             }
-            QColor lighter = RGBColor(metricDetail.penColor);
+            QColor lighter = GRGBColorToQColor(metricDetail.penColor);
             lighter.setAlpha(50);
-            sym->setPen(RGBColor(metricDetail.penColor));
+            sym->setPen(GRGBColorToQColor(metricDetail.penColor));
             sym->setBrush(lighter);
 
             out->setSymbol(sym);
@@ -994,9 +994,9 @@ LTMPlot::setData(LTMSettings *set)
                 sym->setStyle(metricDetail.symbolStyle);
                 sym->setSize(12*dpiXFactor);
             }
-            QColor lighter = RGBColor(metricDetail.penColor);
+            QColor lighter = GRGBColorToQColor(metricDetail.penColor);
             lighter.setAlpha(200);
-            sym->setPen(RGBColor(metricDetail.penColor));
+            sym->setPen(GRGBColorToQColor(metricDetail.penColor));
             sym->setBrush(lighter);
 
             top->setSymbol(sym);
@@ -1049,7 +1049,7 @@ LTMPlot::setData(LTMSettings *set)
                         // Qwt uses its own text objects
                         QwtText text(labelString);
                         text.setFont(labelFont);
-                        text.setColor(RGBColor(metricDetail.penColor));
+                        text.setColor(GRGBColorToQColor(metricDetail.penColor));
 
                         // make that mark -- always above with topN
                         QwtPlotMarker *label = new QwtPlotMarker();
@@ -1071,9 +1071,9 @@ LTMPlot::setData(LTMSettings *set)
         if (metricDetail.curveStyle == QwtPlotCurve::Steps) {
             
             // fill the bars
-            QColor brushColor = RGBColor(metricDetail.penColor);
+            QColor brushColor = GRGBColorToQColor(metricDetail.penColor);
             brushColor.setAlpha(200); // now side by side, less transparency required
-            QColor brushColor1 = RGBColor(metricDetail.penColor).darker();
+            QColor brushColor1 = GRGBColorToQColor(metricDetail.penColor).darker();
             QLinearGradient linearGradient(0, 0, 0, height());
             linearGradient.setColorAt(0.0, brushColor1);
             linearGradient.setColorAt(1.0, brushColor);
@@ -1130,19 +1130,19 @@ LTMPlot::setData(LTMSettings *set)
 
         } else if (metricDetail.curveStyle == QwtPlotCurve::Lines) {
 
-            QPen cpen = QPen(RGBColor(metricDetail.penColor));
+            QPen cpen = QPen(GRGBColorToQColor(metricDetail.penColor));
             cpen.setWidth(width);
             QwtSymbol *sym = new QwtSymbol;
             sym->setSize(6*dpiXFactor);
             sym->setStyle(metricDetail.symbolStyle);
-            sym->setPen(QPen(RGBColor(metricDetail.penColor)));
-            sym->setBrush(QBrush(RGBColor(metricDetail.penColor)));
+            sym->setPen(QPen(GRGBColorToQColor(metricDetail.penColor)));
+            sym->setBrush(QBrush(GRGBColorToQColor(metricDetail.penColor)));
             current->setSymbol(sym);
             current->setPen(cpen);
 
             // fill below the line
             if (metricDetail.fillCurve) {
-                QColor fillColor = RGBColor(metricDetail.penColor);
+                QColor fillColor = GRGBColorToQColor(metricDetail.penColor);
                 fillColor.setAlpha(100);
                 current->setBrush(fillColor);
             }
@@ -1155,8 +1155,8 @@ LTMPlot::setData(LTMSettings *set)
                 double testfactor = metricDetail.type == METRIC_PERFORMANCE ? 2 : 1;
                 sym->setSize(6*dpiXFactor*testfactor);
                 sym->setStyle(metricDetail.symbolStyle);
-                sym->setPen(QPen(RGBColor(metricDetail.penColor)));
-                sym->setBrush(QBrush(RGBColor(metricDetail.penColor)));
+                sym->setPen(QPen(GRGBColorToQColor(metricDetail.penColor)));
+                sym->setBrush(QBrush(GRGBColorToQColor(metricDetail.penColor)));
                 current->setSymbol(sym);
             } else {
                 current->setStyle(QwtPlotCurve::NoCurve);
@@ -1167,7 +1167,7 @@ LTMPlot::setData(LTMSettings *set)
             QwtSymbol *sym = new QwtSymbol;
             sym->setSize(4*dpiXFactor);
             sym->setStyle(metricDetail.symbolStyle);
-            sym->setPen(QPen(RGBColor(metricDetail.penColor)));
+            sym->setPen(QPen(GRGBColorToQColor(metricDetail.penColor)));
             sym->setBrush(QBrush(Qt::white));
             current->setSymbol(sym);
 
@@ -1218,7 +1218,7 @@ LTMPlot::setData(LTMSettings *set)
                     // Qwt uses its own text objects
                     QwtText text(labelString);
                     text.setFont(labelFont);
-                    text.setColor(RGBColor(metricDetail.penColor));
+                    text.setColor(GRGBColorToQColor(metricDetail.penColor));
 
                     // make that mark
                     QwtPlotMarker *label = new QwtPlotMarker();
@@ -1376,7 +1376,7 @@ LTMPlot::setData(LTMSettings *set)
 
     // markers
     if (settings->groupBy != LTM_TOD)
-        refreshMarkers(settings, settings->start.date(), settings->end.date(), settings->groupBy, GColor(CPLOTMARKER));
+        refreshMarkers(settings, settings->start.date(), settings->end.date(), settings->groupBy, GColor(GCol::PLOTMARKER));
 
     //qDebug()<<"Final tidy.."<<timer.elapsed();
 
@@ -1675,9 +1675,9 @@ LTMPlot::setCompareData(LTMSettings *set)
             
                 // fill the bars
                 QColor merge;
-                merge.setRed((RGBColor(metricDetail.penColor).red() + cd.color.red()) / 2);
-                merge.setGreen((RGBColor(metricDetail.penColor).green() + cd.color.green()) / 2);
-                merge.setBlue((RGBColor(metricDetail.penColor).blue() + cd.color.blue()) / 2);
+                merge.setRed((GRGBColorToQColor(metricDetail.penColor).red() + cd.color.red()) / 2);
+                merge.setGreen((GRGBColorToQColor(metricDetail.penColor).green() + cd.color.green()) / 2);
+                merge.setBlue((GRGBColorToQColor(metricDetail.penColor).blue() + cd.color.blue()) / 2);
 
                 QColor brushColor = merge;
                 if (metricDetail.stack == true) {
@@ -1922,7 +1922,7 @@ LTMPlot::setCompareData(LTMSettings *set)
                     trend->setVisible(!metricDetail.hidden);
 
                     // cosmetics
-                    QPen cpen = QPen(RGBColor(metricDetail.penColor).darker(200));
+                    QPen cpen = QPen(GRGBColorToQColor(metricDetail.penColor).darker(200));
                     cpen.setWidth(2); // double thickness for trend lines
                     cpen.setStyle(Qt::SolidLine);
                     trend->setPen(cpen);

--- a/src/Charts/LTMTool.cpp
+++ b/src/Charts/LTMTool.cpp
@@ -26,7 +26,7 @@
 #include "RideNavigator.h"
 #include "HelpWhatsThis.h"
 #include "Utils.h"
-#include "Colors.h" // NamedColor and RGBColor
+#include "Colors.h" // RGBColor
 #include "ColorButton.h" // GColorDialog
 
 #include <QApplication>
@@ -2112,7 +2112,7 @@ EditMetricDetailDialog::EditMetricDetailDialog(Context *context, LTMTool *ltmToo
  
     // color background...
     penColor = metricDetail->penColor;
-    setButtonIcon(RGBColor(penColor));
+    setButtonIcon(GRGBColorToQColor(penColor));
 
     QLabel *topN = new QLabel(tr("Highlight Highest"));
     showBest = new QDoubleSpinBox(this);
@@ -2484,7 +2484,7 @@ EditMetricDetailDialog::metricSelected()
         baseLine->setValue(ltmTool->metrics[index].baseline);
         penColor = ltmTool->metrics[index].penColor;
         trendType->setCurrentIndex(ltmTool->metrics[index].trendtype);
-        setButtonIcon(RGBColor(penColor));
+        setButtonIcon(GRGBColorToQColor(penColor));
 
         // curve style
         switch (ltmTool->metrics[index].curveStyle) {
@@ -2662,9 +2662,9 @@ EditMetricDetailDialog::colorClicked()
 {
     QColor color = GColorDialog::getColor(penColor.name());
 
-    if (NamedColor(color)) { // named color
+    if (GIsRGBColor(color)) { // named color
         penColor=color;
-        setButtonIcon(RGBColor(color));
+        setButtonIcon(GRGBColorToQColor(color));
     } else if (color.isValid()) setButtonIcon(penColor=color); // normal rgb color
 }
 

--- a/src/Charts/LTMWindow.cpp
+++ b/src/Charts/LTMWindow.cpp
@@ -66,7 +66,7 @@ LTMWindow::LTMWindow(Context *context) :
     QVBoxLayout *mainLayout = new QVBoxLayout;
 
     QPalette palette;
-    palette.setBrush(QPalette::Window, QBrush(GColor(CTRENDPLOTBACKGROUND)));
+    palette.setBrush(QPalette::Window, QBrush(GColor(GCol::TRENDPLOTBACKGROUND)));
 
     // single plot
     plotWidget = new QWidget(this);
@@ -508,18 +508,18 @@ LTMWindow::configChanged(qint32)
 {
     // tinted palette for headings etc
     QPalette palette;
-    palette.setBrush(QPalette::Window, QBrush(GColor(CTRENDPLOTBACKGROUND)));
-    palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CPLOTBACKGROUND)));
+    palette.setBrush(QPalette::Window, QBrush(GColor(GCol::TRENDPLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Text, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Base, GAlternateColor(GCol::PLOTBACKGROUND));
     setPalette(palette);
 
     // inverted palette for data etc
     QPalette whitepalette;
-    whitepalette.setBrush(QPalette::Window, QBrush(GColor(CTRENDPLOTBACKGROUND)));
-    whitepalette.setColor(QPalette::WindowText, GCColor::invertColor(GColor(CTRENDPLOTBACKGROUND)));
-    whitepalette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CPLOTBACKGROUND)));
-    whitepalette.setColor(QPalette::Text, GCColor::invertColor(GColor(CTRENDPLOTBACKGROUND)));
+    whitepalette.setBrush(QPalette::Window, QBrush(GColor(GCol::TRENDPLOTBACKGROUND)));
+    whitepalette.setColor(QPalette::WindowText, GInvertColor(GColor(GCol::TRENDPLOTBACKGROUND)));
+    whitepalette.setColor(QPalette::Base, GAlternateColor(GColor(GCol::PLOTBACKGROUND)));
+    whitepalette.setColor(QPalette::Text, GInvertColor(GColor(GCol::TRENDPLOTBACKGROUND)));
 
     QFont font;
     font.setPointSize(12); // reasonably big
@@ -988,7 +988,7 @@ LTMWindow::useThruToday()
 void
 LTMWindow::refresh()
 {
-    setProperty("color", GColor(CTRENDPLOTBACKGROUND)); // called on config change
+    setProperty("color", GColor(GCol::TRENDPLOTBACKGROUND)); // called on config change
 
     // not if in compare mode
     if (isCompare()) return; 
@@ -1295,13 +1295,13 @@ LTMWindow::dataTable(bool html)
     // now set to new (avoids a weird crash)
     QString summary;
 
-    QColor bgColor = GColor(CTRENDPLOTBACKGROUND);
-    QColor altColor = GCColor::alternateColor(bgColor);
+    QColor bgColor = GColor(GCol::TRENDPLOTBACKGROUND);
+    QColor altColor = GAlternateColor(bgColor);
 
     // html page prettified with a title
     if (html) {
 
-        summary = GCColor::css();
+        summary = GCColor::inst()->css();
         summary += "<center>";
 
         // device summary for ride summary, otherwise how many activities?

--- a/src/Charts/LTMWindow.h
+++ b/src/Charts/LTMWindow.h
@@ -73,8 +73,8 @@ class LTMToolTip : public QwtPlotPicker
         stGiles.setWeight(QFont::Bold);
         text.setFont(stGiles);
 
-        text.setBackgroundBrush(QBrush( GColor(CPLOTMARKER)));
-        text.setColor(GColor(CRIDEPLOTBACKGROUND));
+        text.setBackgroundBrush(QBrush( GColor(GCol::PLOTMARKER)));
+        text.setColor(GColor(GCol::RIDEPLOTBACKGROUND));
         text.setBorderRadius(6);
         text.setRenderFlags(Qt::AlignCenter | Qt::AlignVCenter);
 

--- a/src/Charts/MUPlot.cpp
+++ b/src/Charts/MUPlot.cpp
@@ -112,15 +112,15 @@ void
 MUPlot::configChanged(qint32)
 {
     QPalette palette;
-    palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
+    palette.setBrush(QPalette::Window, QBrush(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Text, GColor(GCol::PLOTMARKER));
     setPalette(palette);
 
     axisWidget(QwtAxis::XBottom)->setPalette(palette);
     axisWidget(QwtAxis::YLeft)->setPalette(palette);
 
-    setCanvasBackground(GColor(CPLOTBACKGROUND));
+    setCanvasBackground(GColor(GCol::PLOTBACKGROUND));
 }
 
 // get the fonts and colors right for the axis scales
@@ -133,7 +133,7 @@ MUPlot::setAxisTitle(int axis, QString label)
     stGiles.setPointSize(appsettings->value(NULL, GC_FONT_CHARTLABELS_SIZE, 8).toInt());
 
     QwtText title(label);
-    title.setColor(GColor(CPLOTMARKER));
+    title.setColor(GColor(GCol::PLOTMARKER));
     title.setFont(stGiles);
     QwtPlot::setAxisFont(axis, stGiles);
     QwtPlot::setAxisTitle(axis, title);
@@ -246,7 +246,7 @@ MUPlot::setModel(int model)
             fastLine->attach(this);
 
             // now add a handle
-            QColor color = GColor(CPLOTBACKGROUND);
+            QColor color = GColor(GCol::PLOTBACKGROUND);
             double x = MU_FASTMEAN; // mean is ok
             double y = 0.05f * 40.0f; // variance scaled to w(x)
 
@@ -272,7 +272,7 @@ MUPlot::setModel(int model)
             slowCurve->setData(slowNormal = new MUNormal(MU_SLOWMEAN, 0.05f));
             slowCurve->attach(this);
 
-            QColor handleColor = GColor(CCP).darker(30);
+            QColor handleColor = GColor(GCol::CP).darker(30);
             handleColor.setAlpha(64);
 
             // now a mean line
@@ -284,7 +284,7 @@ MUPlot::setModel(int model)
             slowLine->attach(this);
 
             // now add a handle
-            QColor color = GColor(CPLOTBACKGROUND);
+            QColor color = GColor(GCol::PLOTBACKGROUND);
             double x = MU_SLOWMEAN; // mean is ok
             double y = 0.05f * 40.0f; // variance scaled to w(x)
 
@@ -335,7 +335,7 @@ MUPlot::setModel(int model)
         if (antialias) slowCurve->setRenderHint(QwtPlotItem::RenderAntialiased);
 
         // color and brush
-        QColor color = GColor(CCP); // customise ?
+        QColor color = GColor(GCol::CP); // customise ?
         QPen pen(color);
         pen.setWidth(1.0);
 

--- a/src/Charts/MUWidget.cpp
+++ b/src/Charts/MUWidget.cpp
@@ -152,13 +152,13 @@ void
 MUWidget::configChanged(qint32)
 {
     QPalette palette;
-    palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
+    palette.setBrush(QPalette::Window, QBrush(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Text, GColor(GCol::PLOTMARKER));
     setPalette(palette);
 
-    QColor bgColor = GColor(CPLOTBACKGROUND);
-    QColor fgColor = GCColor::invertColor(bgColor);
+    QColor bgColor = GColor(GCol::PLOTBACKGROUND);
+    QColor fgColor = GInvertColor(bgColor);
     QColor border = bgColor;
     border = border.darker(300);
 

--- a/src/Charts/MetadataWindow.cpp
+++ b/src/Charts/MetadataWindow.cpp
@@ -59,5 +59,5 @@ MetadataWindow::rideItemChanged()
 void
 MetadataWindow::configChanged(qint32)
 {
-    setProperty("color", GColor(CPLOTBACKGROUND));
+    setProperty("color", GColor(GCol::PLOTBACKGROUND));
 }

--- a/src/Charts/Overview.cpp
+++ b/src/Charts/Overview.cpp
@@ -29,7 +29,7 @@ static QIcon grayConfig, whiteConfig, accentConfig;
 OverviewWindow::OverviewWindow(Context *context, int scope, bool blank) : GcChartWindow(context), context(context), configured(false), scope(scope), blank(blank)
 {
     setContentsMargins(0,0,0,0);
-    setProperty("color", GColor(COVERVIEWBACKGROUND));
+    setProperty("color", GColor(GCol::OVERVIEWBACKGROUND));
     setShowTitle(false);
 
     // actions...
@@ -561,7 +561,7 @@ badconfig:
         // color is common- if we actuall added one...
         if (add) {
             if (obj.contains("color") && type != OverviewItemType::USERCHART)  add->bgcolor = obj["color"].toString();
-            else add->bgcolor = StandardColor(CCARDBACKGROUND).name();
+            else add->bgcolor = GColorToRGBColor(GCol::CARDBACKGROUND).name();
         }
     }
 

--- a/src/Charts/OverviewItems.cpp
+++ b/src/Charts/OverviewItems.cpp
@@ -688,21 +688,21 @@ ZoneOverviewItem::configChanged(qint32)
 
     // config changed...
     if (series == RideFile::hr) {
-        barset->setLabelColor(GColor(CHEARTRATE));
-        barset->setBorderColor(GColor(CHEARTRATE));
-        barset->setBrush(GColor(CHEARTRATE));
+        barset->setLabelColor(GColor(GCol::HEARTRATE));
+        barset->setBorderColor(GColor(GCol::HEARTRATE));
+        barset->setBrush(GColor(GCol::HEARTRATE));
     } else if (series == RideFile::watts) {
-        barset->setLabelColor(GColor(CPOWER));
-        barset->setBorderColor(GColor(CPOWER));
-        barset->setBrush(GColor(CPOWER));
+        barset->setLabelColor(GColor(GCol::POWER));
+        barset->setBorderColor(GColor(GCol::POWER));
+        barset->setBrush(GColor(GCol::POWER));
     } else if (series == RideFile::wbal) {
-        barset->setLabelColor(GColor(CWBAL));
-        barset->setBorderColor(GColor(CWBAL));
-        barset->setBrush(GColor(CWBAL));
+        barset->setLabelColor(GColor(GCol::WBAL));
+        barset->setBorderColor(GColor(GCol::WBAL));
+        barset->setBrush(GColor(GCol::WBAL));
     } else if (series == RideFile::kph) {
-        barset->setLabelColor(GColor(CSPEED));
-        barset->setBorderColor(GColor(CSPEED));
-        barset->setBrush(GColor(CSPEED));
+        barset->setLabelColor(GColor(GCol::SPEED));
+        barset->setBorderColor(GColor(GCol::SPEED));
+        barset->setBrush(GColor(GCol::SPEED));
     }
 
     categories.clear();
@@ -768,7 +768,7 @@ ZoneOverviewItem::configChanged(qint32)
     barcategoryaxis->setCategories(categories);
 
     // config axes
-    QPen axisPen(GColor(CCARDBACKGROUND));
+    QPen axisPen(GColor(GCol::CARDBACKGROUND));
     axisPen.setWidth(1); // almost invisible
     chart->createDefaultAxes();
     chart->setAxisX(barcategoryaxis, barseries);
@@ -1702,7 +1702,7 @@ TopNOverviewItem::setDateRange(DateRange dr)
         if (index >= 0 && index < stressdata.sb().count()) tsb = stressdata.sb()[index];
 
         // add to the list
-        QColor color = (item->color.red() == 1 && item->color.green() == 1 && item->color.blue() == 1) ? GColor(CPLOTMARKER) : item->color;
+        QColor color = (item->color.red() == 1 && item->color.green() == 1 && item->color.blue() == 1) ? GColor(GCol::PLOTMARKER) : item->color;
         ranked << topnentry(item->dateTime.date(), v, value, color, tsb, item);
 
         // biggest value?
@@ -1963,8 +1963,8 @@ DonutOverviewItem::setDateRange(DateRange dr)
 
     // now do the colors
     double i=1;
-    QColor min=GColor(CPLOTMARKER);
-    QColor max=GCColor::invertColor(GColor(CCARDBACKGROUND));
+    QColor min=GColor(GCol::PLOTMARKER);
+    QColor max=GInvertColor(GCol::CARDBACKGROUND);
     bool exploded=false;
     foreach(QPieSlice *slice, add->slices()) {
 
@@ -2379,7 +2379,7 @@ IntervalOverviewItem::setDateRange(DateRange dr)
         add.z = z;
         add.fill = item->color;
         add.item = item; // for click thru
-        if (add.fill.red() == 1 && add.fill.green() == 1 && add.fill.blue() == 1) add.fill = GColor(CPLOTMARKER);
+        if (GIsRGBColor(add.fill) && add.fill.blue() == 1) add.fill = GColor(GCol::PLOTMARKER);
         add.label = item->getText("Workout Code","blank");
         points << add;
 
@@ -2445,7 +2445,7 @@ IntervalOverviewItem::setData(RideItem *item, bool animate)
         add.y = y;
         add.z = z;
 
-        if (interval == this->hover || interval->selected) add.fill = GColor(CPLOTMARKER);
+        if (interval == this->hover || interval->selected) add.fill = GColor(GCol::PLOTMARKER);
         else add.fill = interval->color;
         add.label = interval->name;
         points << add;
@@ -2687,7 +2687,7 @@ KPIOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *, 
     QFontMetrics fm(parent->bigfont);
     QRectF rect = QFontMetrics(parent->bigfont, parent->device()).boundingRect(value);
 
-    painter->setPen(GColor(CPLOTMARKER));
+    painter->setPen(GColor(GCol::PLOTMARKER));
     painter->setFont(parent->bigfont);
     painter->drawText(QPointF((geometry().width() - rect.width()) / 2.0f,
                               mid + (fm.ascent() / 3.0f)), value); // divided by 3 to account for "gap" at top of font
@@ -2731,7 +2731,7 @@ KPIOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *, 
             if (!percenttext.startsWith("nan") && !percenttext.startsWith("inf") && percenttext != "0%") {
 
                 // title color, copied code from chartspace.cpp, should really be a cleaner way to get these
-                if (GCColor::luminance(GColor(CCARDBACKGROUND)) < 127) painter->setPen(QColor(200,200,200));
+                if (GLuminance(GCol::CARDBACKGROUND) < 127) painter->setPen(QColor(200,200,200));
                 else painter->setPen(QColor(70,70,70));
 
                 painter->setFont(parent->midfont);
@@ -2935,7 +2935,7 @@ DataOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *,
     bold.setBold(true);
 
     // normal just grey, we highlight with plot marker
-    QColor cnormal = (GCColor::luminance(GColor(CCARDBACKGROUND)) < 127) ? QColor(200,200,200) : QColor(70,70,70);
+    QColor cnormal = (GLuminance(GCol::CARDBACKGROUND) < 127) ? QColor(200,200,200) : QColor(70,70,70);
 
 
     // step 2: where is the mouse hovering, paint a background etc ....
@@ -3103,7 +3103,7 @@ DataOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *,
                 // highlight rows when hovering and click thru not available
                 if ((j == hoverrow || j == hoveredrow) && !scrollbar->isDragging()) {
                     painter->setFont(bold);
-                    painter->setPen(GColor(CPLOTMARKER));
+                    painter->setPen(GColor(GCol::PLOTMARKER));
                 } else {
                     painter->setFont(normal);
                     painter->setPen(cnormal);
@@ -3161,7 +3161,7 @@ RPEOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *, 
     QFontMetrics fm(parent->bigfont);
     QRectF rect = QFontMetrics(parent->bigfont, parent->device()).boundingRect(value);
 
-    painter->setPen(GColor(CPLOTMARKER));
+    painter->setPen(GColor(GCol::PLOTMARKER));
     painter->setFont(parent->bigfont);
     painter->drawText(QPointF((geometry().width() - rect.width()) / 2.0f, mid + (fm.ascent() / 3.0f)), value); // divided by 3 to account for "gap" at top of font
     painter->drawText(QPointF((geometry().width() - rect.width()) / 2.0f, mid + (fm.ascent() / 3.0f)), value); // divided by 3 to account for "gap" at top of font
@@ -3226,7 +3226,7 @@ MetricOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem 
         painter->drawPixmap(QPointF(ROWHEIGHT, ROWHEIGHT*2), *medal);
 
         // rank
-        if (beststring == tr("Career"))  painter->setPen(GColor(CPLOTMARKER));
+        if (beststring == tr("Career"))  painter->setPen(GColor(GCol::PLOTMARKER));
         else painter->setPen(QPen(QColor(150,150,150)));
         painter->setFont(parent->midfont);
         painter->drawText(QRectF(0, (ROWHEIGHT*2)+medal->height()+10, medal->width()+(ROWHEIGHT*2), ROWHEIGHT*2), beststring, Qt::AlignTop|Qt::AlignHCenter);
@@ -3245,7 +3245,7 @@ MetricOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem 
     QFontMetrics fm(parent->bigfont);
     QRectF rect = QFontMetrics(parent->bigfont, parent->device()).boundingRect(value);
 
-    painter->setPen(GColor(CPLOTMARKER));
+    painter->setPen(GColor(GCol::PLOTMARKER));
     painter->setFont(parent->bigfont);
     painter->drawText(QPointF((geometry().width() - rect.width()) / 2.0f,
                               mid + (fm.ascent() / 3.0f)), value); // divided by 3 to account for "gap" at top of font
@@ -3404,7 +3404,7 @@ TopNOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *,
     QRectF barrect = QRectF(0,10, width, 30);
 
     // text color
-    QColor cnormal = (GCColor::luminance(GColor(CCARDBACKGROUND)) < 127) ? QColor(200,200,200) : QColor(70,70,70);
+    QColor cnormal = (GLuminance(GCol::CARDBACKGROUND) < 127) ? QColor(200,200,200) : QColor(70,70,70);
 
     // PAINT
     for (int i=0; i<maxrows && i<ranked.count(); i++) {
@@ -3485,7 +3485,7 @@ MetaOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *,
         } else {
 
             // any other kind of metadata just paint it
-            painter->setPen(GColor(CPLOTMARKER));
+            painter->setPen(GColor(GCol::PLOTMARKER));
             painter->setFont(parent->bigfont);
             painter->drawText(QPointF((geometry().width() - rect.width()) / 2.0f,
                                   mid + (fm.ascent() / 3.0f)), value); // divided by 3 to account for "gap" at top of font
@@ -3508,7 +3508,7 @@ MetaOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *,
         QFontMetrics fm(parent->bigfont);
         QRectF rect = QFontMetrics(parent->bigfont, parent->device()).boundingRect(value);
 
-        painter->setPen(GColor(CPLOTMARKER));
+        painter->setPen(GColor(GCol::PLOTMARKER));
         painter->setFont(parent->bigfont);
         painter->drawText(QPointF((geometry().width() - rect.width()) / 2.0f,
                                   mid + (fm.ascent() / 3.0f)), value); // divided by 3 to account for "gap" at top of font
@@ -3588,7 +3588,7 @@ PMCOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *, 
                               nexty + (tfm.ascent() / 3.0f)), string); // divided by 3 to account for "gap" at top of font
     nexty += rect.height() + 30;
 
-    painter->setPen(PMCData::sbColor(sb, GColor(CPLOTMARKER)));
+    painter->setPen(PMCData::sbColor(sb, GColor(GCol::PLOTMARKER)));
     painter->setFont(parent->bigfont);
     string = QString("%1").arg(round(sb));
     rect = bfm.boundingRect(string);
@@ -3609,7 +3609,7 @@ PMCOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *, 
                                       nexty + (tfm.ascent() / 3.0f)), string); // divided by 3 to account for "gap" at top of font
         nexty += rect.height() + 30;
 
-        painter->setPen(PMCData::ltsColor(lts, GColor(CPLOTMARKER)));
+        painter->setPen(PMCData::ltsColor(lts, GColor(GCol::PLOTMARKER)));
         painter->setFont(parent->bigfont);
         string = QString("%1").arg(round(lts));
         rect = bfm.boundingRect(string);
@@ -3632,7 +3632,7 @@ PMCOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *, 
                                   nexty + (tfm.ascent() / 3.0f)), string); // divided by 3 to account for "gap" at top of font
         nexty += rect.height() + 30;
 
-        painter->setPen(PMCData::stsColor(sts, GColor(CPLOTMARKER)));
+        painter->setPen(PMCData::stsColor(sts, GColor(GCol::PLOTMARKER)));
         painter->setFont(parent->bigfont);
         string = QString("%1").arg(round(sts));
         rect = bfm.boundingRect(string);
@@ -3655,7 +3655,7 @@ PMCOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *, 
                                   nexty + (tfm.ascent() / 3.0f)), string); // divided by 3 to account for "gap" at top of font
         nexty += rect.height() + 30;
 
-        painter->setPen(PMCData::rrColor(rr, GColor(CPLOTMARKER)));
+        painter->setPen(PMCData::rrColor(rr, GColor(GCol::PLOTMARKER)));
         painter->setFont(parent->bigfont);
         string = QString("%1").arg(round(rr));
         rect = bfm.boundingRect(string);
@@ -3674,7 +3674,7 @@ void ZoneOverviewItem::itemPaint(QPainter *, const QStyleOptionGraphicsItem *, Q
 void DonutOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget *)
 {
     painter->setFont(parent->bigfont);
-    painter->setPen(GColor(CPLOTMARKER));
+    painter->setPen(GColor(GCol::PLOTMARKER));
     painter->drawText(chart->geometry(), Qt::AlignHCenter | Qt::AlignVCenter, value);
     painter->setPen(QColor(100,100,100));
     QFontMetrics fm(parent->midfont);
@@ -4272,7 +4272,7 @@ RPErating::setValue(QString value)
     this->value = value;
     int v = qRound(value.toDouble());
     if (v <0 || v>10) {
-        color = GColor(CPLOTMARKER);
+        color = GColor(GCol::PLOTMARKER);
         description = QObject::tr("Invalid");
     } else {
         description = FosterDesc[v];
@@ -4419,7 +4419,7 @@ RPErating::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
 
         // draw a rectangle with a 5px gap
         painter->setPen(Qt::NoPen);
-        painter->fillRect(geom.x()+parent->x()+(width *(i+1)), parent->y()+geom.y()+ROWHEIGHT*1.5f, width-5, ROWHEIGHT*0.25f, QBrush(GColor(CCARDBACKGROUND).darker(200)));
+        painter->fillRect(geom.x()+parent->x()+(width *(i+1)), parent->y()+geom.y()+ROWHEIGHT*1.5f, width-5, ROWHEIGHT*0.25f, QBrush(GColor(GCol::CARDBACKGROUND).darker(200)));
     }
 }
 
@@ -4667,7 +4667,7 @@ BubbleViz::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
     // blank when no points
     if (points.count() == 0 || miny==maxy || minx==maxx) return;
 
-    painter->setPen(GColor(CPLOTMARKER));
+    painter->setPen(GColor(GCol::PLOTMARKER));
 
     // chart canvas
     QRectF canvas= QRectF(parent->x()+geom.x(), parent->y()+geom.y(), geom.width(),geom.height());
@@ -4897,7 +4897,7 @@ BubbleViz::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
     painter->drawText(ylabelspace.right() - bminy.width(),  ylabelspace.bottom()-(miny*yratio) + (bminy.height()/2), QString("%1").arg(round(miny+yoff)));
 
     // hover point?
-    painter->setPen(GColor(CPLOTMARKER));
+    painter->setPen(GColor(GCol::PLOTMARKER));
 
     if (hover && nearvalue >= 0) {
 
@@ -4914,7 +4914,7 @@ BubbleViz::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
         else xlab = Utils::removeDP(QString("%1").arg(nearest.x+xoff,0,'f',parent->xdp));
         bminx = tfm.tightBoundingRect(QString("%1").arg(xlab));
         bminx.moveTo(center.x() - (bminx.width()/2),  xlabelspace.bottom()-bminx.height());
-        painter->fillRect(bminx, QBrush(GColor(CCARDBACKGROUND))); // overwrite range labels
+        painter->fillRect(bminx, QBrush(GColor(GCol::CARDBACKGROUND))); // overwrite range labels
         painter->drawText(center.x() - (bminx.width()/2),  xlabelspace.bottom(), xlab);
 
         // ylabel
@@ -4924,13 +4924,13 @@ BubbleViz::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
         else ylab = Utils::removeDP(QString("%1").arg(nearest.y+yoff,0,'f',parent->ydp));
         bminy = tfm.tightBoundingRect(QString("%1").arg(ylab));
         bminy.moveTo(ylabelspace.right() - bminy.width(),  center.y() - (bminy.height()/2));
-        painter->fillRect(bminy, QBrush(GColor(CCARDBACKGROUND))); // overwrite range labels
+        painter->fillRect(bminy, QBrush(GColor(GCol::CARDBACKGROUND))); // overwrite range labels
         painter->drawText(ylabelspace.right() - bminy.width(),  center.y() + (bminy.height()/2), ylab);
 
         // plot marker
         QPen pen(Qt::NoPen);
         painter->setPen(pen);
-        painter->setBrush(GColor(CPLOTMARKER));
+        painter->setBrush(GColor(GCol::PLOTMARKER));
 
         // draw  the one we are near with no alpha
         double size = (nearest.z/mean) * area;
@@ -4943,7 +4943,7 @@ BubbleViz::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
         painter->setClipping(false);
 
         // now put the label at the top of the canvas
-        painter->setPen(QPen(GColor(CPLOTMARKER)));
+        painter->setPen(QPen(GColor(GCol::PLOTMARKER)));
         bminx = tfm.tightBoundingRect(nearest.label);
         painter->drawText(canvas.center().x()-(bminx.width()/2.0f),
                           canvas.top()+bminx.height()-10, nearest.label);
@@ -5022,7 +5022,7 @@ Sparkline::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
         }
 
         if (fill) {
-            QColor fillColor=GColor(CPLOTMARKER);
+            QColor fillColor=GColor(GCol::PLOTMARKER);
             fillColor.setAlpha(64);
             QPainterPath fillpath = path;
             fillpath.lineTo((points.last().x()*xfactor)+xoffset,bottom);
@@ -5053,7 +5053,7 @@ Sparkline::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
             double x = (points.first().x()*xfactor)+xoffset-25;
             double y = bottom-((points.first().y()-min)*yfactor)-25;
             if (std::isfinite(x) && std::isfinite(y)) {
-                painter->setBrush(QBrush(GColor(CPLOTMARKER).darker(150)));
+                painter->setBrush(QBrush(GColor(GCol::PLOTMARKER).darker(150)));
                 painter->setPen(Qt::NoPen);
                 painter->drawEllipse(QRectF(x, y, 50, 50));
             }
@@ -5321,7 +5321,7 @@ ProgressBar::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
     if (factor < 0) factor = 0;
 
     QRectF bar(box.left(), box.top(), box.width() * factor, ROWHEIGHT/3.0);
-    painter->fillRect(bar, QBrush(GColor(CPLOTMARKER)));
+    painter->fillRect(bar, QBrush(GColor(GCol::PLOTMARKER)));
 
 }
 
@@ -5348,27 +5348,27 @@ Button::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
     painter->setRenderHint(QPainter::Antialiasing);
 
     // button background
-    QColor pc = GCColor::invertColor(GColor(CCARDBACKGROUND));
+    QColor pc = GInvertColor(GCol::CARDBACKGROUND);
     pc.setAlpha(64);
     QPen line(pc,gl_border, Qt::SolidLine);
     line.setJoinStyle(Qt::RoundJoin);
     painter->setPen(line);
     QPointF pos=mapToParent(geom.x(), geom.y());
     if (isUnderMouse()) {
-        QColor hover=GColor(CPLOTMARKER);
+        QColor hover=GColor(GCol::PLOTMARKER);
         if (state==Clicked) hover.setAlpha(200);
         else hover.setAlpha(100);
         painter->setBrush(QBrush(hover));
-    } else painter->setBrush(QBrush(GColor(CCARDBACKGROUND)));
+    } else painter->setBrush(QBrush(GColor(GCol::CARDBACKGROUND)));
     painter->drawRoundedRect(pos.x()+gl_border, pos.y()+gl_border, geom.width()-(gl_border*2), geom.height()-(gl_border*2), gl_radius, gl_radius);
 
     // text using large font clipped
     if (isUnderMouse()) {
-        QColor tc = GCColor::invertColor(CPLOTMARKER);
+        QColor tc = GInvertColor(GCol::PLOTMARKER);
         tc.setAlpha(200);
         painter->setPen(tc);
     } else {
-        QColor tc = GCColor::invertColor(GColor(CCARDBACKGROUND));
+        QColor tc = GInvertColor(GCol::CARDBACKGROUND);
         tc.setAlpha(200);
         painter->setPen(tc);
     }
@@ -5486,7 +5486,7 @@ VScrollBar::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
         double barheight = geom.height() * (geom.height() / height);
         QColor barcolor(127,127,127,64);
         if (state == DRAG) {
-            barcolor = GColor(CPLOTMARKER);
+            barcolor = GColor(GCol::PLOTMARKER);
         } else if (hover) {
             if (barhover) barcolor = QColor(127,127,127,255);
             else barcolor = QColor(127,127,127,127);

--- a/src/Charts/OverviewItems.h
+++ b/src/Charts/OverviewItems.h
@@ -551,7 +551,7 @@ class IntervalOverviewItem : public ChartSpaceItem
 class BPointF {
 public:
 
-    BPointF() : x(0), y(0), z(0), xoff(0), yoff(0), fill(GColor(Qt::gray)), item(NULL) {}
+    BPointF() : x(0), y(0), z(0), xoff(0), yoff(0), fill(GColor(GCol::RIDEPLOTXAXIS)), item(NULL) {}
 
     double score(BPointF &other);
 

--- a/src/Charts/PfPvPlot.cpp
+++ b/src/Charts/PfPvPlot.cpp
@@ -219,7 +219,7 @@ PfPvPlot::PfPvPlot(Context *context)
 void
 PfPvPlot::configChanged(qint32)
 {
-    setCanvasBackground(GColor(CPLOTBACKGROUND));
+    setCanvasBackground(GColor(GCol::PLOTBACKGROUND));
 
     // frame with inverse of background
     QwtSymbol *sym = new QwtSymbol;
@@ -232,23 +232,23 @@ PfPvPlot::configChanged(qint32)
     curve->setRenderHint(QwtPlotItem::RenderAntialiased);
 
     QPalette palette;
-    palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
+    palette.setBrush(QPalette::Window, QBrush(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Text, GColor(GCol::PLOTMARKER));
     setPalette(palette);
 
     axisWidget(QwtAxis::XBottom)->setPalette(palette);
     axisWidget(QwtAxis::YLeft)->setPalette(palette);
 
     // use grid line color for mX, mY and CPcurve
-    QPen marker = GColor(CPLOTMARKER);
-    QPen cp = GColor(CCP);
+    QPen marker = GColor(GCol::PLOTMARKER);
+    QPen cp = GColor(GCol::CP);
     mX->setLinePen(marker);
     mY->setLinePen(marker);
     cpCurve->setPen(cp);
 
     setCL(appsettings->cvalue(context->athlete->cyclist, GC_CRANKLENGTH).toDouble() / 1000.0);
-    QPen pmax = GColor(CCP);
+    QPen pmax = GColor(GCol::CP);
     pmax.setStyle(Qt::DashLine);
     pmaxCurve->setPen(pmax);
 
@@ -480,7 +480,7 @@ PfPvPlot::refreshIntervalMarkers()
             QwtSymbol *sym = new QwtSymbol;
             sym->setStyle(QwtSymbol::Diamond);
             sym->setSize(8*dpiXFactor);
-            sym->setPen(QPen(GColor(CPLOTMARKER)));
+            sym->setPen(QPen(GColor(GCol::PLOTMARKER)));
             sym->setBrush(QBrush(color));
 
             QwtPlotMarker *p = new QwtPlotMarker();
@@ -1021,19 +1021,19 @@ PfPvPlot::recalcCompare()
     if (totaltime) {
 
         QwtText t0(QString("%1%").arg(timeInQuadrant[0] / totaltime * 100, 0, 'f', 1),QwtText::PlainText);
-        t0.setColor(GColor(CPLOTMARKER));
+        t0.setColor(GColor(GCol::PLOTMARKER));
         tiqMarker[0]->setLabel(t0);
 
         QwtText t1(QString("%1%").arg(timeInQuadrant[1] / totaltime * 100, 0, 'f', 1),QwtText::PlainText);
-        t1.setColor(GColor(CPLOTMARKER));
+        t1.setColor(GColor(GCol::PLOTMARKER));
         tiqMarker[1]->setLabel(t1);
 
         QwtText t2(QString("%1%").arg(timeInQuadrant[2] / totaltime * 100, 0, 'f', 1),QwtText::PlainText);
-        t2.setColor(GColor(CPLOTMARKER));
+        t2.setColor(GColor(GCol::PLOTMARKER));
         tiqMarker[2]->setLabel(t2);
 
         QwtText t3(QString("%1%").arg(timeInQuadrant[3] / totaltime * 100, 0, 'f', 1),QwtText::PlainText);
-        t3.setColor(GColor(CPLOTMARKER));
+        t3.setColor(GColor(GCol::PLOTMARKER));
         tiqMarker[3]->setLabel(t3);
 
     } else {
@@ -1147,19 +1147,19 @@ PfPvPlot::recalc()
         if (totaltime) {
 
             QwtText t0(QString("%1%").arg(timeInQuadrant[0] / totaltime * 100, 0, 'f', 1),QwtText::PlainText);
-            t0.setColor(GColor(CPLOTMARKER));
+            t0.setColor(GColor(GCol::PLOTMARKER));
             tiqMarker[0]->setLabel(t0);
 
             QwtText t1(QString("%1%").arg(timeInQuadrant[1] / totaltime * 100, 0, 'f', 1),QwtText::PlainText);
-            t1.setColor(GColor(CPLOTMARKER));
+            t1.setColor(GColor(GCol::PLOTMARKER));
             tiqMarker[1]->setLabel(t1);
 
             QwtText t2(QString("%1%").arg(timeInQuadrant[2] / totaltime * 100, 0, 'f', 1),QwtText::PlainText);
-            t2.setColor(GColor(CPLOTMARKER));
+            t2.setColor(GColor(GCol::PLOTMARKER));
             tiqMarker[2]->setLabel(t2);
 
             QwtText t3(QString("%1%").arg(timeInQuadrant[3] / totaltime * 100, 0, 'f', 1),QwtText::PlainText);
-            t3.setColor(GColor(CPLOTMARKER));
+            t3.setColor(GColor(GCol::PLOTMARKER));
             tiqMarker[3]->setLabel(t3);
 
         } else {

--- a/src/Charts/PfPvWindow.cpp
+++ b/src/Charts/PfPvWindow.cpp
@@ -66,7 +66,7 @@ PfPvDoubleClickPicker::trackerTextF( const QPointF &pos ) const
     QString text = QString(tr("%1 rpm, %2 watts")).arg(p.x()).arg(p.y());
 
     QwtText returning(text);
-    returning.setColor(GColor(CPLOTMARKER));
+    returning.setColor(GColor(GCol::PLOTMARKER));
 
     // trigger plot doing interval hover ...
     pfPvPlot->mouseTrack(p.x(), p.y());
@@ -130,7 +130,7 @@ PfPvWindow::PfPvWindow(Context *context) :
     // allow zooming
     pfpvZoomer = new QwtPlotZoomer(pfPvPlot->canvas());
     pfpvZoomer->setRubberBand(QwtPicker::RectRubberBand);
-    pfpvZoomer->setRubberBandPen(GColor(CPLOTSELECT));
+    pfpvZoomer->setRubberBandPen(GColor(GCol::PLOTSELECT));
     pfpvZoomer->setTrackerMode(QwtPicker::AlwaysOff);
     pfpvZoomer->setEnabled(true);
     pfpvZoomer->setMousePattern(QwtEventPattern::MouseSelect1, Qt::LeftButton);
@@ -226,7 +226,7 @@ PfPvWindow::PfPvWindow(Context *context) :
 void
 PfPvWindow::configChanged(qint32)
 {
-    setProperty("color", GColor(CPLOTBACKGROUND)); // called on config change
+    setProperty("color", GColor(GCol::PLOTBACKGROUND)); // called on config change
 }
 
 bool

--- a/src/Charts/PowerHist.cpp
+++ b/src/Charts/PowerHist.cpp
@@ -130,8 +130,8 @@ void
 PowerHist::configChanged(qint32)
 {
     // plot background
-    if (rangemode) setCanvasBackground(GColor(CTRENDPLOTBACKGROUND));
-    else setCanvasBackground(GColor(CPLOTBACKGROUND));
+    if (rangemode) setCanvasBackground(GColor(GCol::TRENDPLOTBACKGROUND));
+    else setCanvasBackground(GColor(GCol::PLOTBACKGROUND));
 
     // curve
     QPen pen;
@@ -148,37 +148,37 @@ PowerHist::configChanged(qint32)
         case RideFile::watts:
         case RideFile::aPower:
         case RideFile::wattsKg:
-            pen.setColor(GColor(CPOWER).darker(200));
-            brush_color = GColor(CPOWER);
+            pen.setColor(GColor(GCol::POWER).darker(200));
+            brush_color = GColor(GCol::POWER);
             break;
         case RideFile::nm:
-            pen.setColor(GColor(CTORQUE).darker(200));
-            brush_color = GColor(CTORQUE);
+            pen.setColor(GColor(GCol::TORQUE).darker(200));
+            brush_color = GColor(GCol::TORQUE);
             break;
         case RideFile::kph:
-            pen.setColor(GColor(CSPEED).darker(200));
-            brush_color = GColor(CSPEED);
+            pen.setColor(GColor(GCol::SPEED).darker(200));
+            brush_color = GColor(GCol::SPEED);
             break;
         case RideFile::cad:
-            pen.setColor(GColor(CCADENCE).darker(200));
-            brush_color = GColor(CCADENCE);
+            pen.setColor(GColor(GCol::CADENCE).darker(200));
+            brush_color = GColor(GCol::CADENCE);
             break;
         case RideFile::smo2:
-            pen.setColor(GColor(CSMO2).darker(200));
-            brush_color = GColor(CSMO2);
+            pen.setColor(GColor(GCol::SMO2).darker(200));
+            brush_color = GColor(GCol::SMO2);
             break;
         case RideFile::gear:
-            pen.setColor(GColor(CGEAR).darker(200));
-            brush_color = GColor(CGEAR);
+            pen.setColor(GColor(GCol::GEAR).darker(200));
+            brush_color = GColor(GCol::GEAR);
             break;
         case RideFile::wbal:
-            pen.setColor(GColor(CWBAL).darker(200));
-            brush_color = GColor(CGEAR);
+            pen.setColor(GColor(GCol::WBAL).darker(200));
+            brush_color = GColor(GCol::GEAR);
             break;
         default:
         case RideFile::hr:
-            pen.setColor(GColor(CHEARTRATE).darker(200));
-            brush_color = GColor(CHEARTRATE);
+            pen.setColor(GColor(GCol::HEARTRATE).darker(200));
+            brush_color = GColor(GCol::HEARTRATE);
             break;
         }
     }
@@ -202,12 +202,12 @@ PowerHist::configChanged(qint32)
     }
 
     // intervalselection
-    QPen ivl(GColor(CINTERVALHIGHLIGHTER).darker(200));
+    QPen ivl(GColor(GCol::INTERVALHIGHLIGHTER).darker(200));
     ivl.setWidth(width);
     curveSelected->setPen(ivl);
-    QColor ivlbrush = GColor(CINTERVALHIGHLIGHTER);
-    if (rangemode) ivlbrush.setAlpha(GColor(CTRENDPLOTBACKGROUND) == QColor(Qt::white) ? 64 : 200);
-    else ivlbrush.setAlpha(GColor(CPLOTBACKGROUND) == QColor(Qt::white) ? 64 : 200);
+    QColor ivlbrush = GColor(GCol::INTERVALHIGHLIGHTER);
+    if (rangemode) ivlbrush.setAlpha(GColor(GCol::TRENDPLOTBACKGROUND) == QColor(Qt::white) ? 64 : 200);
+    else ivlbrush.setAlpha(GColor(GCol::PLOTBACKGROUND) == QColor(Qt::white) ? 64 : 200);
     curveSelected->setBrush(ivlbrush);   // fill below the line
 
     // hover curve
@@ -215,20 +215,20 @@ PowerHist::configChanged(qint32)
     hvl.setWidth(width);
     curveHover->setPen(hvl);
     QColor hvlbrush = QColor(Qt::darkGray);
-    if (rangemode) hvlbrush.setAlpha((GColor(CTRENDPLOTBACKGROUND) == QColor(Qt::white) ? 64 : 200));
-    else hvlbrush.setAlpha((GColor(CPLOTBACKGROUND) == QColor(Qt::white) ? 64 : 200));
+    if (rangemode) hvlbrush.setAlpha((GColor(GCol::TRENDPLOTBACKGROUND) == QColor(Qt::white) ? 64 : 200));
+    else hvlbrush.setAlpha((GColor(GCol::PLOTBACKGROUND) == QColor(Qt::white) ? 64 : 200));
     curveHover->setBrush(hvlbrush);   // fill below the line
 
     // grid
-    QPen gridPen(GColor(CPLOTGRID));
+    QPen gridPen(GColor(GCol::PLOTGRID));
     //gridPen.setStyle(Qt::DotLine);
     grid->setPen(gridPen);
 
     QPalette palette;
-    if (rangemode) palette.setBrush(QPalette::Window, QBrush(GColor(CTRENDPLOTBACKGROUND)));
-    else palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
+    if (rangemode) palette.setBrush(QPalette::Window, QBrush(GColor(GCol::TRENDPLOTBACKGROUND)));
+    else palette.setBrush(QPalette::Window, QBrush(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Text, GColor(GCol::PLOTMARKER));
     setPalette(palette);
 
     axisWidget(QwtAxis::XBottom)->setPalette(palette);
@@ -891,11 +891,11 @@ PowerHist::recalc(bool force)
                 QwtText text(QString("%1%2").arg(round(yval)).arg(absolutetime ? "" : "%"), QwtText::PlainText);
                 text.setFont(labelFont);
                 if (series == RideFile::watts)
-                    text.setColor(GColor(CPOWER).darker(200));
+                    text.setColor(GColor(GCol::POWER).darker(200));
                 else if (series == RideFile::hr)
-                    text.setColor(GColor(CHEARTRATE).darker(200));
+                    text.setColor(GColor(GCol::HEARTRATE).darker(200));
                 else
-                    text.setColor(GColor(CSPEED).darker(200));
+                    text.setColor(GColor(GCol::SPEED).darker(200));
                 label->setLabel(text);
                 label->setValue(xval+0.312f, yval);
                 label->setYAxis(QwtAxis::YLeft);

--- a/src/Charts/PowerHist.h
+++ b/src/Charts/PowerHist.h
@@ -87,8 +87,8 @@ class penTooltip: public QwtPlotZoomer
             stGiles.setWeight(QFont::Bold);
             text.setFont(stGiles);
 
-            text.setBackgroundBrush(QBrush( GColor(CPLOTMARKER)));
-            text.setColor(GColor(CRIDEPLOTBACKGROUND));
+            text.setBackgroundBrush(QBrush( GColor(GCol::PLOTMARKER)));
+            text.setColor(GColor(GCol::RIDEPLOTBACKGROUND));
             text.setBorderRadius(6);
             text.setRenderFlags(Qt::AlignCenter | Qt::AlignVCenter);
             return text;

--- a/src/Charts/PythonChart.cpp
+++ b/src/Charts/PythonChart.cpp
@@ -46,8 +46,8 @@ PythonConsole::PythonConsole(Context *context, PythonHost *pythonHost, QWidget *
     setFrameStyle(QFrame::NoFrame);
     setAcceptRichText(false);
     document()->setMaximumBlockCount(512); // lets not get carried away!
-    putData(GColor(CPLOTMARKER), QString(tr("Python Console (%1)").arg(python->version)));
-    putData(GCColor::invertColor(GColor(CPLOTBACKGROUND)), "\n>>> ");
+    putData(GColor(GCol::PLOTMARKER), QString(tr("Python Console (%1)").arg(python->version)));
+    putData(GInvertColor(GCol::PLOTBACKGROUND), "\n>>> ");
 
     connect(context, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));
     connect(context, SIGNAL(rMessage(QString)), this, SLOT(rMessage(QString)));
@@ -67,8 +67,8 @@ PythonConsole::configChanged(qint32)
     QFont courier("Courier", QFont().pointSize());
     setFont(courier);
     QPalette p = palette();
-    p.setColor(QPalette::Base, GColor(CPLOTBACKGROUND));
-    p.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+    p.setColor(QPalette::Base, GColor(GCol::PLOTBACKGROUND));
+    p.setColor(QPalette::Text, GInvertColor(GCol::PLOTBACKGROUND));
     setPalette(p);
     setStyleSheet(AbstractView::ourStyleSheet());
 }
@@ -76,7 +76,7 @@ PythonConsole::configChanged(qint32)
 void
 PythonConsole::rMessage(QString x)
 {
-    putData(GColor(CPLOTMARKER), x);
+    putData(GColor(GCol::PLOTMARKER), x);
 }
 
 void PythonConsole::putData(QColor color, QString string)
@@ -157,7 +157,7 @@ void PythonConsole::keyPressEvent(QKeyEvent *e)
 
                 // new prompt
                 putData("\n");
-                putData(GCColor::invertColor(GColor(CPLOTBACKGROUND)), ">>> ");
+                putData(GInvertColor(GCol::PLOTBACKGROUND), ">>> ");
 
             } else {
                 // normal C just do the usual
@@ -210,7 +210,7 @@ void PythonConsole::keyPressEvent(QKeyEvent *e)
                 }
 
                 // the run command should result in some messages being generated
-                putData(GColor(CPLOTMARKER), python->messages.join(""));
+                putData(GColor(GCol::PLOTMARKER), python->messages.join(""));
                 python->messages.clear();
 
             } catch(std::exception& ex) {
@@ -234,7 +234,7 @@ void PythonConsole::keyPressEvent(QKeyEvent *e)
         }
 
         // prompt ">"
-        putData(GCColor::invertColor(GColor(CPLOTBACKGROUND)), ">>> ");
+        putData(GInvertColor(GCol::PLOTBACKGROUND), ">>> ");
     }
     break;
 
@@ -254,7 +254,7 @@ PythonConsole::setCurrentLine(QString p)
 
     select.select(QTextCursor::LineUnderCursor);
     select.removeSelectedText();
-    putData(GCColor::invertColor(GColor(CPLOTBACKGROUND)), ">>> ");
+    putData(GInvertColor(GCol::PLOTBACKGROUND), ">>> ");
     putData(p);
 }
 
@@ -327,8 +327,8 @@ PythonChart::PythonChart(Context *context, bool ridesummary) : GcChartWindow(con
         QFont courier("Courier", QFont().pointSize());
         script->setFont(courier);
         QPalette p = palette();
-        p.setColor(QPalette::Base, GColor(CPLOTBACKGROUND));
-        p.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+        p.setColor(QPalette::Base, GColor(GCol::PLOTBACKGROUND));
+        p.setColor(QPalette::Text, GInvertColor(GCol::PLOTBACKGROUND));
         script->setPalette(p);
         script->setStyleSheet(AbstractView::ourStyleSheet());
 
@@ -504,23 +504,23 @@ PythonChart::eventFilter(QObject *, QEvent *e)
 void
 PythonChart::configChanged(qint32)
 {
-    QColor bgcolor = !ridesummary ? GColor(CTRENDPLOTBACKGROUND) : GColor(CPLOTBACKGROUND);
+    QColor bgcolor = !ridesummary ? GColor(GCol::TRENDPLOTBACKGROUND) : GColor(GCol::PLOTBACKGROUND);
     setProperty("color", bgcolor);
     if (plot) plot->setBackgroundColor(bgcolor);
 
     // tinted palette for headings etc
     QPalette palette;
-    palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CPLOTBACKGROUND)));
+    palette.setBrush(QPalette::Window, QBrush(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Text, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Base, GAlternateColor(GCol::PLOTBACKGROUND));
     setPalette(palette);
     script->setPalette(palette);
     script->setStyleSheet(AbstractView::ourStyleSheet());
 
     // refresh highlighter
     if (syntax) delete syntax;
-    syntax = new PythonSyntax(script->document(), GCColor::luminance(GColor(CPLOTBACKGROUND)) < 127);
+    syntax = new PythonSyntax(script->document(), GLuminance(GColor(GCol::PLOTBACKGROUND)) < 127);
     runScript();
 }
 
@@ -627,7 +627,7 @@ PythonChart::runScript()
 
             // output on console
             if (python->messages.count()) {
-                console->putData(GColor(CPLOTMARKER), python->messages.join("\n"));
+                console->putData(GColor(GCol::PLOTMARKER), python->messages.join("\n"));
                 python->messages.clear();
             }
 

--- a/src/Charts/RCanvas.cpp
+++ b/src/Charts/RCanvas.cpp
@@ -83,12 +83,12 @@ void
 RCanvas::configChanged(qint32)
 {
     // set the background
-    setBackgroundBrush(QBrush(GColor(CPLOTBACKGROUND)));
+    setBackgroundBrush(QBrush(GColor(GCol::PLOTBACKGROUND)));
 
     // set background etc to the prevailing defaults
     QPalette p = palette();
-    p.setColor(QPalette::Base, GColor(CPLOTBACKGROUND));
-    p.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+    p.setColor(QPalette::Base, GColor(GCol::PLOTBACKGROUND));
+    p.setColor(QPalette::Text, GInvertColor(GCol::PLOTBACKGROUND));
     setPalette(p);
     setStyleSheet(AbstractView::ourStyleSheet());
 }

--- a/src/Charts/RChart.cpp
+++ b/src/Charts/RChart.cpp
@@ -36,8 +36,8 @@ RConsole::RConsole(Context *context, RChart *parent)
     setFrameStyle(QFrame::NoFrame);
     setAcceptRichText(false);
     document()->setMaximumBlockCount(512); // lets not get carried away!
-    putData(GColor(CPLOTMARKER), QString(tr("R Console (%1)").arg(rtool->version)));
-    putData(GCColor::invertColor(GColor(CPLOTBACKGROUND)), "\n> ");
+    putData(GColor(GCol::PLOTMARKER), QString(tr("R Console (%1)").arg(rtool->version)));
+    putData(GInvertColor(GCol::PLOTBACKGROUND), "\n> ");
 
     connect(context, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));
     connect(context, SIGNAL(rMessage(QString)), this, SLOT(rMessage(QString)));
@@ -57,8 +57,8 @@ RConsole::configChanged(qint32)
     QFont courier("Courier", QFont().pointSize());
     setFont(courier);
     QPalette p = palette();
-    p.setColor(QPalette::Base, GColor(CPLOTBACKGROUND));
-    p.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+    p.setColor(QPalette::Base, GColor(GCol::PLOTBACKGROUND));
+    p.setColor(QPalette::Text, GInvertColor(GCol::PLOTBACKGROUND));
     setPalette(p);
     setStyleSheet(AbstractView::ourStyleSheet());
 
@@ -69,7 +69,7 @@ RConsole::configChanged(qint32)
 void
 RConsole::rMessage(QString x)
 {
-    putData(GColor(CPLOTMARKER), x);
+    putData(GColor(GCol::PLOTMARKER), x);
 }
 
 void RConsole::putData(QColor color, QString string)
@@ -149,7 +149,7 @@ void RConsole::keyPressEvent(QKeyEvent *e)
 
                 // new prompt
                 putData("\n");
-                putData(GCColor::invertColor(GColor(CPLOTBACKGROUND)), "> ");
+                putData(GInvertColor(GCol::PLOTBACKGROUND), "> ");
 
             } else {
                 // normal C just do the usual
@@ -202,7 +202,7 @@ void RConsole::keyPressEvent(QKeyEvent *e)
                 if(rc == 0 && ret != NULL && !Rf_isNull(ret) && !line.contains("<-") && !line.contains("print"))
                     Rf_PrintValue(ret);
 
-                putData(GColor(CPLOTMARKER), rtool->messages.join(""));
+                putData(GColor(GCol::PLOTMARKER), rtool->messages.join(""));
                 rtool->messages.clear();
 
             } catch(std::exception& ex) {
@@ -227,9 +227,9 @@ void RConsole::keyPressEvent(QKeyEvent *e)
 
         // prompt ">" for new command and ">>" for a continuation line
         if (rtool->R->program.count()==0)
-            putData(GCColor::invertColor(GColor(CPLOTBACKGROUND)), "> ");
+            putData(GInvertColor(GCol::PLOTBACKGROUND), "> ");
         else
-            putData(GCColor::invertColor(GColor(CPLOTBACKGROUND)), ">>");
+            putData(GInvertColor(GCol::PLOTBACKGROUND), ">>");
     }
     break;
 
@@ -249,7 +249,7 @@ RConsole::setCurrentLine(QString p)
 
     select.select(QTextCursor::LineUnderCursor);
     select.removeSelectedText();
-    putData(GCColor::invertColor(GColor(CPLOTBACKGROUND)), "> ");
+    putData(GInvertColor(GCol::PLOTBACKGROUND), "> ");
     putData(p);
 }
 
@@ -316,8 +316,8 @@ RChart::RChart(Context *context, bool ridesummary) : GcChartWindow(context), con
         QFont courier("Courier", QFont().pointSize());
         script->setFont(courier);
         QPalette p = palette();
-        p.setColor(QPalette::Base, GColor(CPLOTBACKGROUND));
-        p.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+        p.setColor(QPalette::Base, GColor(GCol::PLOTBACKGROUND));
+        p.setColor(QPalette::Text, GInvertColor(GCol::PLOTBACKGROUND));
         script->setPalette(p);
         script->setStyleSheet(AbstractView::ourStyleSheet());
 
@@ -464,17 +464,17 @@ RChart::eventFilter(QObject *, QEvent *e)
 void
 RChart::configChanged(qint32)
 {
-    QColor bgcolor = !ridesummary ? GColor(CTRENDPLOTBACKGROUND) : GColor(CPLOTBACKGROUND);
+    QColor bgcolor = !ridesummary ? GColor(GCol::TRENDPLOTBACKGROUND) : GColor(GCol::PLOTBACKGROUND);
     setProperty("color", bgcolor);
     chart->setBackgroundColor(bgcolor);
 
 
     // tinted palette for headings etc
     QPalette palette;
-    palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CPLOTBACKGROUND)));
+    palette.setBrush(QPalette::Window, QBrush(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Text, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Base, GAlternateColor(GCol::PLOTBACKGROUND));
     setPalette(palette);
 
     runScript(); // to update
@@ -565,7 +565,7 @@ RChart::runScript()
             // output on console
             if (rtool->messages.count()) {
                 console->putData("\n");
-                console->putData(GColor(CPLOTMARKER), rtool->messages.join(""));
+                console->putData(GColor(GCol::PLOTMARKER), rtool->messages.join(""));
                 rtool->messages.clear();
             }
 

--- a/src/Charts/RideEditor.cpp
+++ b/src/Charts/RideEditor.cpp
@@ -254,45 +254,45 @@ RideEditor::RideEditor(Context *context) : QWidget(context->mainWindow), data(NU
 void
 RideEditor::configChanged(qint32) 
 {
-    setProperty("color", GColor(CPLOTBACKGROUND));
+    setProperty("color", GColor(GCol::PLOTBACKGROUND));
 
     QPalette palette;
-    palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
-    palette.setBrush(QPalette::Base, QBrush(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::WindowText, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::Normal, QPalette::Window, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+    palette.setBrush(QPalette::Window, QBrush(GColor(GCol::PLOTBACKGROUND)));
+    palette.setBrush(QPalette::Base, QBrush(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GInvertColor(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::Text, GInvertColor(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::Normal, QPalette::Window, GInvertColor(GColor(GCol::PLOTBACKGROUND)));
     setPalette(palette);
     tabbar->setPalette(palette);
-    QColor faded = GCColor::invertColor(GColor(CPLOTBACKGROUND));
+    QColor faded = GInvertColor(GCol::PLOTBACKGROUND);
     tabbar->setStyleSheet(QString("QTabBar::tab { background-color: %1; border: 0.5px solid %1; color: rgba(%3,%4,%5,50%) }"
                                   "QTabBar::tab:selected { background-color: %1; color: %2; border-bottom: %7px solid %1; border-bottom-color: %6 }"
                                   "QTabBar::close-button:!selected { background-color: %1; }")
-                    .arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name())
+                    .arg(GColor(GCol::PLOTBACKGROUND).name())
+                    .arg(GInvertColor(GCol::PLOTBACKGROUND).name())
                     .arg(faded.red()).arg(faded.green()).arg(faded.blue())
-                    .arg(GColor(CPLOTMARKER).name())
+                    .arg(GColor(GCol::PLOTMARKER).name())
                     .arg(4 * dpiXFactor));
     table->setPalette(palette);
     table->setStyleSheet(QString("QTableView { background-color: %1; color: %2; border: %1 }"
                                  "QTableView QTableCornerButton::section { background-color: %1; color: %2; border: %1 }"
                                  "QHeaderView { background-color: %1; color: %2; border: %1 }")
-                    .arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name()));
+                    .arg(GColor(GCol::PLOTBACKGROUND).name())
+                    .arg(GInvertColor(GCol::PLOTBACKGROUND).name()));
     table->horizontalHeader()->setStyleSheet(QString("QHeaderView::section { background-color: %1; color: %2; border: 0px; border-bottom: %3px solid %2; }")
-                    .arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name())
+                    .arg(GColor(GCol::PLOTBACKGROUND).name())
+                    .arg(GInvertColor(GCol::PLOTBACKGROUND).name())
                     .arg(2 * dpiYFactor));
     table->verticalHeader()->setStyleSheet(QString("QHeaderView::section { background-color: %1; color: %2; border: 0px }")
-                    .arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name()));
+                    .arg(GColor(GCol::PLOTBACKGROUND).name())
+                    .arg(GInvertColor(GCol::PLOTBACKGROUND).name()));
     table->horizontalHeader()->setDefaultAlignment(Qt::AlignLeft | Qt::AlignVCenter);
 #ifndef Q_OS_MAC
     table->verticalScrollBar()->setStyleSheet(AbstractView::ourStyleSheet());
     table->horizontalScrollBar()->setStyleSheet(AbstractView::ourStyleSheet());
 #endif
-    toolbar->setStyleSheet(QString("::enabled { background: %1; color: %2; border: 0px; } ").arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name()));
+    toolbar->setStyleSheet(QString("::enabled { background: %1; color: %2; border: 0px; } ").arg(GColor(GCol::PLOTBACKGROUND).name())
+                    .arg(GInvertColor(GCol::PLOTBACKGROUND).name()));
 
     // the xdata editors
     QMapIterator<QString, XDataEditor *>it(xdataEditors);
@@ -1290,7 +1290,7 @@ void CellDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
 
         painter->save();
         painter->translate(option.rect.x(), option.rect.y());
-        meh->drawContents(painter, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+        meh->drawContents(painter, GInvertColor(GCol::PLOTBACKGROUND));
         painter->restore();
         delete meh;
 
@@ -1643,8 +1643,8 @@ RideEditor::setTabBar(bool force)
         tb->setText("+");
         tb->setAutoRaise(true);
         tb->setStyleSheet(QString("QToolButton { background: %1; color: %2; border: 0px; } ")
-                          .arg(GColor(CPLOTBACKGROUND).name())
-                          .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name()));
+                          .arg(GColor(GCol::PLOTBACKGROUND).name())
+                          .arg(GInvertColor(GCol::PLOTBACKGROUND).name()));
 
         tabbar->setTabButton(tabbar->count()-1, QTabBar::LeftSide, tb);
         tabbar->setTabButton(tabbar->count()-1, QTabBar::RightSide, 0);
@@ -3049,29 +3049,29 @@ void XDataEditor::configChanged()
 {
 
     QPalette palette;
-    palette.setColor(QPalette::Active, QPalette::Window, GColor(CPLOTBACKGROUND));
-    palette.setColor(QPalette::Active, QPalette::Base, GColor(CPLOTBACKGROUND));
-    palette.setColor(QPalette::Active, QPalette::WindowText, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::Active, QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::Active, QPalette::Window, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::Inactive, QPalette::Window, GColor(CPLOTBACKGROUND));
-    palette.setColor(QPalette::Inactive, QPalette::Base, GColor(CPLOTBACKGROUND));
-    palette.setColor(QPalette::Inactive, QPalette::WindowText, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::Inactive, QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::Inactive, QPalette::Window, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+    palette.setColor(QPalette::Active, QPalette::Window, GColor(GCol::PLOTBACKGROUND));
+    palette.setColor(QPalette::Active, QPalette::Base, GColor(GCol::PLOTBACKGROUND));
+    palette.setColor(QPalette::Active, QPalette::WindowText, GInvertColor(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::Active, QPalette::Text, GInvertColor(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::Active, QPalette::Window, GInvertColor(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::Inactive, QPalette::Window, GColor(GCol::PLOTBACKGROUND));
+    palette.setColor(QPalette::Inactive, QPalette::Base, GColor(GCol::PLOTBACKGROUND));
+    palette.setColor(QPalette::Inactive, QPalette::WindowText, GInvertColor(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::Inactive, QPalette::Text, GInvertColor(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::Inactive, QPalette::Window, GInvertColor(GColor(GCol::PLOTBACKGROUND)));
     setPalette(palette);
     setFrameStyle(QFrame::NoFrame);
     setStyleSheet(QString("QTableView QTableCornerButton::section { background-color: %1; color: %2; border: %1 }"
                                   "QHeaderView { background-color: %1; color: %2; border: %1 }")
-                    .arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name()));
+                    .arg(GColor(GCol::PLOTBACKGROUND).name())
+                    .arg(GInvertColor(GCol::PLOTBACKGROUND).name()));
     horizontalHeader()->setStyleSheet(QString("QHeaderView::section { background-color: %1; color: %2; border: 0px; border-bottom: %3px solid %2; }")
-                    .arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name())
+                    .arg(GColor(GCol::PLOTBACKGROUND).name())
+                    .arg(GInvertColor(GCol::PLOTBACKGROUND).name())
                     .arg(2 * dpiYFactor));
     verticalHeader()->setStyleSheet(QString("QHeaderView::section { background-color: %1; color: %2; border: 0px }")
-                    .arg(GColor(CPLOTBACKGROUND).name())
-                    .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name()));
+                    .arg(GColor(GCol::PLOTBACKGROUND).name())
+                    .arg(GInvertColor(GCol::PLOTBACKGROUND).name()));
 #ifndef Q_OS_MAC
     verticalScrollBar()->setStyleSheet(AbstractView::ourStyleSheet());
     horizontalScrollBar()->setStyleSheet(AbstractView::ourStyleSheet());

--- a/src/Charts/RideMapWindow.cpp
+++ b/src/Charts/RideMapWindow.cpp
@@ -370,7 +370,7 @@ RideMapWindow::osmCustomTSURLEditingFinished()
 void
 RideMapWindow::configChanged(qint32 value)
 {
-    setProperty("color", GColor(CPLOTBACKGROUND));
+    setProperty("color", GColor(GCol::PLOTBACKGROUND));
 #ifndef Q_OS_MAC
     overlayIntervals->setStyleSheet(AbstractView::ourStyleSheet());
 #endif
@@ -464,8 +464,8 @@ void RideMapWindow::createHtml()
     }
 
     // No GPS data, so sorry no map
-    QColor bgColor = GColor(CPLOTBACKGROUND);
-    QColor fgColor = GCColor::invertColor(bgColor);
+    QColor bgColor = GColor(GCol::PLOTBACKGROUND);
+    QColor fgColor = GInvertColor(bgColor);
     if (   (   context->isCompareIntervals
             && ! hasComparePositions)
         || (   ! context->isCompareIntervals
@@ -1044,7 +1044,7 @@ RideMapWindow::buildPositionList
 
 QColor RideMapWindow::GetColor(int watts)
 {
-    if (range < 0 || hideShadedZones()) return GColor(MAPROUTELINE);
+    if (range < 0 || hideShadedZones()) return GColor(GCol::MAPROUTELINE);
     else return zoneColor(context->athlete->zones(myRideItem ? myRideItem->sport : "Bike")->whichZone(range, watts), 7);
 }
 

--- a/src/Charts/ScatterPlot.cpp
+++ b/src/Charts/ScatterPlot.cpp
@@ -553,7 +553,7 @@ void ScatterPlot::setData (ScatterSettings *settings)
 
     if (settings->gridlines) {
 
-        QPen gridPen(GColor(CPLOTGRID));
+        QPen gridPen(GColor(GCol::PLOTGRID));
         grid = new QwtPlotGrid();
         grid->setPen(gridPen);
         grid->enableX(true);
@@ -767,7 +767,7 @@ ScatterPlot::refreshIntervalMarkers(ScatterSettings *settings)
             QwtSymbol *sym = new QwtSymbol;
             sym->setStyle(QwtSymbol::Diamond);
             sym->setSize(8*dpiXFactor);
-            sym->setPen(QPen(GColor(CPLOTMARKER)));
+            sym->setPen(QPen(GColor(GCol::PLOTMARKER)));
             sym->setBrush(QBrush(color));
 
             QwtPlotMarker *p = new QwtPlotMarker();
@@ -787,12 +787,12 @@ void
 ScatterPlot::configChanged(qint32)
 {
     // setColors bg
-    setCanvasBackground(GColor(CPLOTBACKGROUND));
+    setCanvasBackground(GColor(GCol::PLOTBACKGROUND));
 
     QPalette palette;
-    palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
+    palette.setBrush(QPalette::Window, QBrush(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Text, GColor(GCol::PLOTMARKER));
 
     axisWidget(QwtAxis::XBottom)->setPalette(palette);
     axisWidget(QwtAxis::YLeft)->setPalette(palette);

--- a/src/Charts/ScatterWindow.cpp
+++ b/src/Charts/ScatterWindow.cpp
@@ -242,12 +242,12 @@ ScatterWindow::ScatterWindow(Context *context) :
 void
 ScatterWindow::configChanged(qint32)
 {
-    setProperty("color", GColor(CPLOTBACKGROUND));
+    setProperty("color", GColor(GCol::PLOTBACKGROUND));
 
     QPalette palette;
-    palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
+    palette.setBrush(QPalette::Window, QBrush(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Text, GColor(GCol::PLOTMARKER));
     setPalette(palette);
 }
 

--- a/src/Charts/SmallPlot.cpp
+++ b/src/Charts/SmallPlot.cpp
@@ -93,8 +93,8 @@ SmallPlotPicker::trackerText(const QPoint &point) const
     stGiles.setWeight(QFont::Bold);
     tooltip.setFont(stGiles);
 
-    tooltip.setBackgroundBrush(QBrush(GColor(CPLOTMARKER)));
-    tooltip.setColor(GColor(CRIDEPLOTBACKGROUND));
+    tooltip.setBackgroundBrush(QBrush(GColor(GCol::PLOTMARKER)));
+    tooltip.setColor(GColor(GCol::RIDEPLOTBACKGROUND));
     tooltip.setBorderRadius(6);
     tooltip.setRenderFlags(Qt::AlignCenter | Qt::AlignVCenter);
 
@@ -104,15 +104,15 @@ SmallPlotPicker::trackerText(const QPoint &point) const
 
 SmallPlot::SmallPlot(QWidget *parent) : QwtPlot(parent), d_mrk(NULL), smooth(30), tracking(false)
 {
-    setCanvasBackground(GColor(CPLOTBACKGROUND));
+    setCanvasBackground(GColor(GCol::PLOTBACKGROUND));
     static_cast<QwtPlotCanvas*>(canvas())->setFrameStyle(QFrame::NoFrame);
 
     setXTitle();
     setAxesCount(QwtAxis::YLeft, 2);
 
     altCurve = new QwtPlotCurve(tr("Altitude"));
-    altCurve->setPen(QPen(GColor(CALTITUDE)));
-    QColor brush_color = GColor(CALTITUDEBRUSH);
+    altCurve->setPen(QPen(GColor(GCol::ALTITUDE)));
+    QColor brush_color = GColor(GCol::ALTITUDEBRUSH);
     brush_color.setAlpha(180);
     altCurve->setBrush(brush_color);
     altCurve->setYAxis(QwtAxisId(QwtAxis::YLeft,1));
@@ -121,13 +121,13 @@ SmallPlot::SmallPlot(QWidget *parent) : QwtPlot(parent), d_mrk(NULL), smooth(30)
     wattsCurve = new QwtPlotCurve("Power");
     //timeCurves.resize(36);// wattsCurve->setRenderHint(QwtPlotItem::RenderAntialiased);
     wattsCurve->setYAxis(QwtAxisId(QwtAxis::YLeft,0));
-    wattsCurve->setPen(QPen(GColor(CPOWER)));
-    wattsCurve->attach(this);
+    wattsCurve->setPen(QPen(GColor(GCol::POWER)));
+	wattsCurve->attach(this);
 
     hrCurve = new QwtPlotCurve("Heart Rate");
     // hrCurve->setRenderHint(QwtPlotItem::RenderAntialiased);
     hrCurve->setYAxis(QwtAxisId(QwtAxis::YLeft,0));
-    hrCurve->setPen(QPen(GColor(CHEARTRATE)));
+    hrCurve->setPen(QPen(GColor(GCol::HEARTRATE)));
     hrCurve->attach(this);
 
     // grid lines on such a small plot look AWFUL
@@ -135,7 +135,7 @@ SmallPlot::SmallPlot(QWidget *parent) : QwtPlot(parent), d_mrk(NULL), smooth(30)
     //grid->enableX(false);
     //QPen gridPen;
     //gridPen.setStyle(Qt::DotLine);
-    //grid->setPen(QPen(GColor(CPLOTGRID)));
+    //grid->setPen(QPen(GColor(GCol::PLOTGRID)));
     //grid->attach(this);
 
     //timeCurves.resize(36);
@@ -173,7 +173,7 @@ SmallPlot::enableTracking()
     picker->setTrackerMode(QwtPlotPicker::ActiveOnly);
     picker->setStateMachine(new QwtPickerTrackerMachine());
     picker->setRubberBand(QwtPicker::VLineRubberBand);
-    picker->setRubberBandPen(QPen(GColor(CPLOTMARKER)));
+    picker->setRubberBandPen(QPen(GColor(GCol::PLOTMARKER)));
     connect(picker, SIGNAL(moved(const QPoint&)), this, SLOT(pointMoved(const QPoint&)));
 }
 

--- a/src/Charts/TreeMapPlot.cpp
+++ b/src/Charts/TreeMapPlot.cpp
@@ -101,7 +101,7 @@ TreeMapPlot::paintEvent(QPaintEvent *)
 
     // Init paint settings
     QPainter painter(this);
-    QColor color = GColor(CTRENDPLOTBACKGROUND);
+    QColor color = GColor(GCol::TRENDPLOTBACKGROUND);
     QPen pen(color);
     pen.setWidth(10); // root
     QBrush brush(color);

--- a/src/Charts/TreeMapWindow.cpp
+++ b/src/Charts/TreeMapWindow.cpp
@@ -220,7 +220,7 @@ TreeMapWindow::refresh()
 {
     if (!amVisible()) return;
 
-    setProperty("color", GColor(CTRENDPLOTBACKGROUND));
+    setProperty("color", GColor(GCol::TRENDPLOTBACKGROUND));
 
     // refresh for changes to ridefiles / zones
     if (active == false) {

--- a/src/Charts/UserChart.cpp
+++ b/src/Charts/UserChart.cpp
@@ -72,8 +72,8 @@ UserChart::UserChart(QWidget *parent, Context *context, bool rangemode, QString 
 
     // defaults, can be overriden via setBackgroundColor()
     if (bg != "") chartinfo.bgcolor = bg;
-    else if (rangemode) chartinfo.bgcolor = StandardColor(CTRENDPLOTBACKGROUND).name();
-    else chartinfo.bgcolor = StandardColor(CPLOTBACKGROUND).name();
+    else if (rangemode) chartinfo.bgcolor = GColorToRGBColor(GCol::TRENDPLOTBACKGROUND).name();
+    else chartinfo.bgcolor = GColorToRGBColor(GCol::PLOTBACKGROUND).name();
 
     // set default background color
     configChanged(0);
@@ -86,10 +86,10 @@ UserChart::configChanged(qint32)
 
     // tinted palette for headings etc
     QPalette palette;
-    palette.setBrush(QPalette::Window, RGBColor(chartinfo.bgcolor));
-    palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Base, RGBColor(chartinfo.bgcolor) /*GCColor::alternateColor(bgcolor)*/);
+    palette.setBrush(QPalette::Window, GRGBColorToQColor(chartinfo.bgcolor));
+    palette.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Text, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Base, GRGBColorToQColor(chartinfo.bgcolor) /*GAlternateColor(bgcolor)*/);
     setPalette(palette);
 
     setAutoFillBackground(true);
@@ -196,7 +196,7 @@ UserChart::refresh()
     }
 
     // ok, we've run out of excuses, looks like we need to plot
-    chart->setBackgroundColor(RGBColor(chartinfo.bgcolor));
+    chart->setBackgroundColor(GRGBColorToQColor(chartinfo.bgcolor));
     chart->initialiseChart(chartinfo.title, chartinfo.type, chartinfo.animate, chartinfo.legendpos, chartinfo.stack, chartinfo.orientation, chartinfo.scale);
 
     // now generate the series data
@@ -287,7 +287,7 @@ UserChart::refresh()
             }
             series.colors.clear();
             QColor min=QColor(series.color);
-            QColor max=GCColor::invertColor(GColor(CPLOTBACKGROUND));
+            QColor max=GInvertColor(GCol::PLOTBACKGROUND);
             for(int i=0; i<series.labels.count(); i++) {
                 QColor color = QColor(min.red() + (double(max.red()-min.red()) * (i/double(series.labels.count()))),
                               min.green() + (double(max.green()-min.green()) * (i/double(series.labels.count()))),
@@ -315,7 +315,7 @@ UserChart::refresh()
         // force plot marker color for x-axis, helps to refresh after
         // config has changed. might be a better way to handle this but
         // it works for now.
-        if (axis.orientation == Qt::Horizontal)  axis.labelcolor = axis.axiscolor = GColor(CPLOTMARKER);
+        if (axis.orientation == Qt::Horizontal)  axis.labelcolor = axis.axiscolor = GColor(GCol::PLOTMARKER);
 
         // on a user chart the series sets the categories for a bar chart
         // find the first series for this axis and set the categories
@@ -1324,8 +1324,8 @@ UserChartSettings::refreshAxesTab()
                     break;
                 }
             }
-            found.axiscolor = GColor(CPLOTMARKER);
-            found.labelcolor = GColor(CPLOTMARKER);
+            found.axiscolor = GColor(GCol::PLOTMARKER);
+            found.labelcolor = GColor(GCol::PLOTMARKER);
             want << found;
             have << series.xname;
         }
@@ -1564,7 +1564,7 @@ EditUserSeriesDialog::EditUserSeriesDialog(Context *context, bool rangemode, Gen
     cf->addRow(tr("Symbol"), zz);
 
     // we allow colors using the GC palette and default to power colors
-    color = new ColorButton(this, "Color", QColor(1,1,CPOWER), true, false);
+    color = new ColorButton(this, "Color", QColor(1,1,static_cast<int>(GCol::POWER)), true, false);
     zz = new QHBoxLayout();
     zz->addWidget(color);
     zz->addStretch();

--- a/src/Charts/UserChartOverviewItem.cpp
+++ b/src/Charts/UserChartOverviewItem.cpp
@@ -29,7 +29,7 @@ UserChartOverviewItem::UserChartOverviewItem(ChartSpace *parent, QString name, Q
     deep = 30;
 
     // create the chart and place on scene
-    chart = new UserChart(NULL, parent->context, parent->scope == OverviewScope::TRENDS ? true : false, StandardColor(CCARDBACKGROUND).name());
+    chart = new UserChart(NULL, parent->context, parent->scope == OverviewScope::TRENDS ? true : false, GColorToRGBColor(GCol::CARDBACKGROUND).name());
     chart->hide();
     proxy = parent->getScene()->addWidget(chart);
     proxy->setParent(this);
@@ -60,7 +60,7 @@ UserChartOverviewItem::color()
 void
 UserChartOverviewItem::configChanged(qint32)
 {
-    //chart->setBackgroundColor(GColor(CCARDBACKGROUND));
+    //chart->setBackgroundColor(GColor(GCol::CARDBACKGROUND));
 }
 
 void

--- a/src/Cloud/CloudService.cpp
+++ b/src/Cloud/CloudService.cpp
@@ -2020,7 +2020,7 @@ void
 CloudServiceAutoDownloadWidget::paintEvent(QPaintEvent*)
 {
     QPainter painter(this);
-    QBrush brush(GColor(CPLOTBACKGROUND));
+    QBrush brush(GColor(GCol::PLOTBACKGROUND));
     painter.fillRect(0,0,width(),height(), brush);
 
     QString statusstring;
@@ -2034,15 +2034,15 @@ CloudServiceAutoDownloadWidget::paintEvent(QPaintEvent*)
     QFont font;
     QFontMetrics fm(font);
     painter.setFont(font);
-    painter.setPen(GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-    QRectF textbox = QRectF(0,0, fm.horizontalAdvance(statusstring), height() / 2.0f);
+    painter.setPen(GInvertColor(GColor(GCol::PLOTBACKGROUND)));
+    QRectF textbox = QRectF(0,0, fm.width(statusstring), height() / 2.0f);
     painter.drawText(textbox, Qt::AlignVCenter | Qt::AlignCenter, statusstring);
 
     // rectangle
     QRectF pr(textbox.width()+(5.0f*dpiXFactor), textbox.top()+(8.0f*dpiXFactor), width()-(10.0f*dpiXFactor)-textbox.width(), (height()/2.0f)-(16*dpiXFactor));
 
     // progress rect
-    QColor col = GColor(CPLOTMARKER);
+    QColor col = GColor(GCol::PLOTMARKER);
     col.setAlpha(150);
     brush= QBrush(col);
 

--- a/src/Core/DataFilter.cpp
+++ b/src/Core/DataFilter.cpp
@@ -5148,7 +5148,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, const Result &x, long it, R
                         // apply item color, remembering that 1,1,1 means use default (reverse in this case)
                         if (ii->color == QColor(1,1,1,1)) {
                             // use the inverted color, not plot marker as that hideous
-                            QColor col =GCColor::invertColor(GColor(CPLOTBACKGROUND));
+                            QColor col =GInvertColor(GCol::PLOTBACKGROUND);
                             // white is jarring on a dark background!
                             if (col==QColor(Qt::white)) col=QColor(127,127,127);
                             asstring = col.name();

--- a/src/Core/GcCalendarModel.h
+++ b/src/Core/GcCalendarModel.h
@@ -249,10 +249,10 @@ public:
             if (arr) {
                 foreach (int i, *arr) {
                     if (context->rideItem() && sourceModel()->data(index(i, dateIndex, QModelIndex())).toDateTime() == context->rideItem()->dateTime) {
-                        colors << GColor(CCALCURRENT); // its the current ride!
+                        colors << GColor(GCol::CALCURRENT); // its the current ride!
                     } else {
                         QColor user = QColor(sourceModel()->data(index(i, colorIndex, QModelIndex())).toString());
-                        if (user == QColor(1,1,1)) colors << GColor(CPLOTMARKER);
+                        if (user == QColor(1,1,1)) colors << GColor(GCol::PLOTMARKER);
                         else colors << user;
                     }
                 }
@@ -261,7 +261,7 @@ public:
 #ifdef GC_HAVE_ICAL
             // added planned workouts
             for (int k= context->athlete->rideCalendar->data(date(proxyIndex), EventCountRole).toInt(); k>0; k--)
-                colors.append(GColor(CCALPLANNED));
+                colors.append(GColor(GCol::CALPLANNED));
 #endif
 
             return QVariant::fromValue<QList<QColor> >(colors);
@@ -276,7 +276,7 @@ public:
                 foreach (int i, *arr) {
                     QString filename = sourceModel()->data(index(i, filenameIndex, QModelIndex())).toString();
                     if (context->isfiltered && context->filters.contains(filename))
-                        colors << GColor(CCALCURRENT);
+                        colors << GColor(GCol::CALCURRENT);
                     else
                         colors << QColor(Qt::black);
                 }
@@ -304,18 +304,18 @@ public:
 
         case CellColorRole:   // what color for the cell?
             if (date(proxyIndex) == QDate::currentDate())
-                return GColor(CCALTODAY);
+                return GColor(GCol::CALTODAY);
             if (date(proxyIndex).month() == month)
-                return GColor(CPLOTBACKGROUND);
+                return GColor(GCol::PLOTBACKGROUND);
             else
-                return GColor(CPLOTBACKGROUND).darker(200);
+                return GColor(GCol::PLOTBACKGROUND).darker(200);
             break;
 
         case HeaderColorRole: // what color for the cell heading
             if (date(proxyIndex).month() == month)
-                return GColor(CPLOTBACKGROUND);
+                return GColor(GCol::PLOTBACKGROUND);
             else
-                return GColor(CPLOTBACKGROUND).darker(200);
+                return GColor(GCol::PLOTBACKGROUND).darker(200);
             break;
 
         case FilenamesRole:
@@ -486,7 +486,7 @@ class GcCalendarDelegate : public QItemDelegate
         // date...
         QString datestring = index.data(GcCalendarModel::DateStringRole).toString();
         QTextOption textOption(Qt::AlignRight);
-        painter->setPen(GCColor::invertColor(hg));
+        painter->setPen(GInvertColor(hg));
         painter->drawText(hd, datestring, textOption);
 
         // text

--- a/src/Core/GcUpgrade.cpp
+++ b/src/Core/GcUpgrade.cpp
@@ -204,7 +204,7 @@ GcUpgrade::upgrade(const QDir &home)
         if (charts.exists()) charts.remove();
 
         // 3. Reset colour defaults **
-        GCColor::applyTheme(defaults.theme); // set to default theme
+        GCColor::inst()->applyTheme(defaults.theme); // set to default theme
 
         // 4. Theme and Chrome Color
 #if 0 // this is no longer required, but keeping in case we need to reinstate- XXX fixme
@@ -225,9 +225,10 @@ GcUpgrade::upgrade(const QDir &home)
         QString colorstring = QString("%1:%2:%3").arg(chromeColor.red())
                                                  .arg(chromeColor.green())
                                                  .arg(chromeColor.blue());
-        appsettings->setValue("CCHROME", colorstring);
-        GCColor::setColor(CCHROME, chromeColor);
+        appsettings->setValue("GCol::CHROME", colorstring);
+        GCColor::inst()->(GCol::CHROME, chromeColor);
 #endif
+
 
         // 5. Metrics and Notes keywords
         QString filename = home.canonicalPath()+"/metadata.xml";
@@ -394,11 +395,10 @@ GcUpgrade::upgrade(const QDir &home)
 
         // reset themes on basis of plot background (first 2 themes are default dark and light themes
 #if 0
-        if (GCColor::luminance(GColor(CPLOTBACKGROUND)) < 127)  GCColor::applyTheme(0);
-        else GCColor::applyTheme(1);
+        if (GCColor::luminance(GColor(GCol::PLOTBACKGROUND)) < 127)  GCColor::inst()->(0);
+        else GCColor::inst()->applyTheme(defaults.theme);
 #endif
-        GCColor::applyTheme(defaults.theme);
-
+        GCColor::inst()->applyTheme(defaults.theme);
     }
 
     //----------------------------------------------------------------------
@@ -641,8 +641,8 @@ GcUpgrade::upgrade(const QDir &home)
 
         // trend plot matches ride plot, as newly introduced
         // just do for first time we run 3.2 and set to ride plot
-        QColor color = GCColor::getColor(CRIDEPLOTBACKGROUND);
-        GCColor::setColor(CTRENDPLOTBACKGROUND, color);
+        QColor color = GColor(GCol::RIDEPLOTBACKGROUND);
+        GCColor::inst()->setQColor(GCol::TRENDPLOTBACKGROUND, color);
 
         // and update config
         QString colorstring = QString("%1:%2:%3").arg(color.red())

--- a/src/Core/RideItem.cpp
+++ b/src/Core/RideItem.cpp
@@ -333,7 +333,7 @@ IntervalItem *
 RideItem::newInterval(QString name, double start, double stop, double startKM, double stopKM, QColor color, bool test)
 {
     // add a new interval to the end of the list
-    color = color == Qt::black ? standardColor(intervals(RideFileInterval::USER).count()) : color;
+    color = color == Qt::black ? GStandardQColor(intervals(RideFileInterval::USER).count()) : color;
 
     IntervalItem *add = new IntervalItem(this, name, start, stop, startKM, stopKM, 1,
                                          color, test, RideFileInterval::USER);
@@ -961,7 +961,7 @@ RideItem::updateIntervals()
                                                       f->timeToDistance(interval->start),
                                                       f->timeToDistance(interval->stop),
                                                       seq,
-                                                      (interval->color == Qt::black) ? standardColor(count) : interval->color,
+                                                      (interval->color == Qt::black) ? GStandardQColor(count) : interval->color,
                                                       interval->test,
                                                       RideFileInterval::USER);
 

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -553,7 +553,7 @@ GSettings::upgradeSystem() {
     //DEPRECATED IN V3.5 migrateValue(GC_FONT_CHARTMARKERS_SIZE);
     //DEPRECATED IN V3.5 migrateValue(GC_FONT_CALENDAR_SIZE);
 
-    QStringList colorProperties = GCColor::getConfigKeys();
+    QStringList colorProperties = GCColor::inst()->getConfigKeys();
     QStringListIterator colorIterator(colorProperties);
     while (colorIterator.hasNext()) {
         QString key = QString(colorIterator.next().data());

--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -589,16 +589,13 @@ main(int argc, char *argv[])
             gcTranslator.load(":translations" + translation_file);
         application->installTranslator(&gcTranslator);
 
-        // Now the translator is installed, set default colors with translated names
-        GCColor::setupColors();
-
         // has a default theme been applied (first run) ?
         QString powercolor = appsettings->value(NULL, "COLORPOWER", "").toString();
-        if (powercolor == "")  GCColor::applyTheme(defaults.theme);
+        if (powercolor == "")  GCColor::inst()->applyTheme(defaults.theme);
 
         // migration
         appsettings->migrateQSettingsSystem(); // colors must be setup before migration can take place, but reading has to be from the migrated ones
-        GCColor::readConfig();
+        GCColor::inst()->readConfig();
 
         // Initialize metrics once the translator is installed
         RideMetricFactory::instance().initialize();

--- a/src/FileIO/FixPyScriptsDialog.cpp
+++ b/src/FileIO/FixPyScriptsDialog.cpp
@@ -137,8 +137,8 @@ EditFixPyScriptDialog::EditFixPyScriptDialog(Context *context, FixPyScript *fix,
     QFont courier("Courier", QFont().pointSize());
     script->setFont(courier);
     QPalette p = palette();
-    p.setColor(QPalette::Base, GColor(CPLOTBACKGROUND));
-    p.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+    p.setColor(QPalette::Base, GColor(GCol::PLOTBACKGROUND));
+    p.setColor(QPalette::Text, GInvertColor(GCol::PLOTBACKGROUND));
     script->setPalette(p);
     script->setStyleSheet(AbstractView::ourStyleSheet());
     scriptLayout->addWidget(script);

--- a/src/FileIO/RideFile.cpp
+++ b/src/FileIO/RideFile.cpp
@@ -421,57 +421,57 @@ QColor
 RideFile::colorFor(SeriesType series)
 {
     switch (series) {
-    case RideFile::cad: return GColor(CCADENCE);
-    case RideFile::cadd: return GColor(CCADENCE);
-    case RideFile::hr: return GColor(CHEARTRATE);
-    case RideFile::hrd: return GColor(CHEARTRATE);
-    case RideFile::kph: return GColor(CSPEED);
-    case RideFile::kphd: return GColor(CSPEED);
-    case RideFile::nm: return GColor(CTORQUE);
-    case RideFile::nmd: return GColor(CTORQUE);
-    case RideFile::watts: return GColor(CPOWER);
-    case RideFile::wattsd: return GColor(CPOWER);
-    case RideFile::xPower: return GColor(CXPOWER);
-    case RideFile::aPower: return GColor(CAPOWER);
-    case RideFile::aTISS: return GColor(CNPOWER);
-    case RideFile::anTISS: return GColor(CNPOWER);
-    case RideFile::IsoPower: return GColor(CNPOWER);
-    case RideFile::alt: return GColor(CALTITUDE);
-    case RideFile::headwind: return GColor(CWINDSPEED);
-    case RideFile::temp: return GColor(CTEMP);
-    case RideFile::lrbalance: return GColor(CBALANCELEFT);
-    case RideFile::lte: return GColor(CLTE);
-    case RideFile::rte: return GColor(CRTE);
-    case RideFile::lps: return GColor(CLPS);
-    case RideFile::rps: return GColor(CRPS);
-    case RideFile::lpco: return GColor(CLPS);
-    case RideFile::rpco: return GColor(CRPS);
-    case RideFile::lppb: return GColor(CLPS);
-    case RideFile::rppb: return GColor(CRPS);
-    case RideFile::lppe: return GColor(CLPS);
-    case RideFile::rppe: return GColor(CRPS);
-    case RideFile::lpppb: return GColor(CLPS);
-    case RideFile::rpppb: return GColor(CRPS);
-    case RideFile::lpppe: return GColor(CLPS);
-    case RideFile::rpppe: return GColor(CRPS);
+    case RideFile::cad: return GColor(GCol::CADENCE);
+    case RideFile::cadd: return GColor(GCol::CADENCE);
+    case RideFile::hr: return GColor(GCol::HEARTRATE);
+    case RideFile::hrd: return GColor(GCol::HEARTRATE);
+    case RideFile::kph: return GColor(GCol::SPEED);
+    case RideFile::kphd: return GColor(GCol::SPEED);
+    case RideFile::nm: return GColor(GCol::TORQUE);
+    case RideFile::nmd: return GColor(GCol::TORQUE);
+    case RideFile::watts: return GColor(GCol::POWER);
+    case RideFile::wattsd: return GColor(GCol::POWER);
+    case RideFile::xPower: return GColor(GCol::XPOWER);
+    case RideFile::aPower: return GColor(GCol::APOWER);
+    case RideFile::aTISS: return GColor(GCol::NPOWER);
+    case RideFile::anTISS: return GColor(GCol::NPOWER);
+    case RideFile::IsoPower: return GColor(GCol::NPOWER);
+    case RideFile::alt: return GColor(GCol::ALTITUDE);
+    case RideFile::headwind: return GColor(GCol::WINDSPEED);
+    case RideFile::temp: return GColor(GCol::TEMP);
+    case RideFile::lrbalance: return GColor(GCol::BALANCELEFT);
+    case RideFile::lte: return GColor(GCol::LTE);
+    case RideFile::rte: return GColor(GCol::RTE);
+    case RideFile::lps: return GColor(GCol::LPS);
+    case RideFile::rps: return GColor(GCol::RPS);
+    case RideFile::lpco: return GColor(GCol::LPS);
+    case RideFile::rpco: return GColor(GCol::RPS);
+    case RideFile::lppb: return GColor(GCol::LPS);
+    case RideFile::rppb: return GColor(GCol::RPS);
+    case RideFile::lppe: return GColor(GCol::LPS);
+    case RideFile::rppe: return GColor(GCol::RPS);
+    case RideFile::lpppb: return GColor(GCol::LPS);
+    case RideFile::rpppb: return GColor(GCol::RPS);
+    case RideFile::lpppe: return GColor(GCol::LPS);
+    case RideFile::rpppe: return GColor(GCol::RPS);
     case RideFile::interval: return QColor(Qt::white);
-    case RideFile::wattsKg: return GColor(CPOWER);
-    case RideFile::wprime: return GColor(CWBAL);
-    case RideFile::smo2: return GColor(CSMO2);
-    case RideFile::thb: return GColor(CTHB);
-    case RideFile::o2hb: return GColor(CO2HB);
-    case RideFile::hhb: return GColor(CHHB);
-    case RideFile::slope: return GColor(CSLOPE);
-    case RideFile::rvert: return GColor(CRV);
-    case RideFile::rcontact: return GColor(CRGCT);
-    case RideFile::rcad: return GColor(CRCAD);
-    case RideFile::gear: return GColor(CGEAR);
+    case RideFile::wattsKg: return GColor(GCol::POWER);
+    case RideFile::wprime: return GColor(GCol::WBAL);
+    case RideFile::smo2: return GColor(GCol::SMO2);
+    case RideFile::thb: return GColor(GCol::THB);
+    case RideFile::o2hb: return GColor(GCol::O2HB);
+    case RideFile::hhb: return GColor(GCol::HHB);
+    case RideFile::slope: return GColor(GCol::SLOPE);
+    case RideFile::rvert: return GColor(GCol::RV);
+    case RideFile::rcontact: return GColor(GCol::RGCT);
+    case RideFile::rcad: return GColor(GCol::RCAD);
+    case RideFile::gear: return GColor(GCol::GEAR);
     case RideFile::secs:
     case RideFile::km:
     case RideFile::vam:
     case RideFile::lon:
     case RideFile::lat:
-    default: return GColor(CPLOTMARKER);
+    default: return GColor(GCol::PLOTMARKER);
     }
 }
 

--- a/src/Gui/AbstractView.cpp
+++ b/src/Gui/AbstractView.cpp
@@ -241,13 +241,13 @@ AbstractView::ourStyleSheet()
            "}"
            "QTableWidget::item:hover { color: black; background: lightGray; }"
            "QTreeView::item:hover { color: black; background: lightGray; }"
-           "").arg(GColor(CPLOTBACKGROUND).name())
-            .arg(GColor(CPLOTGRID).name())
-            .arg(GCColor::alternateColor(GColor(CPLOTBACKGROUND)).name())
+           "").arg(GColor(GCol::PLOTBACKGROUND).name())
+            .arg(GColor(GCol::PLOTGRID).name())
+            .arg(GAlternateColor(GCol::PLOTBACKGROUND).name())
             .arg(8 * dpiXFactor) // width
             .arg(4 * dpiXFactor) // border radius
-            .arg(GColor(CPLOTMARKER).name())
-            .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name())
+            .arg(GColor(GCol::PLOTMARKER).name())
+            .arg(GInvertColor(GColor(GCol::PLOTBACKGROUND)).name())
             ;
 }
 

--- a/src/Gui/AnalysisSidebar.cpp
+++ b/src/Gui/AnalysisSidebar.cpp
@@ -108,7 +108,7 @@ AnalysisSidebar::AnalysisSidebar(Context *context) : QWidget(context->mainWindow
     QTreeWidgetItem *tree = new QTreeWidgetItem(intervalTree->invisibleRootItem(), RideFileInterval::USER);
     tree->setData(0, Qt::UserRole, QVariant::fromValue((void *)NULL)); // no intervalitem related
     tree->setText(0, RideFileInterval::typeDescription(RideFileInterval::USER));
-    tree->setForeground(0, GColor(CPLOTMARKER));
+    tree->setForeground(0, GColor(GCol::PLOTMARKER));
     QFont bold;
     bold.setWeight(QFont::Bold);
     tree->setFont(0, bold);
@@ -245,7 +245,7 @@ AnalysisSidebar::setRide(RideItem*ride)
                 tree = new QTreeWidgetItem(intervalTree->invisibleRootItem(), interval->type);
                 tree->setData(0, Qt::UserRole, QVariant::fromValue((void *)NULL)); // no intervalitem related
                 tree->setText(0, RideFileInterval::typeDescription(interval->type));
-                tree->setForeground(0, GColor(CPLOTMARKER));
+                tree->setForeground(0, GColor(GCol::PLOTMARKER));
                 tree->setFont(0, bold);
                 tree->setExpanded(true);
                 tree->setFlags(Qt::ItemIsEnabled);
@@ -321,23 +321,23 @@ AnalysisSidebar::close()
 void
 AnalysisSidebar::configChanged(qint32)
 {
-    //calendarWidget->setPalette(GCColor::palette());
-    //intervalSummaryWindow->setPalette(GCColor::palette());
-    //intervalSummaryWindow->setStyleSheet(GCColor::stylesheet());
+    //calendarWidget->setPalette(GCColor::inst()->palette());
+    //intervalSummaryWindow->setPalette(GCColor::inst()->palette());
+    //intervalSummaryWindow->setStyleSheet(GCColor::inst()->stylesheet());
 
-    splitter->setPalette(GCColor::palette());
-    activityHistory->setStyleSheet(QString("background: %1;").arg(GColor(CPLOTBACKGROUND).name()));
-    rideNavigator->tableView->viewport()->setPalette(GCColor::palette());
-    rideNavigator->tableView->viewport()->setStyleSheet(QString("background: %1;").arg(GColor(CPLOTBACKGROUND).name()));
+    splitter->setPalette(GCColor::inst()->palette());
+    activityHistory->setStyleSheet(QString("background: %1;").arg(GColor(GCol::PLOTBACKGROUND).name()));
+    rideNavigator->tableView->viewport()->setPalette(GCColor::inst()->palette());
+    rideNavigator->tableView->viewport()->setStyleSheet(QString("background: %1;").arg(GColor(GCol::PLOTBACKGROUND).name()));
 
     // interval tree
-    intervalTree->setPalette(GCColor::palette());
-    intervalTree->setStyleSheet(GCColor::stylesheet());
+    intervalTree->setPalette(GCColor::inst()->palette());
+    intervalTree->setStyleSheet(GCColor::inst()->stylesheet());
     QMapIterator<RideFileInterval::intervaltype, QTreeWidgetItem*> i(trees);
     i.toFront();
     while(i.hasNext()) {
         i.next();
-        i.value()->setForeground(0, GColor(CPLOTMARKER));
+        i.value()->setForeground(0, GColor(GCol::PLOTMARKER));
     }
 
     repaint();

--- a/src/Gui/AthleteConfigDialog.cpp
+++ b/src/Gui/AthleteConfigDialog.cpp
@@ -176,7 +176,7 @@ AthleteConfig::AthleteConfig(QDir home, Context *context) :
     // otherwise just use same as the system color for text
     QPalette std;
     QColor tabselect = std.color(QPalette::Text);
-    if (GColor(CPLOTBACKGROUND) == std.color(QPalette::Base)) tabselect = GColor(CPLOTMARKER);
+    if (GColor(GCol::PLOTBACKGROUND) == std.color(QPalette::Base)) tabselect = GColor(GCol::PLOTMARKER);
 
 #ifndef Q_OS_MAC
     QString styling = QString("QTabWidget { background: %1; }"

--- a/src/Gui/AthleteTab.cpp
+++ b/src/Gui/AthleteTab.cpp
@@ -238,9 +238,9 @@ ProgressLine::paintEvent(QPaintEvent *)
 {
 
     // nothing for test...
-    QColor translucentGray = GColor(CPLOTMARKER);
+    QColor translucentGray = GColor(GCol::PLOTMARKER);
     translucentGray.setAlpha(240);
-    QColor translucentWhite = GColor(CPLOTBACKGROUND);
+    QColor translucentWhite = GColor(GCol::PLOTBACKGROUND);
 
     // setup a painter and the area to paint
     QPainter painter(this);

--- a/src/Gui/AthleteView.cpp
+++ b/src/Gui/AthleteView.cpp
@@ -300,7 +300,7 @@ AthleteCard::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *, QWid
 
     // load status
     QRectF progressbar(0, geometry().height()-gl_progress_width, geometry().width() * (loadprogress/100), gl_progress_width);
-    painter->fillRect(progressbar, QBrush(GColor(CPLOTMARKER)));
+    painter->fillRect(progressbar, QBrush(GColor(GCol::PLOTMARKER)));
 
     // refresh status
     if (refresh && Context::isValid(context)) {

--- a/src/Gui/ChartSpace.cpp
+++ b/src/Gui/ChartSpace.cpp
@@ -311,19 +311,19 @@ ChartSpaceItem::underMouse()
 void
 ChartSpaceItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *opt, QWidget *widget) {
 
-    if (drag) painter->setBrush(QBrush(GColor(CPLOTMARKER)));
-    else painter->setBrush(RGBColor(color()));
+    if (drag) painter->setBrush(QBrush(GColor(GCol::PLOTMARKER)));
+    else painter->setBrush(GRGBColorToQColor(color()));
 
     QPainterPath path;
     path.addRoundedRect(QRectF(0,0,geometry().width(),geometry().height()), ROWHEIGHT/5, ROWHEIGHT/5);
     painter->setPen(Qt::NoPen);
     //painter->fillPath(path, brush.color());
     painter->drawPath(path);
-    painter->setPen(GColor(CPLOTGRID));
+    painter->setPen(GColor(GCol::PLOTGRID));
     //XXXpainter->drawLine(QLineF(0,ROWHEIGHT*2,geometry().width(),ROWHEIGHT*2));
     //painter->fillRect(QRectF(0,0,geometry().width()+1,geometry().height()+1), brush);
     //titlefont.setWeight(QFont::Bold);
-    if (GCColor::luminance(RGBColor(color())) < 127) painter->setPen(QColor(200,200,200));
+    if (GLuminance(GRGBColorToQColor(color())) < 127) painter->setPen(QColor(200,200,200));
     else painter->setPen(QColor(70,70,70));
 
     painter->setFont(parent->titlefont);
@@ -346,7 +346,7 @@ ChartSpaceItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *opt, QW
                 path.addRoundedRect(QRectF(geometry().width()-40-ROWHEIGHT,0,
                                     ROWHEIGHT+40, ROWHEIGHT+40), ROWHEIGHT/5, ROWHEIGHT/5);
                 painter->setPen(Qt::NoPen);
-                QColor darkgray(RGBColor(color()).lighter(200));
+                QColor darkgray(GRGBColorToQColor(color()).lighter(200));
                 painter->setBrush(darkgray);
                 painter->drawPath(path);
                 painter->fillRect(QRectF(geometry().width()-40-ROWHEIGHT, 0, ROWHEIGHT+40-(ROWHEIGHT/5), ROWHEIGHT+40), QBrush(darkgray));
@@ -369,7 +369,7 @@ ChartSpaceItem::paint(QPainter *painter, const QStyleOptionGraphicsItem *opt, QW
     if (!drag) {
         QPainterPath path;
         path.addRoundedRect(QRectF(1*dpiXFactor,1*dpiXFactor,geometry().width()-(2*dpiXFactor),geometry().height()-(2*dpiXFactor)), ROWHEIGHT/5, ROWHEIGHT/5);
-        QColor edge(RGBColor(color()));
+        QColor edge(GRGBColorToQColor(color()));
         edge = edge.darker(105);
         QPen pen(edge);
         pen.setWidth(3*dpiXFactor);
@@ -622,7 +622,7 @@ ChartSpace::updateGeometry()
 void
 ChartSpace::configChanged(qint32 why)
 {
-    grayConfig = colouredIconFromPNG(":images/configure.png", GColor(COVERVIEWBACKGROUND).lighter(75));
+    grayConfig = colouredIconFromPNG(":images/configure.png", GColor(GCol::OVERVIEWBACKGROUND).lighter(75));
     whiteConfig = colouredIconFromPNG(":images/configure.png", QColor(100,100,100));
     accentConfig = colouredIconFromPNG(":images/configure.png", QColor(150,150,150));
 
@@ -638,32 +638,32 @@ ChartSpace::configChanged(qint32 why)
     tinyfont.setPixelSize(pixelSizeForFont(smallfont, ROWHEIGHT*0.5f));
     tinyfont.setHintingPreference(QFont::HintingPreference::PreferNoHinting);
 
-    setProperty("color", GColor(COVERVIEWBACKGROUND));
-    view->setBackgroundBrush(QBrush(GColor(COVERVIEWBACKGROUND)));
-    scene->setBackgroundBrush(QBrush(GColor(COVERVIEWBACKGROUND)));
+    setProperty("color", GColor(GCol::OVERVIEWBACKGROUND));
+    view->setBackgroundBrush(QBrush(GColor(GCol::OVERVIEWBACKGROUND)));
+    scene->setBackgroundBrush(QBrush(GColor(GCol::OVERVIEWBACKGROUND)));
     scrollbar->setStyleSheet(AbstractView::ourStyleSheet());
 
     // text edit colors
     QPalette palette;
-    palette.setColor(QPalette::Window, GColor(COVERVIEWBACKGROUND));
+    palette.setColor(QPalette::Window, GColor(GCol::OVERVIEWBACKGROUND));
 
     // only change base if moved away from white plots
     // which is a Mac thing
 #ifndef Q_OS_MAC
-    if (GColor(COVERVIEWBACKGROUND) != Qt::white)
+    if (GColor(GCol::OVERVIEWBACKGROUND) != Qt::white)
 #endif
     {
-        //palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CTRAINPLOTBACKGROUND)));
-        palette.setColor(QPalette::Base, GColor(COVERVIEWBACKGROUND));
-        palette.setColor(QPalette::Window, GColor(COVERVIEWBACKGROUND));
+        //palette.setColor(QPalette::Base, GAlternateColor(GCol::TRAINPLOTBACKGROUND));
+        palette.setColor(QPalette::Base, GColor(GCol::OVERVIEWBACKGROUND));
+        palette.setColor(QPalette::Window, GColor(GCol::OVERVIEWBACKGROUND));
     }
 
 #ifndef Q_OS_MAC // the scrollers appear when needed on Mac, we'll keep that
     //code->setStyleSheet(TabView::ourStyleSheet());
 #endif
 
-    palette.setColor(QPalette::WindowText, GCColor::invertColor(GColor(COVERVIEWBACKGROUND)));
-    palette.setColor(QPalette::Text, GCColor::invertColor(GColor(COVERVIEWBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GInvertColor(GCol::OVERVIEWBACKGROUND));
+    palette.setColor(QPalette::Text, GInvertColor(GCol::OVERVIEWBACKGROUND));
     //code->setPalette(palette);
 
     foreach(ChartSpaceItem *item, items) item->configChanged(why);
@@ -1307,8 +1307,8 @@ ChartSpaceItem::clicked()
     if (isVisible()) hide();
     else show();
 
-    //if (brush.color() == GColor(CChartSpaceItemBACKGROUND)) brush.setColor(Qt::red);
-    //else brush.setColor(GColor(CChartSpaceItemBACKGROUND));
+    //if (brush.color() == GColor(GCol::hartSpaceItemBACKGROUND)) brush.setColor(Qt::red);
+    //else brush.setColor(GColor(GCol::hartSpaceItemBACKGROUND));
 
     update(geometry());
 }

--- a/src/Gui/ChartSpace.h
+++ b/src/Gui/ChartSpace.h
@@ -131,7 +131,7 @@ class ChartSpaceItem : public QGraphicsWidget
             this->setGraphicsEffect(effect);
 #endif
 
-            bgcolor = StandardColor(CCARDBACKGROUND).name();
+            bgcolor = GColorToRGBColor(GCol::CARDBACKGROUND).name();
 
             // watch geom changes
             connect(this, SIGNAL(geometryChanged()), SLOT(geometryChanged()));

--- a/src/Gui/ColorButton.cpp
+++ b/src/Gui/ColorButton.cpp
@@ -52,8 +52,8 @@ ColorButton::setColor(QColor ncolor)
         painter.setPen(Qt::gray);
 
         // gc standard colors
-        if (color.red() == 1 && color.green()==1) {
-            painter.setBrush(QBrush(GColor(color.blue())));
+        if (GIsRGBColor(color)) {
+            painter.setBrush(QBrush(GColor(static_cast<GCol>(color.blue()))));
         } else {
             painter.setBrush(QBrush(color));
         }
@@ -126,19 +126,18 @@ GColorDialog::GColorDialog(QColor selected, QWidget *parent, bool all) : QDialog
     connect(mapper, &QSignalMapper::mappedInt, this, &GColorDialog::gcClicked);
 
     // now add all the colours to select
-    colorSet = GCColor::colorSet();
-    for (int i=0; colorSet[i].name != ""; i++) {
+    for (const auto& color : GCColor::inst()->getColorTable()) {
 
-        if (!all && colorSet[i].group != tr("Data")) continue;
+        if (!all && color.second.group != tr("Data")) continue;
 
         QTreeWidgetItem *add;
-        ColorButton *colorButton = new ColorButton(this, colorSet[i].name, colorSet[i].color, false, true);
+        ColorButton *colorButton = new ColorButton(this, color.second.name, color.second.qColor, false, true);
         // we can click the button to choose the color directly
         connect(colorButton, SIGNAL(clicked()), mapper, SLOT(map()));
-        mapper->setMapping(colorButton, i);
+        mapper->setMapping(colorButton, static_cast<int>(color.first));
         add = new QTreeWidgetItem(colorlist->invisibleRootItem());
-        add->setData(0, Qt::UserRole, i);
-        add->setText(0, colorSet[i].name);
+        add->setData(0, Qt::UserRole, static_cast<int>(color.first));
+        add->setText(0, color.second.name);
         colorlist->setItemWidget(add, 1, colorButton);
     }
 
@@ -152,7 +151,7 @@ GColorDialog::GColorDialog(QColor selected, QWidget *parent, bool all) : QDialog
     colorlist->sortByColumn(0, Qt::AscendingOrder);
 
     // set the default to the current selection
-    if (original.red() == 1 && original.green() == 1) {
+    if (GIsRGBColor(original)) {
         tabwidget->setCurrentIndex(0);
         for(int i=0; i<colorlist->invisibleRootItem()->childCount(); i++) {
             if (colorlist->invisibleRootItem()->child(i)->data(0, Qt::UserRole).toInt() == original.blue()) {
@@ -160,10 +159,10 @@ GColorDialog::GColorDialog(QColor selected, QWidget *parent, bool all) : QDialog
                 break;
             }
         }
-        colordialog->setCurrentColor(GColor(original.blue()));
+        colordialog->setCurrentColor(GColor(static_cast<GCol>(original.blue())));
     } else {
         tabwidget->setCurrentIndex(1);
-        colorlist->setCurrentItem(colorlist->invisibleRootItem()->child(CPOWER));
+        colorlist->setCurrentItem(colorlist->invisibleRootItem()->child(static_cast<int>(GCol::POWER)));
         colordialog->setCurrentColor(original);
     }
     // returning what we got

--- a/src/Gui/ColorButton.h
+++ b/src/Gui/ColorButton.h
@@ -107,7 +107,6 @@ class GColorDialog : public QDialog
         QColorDialog *colordialog;
 
         // gc dialog (second tab)
-        const Colors *colorSet;
         QWidget *gcdialog;
         QLineEdit *searchEdit;
         QTreeWidget *colorlist;

--- a/src/Gui/Colors.h
+++ b/src/Gui/Colors.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2010 Mark Liversedge (liversedge@gmail.com)
+ * GCol & GThmCol - Copyright (c) 2022 Paul Johnson (paul49457@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -20,6 +21,7 @@
 #define _GC_Colors_h 1
 #include "GoldenCheetah.h"
 
+#include <map>
 #include <QString>
 #include <QObject>
 #include <QColor>
@@ -27,9 +29,126 @@
 #include <QGradient>
 #include <QLinearGradient>
 
+ // Define how many configurable metric colors are available
+enum class GCol : uint8_t {
+    PLOTBACKGROUND = 0,
+    RIDEPLOTBACKGROUND,
+    TRENDPLOTBACKGROUND,
+    TRAINPLOTBACKGROUND,
+    PLOTSYMBOL,
+    RIDEPLOTXAXIS,
+    RIDEPLOTYAXIS,
+    PLOTTHUMBNAIL,
+    PLOTTITLE,
+    PLOTSELECT,
+    PLOTTRACKER,
+    PLOTMARKER,
+    PLOTGRID,
+    INTERVALHIGHLIGHTER,
+    HEARTRATE,
+    CORETEMP,
+    SPEED,
+    ACCELERATION,
+    POWER,
+    NPOWER,
+    XPOWER,
+    APOWER,
+    TPOWER,
+    CP,
+    CADENCE,
+    ALTITUDE,
+    ALTITUDEBRUSH,
+    WINDSPEED,
+    TORQUE,
+    SLOPE,
+    GEAR,
+    RV,
+    RCAD,
+    RGCT,
+    SMO2,
+    THB,
+    O2HB,
+    HHB,
+    LOAD,
+    TSS,
+    STS,
+    LTS,
+    SB,
+    DAILYSTRESS,
+    BIKESCORE,
+    CALENDARTEXT,
+    ZONE1,
+    ZONE2,
+    ZONE3,
+    ZONE4,
+    ZONE5,
+    ZONE6,
+    ZONE7,
+    ZONE8,
+    ZONE9,
+    ZONE10,
+    HZONE1,
+    HZONE2,
+    HZONE3,
+    HZONE4,
+    HZONE5,
+    HZONE6,
+    HZONE7,
+    HZONE8,
+    HZONE9,
+    HZONE10,
+    AEROVE,
+    AEROEL,
+    CALCELL,
+    CALHEAD,
+    CALCURRENT,
+    CALACTUAL,
+    CALPLANNED,
+    CALTODAY,
+    POPUP,
+    POPUPTEXT,
+    TILEBAR ,
+    TILEBARSELECT,
+    TOOLBAR,
+    RIDEGROUP,
+    SPINSCANLEFT,
+    SPINSCANRIGHT,
+    TEMP,
+    DIAL,
+    ALTPOWER,
+    BALANCELEFT,
+    BALANCERIGHT,
+    WBAL,
+    RIDECP,
+    ATISS,
+    ANTISS,
+    LTE,
+    RTE,
+    LPS,
+    RPS,
+    CHROME,
+    OVERVIEWBACKGROUND,
+    CARDBACKGROUND,
+    VO2,
+    VENTILATION,
+    VCO2,
+    TIDALVOLUME,
+    RESPFREQUENCY,
+    FEO2,
+    HOVER,
+    CHARTBAR,
+    CARDBACKGROUND2,
+    CARDBACKGROUND3,
+    MAPROUTELINE,
+    COLORRR,
+    NUMOFCFGCOLORS
+};
+
+// Returned colors when functions are accessed with an out of range value
+#define INVALIDGCOLORLUMINANCE  127
+#define INVALIDGCOLOR           QColor(127, 127, 127)
 
 // A selection of distinct colours, user can adjust also
-extern QList<QColor> standardColors;
 extern QIcon colouredIconFromPNG(QString filename, QColor color);
 extern QPixmap colouredPixmapFromPNG(QString filename, QColor color);
 
@@ -37,72 +156,59 @@ extern QPixmap colouredPixmapFromPNG(QString filename, QColor color);
 extern double dpiXFactor, dpiYFactor;
 extern QFont baseFont;
 
-// turn color to rgb, checks if a named color
-#define StandardColor(x) (QColor(1,1,x))
-#define NamedColor(x) (x.red()==1 && x.green()==1)
-#define RGBColor(x) (NamedColor(x) ? GColor(x.blue()) : x)
-
 // get the pixel size for a font that is no taller
 // than height in pixels (let QT adapt for device ratios)
 int pixelSizeForFont(QFont &font, int height);
 
-class Context;
-
-// set appearace defaults based upon screen size
-struct SizeSettings {
-
-    // this applies up to the following geometry
-    int maxheight,
-        maxwidth;
-
-    // font size
-    int defaultFont,
-        titleFont,
-        markerFont,
-        labelFont,
-        calendarFont;
-
-    // screen dimension
-    int width,
-        height;
-};
-
-extern SizeSettings defaultAppearance[];
-extern float GCDPIScale; // font scaling for display
-extern QColor standardColor(int num);
-
-class Colors
-{
-public:
-        static unsigned long fingerprint(const Colors*set);
-        QString group,
-                name,
-                setting;
-        QColor  color;
+// Color definitions within a theme
+enum class GThmCol : uint8_t {
+    PLOTBACKGROUND = 0,         // Plot Background
+    TOOLBARANDSIDEBAR,          // Toolbar and Sidebar Chrome
+    ACCENTCOLORMARKERS,         // Accent color (markers" >
+    SELECTIONCOLOR,             // Selection color
+    CPWBALRIDECP,               // Critical Power and W'Bal
+    HEARTRATE,                  // Heartrate
+    SPEED,                      // Speed
+    POWER,                      // Power
+    CADENCE,                    // Cadence
+    TORQUE,                     // Toprque
+    OVERVIEWBACKGROUND,         // Overview Background
+    OVERVIEWTILEBACKGROUND1,    // Overview Tile Background
+    OVERVIEWTILEBACKGROUND2,    // Overview Tile Background 2
+    OVERVIEWTILEBACKGROUND3,    // Overview Tile Background 3
 };
 
 class ColorTheme
 {
     public:
-        ColorTheme(QString name, bool dark, QList<QColor>colors) : name(name), dark(dark), colors(colors) {}
+        ColorTheme() : name(""), dark(false), stealth(false) {};
 
         // all public
         QString name;
         bool dark;
         bool stealth;
-        QList<QColor> colors;
+        std::map<GThmCol, QColor> colors;
 };
 
 class Themes
 {
-
     Q_DECLARE_TR_FUNCTIONS(Themes);
 
     public:
-        Themes(); // will init the array of themes
 
         QList<ColorTheme> themes;
-};
+
+        Themes(Themes const&) = delete;
+        Themes& operator=(Themes const&) = delete;
+
+        static Themes* inst() {
+            static Themes* s{ new Themes };
+            return s;
+        }
+
+    private:
+        Themes();
+ };
 
 class ColorLabel : public QLabel
 {
@@ -116,48 +222,77 @@ class ColorLabel : public QLabel
         ColorTheme theme;
 };
 
+class Colors {
+public:
+    static unsigned long fingerprint(const std::map<GCol, Colors>& colorTable);
+
+    // all public
+    const QString group;
+    const QString name;
+    const QString setting;
+    const QColor  qDarkColor;
+    const QColor  qLightColor;
+    QColor  qColor;
+};
+
 class GCColor : public QObject
 {
     Q_OBJECT
 
     public:
-        static QColor getColor(int);
-        static void setColor(int,QColor);
-        static const Colors *colorSet();
-        static const Colors *defaultColorSet(bool dark);
-        static void resetColors();
-        static double luminance(QColor color); // return the relative luminance
-        static QColor invertColor(QColor); // return the contrasting color
-        static QColor alternateColor(QColor); // return the alternate background
-        static QColor selectedColor(QColor); // return the on select background color
-        static QColor htmlCode(QColor x) { return x.name(); } // return the alternate background
-        static Themes &themes(); 
-        static void applyTheme(int index);
+        GCColor(GCColor const&) = delete;
+        GCColor& operator=(GCColor const&) = delete;
+
+        static GCColor* inst() {
+            static GCColor* s{ new GCColor };
+            return s;
+        }
+
+        // gColor and qColor functions
+        QColor getQColor(const GCol& gColor);
+        bool setQColor(const GCol& gColor, const QColor& qColor);
+        double luminance(const GCol& gColor); // return the relative luminance
+        double luminance(const QColor& qColor); // return the relative luminance
+        QColor selectedQColor(const QColor& qColor);
+        QColor invertQColor(const GCol& gColor); // return the contrasting color
+        QColor invertQColor(const QColor& qColor); // return the contrasting color
+        QColor alternateQColor(const GCol& gColor); // return the alternate background
+        QColor alternateQColor(const QColor& qColor); // return the alternate background
+
+        // functions to convert between gColors -> rgb colors -> qColors
+        // An RGB color has red & green = 1, and blue is set to a GCol enumerated value
+        QColor gColorToRGBColor(const GCol& gColor);
+        bool isRGBColor(const QColor& qc);
+        QColor rgbColorToQColor(const QColor& qColor);
+
+        QColor determineThemeQColor(int index, const GCol& gColor);
+
+        void resetColors();
+        std::map<GCol, Colors>& getColorTable();
+
+        void applyTheme(int index);
 
         // for styling things with current preferences
-        static QLinearGradient linearGradient(int size, bool active, bool alternate=false);
-        static QString css(bool ridesummary=true);
-        static QPalette palette();
-        static QString stylesheet(bool train=false);
-        static void readConfig();
-        static void setupColors();
-        static void dumpColors();
+        QLinearGradient linearGradient(int size);
+        QString css(bool ridesummary = true);
+        QPalette palette();
+        QString stylesheet(bool train = false);
+        QColor standardQColor(int index);
+
+        void readConfig();
+        void dumpColors();
 
         // for upgrade/migration of Config
-        static QStringList getConfigKeys();
+        QStringList getConfigKeys();
 
+    private:
+        GCColor();
+
+        // Number of configurable metric colors
+        std::map<GCol, Colors> colorTable;
+
+        QList<QColor> standardColors;
 };
-
-// color chooser that also supports the standard colors (CPLOTMARKER, CPOWER)
-// and returns them as a QColor(1,1,1,<int>) where <int> is the color number
-// .e.g CPOWER is 18, see below for full list
-#if 0
-class GColorDialog : public QDialog
-{
-    GColorDialog(QWidget *parent);
-
-};
-#endif
 
 // return a color for a ride file
 class GlobalContext;
@@ -180,121 +315,21 @@ class ColorEngine : public QObject
         GlobalContext *gc; // bootstrapping
 };
 
+// shorthand macros due to number of instances
 
-// shorthand
-#define GColor(x) GCColor::getColor(x)
+#define GStandardQColor(x) (GCColor::inst()->standardQColor(x))
 
-// Define how many cconfigurable metric colors are available
-#define CNUMOFCFGCOLORS       110
+// gColor and qColor functions
+#define GColor(x) (GCColor::inst()->getQColor(x))
+#define GAlternateColor(x) (GCColor::inst()->alternateQColor(x))
+#define GLuminance(x) (GCColor::inst()->luminance(x))
+#define GInvertColor(x) (GCColor::inst()->invertQColor(x))
+#define GSelectedColor(x) (GCColor::inst()->selectedQColor(x))
 
-#define CPLOTBACKGROUND       0
-#define CRIDEPLOTBACKGROUND   1
-#define CTRENDPLOTBACKGROUND  2
-#define CTRAINPLOTBACKGROUND  3
-#define CPLOTSYMBOL           4
-#define CRIDEPLOTXAXIS        5
-#define CRIDEPLOTYAXIS        6
-#define CPLOTTHUMBNAIL        7
-#define CPLOTTITLE            8
-#define CPLOTSELECT           9
-#define CPLOTTRACKER          10
-#define CPLOTMARKER           11
-#define CPLOTGRID             12
-#define CINTERVALHIGHLIGHTER  13
-#define CHEARTRATE            14
-#define CCORETEMP             15
-#define CSPEED                16
-#define CACCELERATION         17
-#define CPOWER                18
-#define CNPOWER               19
-#define CXPOWER               20
-#define CAPOWER               21
-#define CTPOWER               22
-#define CCP                   23
-#define CCADENCE              24
-#define CALTITUDE             25
-#define CALTITUDEBRUSH        26
-#define CWINDSPEED            27
-#define CTORQUE               28
-#define CSLOPE                29
-#define CGEAR                 30
-#define CRV                   31
-#define CRCAD                 32
-#define CRGCT                 33
-#define CSMO2                 34
-#define CTHB                  35
-#define CO2HB                 36
-#define CHHB                  37
-#define CLOAD                 38
-#define CTSS                  39
-#define CSTS                  40
-#define CLTS                  41
-#define CSB                   42
-#define CDAILYSTRESS          43
-#define CBIKESCORE            44
-#define CCALENDARTEXT         45
-#define CZONE1                46
-#define CZONE2                47
-#define CZONE3                48
-#define CZONE4                49
-#define CZONE5                50
-#define CZONE6                51
-#define CZONE7                52
-#define CZONE8                53
-#define CZONE9                54
-#define CZONE10               55
-#define CHZONE1               56
-#define CHZONE2               57
-#define CHZONE3               58
-#define CHZONE4               59
-#define CHZONE5               60
-#define CHZONE6               61
-#define CHZONE7               62
-#define CHZONE8               63
-#define CHZONE9               64
-#define CHZONE10              65
-#define CAEROVE               66
-#define CAEROEL               67
-#define CCALCELL              68
-#define CCALHEAD              69
-#define CCALCURRENT           70
-#define CCALACTUAL            71
-#define CCALPLANNED           72
-#define CCALTODAY             73
-#define CPOPUP                74
-#define CPOPUPTEXT            75
-#define CTILEBAR              76
-#define CTILEBARSELECT        77
-#define CTOOLBAR              78
-#define CRIDEGROUP            79
-#define CSPINSCANLEFT         80
-#define CSPINSCANRIGHT        81
-#define CTEMP                 82
-#define CDIAL                 83
-#define CALTPOWER             84
-#define CBALANCELEFT          85
-#define CBALANCERIGHT         86
-#define CWBAL                 87
-#define CRIDECP               88
-#define CATISS                89
-#define CANTISS               90
-#define CLTE                  91
-#define CRTE                  92
-#define CLPS                  93
-#define CRPS                  94
-#define CCHROME               95
-#define COVERVIEWBACKGROUND   96
-#define CCARDBACKGROUND       97
-#define CVO2                  98
-#define CVENTILATION          99
-#define CVCO2                 100
-#define CTIDALVOLUME          101
-#define CRESPFREQUENCY        102
-#define CFEO2                 103
-#define CHOVER                104
-#define CCHARTBAR             105
-#define CCARDBACKGROUND2      106
-#define CCARDBACKGROUND3      107
-#define MAPROUTELINE          108
-#define COLORRR               109
+// functions to convert between gColors -> rgb colors -> qColors
+// An RGB color has red & green = 1, and blue is set to a GCol enumerated value
+#define GColorToRGBColor(x) (GCColor::inst()->gColorToRGBColor(x))
+#define GIsRGBColor(x) (GCColor::inst()->isRGBColor(x))
+#define GRGBColorToQColor(x) (GCColor::inst()->rgbColorToQColor(x))
+
 #endif

--- a/src/Gui/ComparePane.cpp
+++ b/src/Gui/ComparePane.cpp
@@ -38,11 +38,6 @@
 #include <QTextEdit>
 
 
-QColor standardColor(int num)
-{
-   return standardColors.at(num % standardColors.count());
-}
-
 // we need to fix the sort order! (fixed for time fields)
 class CTableWidgetItem : public QTableWidgetItem
 {
@@ -161,7 +156,7 @@ void
 ComparePane::configChanged(qint32)
 {
     // via standard style sheet
-    table->setStyleSheet(GCColor::stylesheet());
+    table->setStyleSheet(GCColor::inst()->stylesheet());
 
     // refresh table...
     refreshTable();
@@ -780,7 +775,7 @@ ComparePane::dropEvent(QDropEvent *event)
             // just use standard colors and cycle round
             // we will of course repeat, but the user can
             // just edit them using the button
-            add.color = standardColors.at((i + context->compareIntervals.count()) % standardColors.count());
+            add.color = GStandardQColor(i + context->compareIntervals.count());
 
             // construct a fake RideItem, slightly hacky need to fix this later XXX fixme
             //                            mostly cut and paste from RideItem::refresh
@@ -962,7 +957,7 @@ ComparePane::dropEvent(QDropEvent *event)
                             // just use standard colors and cycle round
                             // we will of course repeat, but the user can
                             // just edit them using the button
-                            add.color = standardColors.at((newOnes.count()) % standardColors.count());
+                            add.color = GStandardQColor(newOnes.count());
 
                             // now add but only if not empty
                             if (!add.data->dataPoints().empty()) newOnes << add;
@@ -1015,7 +1010,7 @@ ComparePane::dropEvent(QDropEvent *event)
             // just use standard colors and cycle round
             // we will of course repeat, but the user can
             // just edit them using the button
-            add.color = standardColors.at((i + context->compareDateRanges.count()) % standardColors.count());
+            add.color = GStandardQColor(i + context->compareDateRanges.count());
 
             // even empty date ranges are valid
             newOnes << add;

--- a/src/Gui/DiarySidebar.cpp
+++ b/src/Gui/DiarySidebar.cpp
@@ -142,7 +142,7 @@ GcLabel::paintEvent(QPaintEvent *)
         if (!underMouse()) {
             painter.fillRect(all, bgColor);
         } else {
-            if (filtered) painter.fillRect(all, GColor(CCALCURRENT));
+            if (filtered) painter.fillRect(all, GColor(GCol::CALCURRENT));
             else painter.fillRect(all, Qt::lightGray);
         }
 
@@ -151,18 +151,17 @@ GcLabel::paintEvent(QPaintEvent *)
     }
 
     if (selected) {
-        painter.fillRect(all, GColor(CCALCURRENT));
+        painter.fillRect(all, GColor(GCol::CALCURRENT));
     }
 
     if (text() != "<" && text() != ">") {
         painter.setFont(this->font());
 
-        if (filtered && !selected && !underMouse()) painter.setPen(GColor(CCALCURRENT));
+        if (filtered && !selected && !underMouse()) painter.setPen(GColor(GCol::CALCURRENT));
         else {
 
             if (isChrome) {
-
-                if (GCColor::luminance(GColor(CCHROME)) < 127)
+                if (GLuminance(GColor(GCol::CHROME)) < 127)
                     painter.setPen(QColor(Qt::white));
                 else
                     painter.setPen(QColor(30,30,30,200));
@@ -173,7 +172,7 @@ GcLabel::paintEvent(QPaintEvent *)
         painter.drawText(norm, alignment(), text());
 
         if (highlighted) {
-            QColor over = GColor(CCALCURRENT);
+            QColor over = GColor(GCol::CALCURRENT);
             over.setAlpha(180);
             painter.setPen(over);
 
@@ -191,7 +190,7 @@ GcLabel::paintEvent(QPaintEvent *)
 
     if (text() != ""  && filtered) {
         QPen pen;
-        pen.setColor(GColor(CCALCURRENT));
+        pen.setColor(GColor(GCol::CALCURRENT));
         pen.setWidth(3);
         painter.setPen(pen);
         painter.drawRect(QRect(0,0,width(),height()));
@@ -379,11 +378,11 @@ GcMiniCalendar::GcMiniCalendar(Context *context, bool master) : context(context)
 void
 GcMiniCalendar::configChanged(qint32)
 {
-    QColor bgColor = GColor(CPLOTBACKGROUND);
-    QColor fgColor = GCColor::invertColor(bgColor);
+    QColor bgColor = GColor(GCol::PLOTBACKGROUND);
+    QColor fgColor = GInvertColor(bgColor);
     //XXX setStyleSheet(QString("color: %1; background: %2;").arg(fgColor.name()).arg(bgColor.name())); // clear any shit left behind from parents (Larkin ?)
     tint.setColor(QPalette::Window, bgColor);
-    tint.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
+    tint.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
     white.setColor(QPalette::WindowText, fgColor);
     white.setColor(QPalette::Window, bgColor);
     grey.setColor(QPalette::WindowText, fgColor);
@@ -421,12 +420,12 @@ GcMiniCalendar::event(QEvent *e)
         QPainter painter(this);
         QRect all(0,0,width(),height());
         //painter.fillRect(all, QColor("#B3B4BA"));
-        painter.fillRect(all, GColor(CPLOTBACKGROUND));
+        painter.fillRect(all, GColor(GCol::PLOTBACKGROUND));
 
         if (_ride) {
             QDate when = _ride->dateTime.date();
             if (when >= QDate(year,month,01) && when < QDate(year,month,01).addMonths(1))
-            painter.fillRect(all, GColor(CPLOTMARKER));
+            painter.fillRect(all, GColor(GCol::PLOTMARKER));
         }
     }
 
@@ -618,7 +617,7 @@ GcMiniCalendar::setDate(int _month, int _year)
                 if (colors.count()) {
                     d->setBg(true);
                     d->setPalette(grey);
-                    if (colors.at(0) == QColor(1,1,1)) d->setBgColor(GColor(CPLOTMARKER)); // default
+                    if (colors.at(0) == QColor(1,1,1)) d->setBgColor(GColor(GCol::PLOTMARKER)); // default
                     else d->setBgColor(colors.at(0)); // use first always
                 } else {
                     d->setBg(false);
@@ -697,8 +696,8 @@ GcMultiCalendar::GcMultiCalendar(Context *context) : QScrollArea(context->mainWi
 void
 GcMultiCalendar::configChanged(qint32)
 {
-    QColor bgColor = GColor(CPLOTBACKGROUND);
-    QColor fgColor = GCColor::invertColor(bgColor);
+    QColor bgColor = GColor(GCol::PLOTBACKGROUND);
+    QColor fgColor = GInvertColor(bgColor);
 
     QPalette pal;
     pal.setColor(QPalette::Window, bgColor);

--- a/src/Gui/GcSideBarItem.cpp
+++ b/src/Gui/GcSideBarItem.cpp
@@ -374,8 +374,8 @@ GcSplitterHandle::paintBackground(QPaintEvent *)
     painter.setPen(Qt::NoPen);
     painter.fillRect(all, QColor(Qt::white));
 
-    QLinearGradient active = GCColor::linearGradient(height(), true, !metal);
-    QLinearGradient inactive = GCColor::linearGradient(height(), false, !metal);
+    QLinearGradient active = GCColor::inst()->linearGradient(height());
+    QLinearGradient inactive = GCColor::inst()->linearGradient(height());
 
     painter.fillRect(all, isActiveWindow() ? active : inactive);
     painter.restore();
@@ -415,8 +415,8 @@ GcSplitterControl::paintBackground(QPaintEvent *)
     // setup a painter and the area to paint
     QPainter painter(this);
 
-    QLinearGradient active = GCColor::linearGradient(22 *dpiYFactor, true);
-    QLinearGradient inactive = GCColor::linearGradient(22 *dpiYFactor, false);
+    QLinearGradient active = GCColor::inst()->linearGradient(22 *dpiYFactor);
+    QLinearGradient inactive = GCColor::inst()->linearGradient(22 *dpiYFactor);
 
     // fill with a linear gradient
     painter.setPen(Qt::NoPen);

--- a/src/Gui/GcToolBar.cpp
+++ b/src/Gui/GcToolBar.cpp
@@ -58,6 +58,5 @@ GcToolBar::paintBackground(QPaintEvent *)
     QRect all(0,0,width(),height());
 
     painter.setPen(Qt::NoPen);
-    painter.fillRect(all, GColor(CTOOLBAR));
-
+    painter.fillRect(all, GColor(GCol::TOOLBAR));
 }

--- a/src/Gui/LTMSidebar.cpp
+++ b/src/Gui/LTMSidebar.cpp
@@ -301,10 +301,10 @@ LTMSidebar::presetSelectionChanged()
 void
 LTMSidebar::configChanged(qint32)
 {
-    seasonsWidget->setStyleSheet(GCColor::stylesheet());
-    eventsWidget->setStyleSheet(GCColor::stylesheet());
-    chartsWidget->setStyleSheet(GCColor::stylesheet());
-    filtersWidget->setStyleSheet(GCColor::stylesheet());
+    seasonsWidget->setStyleSheet(GCColor::inst()->stylesheet());
+    eventsWidget->setStyleSheet(GCColor::inst()->stylesheet());
+    chartsWidget->setStyleSheet(GCColor::inst()->stylesheet());
+    filtersWidget->setStyleSheet(GCColor::inst()->stylesheet());
     setAutoFilterMenu();
 
     // set or reset the autofilter widgets

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -450,7 +450,7 @@ MainWindow::MainWindow(const QDir &home)
      * Application Menus
      *--------------------------------------------------------------------*/
 #ifdef WIN32
-    QString menuColorString = GColor(CTOOLBAR).name();
+    QString menuColorString = GColor(GCol::TOOLBAR).name();
     menuBar()->setStyleSheet(QString("QMenuBar { color: black; background: %1; }"
                              "QMenuBar::item { color: black; background: %1; }").arg(menuColorString));
     menuBar()->setContentsMargins(0,0,0,0);
@@ -2521,28 +2521,28 @@ MainWindow::configChanged(qint32)
 {
     // Windows and Linux menu bar should match chrome
     QColor textCol(Qt::black);
-    if (GCColor::luminance(GColor(CTOOLBAR)) < 127)  textCol = QColor(Qt::white);
-    QString menuColorString = GColor(CTOOLBAR).name();
+    if (GLuminance(GColor(GCol::TOOLBAR)) < 127)  textCol = QColor(Qt::white);
+    QString menuColorString = GColor(GCol::TOOLBAR).name();
     menuBar()->setStyleSheet(QString("QMenuBar { color: %1; background: %2; }"
                              "QMenuBar::item { color: %1; background: %2; }")
                              .arg(textCol.name()).arg(menuColorString));
     // search filter box match chrome color
-    searchBox->setStyleSheet(QString("QLineEdit { background: %1; color: %2; }").arg(GColor(CTOOLBAR).name()).arg(GCColor::invertColor(GColor(CTOOLBAR)).name()));
+    searchBox->setStyleSheet(QString("QLineEdit { background: %1; color: %2; }").arg(GColor(GCol::TOOLBAR).name()).arg(GInvertColor(GCol::TOOLBAR).name()));
 
     // perspective selector mimics sidebar colors
     QColor selected;
-    if (GCColor::invertColor(GColor(CTOOLBAR)) == Qt::white) selected = QColor(Qt::lightGray);
+    if (GInvertColor(GColor(GCol::TOOLBAR)) == Qt::white) selected = QColor(Qt::lightGray);
     else selected = QColor(Qt::darkGray);
     perspectiveSelector->setStyleSheet(QString("QComboBox { background: %1; color: %2; }"
                                                "QComboBox::item { background: %1; color: %2; }"
-                                               "QComboBox::item::selected { background: %3; color: %1; }").arg(GColor(CTOOLBAR).name()).arg(GCColor::invertColor(GColor(CTOOLBAR)).name()).arg(selected.name()));
+                                               "QComboBox::item::selected { background: %3; color: %1; }").arg(GColor(GCol::TOOLBAR).name()).arg(GInvertColor(GCol::TOOLBAR).name()).arg(selected.name()));
 
     QString buttonstyle = QString("QPushButton { border: none; border-radius: %2px; background-color: %1; "
                                                 "padding-left: 0px; padding-right: 0px; "
                                                 "padding-top:  0px; padding-bottom: 0px; }"
                                   "QPushButton:hover { background-color: %3; }"
                                   "QPushButton:hover:pressed { background-color: %3; }"
-                                ).arg(GColor(CTOOLBAR).name()).arg(3 * dpiXFactor).arg(GColor(CHOVER).name());
+                                ).arg(GColor(GCol::TOOLBAR).name()).arg(3 * dpiXFactor).arg(GColor(GCol::HOVER).name());
 
     back->setStyleSheet(buttonstyle);
     forward->setStyleSheet(buttonstyle);
@@ -2557,12 +2557,12 @@ MainWindow::configChanged(qint32)
     tabbar->setDrawBase(false);
 
     // on select
-    QColor bg_select = GCColor::selectedColor(GColor(CTOOLBAR));
-    QColor fg_select = GCColor::invertColor(bg_select);
+    QColor bg_select = GSelectedColor(GColor(GCol::TOOLBAR));
+    QColor fg_select = GInvertColor(bg_select);
 
     tabbar->setStyleSheet(QString("QTabBar::tab { background-color: %1; color: %2;}"
-        "QTabBar::tab::selected { background-color: %3; color: %4; }").arg(GColor(CTOOLBAR).name())
-                                                                        .arg(GCColor::invertColor(GColor(CTOOLBAR)).name())
+        "QTabBar::tab::selected { background-color: %3; color: %4; }").arg(GColor(GCol::TOOLBAR).name())
+                                                                        .arg(GInvertColor(GCol::TOOLBAR).name())
                                                                         .arg(bg_select.name())
                                                                         .arg(fg_select.name()));
     tabbar->setDocumentMode(true);

--- a/src/Gui/NewSideBar.cpp
+++ b/src/Gui/NewSideBar.cpp
@@ -124,7 +124,7 @@ NewSideBar::configChanged(qint32)
     QFontMetrics fm(font);
     top->setFixedHeight(fm.height() + 16); // no scaling...
     bottom->setFixedHeight(22 * dpiXFactor);
-    QColor col=GColor(CCHROME);
+    QColor col=GColor(GCol::CHROME);
     QString style=QString("QWidget { background: rgb(%1,%2,%3); }").arg(col.red()).arg(col.green()).arg(col.blue());
     top->setStyleSheet(style);
     bottom->setStyleSheet(style);
@@ -219,12 +219,12 @@ void
 NewSideBarItem::configChanged(qint32)
 {
     // set background colors
-    bg_normal = GColor(CCHROME);
+    bg_normal = GColor(GCol::CHROME);
     QString style = QString("QWidget { background: rgb(%1,%2,%3); }").arg(bg_normal.red()).arg(bg_normal.green()).arg(bg_normal.blue());
     setStyleSheet(style);
 
     // set foreground colors
-    fg_normal = GCColor::invertColor(GColor(CCHROME));
+    fg_normal = GInvertColor(GCol::CHROME);
 
     // if foreground is white then we're "dark" if its
     // black the we're "light" so this controls palette
@@ -234,11 +234,11 @@ NewSideBarItem::configChanged(qint32)
     else fg_disabled = QColor(180,180,180);
 
     // on select
-    bg_select = GCColor::selectedColor(bg_normal);
-    fg_select = GCColor::invertColor(bg_select);
+    bg_select = GSelectedColor(bg_normal);
+    fg_select = GInvertColor(bg_select);
 
     // on hover
-    bg_hover =GColor(CHOVER);
+    bg_hover =GColor(GCol::HOVER);
 
     iconNormal = QPixmap::fromImage(imageRGB(icon, fg_normal), Qt::ColorOnly|Qt::PreferDither|Qt::DiffuseAlphaDither);
     iconNormal = iconNormal.scaled(24*dpiXFactor, 24*dpiXFactor, Qt::IgnoreAspectRatio, Qt::SmoothTransformation);
@@ -265,7 +265,7 @@ NewSideBarItem::paintEvent(QPaintEvent *)
     else painter.drawPixmap(27*dpiXFactor,6*dpiXFactor,24*dpiXFactor,24*dpiXFactor,iconDisabled);
 
     // block
-    if (selected) painter.fillRect(QRectF(0,0,3*dpiXFactor,gl_itemheight*dpiXFactor), QBrush(GColor(CPLOTMARKER)));
+    if (selected) painter.fillRect(QRectF(0,0,3*dpiXFactor,gl_itemheight*dpiXFactor), QBrush(GColor(GCol::PLOTMARKER)));
 
     // draw name
     QPen pen(fg_normal);

--- a/src/Gui/Pages.h
+++ b/src/Gui/Pages.h
@@ -479,7 +479,6 @@ class ColorsPage : public QWidget
         QLineEdit *searchEdit;
         QTreeWidget *colors;
         QTreeWidget *themes;
-        const Colors *colorSet;
         QPushButton *applyTheme;
 
         struct {

--- a/src/Gui/Perspective.cpp
+++ b/src/Gui/Perspective.cpp
@@ -123,7 +123,7 @@ Perspective::Perspective(Context *context, QString title, int type) :
 
     QPalette palette;
     //palette.setBrush(backgroundRole(), QColor("#B3B4B6"));
-    palette.setBrush(backgroundRole(), type == VIEW_TRAIN ? GColor(CTRAINPLOTBACKGROUND) : GColor(CPLOTBACKGROUND));
+    palette.setBrush(backgroundRole(), type == VIEW_TRAIN ? GColor(GCol::TRAINPLOTBACKGROUND) : GColor(GCol::PLOTBACKGROUND));
     setAutoFillBackground(false);
 
     // each style has its own container widget
@@ -328,7 +328,7 @@ Perspective::configChanged(qint32)
     tileArea->verticalScrollBar()->setStyleSheet(AbstractView::ourStyleSheet());
 //#endif
     QPalette palette;
-    palette.setBrush(backgroundRole(), type() == VIEW_TRAIN ? GColor(CTRAINPLOTBACKGROUND) : GColor(CPLOTBACKGROUND));
+    palette.setBrush(backgroundRole(), type() == VIEW_TRAIN ? GColor(GCol::TRAINPLOTBACKGROUND) : GColor(GCol::PLOTBACKGROUND));
     setPalette(palette);
     tileWidget->setPalette(palette);
     tileArea->setPalette(palette);
@@ -338,11 +338,11 @@ Perspective::configChanged(qint32)
     // basic chart setup
     for (int i=0; i<charts.count(); i++) {
         if (currentStyle == 0) {
-            if (charts[i]->type() == GcWindowTypes::Overview || charts[i]->type() == GcWindowTypes::OverviewTrends) chartbar->setColor(i, GColor(COVERVIEWBACKGROUND));
-            else if (charts[i]->type() == GcWindowTypes::UserAnalysis || charts[i]->type() == GcWindowTypes::UserTrends) chartbar->setColor(i, RGBColor(QColor(charts[i]->property("color").toString())));
+            if (charts[i]->type() == GcWindowTypes::Overview || charts[i]->type() == GcWindowTypes::OverviewTrends) chartbar->setColor(i, GColor(GCol::OVERVIEWBACKGROUND));
+            else if (charts[i]->type() == GcWindowTypes::UserAnalysis || charts[i]->type() == GcWindowTypes::UserTrends) chartbar->setColor(i, GRGBColorToQColor(QColor(charts[i]->property("color").toString())));
             else {
-                if (type() == VIEW_TRAIN)chartbar->setColor(i, GColor(CTRAINPLOTBACKGROUND));
-                else chartbar->setColor(i, GColor(CPLOTBACKGROUND));
+                if (type() == VIEW_TRAIN)chartbar->setColor(i, GColor(GCol::TRAINPLOTBACKGROUND));
+                else chartbar->setColor(i, GColor(GCol::PLOTBACKGROUND));
             }
         }
 
@@ -396,7 +396,7 @@ Perspective::userChartConfigChanged(UserChartWindow *chart)
         // let chartbar know...
         for(int index=0; index < charts.count(); index++) {
             if (charts[index] == (GcChartWindow*)(chart)) {
-                chartbar->setColor(index, RGBColor(QColor(charts[index]->property("color").toString())));
+                chartbar->setColor(index, GRGBColorToQColor(QColor(charts[index]->property("color").toString())));
                 return;
             }
         }
@@ -743,10 +743,10 @@ Perspective::addChart(GcChartWindow* newone)
             chartbar->addWidget(newone->property("title").toString());
 
             // tab colors
-            if (newone->type() == GcWindowTypes::Overview || newone->type() == GcWindowTypes::OverviewTrends) chartbar->setColor(chartnum, GColor(COVERVIEWBACKGROUND));
+            if (newone->type() == GcWindowTypes::Overview || newone->type() == GcWindowTypes::OverviewTrends) chartbar->setColor(chartnum, GColor(GCol::OVERVIEWBACKGROUND));
             else {
-                if (type() == VIEW_TRAIN)chartbar->setColor(chartnum, GColor(CTRAINPLOTBACKGROUND));
-                else chartbar->setColor(chartnum, GColor(CPLOTBACKGROUND));
+                if (type() == VIEW_TRAIN)chartbar->setColor(chartnum, GColor(GCol::TRAINPLOTBACKGROUND));
+                else chartbar->setColor(chartnum, GColor(GCol::PLOTBACKGROUND));
             }
 
             // lets not bother with a title in tab view- its in the name of the tab already!

--- a/src/Gui/RideNavigator.cpp
+++ b/src/Gui/RideNavigator.cpp
@@ -188,8 +188,8 @@ RideNavigator::configChanged(qint32 state)
         QString("QHeaderView { background-color: %1; color: %2; }"
                 "QHeaderView::section { background-color: %1; color: %2; "
                 " border: 0px ; }")
-                .arg(GColor(CPLOTBACKGROUND).name())
-                .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name()));
+                .arg(GColor(GCol::PLOTBACKGROUND).name())
+                .arg(GInvertColor(GCol::PLOTBACKGROUND).name()));
     }
 
 #endif
@@ -1151,11 +1151,11 @@ void NavigatorCellDelegate::paint(QPainter *painter, const QStyleOptionViewItem 
     if (userColor == QColor(1,1,1)) {
         rideBG = false; // default so don't swap round...
         isnormal = true; // just default so no bg or box
-        userColor = GColor(CPLOTMARKER);
+        userColor = GColor(GCol::PLOTMARKER);
     }
 
     // basic background
-    QBrush background = QBrush(GColor(CPLOTBACKGROUND));
+    QBrush background = QBrush(GColor(GCol::PLOTBACKGROUND));
 
     // runs are darker
     //if (isRun) {
@@ -1177,7 +1177,7 @@ void NavigatorCellDelegate::paint(QPainter *painter, const QStyleOptionViewItem 
         // draw border of each cell
         QPen rpen;
         rpen.setWidth(1);
-        rpen.setColor(GColor(CPLOTBACKGROUND));
+        rpen.setColor(GColor(GCol::PLOTBACKGROUND));
         QPen isColor = painter->pen();
         QFont isFont = painter->font();
         painter->setPen(rpen);
@@ -1234,7 +1234,7 @@ void NavigatorCellDelegate::paint(QPainter *painter, const QStyleOptionViewItem 
             if (!selected) {
                 // not selected, so invert ride plot color
                 if (hover) painter->setPen(QPen(Qt::black));
-                else painter->setPen(rideBG ? rideNavigator->reverseColor : GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+                else painter->setPen(rideBG ? rideNavigator->reverseColor : GInvertColor(GCol::PLOTBACKGROUND));
             }
             painter->drawText(myOption.rect, Qt::AlignLeft | Qt::TextWordWrap, calendarText);
             painter->setPen(isColor);
@@ -1250,7 +1250,7 @@ void NavigatorCellDelegate::paint(QPainter *painter, const QStyleOptionViewItem 
                 // border
                 QPen rpen;
                 rpen.setWidth(1);
-                rpen.setColor(GColor(CPLOTBACKGROUND));
+                rpen.setColor(GColor(GCol::PLOTBACKGROUND));
                 QPen isColor = painter->pen();
                 QFont isFont = painter->font();
                 painter->setPen(rpen);
@@ -1266,11 +1266,11 @@ void NavigatorCellDelegate::paint(QPainter *painter, const QStyleOptionViewItem 
             myOption.rect.setX(0);
             myOption.rect.setHeight(rideNavigator->fontHeight + 2);
             myOption.rect.setWidth(rideNavigator->pwidth);
-            painter->fillRect(myOption.rect, GColor(CPLOTBACKGROUND));
+            painter->fillRect(myOption.rect, GColor(GCol::PLOTBACKGROUND));
         }
         QPen isColor = painter->pen();
-        painter->setPen(QPen(GColor(CPLOTMARKER)));
-        myOption.palette.setColor(QPalette::WindowText, QColor(GColor(CPLOTMARKER))); //XXX
+        painter->setPen(QPen(GColor(GCol::PLOTMARKER)));
+        myOption.palette.setColor(QPalette::WindowText, QColor(GColor(GCol::PLOTMARKER))); //XXX
         painter->drawText(myOption.rect, value);
         painter->setPen(isColor);
     }

--- a/src/Gui/RideNavigatorProxy.h
+++ b/src/Gui/RideNavigatorProxy.h
@@ -315,12 +315,12 @@ public:
                     // hideous code, sorry
                     int groupNo = ((QModelIndex*)proxyIndex.internalPointer())->row();
                     if (groupNo < 0 || groupNo >= groups.count() || proxyIndex.column() == 0)
-                        colorstring= GColor(CPLOTMARKER).name();
+                        colorstring= GColor(GCol::PLOTMARKER).name();
                     else colorstring = sourceModel()->data(sourceModel()->index(groupToSourceRow.value(groups[groupNo])->at(proxyIndex.row()), colorColumn)).toString();
 
                     returning = QColor(colorstring);
                 } else {
-                    returning = GColor(CPLOTMARKER).name();
+                    returning = GColor(GCol::PLOTMARKER).name();
                 }
 
             } else if (role == (Qt::UserRole+1)) { // FILENAME ?

--- a/src/Gui/SplitActivityWizard.cpp
+++ b/src/Gui/SplitActivityWizard.cpp
@@ -636,7 +636,7 @@ SplitSelect::refreshMarkers()
             // vertical line will do for now
             add->setLineStyle(QwtPlotMarker::VLine);
             add->setLabelAlignment(Qt::AlignRight | Qt::AlignTop);
-            add->setLinePen(QPen(GColor(CPLOTMARKER), 0, Qt::DashDotLine));
+            add->setLinePen(QPen(GColor(GCol::PLOTMARKER), 0, Qt::DashDotLine));
             add->setValue(point / 60.0, 0.0);
             add->attach(wizard->smallPlot);
         }
@@ -654,7 +654,7 @@ SplitSelect::refreshMarkers()
             // vertical line will do for now
             add->setLineStyle(QwtPlotMarker::VLine);
             add->setLabelAlignment(Qt::AlignRight | Qt::AlignTop);
-            add->setLinePen(QPen(GColor(CPLOTMARKER), 0, Qt::DashDotLine));
+            add->setLinePen(QPen(GColor(GCol::PLOTMARKER), 0, Qt::DashDotLine));
             add->setValue(point / 60.0, 0.0);
             add->attach(wizard->smallPlot);
         }

--- a/src/Metrics/ExtendedCriticalPower.cpp
+++ b/src/Metrics/ExtendedCriticalPower.cpp
@@ -278,7 +278,7 @@ ExtendedCriticalPower::getPlotCurveForExtendedCP_2_3(TestModel model)
     QwtPlotCurve *extendedCPCurve2 = new QwtPlotCurve("eCP");
     if (appsettings->value(NULL, GC_ANTIALIAS, true).toBool() == true)
         extendedCPCurve2->setRenderHint(QwtPlotItem::RenderAntialiased);
-    QPen e2pen(GColor(CHEARTRATE));
+    QPen e2pen(GColor(GCol::HEARTRATE));
     e2pen.setWidth(1);
     e2pen.setStyle(Qt::DashLine);
     extendedCPCurve2->setPen(e2pen);
@@ -693,7 +693,7 @@ ExtendedCriticalPower::getPlotLevelForExtendedCP_4_3(TestModel model)
     QwtPlotCurve *extendedCPCurve2 = new QwtPlotCurve("eCP2");
     if (appsettings->value(NULL, GC_ANTIALIAS, true).toBool() == true)
         extendedCPCurve2->setRenderHint(QwtPlotItem::RenderAntialiased);
-    QPen e2pen(GColor(CCP));
+    QPen e2pen(GColor(GCol::CP));
     e2pen.setWidth(1);
     e2pen.setStyle(Qt::NoPen);
     extendedCPCurve2->setPen(e2pen);
@@ -718,7 +718,7 @@ ExtendedCriticalPower::getPlotMarkerForExtendedCP(TestModel model)
 
     extendedCurve2_title.asprintf("CP=%.0f W, MMP60=%.0d W, Pmax=%.0d W, W'=%.0f kJ (%s)", model.ecp, model.mmp60, model.pMax, model.etau*model.ecp* 60.0 / 1000.0, model.version.toLatin1().constData());
     QwtText text(extendedCurve2_title, QwtText::PlainText);
-    text.setColor(GColor(CPLOTMARKER));
+    text.setColor(GColor(GCol::PLOTMARKER));
     extendedCurveTitle2->setLabel(text);
 
     return extendedCurveTitle2;
@@ -744,7 +744,7 @@ ExtendedCriticalPower::getPlotCurveForExtendedCP_4_3_WSecond(TestModel model)
     QwtPlotCurve *extendedCPCurve2 = new QwtPlotCurve("eCP_4_3_WSecond");
     if (appsettings->value(NULL, GC_ANTIALIAS, true).toBool() == true)
         extendedCPCurve2->setRenderHint(QwtPlotItem::RenderAntialiased);
-    QPen e2pen(GColor(CCADENCE));
+    QPen e2pen(GColor(GCol::CADENCE));
     e2pen.setWidth(1);
     e2pen.setStyle(Qt::DashLine);
     extendedCPCurve2->setPen(e2pen);
@@ -773,7 +773,7 @@ ExtendedCriticalPower::getPlotCurveForExtendedCP_4_3_WPrime(TestModel model)
     QwtPlotCurve *extendedCPCurve2 = new QwtPlotCurve("eCP_4_3_WPrime");
     if (appsettings->value(NULL, GC_ANTIALIAS, true).toBool() == true)
         extendedCPCurve2->setRenderHint(QwtPlotItem::RenderAntialiased);
-    QPen e2pen(GColor(CPOWER));
+    QPen e2pen(GColor(GCol::POWER));
     e2pen.setWidth(1);
     e2pen.setStyle(Qt::DashLine);
     extendedCPCurve2->setPen(e2pen);
@@ -802,7 +802,7 @@ ExtendedCriticalPower::getPlotCurveForExtendedCP_4_3_CP(TestModel model)
     QwtPlotCurve *extendedCPCurve2 = new QwtPlotCurve("eCP_4_3_CP");
     if (appsettings->value(NULL, GC_ANTIALIAS, true).toBool() == true)
         extendedCPCurve2->setRenderHint(QwtPlotItem::RenderAntialiased);
-    QPen e2pen(GColor(CHEARTRATE));
+    QPen e2pen(GColor(GCol::HEARTRATE));
     e2pen.setWidth(1);
     e2pen.setStyle(Qt::DashLine);
     extendedCPCurve2->setPen(e2pen);
@@ -833,7 +833,7 @@ ExtendedCriticalPower::getPlotCurveForExtendedCP_4_3_WPrime_CP(TestModel model)
     QwtPlotCurve *extendedCPCurve2 = new QwtPlotCurve("eCP_4_3_WPrime_CP");
     if (appsettings->value(NULL, GC_ANTIALIAS, true).toBool() == true)
         extendedCPCurve2->setRenderHint(QwtPlotItem::RenderAntialiased);
-    QPen e2pen(GColor(CCP));
+    QPen e2pen(GColor(GCol::CP));
     e2pen.setWidth(1);
     e2pen.setStyle(Qt::DashLine);
     extendedCPCurve2->setPen(e2pen);
@@ -1187,7 +1187,7 @@ ExtendedCriticalPower::getPlotCurveForExtendedCP_5_3(TestModel model)
     QwtPlotCurve *extendedCPCurve2 = new QwtPlotCurve("eCP_5_3");
     if (appsettings->value(NULL, GC_ANTIALIAS, true).toBool() == true)
         extendedCPCurve2->setRenderHint(QwtPlotItem::RenderAntialiased);
-    QPen e2pen(Qt::cyan); // Qt::cyan GColor(CCP)
+    QPen e2pen(Qt::cyan); // Qt::cyan GColor(GCol::CP)
     e2pen.setWidth(1);
     e2pen.setStyle(Qt::DashLine);
     extendedCPCurve2->setPen(e2pen);
@@ -1216,7 +1216,7 @@ ExtendedCriticalPower::getPlotLevelForExtendedCP_5_3(TestModel model)
     QwtPlotCurve *extendedCPCurve2 = new QwtPlotCurve("level_eCP_5_3");
     if (appsettings->value(NULL, GC_ANTIALIAS, true).toBool() == true)
         extendedCPCurve2->setRenderHint(QwtPlotItem::RenderAntialiased);
-    QPen e2pen(GColor(Qt::lightGray)); // Qt::cyan
+    QPen e2pen(GColor(GCol::RIDEPLOTYAXIS));
     e2pen.setWidth(1);
     e2pen.setStyle(Qt::SolidLine);
     extendedCPCurve2->setPen(e2pen);
@@ -1251,12 +1251,12 @@ ExtendedCriticalPower::getPlotCurveForExtendedCP_5_3_WSecond(TestModel model, bo
     if (appsettings->value(NULL, GC_ANTIALIAS, true).toBool() == true)
         extendedCPCurve->setRenderHint(QwtPlotItem::RenderAntialiased);
 
-    QPen e2pen(GColor(CCADENCE));
+    QPen e2pen(GColor(GCol::CADENCE));
     e2pen.setWidth(1);
     e2pen.setStyle(Qt::DashLine);
     extendedCPCurve->setPen(e2pen);
 
-    QColor color1 = GColor(CCADENCE);
+    QColor color1 = GColor(GCol::CADENCE);
     color1.setAlpha(64);
     QColor color2 = color1.darker();
     QLinearGradient linearGradient(0, 0, 0, model.paa);
@@ -1295,12 +1295,12 @@ ExtendedCriticalPower::getPlotCurveForExtendedCP_5_3_WPrime(TestModel model, boo
     if (appsettings->value(NULL, GC_ANTIALIAS, true).toBool() == true)
         extendedCPCurve->setRenderHint(QwtPlotItem::RenderAntialiased);
 
-    QPen e2pen(GColor(CPOWER));
+    QPen e2pen(GColor(GCol::POWER));
     e2pen.setWidth(1);
     e2pen.setStyle(Qt::DashLine);
     extendedCPCurve->setPen(e2pen);
 
-    QColor color1 = GColor(CPOWER);
+    QColor color1 = GColor(GCol::POWER);
     color1.setAlpha(64);
     QColor color2 = color1.darker();
     QLinearGradient linearGradient(0, 0, 0, model.ecp);
@@ -1340,12 +1340,12 @@ ExtendedCriticalPower::getPlotCurveForExtendedCP_5_3_CP(TestModel model, bool st
     if (appsettings->value(NULL, GC_ANTIALIAS, true).toBool() == true)
         extendedCPCurve->setRenderHint(QwtPlotItem::RenderAntialiased);
 
-    QPen e2pen(GColor(CHEARTRATE));
+    QPen e2pen(GColor(GCol::HEARTRATE));
     e2pen.setWidth(1);
     e2pen.setStyle(Qt::DashLine);
     extendedCPCurve->setPen(e2pen);
 
-    QColor color1 = GColor(CHEARTRATE);
+    QColor color1 = GColor(GCol::HEARTRATE);
     color1.setAlpha(64);
     QColor color2 = color1.darker();
     QLinearGradient linearGradient(0, 0, 0, 1.1*model.ecp);
@@ -1668,12 +1668,12 @@ ExtendedCriticalPower::getPlotCurveForExtendedCP_6_3_WSecond(TestModel model, bo
     if (appsettings->value(NULL, GC_ANTIALIAS, true).toBool() == true)
         extendedCPCurve2->setRenderHint(QwtPlotItem::RenderAntialiased);
 
-    QPen e2pen(GColor(CCADENCE));
+    QPen e2pen(GColor(GCol::CADENCE));
     e2pen.setWidth(1);
     e2pen.setStyle(Qt::DashLine);
     extendedCPCurve2->setPen(e2pen);
 
-    QColor color1 = GColor(CCADENCE);
+    QColor color1 = GColor(GCol::CADENCE);
     color1.setAlpha(64);
     QColor color2 = color1.darker();
     QLinearGradient linearGradient(0, 0, 0, 100);
@@ -1710,12 +1710,12 @@ ExtendedCriticalPower::getPlotCurveForExtendedCP_6_3_WPrime(TestModel model, boo
     if (appsettings->value(NULL, GC_ANTIALIAS, true).toBool() == true)
         extendedCPCurve2->setRenderHint(QwtPlotItem::RenderAntialiased);
 
-    QPen e2pen(GColor(CPOWER));
+    QPen e2pen(GColor(GCol::POWER));
     e2pen.setWidth(1);
     e2pen.setStyle(Qt::DashLine);
     extendedCPCurve2->setPen(e2pen);
 
-    QColor color1 = GColor(CPOWER);
+    QColor color1 = GColor(GCol::POWER);
     color1.setAlpha(64);
     QColor color2 = color1.darker();
     QLinearGradient linearGradient(0, 0, 0, model.ecp);
@@ -1753,12 +1753,12 @@ ExtendedCriticalPower::getPlotCurveForExtendedCP_6_3_CP(TestModel model, bool st
     if (appsettings->value(NULL, GC_ANTIALIAS, true).toBool() == true)
         extendedCPCurve2->setRenderHint(QwtPlotItem::RenderAntialiased);
 
-    QPen e2pen(GColor(CHEARTRATE));
+    QPen e2pen(GColor(GCol::HEARTRATE));
     e2pen.setWidth(1);
     e2pen.setStyle(Qt::DashLine);
     extendedCPCurve2->setPen(e2pen);
 
-    QColor color1 = GColor(CHEARTRATE);
+    QColor color1 = GColor(GCol::HEARTRATE);
     color1.setAlpha(64);
     QColor color2 = color1.darker();
     QLinearGradient linearGradient(0, 0, 0, 1.1*model.ecp);
@@ -2318,7 +2318,7 @@ ExtendedCriticalPower::getPlotCurveForExtendedCP_7_3(TestModel model)
     QwtPlotCurve *extendedCPCurve2 = new QwtPlotCurve("eCP_7_3");
     if (appsettings->value(NULL, GC_ANTIALIAS, true).toBool() == true)
         extendedCPCurve2->setRenderHint(QwtPlotItem::RenderAntialiased);
-    QPen e2pen(Qt::yellow); // Qt::cyan GColor(CCP)
+    QPen e2pen(Qt::yellow); // Qt::cyan GColor(GCol::CP)
     e2pen.setWidth(1);
     e2pen.setStyle(Qt::DashLine);
     extendedCPCurve2->setPen(e2pen);
@@ -2353,7 +2353,7 @@ ExtendedCriticalPower::getPlotCurveForExtendedCP_7_3_balance(TestModel model, in
     QwtPlotCurve *extendedCPCurve2 = new QwtPlotCurve(QString("eCP_7_3 (%1%)").arg(depletion));
     if (appsettings->value(NULL, GC_ANTIALIAS, true).toBool() == true)
         extendedCPCurve2->setRenderHint(QwtPlotItem::RenderAntialiased);
-    QPen e2pen(Qt::yellow); // Qt::cyan GColor(CCP)
+    QPen e2pen(Qt::yellow); // Qt::cyan GColor(GCol::CP)
     e2pen.setWidth(1);
     e2pen.setStyle(Qt::DashDotDotLine);
     extendedCPCurve2->setPen(e2pen);

--- a/src/Metrics/HrZones.cpp
+++ b/src/Metrics/HrZones.cpp
@@ -828,16 +828,16 @@ int HrZones::getRangeSize() const
 QColor hrZoneColor(int z, int) {
     switch(z) {
 
-    case 0  : return GColor(CHZONE1); break;
-    case 1  : return GColor(CHZONE2); break;
-    case 2  : return GColor(CHZONE3); break;
-    case 3  : return GColor(CHZONE4); break;
-    case 4  : return GColor(CHZONE5); break;
-    case 5  : return GColor(CHZONE6); break;
-    case 6  : return GColor(CHZONE7); break;
-    case 7  : return GColor(CHZONE8); break;
-    case 8  : return GColor(CHZONE9); break;
-    case 9  : return GColor(CHZONE10); break;
+    case 0  : return GColor(GCol::HZONE1); break;
+    case 1  : return GColor(GCol::HZONE2); break;
+    case 2  : return GColor(GCol::HZONE3); break;
+    case 3  : return GColor(GCol::HZONE4); break;
+    case 4  : return GColor(GCol::HZONE5); break;
+    case 5  : return GColor(GCol::HZONE6); break;
+    case 6  : return GColor(GCol::HZONE7); break;
+    case 7  : return GColor(GCol::HZONE8); break;
+    case 8  : return GColor(GCol::HZONE9); break;
+    case 9  : return GColor(GCol::HZONE10); break;
     default: return QColor(128,128,128); break;
     }
 }

--- a/src/Metrics/PaceZones.cpp
+++ b/src/Metrics/PaceZones.cpp
@@ -948,16 +948,16 @@ int PaceZones::getRangeSize() const
 QColor paceZoneColor(int z, int) {
 
     switch(z) {
-    case 0: return GColor(CZONE1); break;
-    case 1: return GColor(CZONE2); break;
-    case 2: return GColor(CZONE3); break;
-    case 3: return GColor(CZONE4); break;
-    case 4: return GColor(CZONE5); break;
-    case 5: return GColor(CZONE6); break;
-    case 6: return GColor(CZONE7); break;
-    case 7: return GColor(CZONE8); break;
-    case 8: return GColor(CZONE9); break;
-    case 9: return GColor(CZONE10); break;
+    case 0: return GColor(GCol::ZONE1); break;
+    case 1: return GColor(GCol::ZONE2); break;
+    case 2: return GColor(GCol::ZONE3); break;
+    case 3: return GColor(GCol::ZONE4); break;
+    case 4: return GColor(GCol::ZONE5); break;
+    case 5: return GColor(GCol::ZONE6); break;
+    case 6: return GColor(GCol::ZONE7); break;
+    case 7: return GColor(GCol::ZONE8); break;
+    case 8: return GColor(GCol::ZONE9); break;
+    case 9: return GColor(GCol::ZONE10); break;
     default: return QColor(128,128,128); break;
     }
 }

--- a/src/Metrics/RideMetadata.cpp
+++ b/src/Metrics/RideMetadata.cpp
@@ -412,24 +412,24 @@ RideMetadata::configChanged(qint32)
     }
 
     if (context) { // global doesn't have all the widgets etc
-        setProperty("color", GColor(CPLOTBACKGROUND));
+        setProperty("color", GColor(GCol::PLOTBACKGROUND));
 
         palette = QPalette();
 
-        palette.setColor(QPalette::Window, GColor(CPLOTBACKGROUND));
+        palette.setColor(QPalette::Window, GColor(GCol::PLOTBACKGROUND));
 
         // only change base if moved away from white plots
         // which is a Mac thing
 #ifndef Q_OS_MAC
-        if (GColor(CPLOTBACKGROUND) != Qt::white)
+        if (GColor(GCol::PLOTBACKGROUND) != Qt::white)
 #endif
         {
-            palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CPLOTBACKGROUND)));
-            palette.setColor(QPalette::Window,  GColor(CPLOTBACKGROUND));
+            palette.setColor(QPalette::Base, GAlternateColor(GCol::PLOTBACKGROUND));
+            palette.setColor(QPalette::Window,  GColor(GCol::PLOTBACKGROUND));
         }
 
-        palette.setColor(QPalette::WindowText, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
-        palette.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
+        palette.setColor(QPalette::WindowText, GInvertColor(GCol::PLOTBACKGROUND));
+        palette.setColor(QPalette::Text, GInvertColor(GCol::PLOTBACKGROUND));
         setPalette(palette);
         tabs->setPalette(palette);
 
@@ -501,14 +501,14 @@ RideMetadata::configChanged(qint32)
                               "               border-right: 0px;"
                               "               border-bottom: %3px solid %1; } "
                               "QTabBar::tab:selected { border-bottom-right-radius: 0px; border-bottom-left-radius: 0px; border-bottom-color: %2; }"
-                             ).arg(GColor(CPLOTBACKGROUND).name())                        // 1 tab background color
-                              .arg(GColor(CPLOTMARKER).name())                            // 2 selected bar color
+                             ).arg(GColor(GCol::PLOTBACKGROUND).name())                        // 1 tab background color
+                              .arg(GColor(GCol::PLOTMARKER).name())                            // 2 selected bar color
                               .arg(4*dpiYFactor)                                          // 3 selected bar width
                               .arg(2*dpiXFactor)                                          // 4 padding
                               .arg(75*dpiXFactor)                                         // 5 tab minimum width
-                              .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name())     // 6 tab text color
+                              .arg(GInvertColor(GCol::PLOTBACKGROUND).name())     // 6 tab text color
 #ifdef Q_OS_MAC
-                              .arg( GCColor::alternateColor(GColor(CPLOTBACKGROUND)).name()) // 7 lineedit background
+                              .arg( GAlternateColor(GCol::PLOTBACKGROUND).name()) // 7 lineedit background
 #endif
                             ;
         tabs->setStyleSheet(styling);
@@ -519,7 +519,7 @@ RideMetadata::configChanged(qint32)
                                                     "padding-top:  0px; padding-bottom: 0px; }"
                                       "QPushButton:hover { background-color: %3; }"
                                       "QPushButton:hover:pressed { background-color: %3; }"
-                                    ).arg(GColor(CPLOTBACKGROUND).name()).arg(3 * dpiXFactor).arg(GColor(CHOVER).name());
+                                    ).arg(GColor(GCol::PLOTBACKGROUND).name()).arg(3 * dpiXFactor).arg(GColor(GCol::HOVER).name());
 
         QFont df;
         QFontMetrics fm(df);

--- a/src/Metrics/Zones.cpp
+++ b/src/Metrics/Zones.cpp
@@ -992,16 +992,16 @@ int Zones::getRangeSize() const
 QColor zoneColor(int z, int) {
 
     switch(z) {
-    case 0: return GColor(CZONE1); break;
-    case 1: return GColor(CZONE2); break;
-    case 2: return GColor(CZONE3); break;
-    case 3: return GColor(CZONE4); break;
-    case 4: return GColor(CZONE5); break;
-    case 5: return GColor(CZONE6); break;
-    case 6: return GColor(CZONE7); break;
-    case 7: return GColor(CZONE8); break;
-    case 8: return GColor(CZONE9); break;
-    case 9: return GColor(CZONE10); break;
+    case 0: return GColor(GCol::ZONE1); break;
+    case 1: return GColor(GCol::ZONE2); break;
+    case 2: return GColor(GCol::ZONE3); break;
+    case 3: return GColor(GCol::ZONE4); break;
+    case 4: return GColor(GCol::ZONE5); break;
+    case 5: return GColor(GCol::ZONE6); break;
+    case 6: return GColor(GCol::ZONE7); break;
+    case 7: return GColor(GCol::ZONE8); break;
+    case 8: return GColor(GCol::ZONE9); break;
+    case 9: return GColor(GCol::ZONE10); break;
     default: return QColor(128,128,128,128); break;
     }
 }

--- a/src/Planning/PlanningWindow.cpp
+++ b/src/Planning/PlanningWindow.cpp
@@ -23,7 +23,7 @@ PlanningWindow::PlanningWindow(Context *context) :
     GcChartWindow(context), context(context)
 {
     setContentsMargins(0,0,0,0);
-    setProperty("color", GColor(CTRENDPLOTBACKGROUND));
+    setProperty("color", GColor(GCol::TRENDPLOTBACKGROUND));
 
     setControls(NULL);
 
@@ -45,29 +45,29 @@ PlanningWindow::resizeEvent(QResizeEvent *)
 void
 PlanningWindow::configChanged(qint32)
 {
-    setProperty("color", GColor(CTRENDPLOTBACKGROUND));
+    setProperty("color", GColor(GCol::TRENDPLOTBACKGROUND));
 
     // text edit colors
     QPalette palette;
-    palette.setColor(QPalette::Window, GColor(CTRAINPLOTBACKGROUND));
+    palette.setColor(QPalette::Window, GColor(GCol::TRAINPLOTBACKGROUND));
 
     // only change base if moved away from white plots
     // which is a Mac thing
 #ifndef Q_OS_MAC
-    if (GColor(CTRENDPLOTBACKGROUND) != Qt::white)
+    if (GColor(GCol::TRENDPLOTBACKGROUND) != Qt::white)
 #endif
     {
-        //palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CTRAINPLOTBACKGROUND)));
-        palette.setColor(QPalette::Base, GColor(CTRAINPLOTBACKGROUND));
-        palette.setColor(QPalette::Window, GColor(CTRAINPLOTBACKGROUND));
+        //palette.setColor(QPalette::Base, GAlternateColor(GCol::TRAINPLOTBACKGROUND));
+        palette.setColor(QPalette::Base, GColor(GCol::TRAINPLOTBACKGROUND));
+        palette.setColor(QPalette::Window, GColor(GCol::TRAINPLOTBACKGROUND));
     }
 
 #ifndef Q_OS_MAC // the scrollers appear when needed on Mac, we'll keep that
     //code->setStyleSheet(TabView::ourStyleSheet());
 #endif
 
-    palette.setColor(QPalette::WindowText, GCColor::invertColor(GColor(CTRAINPLOTBACKGROUND)));
-    palette.setColor(QPalette::Text, GCColor::invertColor(GColor(CTRAINPLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GInvertColor(GCol::TRAINPLOTBACKGROUND));
+    palette.setColor(QPalette::Text, GInvertColor(GCol::TRAINPLOTBACKGROUND));
     //code->setPalette(palette);
     repaint();
 }

--- a/src/Python/SIP/Bindings.cpp
+++ b/src/Python/SIP/Bindings.cpp
@@ -1020,7 +1020,7 @@ Bindings::activityMetrics(RideItem* item) const
     if (item->color == QColor(1,1,1,1)) {
 
         // use the inverted color, not plot marker as that hideous
-        QColor col =GCColor::invertColor(GColor(CPLOTBACKGROUND));
+        QColor col =GInvertColor(GCol::PLOTBACKGROUND);
 
         // white is jarring on a dark background!
         if (col==QColor(Qt::white)) col=QColor(127,127,127);
@@ -1157,7 +1157,7 @@ Bindings::seasonMetrics(bool all, DateRange range, QString filter) const
             if (ride->color == QColor(1,1,1,1)) {
 
                 // use the inverted color, not plot marker as that hideous
-                QColor col =GCColor::invertColor(GColor(CPLOTBACKGROUND));
+                QColor col =GInvertColor(GCol::PLOTBACKGROUND);
 
                 // white is jarring on a dark background!
                 if (col==QColor(Qt::white)) col=QColor(127,127,127);
@@ -1362,7 +1362,7 @@ Bindings::seasonIntervals(DateRange range, QString type) const
                     QString color;
                     if (item->color == QColor(1,1,1,1)) {
                         // use the inverted color, not plot marker as that hideous
-                        QColor col =GCColor::invertColor(GColor(CPLOTBACKGROUND));
+                        QColor col =GInvertColor(GCol::PLOTBACKGROUND);
                         // white is jarring on a dark background!
                         if (col==QColor(Qt::white)) col=QColor(127,127,127);
                         color = col.name();
@@ -1478,7 +1478,7 @@ Bindings::activityIntervals(QString type, PyObject* activity) const
             QString color;
             if (item->color == QColor(1,1,1,1)) {
                 // use the inverted color, not plot marker as that hideous
-                QColor col =GCColor::invertColor(GColor(CPLOTBACKGROUND));
+                QColor col =GInvertColor(GCol::PLOTBACKGROUND);
                 // white is jarring on a dark background!
                 if (col==QColor(Qt::white)) col=QColor(127,127,127);
                 color = col.name();

--- a/src/R/RGraphicsDevice.cpp
+++ b/src/R/RGraphicsDevice.cpp
@@ -538,8 +538,8 @@ void RGraphicsDevice::setDeviceAttributes(pDevDesc pDev)
     pDev->startfont = 1;
     pDev->startlty = 0;
 
-    QColor bg=GColor(CPLOTBACKGROUND);
-    QColor fg=GCColor::invertColor(GColor(CPLOTBACKGROUND));
+    QColor bg=GColor(GCol::PLOTBACKGROUND);
+    QColor fg=GInvertColor(GCol::PLOTBACKGROUND);
 
     pDev->startfill = R_RGB(bg.red(),bg.green(),bg.blue());
     pDev->startcol = R_RGB(fg.red(),fg.green(),fg.blue());

--- a/src/R/RTool.cpp
+++ b/src/R/RTool.cpp
@@ -424,9 +424,9 @@ RTool::configChanged()
                                "    col.lab=\"%3\", "
                                "    col.axis=\"%3\")\n"
                                "par.gc <- par()\n"
-                            ).arg(GColor(CPLOTBACKGROUND).name())
-                             .arg(GCColor::invertColor(GColor(CPLOTBACKGROUND)).name())
-                             .arg(GColor(CPLOTMARKER).name());
+                            ).arg(GColor(GCol::PLOTBACKGROUND).name())
+                             .arg(GInvertColor(GCol::PLOTBACKGROUND).name())
+                             .arg(GColor(GCol::PLOTMARKER).name());
 
     // fire and forget, don't care if it fails or not !!
     rtool->R->parseEvalNT(parCommand);
@@ -1095,7 +1095,7 @@ RTool::dfForRideItem(const RideItem *ri)
     if (item->color == QColor(1,1,1,1)) {
 
         // use the inverted color, not plot marker as that hideous
-        QColor col =GCColor::invertColor(GColor(CPLOTBACKGROUND));
+        QColor col = GInvertColor(GCol::PLOTBACKGROUND);
 
         // white is jarring on a dark background!
         if (col==QColor(Qt::white)) col=QColor(127,127,127);
@@ -1330,7 +1330,7 @@ RTool::dfForDateRange(bool all, DateRange range, SEXP filter)
             if (item->color == QColor(1,1,1,1)) {
 
                 // use the inverted color, not plot marker as that hideous
-                QColor col =GCColor::invertColor(GColor(CPLOTBACKGROUND));
+                QColor col = GInvertColor(GCol::PLOTBACKGROUND);
 
                 // white is jarring on a dark background!
                 if (col==QColor(Qt::white)) col=QColor(127,127,127);
@@ -1561,7 +1561,7 @@ RTool::dfForDateRangeIntervals(DateRange range, QStringList types)
             if (interval->color == QColor(1,1,1,1)) {
 
                 // use the inverted color, not plot marker as that hideous
-                QColor col =GCColor::invertColor(GColor(CPLOTBACKGROUND));
+                QColor col = GInvertColor(GCol::PLOTBACKGROUND);
 
                 // white is jarring on a dark background!
                 if (col==QColor(Qt::white)) col=QColor(127,127,127);
@@ -1989,7 +1989,7 @@ RTool::activityIntervals(SEXP pTypes, SEXP datetime)
         if (interval->color == QColor(1,1,1,1)) {
 
             // use the inverted color, not plot marker as that hideous
-            QColor col =GCColor::invertColor(GColor(CPLOTBACKGROUND));
+            QColor col = GInvertColor(GCol::PLOTBACKGROUND);
 
             // white is jarring on a dark background!
             if (col==QColor(Qt::white)) col=QColor(127,127,127);

--- a/src/Train/DialWindow.cpp
+++ b/src/Train/DialWindow.cpp
@@ -174,8 +174,8 @@ DialWindow::telemetryUpdate(const RealtimeData &rtData)
 
             // background for power, if we have a target load
             double load=rtData.getLoad();
-            QColor color = GColor(CTRAINPLOTBACKGROUND);
-            QColor foreground = GColor(CPOWER);
+            QColor color = GColor(GCol::TRAINPLOTBACKGROUND);
+            QColor foreground = GColor(GCol::POWER);
 
             if (displayValue < (load*0.95f) || displayValue > (load * 1.05)) {
                 color = displayValue < load ? QColor(Qt::blue) : QColor(Qt::red);
@@ -595,7 +595,7 @@ void DialWindow::seriesChanged()
     case RealtimeData::VI:
     case RealtimeData::SkibaVI:
     case RealtimeData::FeO2:
-        foreground = GColor(CFEO2);
+        foreground = GColor(GCol::FEO2);
         break;
             
     case RealtimeData::Distance:
@@ -607,43 +607,43 @@ void DialWindow::seriesChanged()
     case RealtimeData::LapDistanceRemaining:
     case RealtimeData::RER:
     case RealtimeData::None:
-            foreground = GColor(CDIAL);
+            foreground = GColor(GCol::DIAL);
             break;
 
     case RealtimeData::Rf:
-        foreground = GColor(CRESPFREQUENCY);
+        foreground = GColor(GCol::RESPFREQUENCY);
         break;
 
     case RealtimeData::RMV:
-        foreground = GColor(CVENTILATION);
+        foreground = GColor(GCol::VENTILATION);
         break;
 
     case RealtimeData::VO2:
-        foreground = GColor(CVO2);
+        foreground = GColor(GCol::VO2);
         break;
 
     case RealtimeData::VCO2:
-        foreground = GColor(CVCO2);
+        foreground = GColor(GCol::VCO2);
         break;
 
     case RealtimeData::TidalVolume:
-        foreground = GColor(CTIDALVOLUME);
+        foreground = GColor(GCol::TIDALVOLUME);
         break;
 
     case RealtimeData::Slope:  
-        foreground = GColor(CSLOPE);
+        foreground = GColor(GCol::SLOPE);
         break;
             
     case RealtimeData::Load:
-        foreground = GColor(CLOAD);
+        foreground = GColor(GCol::LOAD);
         break;
 
     case RealtimeData::BikeScore:
-            foreground = GColor(CBIKESCORE);
+            foreground = GColor(GCol::BIKESCORE);
             break;
 
     case RealtimeData::BikeStress:
-            foreground = GColor(CTSS);
+            foreground = GColor(GCol::TSS);
             break;
 
     case RealtimeData::XPower:
@@ -652,75 +652,75 @@ void DialWindow::seriesChanged()
     case RealtimeData::Watts:
     case RealtimeData::AvgWatts:
     case RealtimeData::AvgWattsLap:
-            foreground = GColor(CPOWER);
+            foreground = GColor(GCol::POWER);
             break;
 
     case RealtimeData::Speed:
     case RealtimeData::VirtualSpeed:
     case RealtimeData::AvgSpeed:
     case RealtimeData::AvgSpeedLap:
-            foreground = GColor(CSPEED);
+            foreground = GColor(GCol::SPEED);
             break;
 
     case RealtimeData::Wbal:
-            foreground = GColor(CWBAL);
+            foreground = GColor(GCol::WBAL);
             break;
 
     case RealtimeData::Cadence:
     case RealtimeData::AvgCadence:
     case RealtimeData::AvgCadenceLap:
-            foreground = GColor(CCADENCE);
+            foreground = GColor(GCol::CADENCE);
             break;
 
     case RealtimeData::HeartRate:
     case RealtimeData::AvgHeartRate:
     case RealtimeData::AvgHeartRateLap:
-            foreground = GColor(CHEARTRATE);
+            foreground = GColor(GCol::HEARTRATE);
             break;
 
     case RealtimeData::AltWatts:
-            foreground = GColor(CALTPOWER);
+            foreground = GColor(GCol::ALTPOWER);
             break;
 
     case RealtimeData::SmO2:
-            foreground = GColor(CSMO2);
+            foreground = GColor(GCol::SMO2);
             break;
 
     case RealtimeData::tHb:
-            foreground = GColor(CTHB);
+            foreground = GColor(GCol::THB);
             break;
 
     case RealtimeData::O2Hb:
-            foreground = GColor(CO2HB);
+            foreground = GColor(GCol::O2HB);
             break;
 
     case RealtimeData::HHb:
-            foreground = GColor(CHHB);
+            foreground = GColor(GCol::HHB);
             break;
 
     case RealtimeData::LeftPedalSmoothness:
-            foreground = GColor(CLPS);
+            foreground = GColor(GCol::LPS);
             break;
 
     case RealtimeData::RightPedalSmoothness:
-            foreground = GColor(CRPS);
+            foreground = GColor(GCol::RPS);
             break;
 
     case RealtimeData::LeftTorqueEffectiveness:
-            foreground = GColor(CLTE);
+            foreground = GColor(GCol::LTE);
             break;
 
     case RealtimeData::RightTorqueEffectiveness:
-           foreground = GColor(CRTE);
+           foreground = GColor(GCol::RTE);
            break;
 
     case RealtimeData::Altitude:
-           foreground = GColor(CALTITUDE);
+           foreground = GColor(GCol::ALTITUDE);
            break;
     }
 
     // ugh. we use style sheets because palettes don't work on labels
-    background = GColor(CTRAINPLOTBACKGROUND);
+    background = GColor(GCol::TRAINPLOTBACKGROUND);
     setProperty("color", background);
     QString sh = QString("QLabel { background: %1; color: %2; }")
                  .arg(background.name())

--- a/src/Train/ErgFilePlot.cpp
+++ b/src/Train/ErgFilePlot.cpp
@@ -93,7 +93,7 @@ QPointF NowData::sample(size_t i) const
 ErgFilePlot::ErgFilePlot(Context *context) : context(context)
 {
     //insertLegend(new QwtLegend(), QwtPlot::BottomLegend);
-    setCanvasBackground(GColor(CTRAINPLOTBACKGROUND));
+    setCanvasBackground(GColor(GCol::TRAINPLOTBACKGROUND));
     static_cast<QwtPlotCanvas*>(canvas())->setFrameStyle(QFrame::NoFrame);
     //courseData = data;                      // what we plot
     setAutoDelete(false);
@@ -108,8 +108,8 @@ ErgFilePlot::ErgFilePlot(Context *context) : context(context)
     //setAxisScaleDraw(QwtAxis::YLeft, sd);
 
     QPalette pal;
-    pal.setColor(QPalette::WindowText, GColor(CRIDEPLOTYAXIS));
-    pal.setColor(QPalette::Text, GColor(CRIDEPLOTYAXIS));
+    pal.setColor(QPalette::WindowText, GColor(GCol::RIDEPLOTYAXIS));
+    pal.setColor(QPalette::Text, GColor(GCol::RIDEPLOTYAXIS));
     axisWidget(QwtAxis::YLeft)->setPalette(pal);
 
     QFont stGiles;
@@ -136,8 +136,8 @@ ErgFilePlot::ErgFilePlot(Context *context) : context(context)
     QwtPlot::setAxisFont(QwtAxis::XBottom, stGiles);
     QwtPlot::setAxisTitle(QwtAxis::XBottom, title);
 
-    pal.setColor(QPalette::WindowText, GColor(CRIDEPLOTXAXIS));
-    pal.setColor(QPalette::Text, GColor(CRIDEPLOTXAXIS));
+    pal.setColor(QPalette::WindowText, GColor(GCol::RIDEPLOTXAXIS));
+    pal.setColor(QPalette::Text, GColor(GCol::RIDEPLOTXAXIS));
     axisWidget(QwtAxis::XBottom)->setPalette(pal);
 
     // axis 1 not currently used
@@ -165,16 +165,16 @@ ErgFilePlot::ErgFilePlot(Context *context) : context(context)
     LodCurve->setYAxis(QwtAxis::YLeft);
 
     // load curve is blue for time and grey for gradient
-    QColor brush_color = QColor(GColor(CTPOWER));
+    QColor brush_color = QColor(GColor(GCol::TPOWER));
     brush_color.setAlpha(64);
     LodCurve->setBrush(brush_color);   // fill below the line
-    QPen Lodpen = QPen(GColor(CTPOWER), 1.0);
+    QPen Lodpen = QPen(GColor(GCol::TPOWER), 1.0);
     LodCurve->setPen(Lodpen);
 
     wbalCurvePredict = new QwtPlotCurve("W'bal Predict");
     wbalCurvePredict->attach(this);
     wbalCurvePredict->setYAxis(QwtAxisId(QwtAxis::YRight, 3));
-    QColor predict = GColor(CWBAL).darker();
+    QColor predict = GColor(GCol::WBAL).darker();
     predict.setAlpha(200);
     QPen wbalPen = QPen(predict, 2.0); // predict darker...
     wbalCurvePredict->setPen(wbalPen);
@@ -183,7 +183,7 @@ ErgFilePlot::ErgFilePlot(Context *context) : context(context)
     wbalCurve = new QwtPlotCurve("W'bal Actual");
     wbalCurve->attach(this);
     wbalCurve->setYAxis(QwtAxisId(QwtAxis::YRight, 3));
-    QPen wbalPenA = QPen(GColor(CWBAL), 1.0); // actual lighter
+    QPen wbalPenA = QPen(GColor(GCol::WBAL), 1.0); // actual lighter
     wbalCurve->setPen(wbalPenA);
     wbalData = new CurveData;
     wbalCurve->setSamples(wbalData->x(), wbalData->y(), wbalData->count());
@@ -194,8 +194,8 @@ ErgFilePlot::ErgFilePlot(Context *context) : context(context)
     sd->setLabelRotation(90);// in the 000s
     sd->setTickLength(QwtScaleDiv::MajorTick, 3);
     setAxisScaleDraw(QwtAxisId(QwtAxis::YRight, 3), sd);
-    pal.setColor(QPalette::WindowText, GColor(CWBAL));
-    pal.setColor(QPalette::Text, GColor(CWBAL));
+    pal.setColor(QPalette::WindowText, GColor(GCol::WBAL));
+    pal.setColor(QPalette::Text, GColor(GCol::WBAL));
     axisWidget(QwtAxisId(QwtAxis::YRight, 3))->setPalette(pal);
     QwtPlot::setAxisFont(QwtAxisId(QwtAxis::YRight, 3), stGiles);
     QwtText title2("W'bal");
@@ -204,7 +204,7 @@ ErgFilePlot::ErgFilePlot(Context *context) : context(context)
 
     // telemetry history
     wattsCurve = new QwtPlotCurve("Power");
-    QPen wattspen = QPen(GColor(CPOWER));
+    QPen wattspen = QPen(GColor(GCol::POWER));
     wattsCurve->setPen(wattspen);
     wattsCurve->attach(this);
     wattsCurve->setYAxis(QwtAxis::YLeft);
@@ -214,7 +214,7 @@ ErgFilePlot::ErgFilePlot(Context *context) : context(context)
 
     // telemetry history
     hrCurve = new QwtPlotCurve("Heartrate");
-    QPen hrpen = QPen(GColor(CHEARTRATE));
+    QPen hrpen = QPen(GColor(GCol::HEARTRATE));
     hrCurve->setPen(hrpen);
     hrCurve->attach(this);
     hrCurve->setYAxis(QwtAxis::YRight);
@@ -223,7 +223,7 @@ ErgFilePlot::ErgFilePlot(Context *context) : context(context)
 
     // telemetry history
     cadCurve = new QwtPlotCurve("Cadence");
-    QPen cadpen = QPen(GColor(CCADENCE));
+    QPen cadpen = QPen(GColor(GCol::CADENCE));
     cadCurve->setPen(cadpen);
     cadCurve->attach(this);
     cadCurve->setYAxis(QwtAxis::YRight);
@@ -232,7 +232,7 @@ ErgFilePlot::ErgFilePlot(Context *context) : context(context)
 
     // telemetry history
     speedCurve = new QwtPlotCurve("Speed");
-    QPen speedpen = QPen(GColor(CSPEED));
+    QPen speedpen = QPen(GColor(GCol::SPEED));
     speedCurve->setPen(speedpen);
     speedCurve->attach(this);
     speedCurve->setYAxis(QwtAxisId(QwtAxis::YRight,2).id);
@@ -244,10 +244,10 @@ ErgFilePlot::ErgFilePlot(Context *context) : context(context)
 
     // CP marker
     QwtText CPText(QString(tr("CP")));
-    CPText.setColor(GColor(CPLOTMARKER));
+    CPText.setColor(GColor(GCol::PLOTMARKER));
     CPMarker = new QwtPlotMarker(CPText);
     CPMarker->setLineStyle(QwtPlotMarker::HLine);
-    CPMarker->setLinePen(GColor(CPLOTMARKER), 1, Qt::DotLine);
+    CPMarker->setLinePen(GColor(GCol::PLOTMARKER), 1, Qt::DotLine);
     CPMarker->setLabel(CPText);
     CPMarker->setLabelAlignment(Qt::AlignLeft | Qt::AlignTop);
     CPMarker->setYAxis(QwtAxis::YLeft);
@@ -277,8 +277,8 @@ ErgFilePlot::ErgFilePlot(Context *context) : context(context)
 void
 ErgFilePlot::configChanged(qint32)
 {
-    setCanvasBackground(GColor(CTRAINPLOTBACKGROUND));
-    CPMarker->setLinePen(GColor(CPLOTMARKER), 1, Qt::DotLine);
+    setCanvasBackground(GColor(GCol::TRAINPLOTBACKGROUND));
+    CPMarker->setLinePen(GColor(GCol::PLOTMARKER), 1, Qt::DotLine);
 
     // set CP Marker
     double CP = 0; // default
@@ -457,9 +457,9 @@ ErgFilePlot::setData(ErgFile *ergfile)
 
         } else {
 
-            QColor brush_color1 = QColor(GColor(CTPOWER));
+            QColor brush_color1 = QColor(GColor(GCol::TPOWER));
             brush_color1.setAlpha(200);
-            QColor brush_color2 = QColor(GColor(CTPOWER));
+            QColor brush_color2 = QColor(GColor(GCol::TPOWER));
             brush_color2.setAlpha(64);
 
             QLinearGradient linearGradient(0, 0, 0, height());
@@ -468,7 +468,7 @@ ErgFilePlot::setData(ErgFile *ergfile)
             linearGradient.setSpread(QGradient::PadSpread);
 
             LodCurve->setBrush(linearGradient);   // fill below the line
-            QPen Lodpen = QPen(GColor(CTPOWER), 1.0);
+            QPen Lodpen = QPen(GColor(GCol::TPOWER), 1.0);
             LodCurve->setPen(Lodpen);
 
         }
@@ -514,12 +514,12 @@ ErgFilePlot::setData(ErgFile *ergfile)
             QwtText text(prefix + decoratedName);
                 
             text.setFont(QFont("Helvetica", 10, QFont::Bold));
-            text.setColor(GColor(CPLOTMARKER));
+            text.setColor(GColor(GCol::PLOTMARKER));
 
             // vertical line
             QwtPlotMarker *add = new QwtPlotMarker();
             add->setLineStyle(QwtPlotMarker::VLine);
-            add->setLinePen(QPen(GColor(CPLOTMARKER), 0, Qt::DashDotLine));
+            add->setLinePen(QPen(GColor(GCol::PLOTMARKER), 0, Qt::DashDotLine));
             add->setLabelAlignment(labelAlignment);
             // convert to imperial according to settings
             double unitsFactor = (!bydist || GlobalContext::context()->useMetricUnits) ? 1.0 : MILES_PER_KM;
@@ -568,8 +568,8 @@ ErgFilePlot::setData(ErgFile *ergfile)
                 QwtPlot::setAxisFont(QwtAxis::XBottom, stGiles);
                 QwtPlot::setAxisTitle(QwtAxis::XBottom, title);
 
-                pal.setColor(QPalette::WindowText, GColor(CRIDEPLOTXAXIS));
-                pal.setColor(QPalette::Text, GColor(CRIDEPLOTXAXIS));
+                pal.setColor(QPalette::WindowText, GColor(GCol::RIDEPLOTXAXIS));
+                pal.setColor(QPalette::Text, GColor(GCol::RIDEPLOTXAXIS));
                 axisWidget(QwtAxis::XBottom)->setPalette(pal);
 
                 // only allocate a new one if its not the current (they get freed by Qwt)
@@ -599,8 +599,8 @@ ErgFilePlot::setData(ErgFile *ergfile)
         QwtPlot::setAxisFont(QwtAxis::XBottom, stGiles);
         QwtPlot::setAxisTitle(QwtAxis::XBottom, title);
 
-        pal.setColor(QPalette::WindowText, GColor(CRIDEPLOTXAXIS));
-        pal.setColor(QPalette::Text, GColor(CRIDEPLOTXAXIS));
+        pal.setColor(QPalette::WindowText, GColor(GCol::RIDEPLOTXAXIS));
+        pal.setColor(QPalette::Text, GColor(GCol::RIDEPLOTXAXIS));
         axisWidget(QwtAxis::XBottom)->setPalette(pal);
 
         // set the axis so we default to an hour workout

--- a/src/Train/LiveMapWebPageWindow.cpp
+++ b/src/Train/LiveMapWebPageWindow.cpp
@@ -77,7 +77,7 @@ LiveMapWebPageWindow::LiveMapWebPageWindow(Context *context) : GcChartWindow(con
     HelpWhatsThis *helpConfig = new HelpWhatsThis(settingsWidget);
     settingsWidget->setWhatsThis(helpConfig->getWhatsThisText(HelpWhatsThis::ChartTrain_LiveMap));
     settingsWidget->setContentsMargins(0,0,0,0);
-    setProperty("color", GColor(CTRAINPLOTBACKGROUND));
+    setProperty("color", GColor(GCol::TRAINPLOTBACKGROUND));
 
     QFormLayout* commonLayout = new QFormLayout(settingsWidget);
 
@@ -214,10 +214,10 @@ void LiveMapWebPageWindow::configChanged(qint32)
 {
     // tinted palette for headings etc
     QPalette palette;
-    palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CPLOTBACKGROUND)));
+    palette.setBrush(QPalette::Window, QBrush(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Text, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Base, GAlternateColor(GCol::PLOTBACKGROUND));
     setPalette(palette);
 
 }

--- a/src/Train/RealtimePlot.cpp
+++ b/src/Train/RealtimePlot.cpp
@@ -251,26 +251,26 @@ RealtimePlot::RealtimePlot(Context *context) :
 
     QPalette pal;
     setAxisScale(QwtAxis::YLeft, 0, 500); // watts
-    pal.setColor(QPalette::WindowText, GColor(CPOWER));
-    pal.setColor(QPalette::Text, GColor(CPOWER));
+    pal.setColor(QPalette::WindowText, GColor(GCol::POWER));
+    pal.setColor(QPalette::Text, GColor(GCol::POWER));
     axisWidget(QwtAxis::YLeft)->setPalette(pal);
     axisWidget(QwtAxis::YLeft)->scaleDraw()->setTickLength(QwtScaleDiv::MajorTick, 3);
 
     setAxisScale(QwtAxis::YRight, 0, 230); // cadence / hr
-    pal.setColor(QPalette::WindowText, GColor(CHEARTRATE));
-    pal.setColor(QPalette::Text, GColor(CHEARTRATE));
+    pal.setColor(QPalette::WindowText, GColor(GCol::HEARTRATE));
+    pal.setColor(QPalette::Text, GColor(GCol::HEARTRATE));
     axisWidget(QwtAxis::YRight)->setPalette(pal);
     axisWidget(QwtAxis::YRight)->scaleDraw()->setTickLength(QwtScaleDiv::MajorTick, 3);
 
     setAxisScale(QwtAxis::XBottom, MAXSAMPLES, 0, 15); // time ago
-    pal.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
-    pal.setColor(QPalette::Text, GColor(CPLOTMARKER));
+    pal.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
+    pal.setColor(QPalette::Text, GColor(GCol::PLOTMARKER));
     axisWidget(QwtAxis::XBottom)->setPalette(pal);
     axisWidget(QwtAxis::XBottom)->scaleDraw()->setTickLength(QwtScaleDiv::MajorTick, 3);
 
     setAxisScale(QwtAxisId(QwtAxis::YRight,2).id, 0, 60); // speed km/h - 60kmh on a turbo is good going!
-    pal.setColor(QPalette::WindowText, GColor(CSPEED));
-    pal.setColor(QPalette::Text, GColor(CSPEED));
+    pal.setColor(QPalette::WindowText, GColor(GCol::SPEED));
+    pal.setColor(QPalette::Text, GColor(GCol::SPEED));
     axisWidget(QwtAxisId(QwtAxis::YRight,2).id)->setPalette(pal);
     axisWidget(QwtAxisId(QwtAxis::YRight,2).id)->scaleDraw()->setTickLength(QwtScaleDiv::MajorTick, 3);
 
@@ -387,44 +387,44 @@ RealtimePlot::configChanged(qint32)
 {
     double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
 
-    setCanvasBackground(GColor(CTRAINPLOTBACKGROUND));
-    QPen pwr30pen = QPen(GColor(CPOWER), width, Qt::DashLine);
+    setCanvasBackground(GColor(GCol::TRAINPLOTBACKGROUND));
+    QPen pwr30pen = QPen(GColor(GCol::POWER), width, Qt::DashLine);
     pwr30Curve->setPen(pwr30pen);
     pwr30Curve->setData(pwr30Data);
 
-    QPen pwrpen = QPen(GColor(CPOWER));
+    QPen pwrpen = QPen(GColor(GCol::POWER));
     pwrpen.setWidth(width);
     pwrCurve->setPen(pwrpen);
 
-    QPen apwrpen = QPen(GColor(CALTPOWER));
+    QPen apwrpen = QPen(GColor(GCol::ALTPOWER));
     apwrpen.setWidth(width);
     altPwrCurve->setPen(apwrpen);
 
-    QPen hrpen = QPen(GColor(CHEARTRATE));
+    QPen hrpen = QPen(GColor(GCol::HEARTRATE));
     hrpen.setWidth(width);
     hrCurve->setPen(hrpen);
 
-    QPen cadpen = QPen(GColor(CCADENCE));
+    QPen cadpen = QPen(GColor(GCol::CADENCE));
     cadpen.setWidth(width);
     cadCurve->setPen(cadpen);
 
-    QPen spdpen = QPen(GColor(CSPEED));
+    QPen spdpen = QPen(GColor(GCol::SPEED));
     spdpen.setWidth(width);
     spdCurve->setPen(spdpen);
 
-    QPen hhbpen = QPen(GColor(CHHB));
+    QPen hhbpen = QPen(GColor(GCol::HHB));
     hhbpen.setWidth(width);
     hhbCurve->setPen(hhbpen);
 
-    QPen o2hbpen = QPen(GColor(CO2HB));
+    QPen o2hbpen = QPen(GColor(GCol::O2HB));
     o2hbpen.setWidth(width);
     o2hbCurve->setPen(o2hbpen);
 
-    QPen smo2pen = QPen(GColor(CSMO2));
+    QPen smo2pen = QPen(GColor(GCol::SMO2));
     smo2pen.setWidth(width);
     smo2Curve->setPen(smo2pen);
 
-    QPen thbpen = QPen(GColor(CTHB));
+    QPen thbpen = QPen(GColor(GCol::THB));
     thbpen.setWidth(width);
     thbCurve->setPen(thbpen);
 

--- a/src/Train/RealtimePlotWindow.cpp
+++ b/src/Train/RealtimePlotWindow.cpp
@@ -28,7 +28,7 @@ RealtimePlotWindow::RealtimePlotWindow(Context *context) :
     this->setWhatsThis(helpContents->getWhatsThisText(HelpWhatsThis::ChartTrain_Realtime));
 
     setContentsMargins(0,0,0,0);
-    setProperty("color", GColor(CTRAINPLOTBACKGROUND));
+    setProperty("color", GColor(GCol::TRAINPLOTBACKGROUND));
 
     QWidget *c = new QWidget;
     HelpWhatsThis *helpConfig = new HelpWhatsThis(c);
@@ -135,7 +135,7 @@ RealtimePlotWindow::RealtimePlotWindow(Context *context) :
 void
 RealtimePlotWindow::configChanged(qint32)
 {
-    setProperty("color", GColor(CTRAINPLOTBACKGROUND));
+    setProperty("color", GColor(GCol::TRAINPLOTBACKGROUND));
     repaint();
 }
 

--- a/src/Train/SpinScanPlot.cpp
+++ b/src/Train/SpinScanPlot.cpp
@@ -65,8 +65,8 @@ SpinScanPlot::SpinScanPlot(QWidget *parent, uint8_t *spinData) : QwtPlot(parent)
     QPalette pal;
     setAxisScale(QwtAxis::YLeft, 0, 90); // max 8 bit plus a little
     setAxisScale(QwtAxis::XBottom, 0, 24); // max 8 bit plus a little
-    pal.setColor(QPalette::WindowText, GColor(CSPINSCANLEFT));
-    pal.setColor(QPalette::Text, GColor(CSPINSCANLEFT));
+    pal.setColor(QPalette::WindowText, GColor(GCol::SPINSCANLEFT));
+    pal.setColor(QPalette::Text, GColor(GCol::SPINSCANLEFT));
     axisWidget(QwtAxis::YLeft)->setPalette(pal);
     axisWidget(QwtAxis::YLeft)->scaleDraw()->setTickLength(QwtScaleDiv::MajorTick, 3);
 
@@ -107,9 +107,9 @@ SpinScanPlot::setAxisTitle(int axis, QString label)
 void
 SpinScanPlot::configChanged(qint32)
 {
-    setCanvasBackground(GColor(CTRAINPLOTBACKGROUND));
+    setCanvasBackground(GColor(GCol::TRAINPLOTBACKGROUND));
 
-    QColor col = GColor(CSPINSCANLEFT);
+    QColor col = GColor(GCol::SPINSCANLEFT);
     col.setAlpha(120);
     QBrush brush = QBrush(col);
     leftCurve->setBrush(brush);
@@ -117,7 +117,7 @@ SpinScanPlot::configChanged(qint32)
     //spinCurve->setStyle(QwtPlotCurve::Steps);
     leftCurve->setData(leftSpinScanData);
 
-    QColor col2 = GColor(CSPINSCANRIGHT);
+    QColor col2 = GColor(GCol::SPINSCANRIGHT);
     col2.setAlpha(120);
     QBrush brush2 = QBrush(col2);
     rightCurve->setBrush(brush2);

--- a/src/Train/SpinScanPlotWindow.cpp
+++ b/src/Train/SpinScanPlotWindow.cpp
@@ -28,7 +28,7 @@ SpinScanPlotWindow::SpinScanPlotWindow(Context *context) :
     this->setWhatsThis(helpContents->getWhatsThisText(HelpWhatsThis::ChartTrain_PedalStroke));
 
     setContentsMargins(0,0,0,0);
-    setProperty("color", GColor(CTRAINPLOTBACKGROUND));
+    setProperty("color", GColor(GCol::TRAINPLOTBACKGROUND));
 
     // setup controls
     QWidget *c = new QWidget;

--- a/src/Train/SpinScanPolarPlot.cpp
+++ b/src/Train/SpinScanPolarPlot.cpp
@@ -77,8 +77,8 @@ SpinScanPolarPlot::SpinScanPolarPlot(QWidget *parent, uint8_t *spinData) : QwtPl
     QPalette pal;
     setAxisScale(QwtAxis::YLeft, -90, 90); // max 8 bit plus a little
     setAxisScale(QwtAxis::XBottom, -90, 90); // max 8 bit plus a little
-    pal.setColor(QPalette::WindowText, GColor(CSPINSCANLEFT));
-    pal.setColor(QPalette::Text, GColor(CSPINSCANLEFT));
+    pal.setColor(QPalette::WindowText, GColor(GCol::SPINSCANLEFT));
+    pal.setColor(QPalette::Text, GColor(GCol::SPINSCANLEFT));
     axisWidget(QwtAxis::YLeft)->setPalette(pal);
     axisWidget(QwtAxis::YLeft)->scaleDraw()->setTickLength(QwtScaleDiv::MajorTick, 3);
 
@@ -118,9 +118,9 @@ SpinScanPolarPlot::setAxisTitle(int axis, QString label)
 void
 SpinScanPolarPlot::configChanged(qint32)
 {
-    setCanvasBackground(GColor(CTRAINPLOTBACKGROUND));
+    setCanvasBackground(GColor(GCol::TRAINPLOTBACKGROUND));
 
-    QColor col = GColor(CSPINSCANRIGHT);
+    QColor col = GColor(GCol::SPINSCANRIGHT);
     col.setAlpha(120);
     QBrush brush = QBrush(col);
     QPen pen(col);
@@ -130,7 +130,7 @@ SpinScanPolarPlot::configChanged(qint32)
     rightCurve->setStyle(QwtPlotCurve::Lines);
     rightCurve->setData(rightSpinScanPolarData);
 
-    QColor col2 = GColor(CSPINSCANLEFT);
+    QColor col2 = GColor(GCol::SPINSCANLEFT);
     col2.setAlpha(120);
     QBrush brush2 = QBrush(col2);
     QPen pen2(col2);

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -622,15 +622,15 @@ TrainSidebar::configChanged(qint32)
 
     useSimulatedSpeed = appsettings->value(this, TRAIN_USESIMULATEDSPEED, false).toBool();
 
-    setProperty("color", GColor(CTRAINPLOTBACKGROUND));
+    setProperty("color", GColor(GCol::TRAINPLOTBACKGROUND));
 #if !defined GC_VIDEO_NONE
-    mediaTree->setStyleSheet(GCColor::stylesheet(true));
+    mediaTree->setStyleSheet(GCColor::inst()->stylesheet(true));
 #ifdef GC_HAVE_VLC  // RLV currently only support for VLC
-    videosyncTree->setStyleSheet(GCColor::stylesheet(true));
+    videosyncTree->setStyleSheet(GCColor::inst()->stylesheet(true));
 #endif
 #endif
-    workoutTree->setStyleSheet(GCColor::stylesheet(true));
-    deviceTree->setStyleSheet(GCColor::stylesheet(true));
+    workoutTree->setStyleSheet(GCColor::inst()->stylesheet(true));
+    deviceTree->setStyleSheet(GCColor::inst()->stylesheet(true));
 
     // DEVICES
 

--- a/src/Train/WebPageWindow.cpp
+++ b/src/Train/WebPageWindow.cpp
@@ -194,13 +194,13 @@ WebPageWindow::~WebPageWindow()
 void 
 WebPageWindow::configChanged(qint32)
 {
-    setProperty("color", GColor(CPLOTBACKGROUND));
+    setProperty("color", GColor(GCol::PLOTBACKGROUND));
     // tinted palette for headings etc
     QPalette palette;
-    palette.setBrush(QPalette::Window, QBrush(GColor(CPLOTBACKGROUND)));
-    palette.setColor(QPalette::WindowText, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Text, GColor(CPLOTMARKER));
-    palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CPLOTBACKGROUND)));
+    palette.setBrush(QPalette::Window, QBrush(GColor(GCol::PLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Text, GColor(GCol::PLOTMARKER));
+    palette.setColor(QPalette::Base, GAlternateColor(GCol::PLOTBACKGROUND));
     setPalette(palette);
 }
 

--- a/src/Train/WorkoutPlotWindow.cpp
+++ b/src/Train/WorkoutPlotWindow.cpp
@@ -29,7 +29,7 @@ WorkoutPlotWindow::WorkoutPlotWindow(Context *context) :
 
     setContentsMargins(0,0,0,0);
     setControls(NULL);
-    setProperty("color", GColor(CTRAINPLOTBACKGROUND));
+    setProperty("color", GColor(GCol::TRAINPLOTBACKGROUND));
 
     QVBoxLayout *layout = new QVBoxLayout;
     setChartLayout(layout);
@@ -68,6 +68,6 @@ WorkoutPlotWindow::setNow(long now)
 void
 WorkoutPlotWindow::configChanged(qint32)
 {
-    setProperty("color", GColor(CTRAINPLOTBACKGROUND));
+    setProperty("color", GColor(GCol::TRAINPLOTBACKGROUND));
     repaint();
 }

--- a/src/Train/WorkoutWidget.cpp
+++ b/src/Train/WorkoutWidget.cpp
@@ -2243,12 +2243,12 @@ WorkoutWidget::apply(QString code)
 void
 WorkoutWidget::configChanged(qint32)
 {
-    setProperty("color", GColor(CTRAINPLOTBACKGROUND));
+    setProperty("color", GColor(GCol::TRAINPLOTBACKGROUND));
 
-    gridPen = QPen(GColor(CPLOTGRID));
+    gridPen = QPen(GColor(GCol::PLOTGRID));
     gridPen.setWidth(1);
 
-    markerPen = QPen(GColor(CPLOTMARKER));
+    markerPen = QPen(GColor(GCol::PLOTMARKER));
     markerPen.setWidth(1);
 
     markerFont.fromString(appsettings->value(this, GC_FONT_CHARTLABELS, QFont().toString()).toString());
@@ -2408,7 +2408,7 @@ WorkoutWidget::paintEvent(QPaintEvent*)
     if (LOG) {
 
         // paint tics for log scale on the canvas
-        QPen power(GColor(CPOWER));
+        QPen power(GColor(GCol::POWER));
         painter.setPen(power);
 
         // typical durations

--- a/src/Train/WorkoutWidgetItems.cpp
+++ b/src/Train/WorkoutWidgetItems.cpp
@@ -44,7 +44,7 @@ WWPowerScale::paint(QPainter *painter)
 
     // fill transparent to deminish "over painted" curves
     // that are shown in borders to give sense of scroll
-    QColor deminish(GColor(CTRAINPLOTBACKGROUND));
+    QColor deminish(GColor(GCol::TRAINPLOTBACKGROUND));
     deminish.setAlpha(175);
     painter->fillRect(workoutWidget()->left(), deminish);
 
@@ -122,7 +122,7 @@ WWPowerScale::paint(QPainter *painter)
     }
 
     // CP !
-    QPen cppen(GColor(CPLOTMARKER));
+    QPen cppen(GColor(GCol::PLOTMARKER));
     cppen.setStyle(Qt::DashLine);
     painter->setPen(cppen);
 
@@ -147,7 +147,7 @@ WWWBalScale::paint(QPainter *painter)
 
     // fill transparent to deminish "over painted" curves
     // that are shown in borders to give sense of scroll
-    QColor deminish(GColor(CTRAINPLOTBACKGROUND));
+    QColor deminish(GColor(GCol::TRAINPLOTBACKGROUND));
     deminish.setAlpha(175);
     painter->fillRect(workoutWidget()->right(), deminish);
 
@@ -174,7 +174,7 @@ WWWBalScale::paint(QPainter *painter)
                     QPoint(tl.x()+WBALSCALEWIDTH, tl.y() + ((i+1) * (height/4))));
 
         // draw rect
-        QColor wbal = GColor(CWBAL);
+        QColor wbal = GColor(GCol::WBAL);
         wbal.setAlpha((255/4) * (i+1));
         painter->fillRect(bound, QBrush(wbal));
 
@@ -242,7 +242,7 @@ WWLap::paint(QPainter *painter)
 
     QFontMetrics fontMetrics(workoutWidget()->bigFont);
     painter->setFont(workoutWidget()->bigFont);
-    painter->setPen(GColor(CPLOTMARKER));
+    painter->setPen(GColor(GCol::PLOTMARKER));
 
     for(int i=0; i<workoutWidget()->laps().count(); i++) {
 
@@ -304,7 +304,7 @@ WWPoint::paint(QPainter *painter)
     } else {
 
         // draw point
-        painter->setBrush(GColor(CPOWER));
+        painter->setBrush(GColor(GCol::POWER));
         painter->drawEllipse(QPointF(center.x(), center.y()), 3.0f*dpiXFactor, 3.0f*dpiXFactor);
     }
 
@@ -316,7 +316,7 @@ void
 WWLine::paint(QPainter *painter)
 {
     // thin ?
-    QPen linePen(workoutWidget()->recording() ? GColor(CTPOWER) : GColor(CPOWER));
+    QPen linePen(workoutWidget()->recording() ? GColor(GCol::TPOWER) : GColor(GCol::POWER));
     linePen.setWidth(1 *dpiXFactor);
     painter->setPen(linePen);
 
@@ -350,9 +350,9 @@ WWLine::paint(QPainter *painter)
         // now fill
         painter->setPen(Qt::NoPen);
 
-            QColor brush_color1 = QColor(GColor(CTPOWER));
+            QColor brush_color1 = QColor(GColor(GCol::TPOWER));
             brush_color1.setAlpha(240);
-            QColor brush_color2 = QColor(GColor(CTPOWER));
+            QColor brush_color2 = QColor(GColor(GCol::TPOWER));
             brush_color2.setAlpha(200);
 
             QLinearGradient linearGradient(0, 0, 0, workoutWidget()->transform(0,0).y());
@@ -374,38 +374,38 @@ WWTelemetry::paint(QPainter *painter)
     if (workoutWidget()->shouldPlotPwr())
     {
         updateAvg(workoutWidget()->watts, workoutWidget()->pwrAvg, workoutWidget()->pwrPlotAvgLength());
-        paintSampleList(painter, GColor(CPOWER), workoutWidget()->pwrAvg, WorkoutWidget::POWER);
+        paintSampleList(painter, GColor(GCol::POWER), workoutWidget()->pwrAvg, WorkoutWidget::POWER);
     }
 
     // Draw HR
     if (workoutWidget()->shouldPlotHr())
     {
         updateAvg(workoutWidget()->hr, workoutWidget()->hrAvg, workoutWidget()->hrPlotAvgLength());
-        paintSampleList(painter, GColor(CHEARTRATE), workoutWidget()->hrAvg, WorkoutWidget::HEARTRATE);
+        paintSampleList(painter, GColor(GCol::HEARTRATE), workoutWidget()->hrAvg, WorkoutWidget::HEARTRATE);
     }
     // Draw Speed
     if (workoutWidget()->shouldPlotSpeed())
     {
         updateAvg(workoutWidget()->speed, workoutWidget()->speedAvg, workoutWidget()->speedPlotAvgLength());
-        paintSampleList(painter, GColor(CSPEED), workoutWidget()->speedAvg, WorkoutWidget::SPEED);
+        paintSampleList(painter, GColor(GCol::SPEED), workoutWidget()->speedAvg, WorkoutWidget::SPEED);
     }
     // Draw Cadence
     if (workoutWidget()->shouldPlotCadence())
     {
         updateAvg(workoutWidget()->cadence, workoutWidget()->cadenceAvg, workoutWidget()->cadencePlotAvgLength());
-        paintSampleList(painter, GColor(CCADENCE), workoutWidget()->cadenceAvg, WorkoutWidget::CADENCE);
+        paintSampleList(painter, GColor(GCol::CADENCE), workoutWidget()->cadenceAvg, WorkoutWidget::CADENCE);
     }
     // Draw VO2
     if (workoutWidget()->shouldPlotVo2())
     {
         updateAvg(workoutWidget()->vo2, workoutWidget()->vo2Avg, workoutWidget()->vo2PlotAvgLength());
-        paintSampleList(painter, GColor(CVO2), workoutWidget()->vo2Avg, WorkoutWidget::VO2);
+        paintSampleList(painter, GColor(GCol::VO2), workoutWidget()->vo2Avg, WorkoutWidget::VO2);
     }
     // Draw Ventilation
     if (workoutWidget()->shouldPlotVentilation())
     {
         updateAvg(workoutWidget()->ventilation, workoutWidget()->ventilationAvg, workoutWidget()->ventilationPlotAvgLength());
-        paintSampleList(painter, GColor(CVENTILATION), workoutWidget()->ventilationAvg, WorkoutWidget::VENTILATION);
+        paintSampleList(painter, GColor(GCol::VENTILATION), workoutWidget()->ventilationAvg, WorkoutWidget::VENTILATION);
     }
 
     //
@@ -424,7 +424,7 @@ WWTelemetry::paint(QPainter *painter)
         int WPRIME = context->athlete->zones("Bike")->getWprime(rnum);
 
         // full color
-        QColor color = GColor(CWBAL);
+        QColor color = GColor(GCol::WBAL);
         QPen wlinePen(color);
         wlinePen.setWidth(1 *dpiXFactor);
         painter->setPen(wlinePen);
@@ -472,7 +472,7 @@ WWRect::paint(QPainter *painter)
     if (onRect != QPointF(-1,-1) && atRect != QPointF(-1,-1) && onRect != atRect) {
 
         // thin ?
-        QPen linePen(GColor(CPLOTMARKER));
+        QPen linePen(GColor(GCol::PLOTMARKER));
         linePen.setWidth(1 *dpiXFactor);
         painter->setPen(linePen);
 
@@ -502,7 +502,7 @@ WWBlockCursor::paint(QPainter *painter)
         QFontMetrics fontMetrics(workoutWidget()->bigFont);
         QRect textBound = fontMetrics.boundingRect(workoutWidget()->cursorBlockText);
         painter->setFont(workoutWidget()->bigFont);
-        painter->setPen(GColor(CPLOTMARKER));
+        painter->setPen(GColor(GCol::PLOTMARKER));
 
         QPointF where(workoutWidget()->cursorBlock.boundingRect().center().x()-(textBound.width()/2),
                       workoutWidget()->cursorBlock.boundingRect().bottom()-10); //XXX 10 is hardcoded space from bottom
@@ -528,7 +528,7 @@ WWBlockSelection::paint(QPainter *painter)
     if (workoutWidget()->selectionBlock == QPainterPath()) return;
 
     // set pen
-    painter->setPen(GColor(CPLOTMARKER));
+    painter->setPen(GColor(GCol::PLOTMARKER));
 
     // now draw the path
     painter->drawPath(workoutWidget()->selectionBlock);
@@ -542,7 +542,7 @@ WWBlockSelection::paint(QPainter *painter)
     QFontMetrics fontMetrics(workoutWidget()->bigFont);
     QRect textBound = fontMetrics.boundingRect(workoutWidget()->selectionBlockText);
     painter->setFont(workoutWidget()->bigFont);
-    painter->setPen(GColor(CPLOTMARKER));
+    painter->setPen(GColor(GCol::PLOTMARKER));
 
     QPointF where(workoutWidget()->selectionBlock.boundingRect().center().x()-(textBound.width()/2),
                   workoutWidget()->selectionBlock.boundingRect().bottom()-10); //XXX 10 is hardcoded space from bottom
@@ -577,7 +577,7 @@ WWWBLine::paint(QPainter *painter)
 
     // should be translucent if recording, as will be "overwritten"
     // by the actual W'bal value
-    QColor color = GColor(CWBAL);
+    QColor color = GColor(GCol::WBAL);
     if (workoutWidget()->recording()) color.setAlpha(64);
 
     // set pen
@@ -622,7 +622,7 @@ WWMMPCurve::paint(QPainter *painter)
     if (workoutWidget()->recording()) return;
 
     // thin ?
-    QPen linePen(GColor(CCP));
+    QPen linePen(GColor(GCol::CP));
     linePen.setWidth(1);
     painter->setPen(linePen);
 
@@ -736,7 +736,7 @@ WWSmartGuide::paint(QPainter *painter)
     if (selected > 0) {
 
         // for now just paint the boundary tics on the x-axis
-        QPen linePen(GColor(CPLOTMARKER));
+        QPen linePen(GColor(GCol::PLOTMARKER));
         linePen.setWidthF(0);
         painter->setPen(linePen);
 
@@ -824,7 +824,7 @@ WWSmartGuide::paint(QPainter *painter)
     if (selected > 0) {
 
         // for now just paint the boundary tics on the y-axis
-        QPen linePen(GColor(CPLOTMARKER));
+        QPen linePen(GColor(GCol::PLOTMARKER));
         linePen.setWidthF(0);
         painter->setPen(linePen);
 
@@ -860,7 +860,7 @@ WWNow::paint(QPainter *painter)
     // get now
     int px = workoutWidget()->transform(context->getNow()/1000.0f,0).x();
 
-    QPen linePen(GColor(CPLOTMARKER));
+    QPen linePen(GColor(GCol::PLOTMARKER));
     linePen.setWidthF(2 *dpiXFactor);
     painter->setPen(linePen);
 

--- a/src/Train/WorkoutWindow.cpp
+++ b/src/Train/WorkoutWindow.cpp
@@ -44,7 +44,7 @@ WorkoutWindow::WorkoutWindow(Context *context) :
     this->setWhatsThis(helpContents->getWhatsThisText(HelpWhatsThis::ChartTrain_WorkoutEditor));
 
     setContentsMargins(0,0,0,0);
-    setProperty("color", GColor(CTRAINPLOTBACKGROUND));
+    setProperty("color", GColor(GCol::TRAINPLOTBACKGROUND));
 
     //
     // Chart settings
@@ -351,7 +351,7 @@ WorkoutWindow::resizeEvent(QResizeEvent *)
 void
 WorkoutWindow::configChanged(qint32)
 {
-    setProperty("color", GColor(CTRAINPLOTBACKGROUND));
+    setProperty("color", GColor(GCol::TRAINPLOTBACKGROUND));
     QFontMetrics fm(workout->bigFont);
     xlabel->setFont(workout->bigFont);
     ylabel->setFont(workout->bigFont);
@@ -364,8 +364,8 @@ WorkoutWindow::configChanged(qint32)
 
     scroll->setStyleSheet(AbstractView::ourStyleSheet());
     toolbar->setStyleSheet(QString("::enabled { background: %1; color: %2; border: 0px; } ")
-                           .arg(GColor(CTRAINPLOTBACKGROUND).name())
-                           .arg(GCColor::invertColor(GColor(CTRAINPLOTBACKGROUND)).name()));
+                           .arg(GColor(GCol::TRAINPLOTBACKGROUND).name())
+                           .arg(GInvertColor(GCol::TRAINPLOTBACKGROUND).name()));
 
     xlabel->setStyleSheet("color: darkGray;");
     ylabel->setStyleSheet("color: darkGray;");
@@ -379,25 +379,25 @@ WorkoutWindow::configChanged(qint32)
 
     // text edit colors
     QPalette palette;
-    palette.setColor(QPalette::Window, GColor(CTRAINPLOTBACKGROUND));
+    palette.setColor(QPalette::Window, GColor(GCol::TRAINPLOTBACKGROUND));
 
     // only change base if moved away from white plots
     // which is a Mac thing
 #ifndef Q_OS_MAC
-    if (GColor(CTRAINPLOTBACKGROUND) != Qt::white)
+    if (GColor(GCol::TRAINPLOTBACKGROUND) != Qt::white)
 #endif
     {
-        //palette.setColor(QPalette::Base, GCColor::alternateColor(GColor(CTRAINPLOTBACKGROUND)));
-        palette.setColor(QPalette::Base, GColor(CTRAINPLOTBACKGROUND));
-        palette.setColor(QPalette::Window, GColor(CTRAINPLOTBACKGROUND));
+        //palette.setColor(QPalette::Base, GAlternateColor(GCol::TRAINPLOTBACKGROUND));
+        palette.setColor(QPalette::Base, GColor(GCol::TRAINPLOTBACKGROUND));
+        palette.setColor(QPalette::Window, GColor(GCol::TRAINPLOTBACKGROUND));
     }
 
 #ifndef Q_OS_MAC // the scrollers appear when needed on Mac, we'll keep that
     code->setStyleSheet(AbstractView::ourStyleSheet());
 #endif
 
-    palette.setColor(QPalette::WindowText, GCColor::invertColor(GColor(CTRAINPLOTBACKGROUND)));
-    palette.setColor(QPalette::Text, GCColor::invertColor(GColor(CTRAINPLOTBACKGROUND)));
+    palette.setColor(QPalette::WindowText, GInvertColor(GCol::TRAINPLOTBACKGROUND));
+    palette.setColor(QPalette::Text, GInvertColor(GCol::TRAINPLOTBACKGROUND));
     code->setPalette(palette);
     repaint();
 }


### PR DESCRIPTION
This PR aims to improve the type safety using enumeration classes rather #defines within the GC Color definitions, this PR makes no change to GC's Colors or appearance. The following describes the changes and a few defects detected & corrected by this PR:

Note: The main changes are within Colors.[h& cpp] and Pages.cpp, all the other file changes are related #defines changing to enumerated class definitions.

⦁	GCColor has been made a singleton class, this enables the duplicate code within ColorsPage::applyThemeIndex(int index) & GCColor::applyTheme(int index) functions to be extracted a placed in a single function detemineThemeQColor() within GCColor, and this detected the following issue:

The two "duplicate" functionalities handled the Hover case differently, this PR implements the code below as it more closely matches the description, but I'm not sure which is the right answer:

`                  case GCol::HOVER:`
`                      // stealthy themes use overview card background for hover color since they are close`
`                     // all other themes get a boring default`
`                      //qColor = theme.stealth ? colorTable[gColor].qColor : (theme.dark ? QColor(50, 50, 50) : QColor(200, 200, 200));`
`                      qColor = theme.stealth ? theme.colors[GThmCol::OVERVIEWTILEBACKGROUND1] : (theme.dark ? QColor(50, 50, 50) : QColor(200, 200, 200));`
`                      break;`
`

⦁	Replaces the #defines for Colors with an enumeration class (GCol) to improve type safety, this change has led to numerous trivial changes in many files, but also detected the following issues fixed by this PR:

OverviewItems.h

        `BPointF() : x(0), y(0), z(0), xoff(0), yoff(0), fill(GColor(Qt::gray)), item(NULL) {}`

A gc color should be passed to the GColor macro not a qt color, so this is now:

        `BPointF() : x(0), y(0), z(0), xoff(0), yoff(0), fill(GColor(GCol::RIDEPLOTXAXIS)), item(NULL) {}`

as Qt::gray has the value of 5, so its replaced with RIDEPLOTXAXIS which has the same value.

ExtendedCriticalPower.cpp

        `QPen e2pen(GColor(Qt::lightGray));`

A gc color should be passed to the GColor macro not a qt color, so this is now:

        `QPen e2pen(GColor(GCol::RIDEPLOTYAXIS));`

as Qt::lightGray has the value of 6, so its replaced with RIDEPLOTYAXIS which has the same value.

⦁	Replaces the theme number indexes with an enumeration class (GThmCol) to improve type safety and makes it easy to determine whether the wrong index is being used.

    `case GCol::SPEED:`
    `    qColor = theme.colors[6];`
    `break;`

becomes:

    `case GCol::SPEED:`
    `    qColor = theme.colors[GThmCol::SPEED];`
    `    break;`

⦁	Error found in GColor function readConfig, the name field is a text desciption of the gc color, but it is being compared against the setting value, therefore these defaults will never be applied:

            `// set sensible defaults for any not set (as new colors are added)`
            `if (ColorList[i].name == "CTOOLBAR") {`
            `    QPalette def;`
            `    ColorList[i].color = def.color(QPalette::Window);`
            `}`
            `if (ColorList[i].name == "CCHARTBAR") {`
            `    ColorList[i].color = ColorList[CTOOLBAR].color;`
            `}`
            `if (ColorList[i].name == "CCALCURRENT") {`
            `    QPalette def;`
            `    ColorList[i].color = def.color(QPalette::Highlight);`

This has been corrected to:

            // set sensible defaults for any not set (as new colors are added)
            if (colorElemt.first == GCol::TOOLBAR) {
                QPalette def;
                colorElemt.second.qColor = def.color(QPalette::Window);
            }
            if (colorElemt.first == GCol::CHARTBAR) {
                colorElemt.second.qColor = colorTable[GCol::TOOLBAR].qColor;
            }
            if (colorElemt.first == GCol::CALCURRENT) {
                QPalette def;
                colorElemt.second.qColor = def.color(QPalette::Highlight);

⦁	The three Lists: ColorList, LightDefaultColorList & DarkDefaultColorList have been combined into a single colorTable definition within GCColor using a std::map<GCol, Colors>, where all fields in the Colors class except the qColor entry are constants. This removes the previous list duplication, and simplifies checking the differences between light & dark for each defined gc color.

              class Colors {
              public:
                  static unsigned long fingerprint(const std::map<GCol, Colors>& colorTable);

                  // all public
                  const QString group;
                  const QString name;
                  const QString setting;
                  const QColor qDarkColor;
                  const QColor qLightColor;
                  QColor  qColor;
              };

⦁	The RGB conversion macros have been converted to functions to enforce type safety:

                `QColor gColorToRGBColor(const GCol& gColor);`
                `bool isRGBColor(const QColor& qColor);`
                `QColor rgbColorToQColor(const QColor& qColor);`

⦁	The "standard" Colors have been moved within GCColor.
⦁	Functions within GCColor class have been logically grouped in the header file.
⦁	Variable names within GCColors.[h&cpp] have been consistently named either gColor or qColor to clarify their type.
⦁	The unused "struct SizeSettings" in GColor.h has been removed.
⦁	The GCColor::isFlat() function only ever returned true, so has been removed
⦁	All the swatches within a theme are now displayed in the Colors Page window rather the first five, allowing the differences between similar themes to be visualised.