### PR TITLE
Cursor in workout text editor was invisible

### DIFF
--- a/contrib/qtsolutions/codeeditor/codeeditor.cpp
+++ b/contrib/qtsolutions/codeeditor/codeeditor.cpp
@@ -117,7 +117,8 @@ void CodeEditor::highlightCurrentLine()
     if (!isReadOnly()) {
         QTextEdit::ExtraSelection selection;
 
-        selection.format.setBackground(lineAreaColor);
+        selection.format.setBackground(QColor(Qt::lightGray));
+        selection.format.setForeground(QColor(Qt::black));
         selection.format.setProperty(QTextFormat::FullWidthSelection, true);
         selection.cursor = textCursor();
         selection.cursor.clearSelection();


### PR DESCRIPTION
The black cursor was invisible on the dark gray background.

Changed the background to a lighter color to get the cursor visible again. To achieve a good contrast, the text color for the selected line is now black. This combination works for dark and light mode.

I tried to change the cursor color, but I wasn't able to get this working in combination with "highlightCurrentLine".

![editor_with_cursor](https://github.com/GoldenCheetah/GoldenCheetah/assets/148800743/d777e909-7495-413f-ad90-fb889bbd276d)
