### PR TITLE
Added a configurable grayscale filter to RideMapWindow

### DIFF
--- a/src/Charts/RideMapWindow.h
+++ b/src/Charts/RideMapWindow.h
@@ -181,6 +181,7 @@ class RideMapWindow : public GcChartWindow
         void hideRouteLineOpacityChanged(int value);
         void showIntervalsChanged(int value);
         void osmCustomTSURLEditingFinished();
+        void osmGrayValueChanged(int value);
 
 
         void forceReplot();
@@ -208,6 +209,8 @@ class RideMapWindow : public GcChartWindow
         QCheckBox* hideShadedZonesCk, * hideYellowLineCk, * hideRouteLineOpacityCk;
         QLabel *osmTSTitle, *osmTSLabel, *osmTSUrlLabel;
         QLineEdit *osmTSUrl;
+        QLabel *osmGrayLabel;
+        QSlider *osmGraySlider;
 
         QLineEdit *gkey;
         QLabel *gkeylabel;
@@ -249,6 +252,7 @@ class RideMapWindow : public GcChartWindow
 
         void setCustomTSWidgetVisible(bool value);
         void setTileServerUrlForTileType(int x);
+        void setGrayscaleForTileType(int x);
 };
 
 #endif

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -311,9 +311,13 @@
 
 // OSM Tileserver
 #define GC_OSM_TS_DEFAULT               "<athlete-preferences>osmts/default"
+#define GC_OSM_DEFAULT_GRAY             "<athlete-preferences>osm/default_gray"
 #define GC_OSM_TS_A                     "<athlete-preferences>osmts/a"
+#define GC_OSM_A_GRAY                   "<athlete-preferences>osm/a_gray"
 #define GC_OSM_TS_B                     "<athlete-preferences>osmts/b"
+#define GC_OSM_B_GRAY                   "<athlete-preferences>osm/b_gray"
 #define GC_OSM_TS_C                     "<athlete-preferences>osmts/c"
+#define GC_OSM_C_GRAY                   "<athlete-preferences>osm/c_gray"
 
 // BodyMeasures Download
 #define GC_BM_LAST_TYPE                 "<athlete-preferences>bm/last_type"


### PR DESCRIPTION
* Added a CSS-grayscale filter to OSM based maps in RideMapWindow
* Added a configuration-option for the intensity level (0..10)
* Configuration is persisted per Tile-Server
* Fixed the visibility of Google/OSM specific settings (previously the settings were only correct after selection of the other Maptype)

Background of this change: OSM-Maps (especially OpenTopoMap) can be very colorful, resulting in hardly visible activities. By adding the CSS grayscale-filter to the tiles, the contrast between the track and the map can be greatly improved. The attached image shows an example for levels 0 and 9

![grayscalefilter](https://github.com/GoldenCheetah/GoldenCheetah/assets/20986896/cd34f30f-e373-45c3-b7c0-ad2c167ae921)


