### PR TITLE
Fixed broken workout directory check for the first start

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -178,8 +178,9 @@ MainWindow::MainWindow(const QDir &home)
 
     // if no workout directory is configured, default to the
     // top level GoldenCheetah directory
-    if (appsettings->value(NULL, GC_WORKOUTDIR).toString() == "")
-        appsettings->setValue(GC_WORKOUTDIR, QFileInfo(context->athlete->home->root().canonicalPath() + "/../").canonicalPath());
+    if (appsettings->value(NULL, GC_WORKOUTDIR, "").toString() == ""){
+        appsettings->setValue(GC_WORKOUTDIR, QFileInfo(context->athlete->home->root().canonicalPath()).canonicalPath());
+    }
 
     /*----------------------------------------------------------------------
      *  GUI setup


### PR DESCRIPTION
Hi,

I'm new to Golden Cheetah and had a rough start, because I wasn't able to save workouts without errors.
![warn](https://github.com/GoldenCheetah/GoldenCheetah/assets/148800743/ec1e9668-d298-4936-a351-4997610b4d0b)

![error](https://github.com/GoldenCheetah/GoldenCheetah/assets/148800743/346b632c-cb81-4b93-ad53-a712a8c3c0ea)

It wasn't really obvious to me that you have to change the athlete folder **after** creating an athlete for the first time and then create a new athlete for this folder. I found some bug reports (like #2945) with the described fix. After I checked the code, this was and still is a real bug.

This pull request tries to deliver a better first use experience. This required two changes:

Fix1:
appsettings->value default fallback is "0" if no fallback value was given. So a fresh GoldenCheetah installation will always use path "0" until a workout directory was set in the settings.
We now use an empty string as fallback to get the condition working

Fix2:
Instead of using the athlete->home parent folder, the old code returned the parent's parent folder. Until a workout directory was set in the settings, the user had to navigate to the (hidden) athletes folder every time by hand.