### PR TITLE
Dialog to show Bluetooth connection status

### DIFF
--- a/src/Train/AddDeviceWizard.cpp
+++ b/src/Train/AddDeviceWizard.cpp
@@ -1037,9 +1037,9 @@ AddPairBTLE::scanFinished(bool foundDevices)
             add->setData(0, UuidRole, deviceInfo.deviceUuid().toString()); // macOS
 
             // Setup display text
-            QLabel *status = new QLabel(this);
-            status->setText(deviceName);
-            channelWidget->setItemWidget(add, 0, status);
+            QLabel *name = new QLabel(this);
+            name->setText(deviceName);
+            channelWidget->setItemWidget(add, 0, name);
         }
     }
     else

--- a/src/Train/BT40Controller.h
+++ b/src/Train/BT40Controller.h
@@ -48,6 +48,8 @@ public:
     bool discover(QString name);
     void setDevice(QString);
     QList<QBluetoothDeviceInfo> getDeviceInfo();
+    QList<DeviceInfo> getAllowedDevices() const;
+    bool hasAllowList() const;
 
     void setLoad(double);
     void setGradient(double);
@@ -105,6 +107,10 @@ public:
 signals:
     void vo2Data(double rf, double rmv, double vo2, double vco2, double tv, double feo2);
     void scanFinished(bool foundAnyDevices);
+    void deviceConnecting(QString address, QString uuid);
+    void deviceConnected(QString address, QString uuid);
+    void deviceDisconnected(QString address, QString uuid);
+    void deviceConnectionError(QString address, QString uuid);
 
 private slots:
     void addDevice(const QBluetoothDeviceInfo&);

--- a/src/Train/BT40Device.h
+++ b/src/Train/BT40Device.h
@@ -77,6 +77,10 @@ private slots:
 
 signals:
     void setNotification(QString msg, int timeout);
+    void deviceConnected(QString address, QString uuid);
+    void deviceDisconnected(QString address, QString uuid);
+    void deviceConnectionError(QString address, QString uuid);
+
 private:
     QObject *parent;
     QBluetoothDeviceInfo m_currentDevice;

--- a/src/Train/BT40DeviceConnectionDialog.cpp
+++ b/src/Train/BT40DeviceConnectionDialog.cpp
@@ -1,0 +1,265 @@
+#include "BT40DeviceConnectionDialog.h"
+
+#include <QTreeWidget>
+#include <QTreeWidgetItem>
+
+#include "BT40Controller.h"
+#include "Colors.h"
+
+BT40DeviceConnectionDialog::BT40DeviceConnectionDialog(BT40Controller *controller)
+    : controller(controller)
+{
+    setAttribute(Qt::WA_DeleteOnClose);
+    setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
+    setModal(true);
+
+    setMinimumWidth(500 * dpiXFactor);
+    setMinimumHeight(400 * dpiYFactor);
+
+    mainLayout = new QVBoxLayout;
+    searching = tr("Searching...");
+    setWindowTitle(tr("Connecting to Bluetooth devices"));
+
+    createSubTitle();
+    createTree();
+    createButtons();
+    setLayout(mainLayout);
+
+    addDevices();
+
+    connect(controller, SIGNAL(deviceConnecting(QString, QString)), this, SLOT(deviceConnecting(QString, QString)));
+    connect(controller, SIGNAL(deviceConnected(QString, QString)), this, SLOT(deviceConnected(QString, QString)));
+    connect(controller, SIGNAL(deviceDisconnected(QString, QString)), this, SLOT(deviceDisconnected(QString, QString)));
+    connect(controller, SIGNAL(deviceConnectionError(QString, QString)), this, SLOT(deviceConnectionError(QString, QString)));
+    connect(controller, SIGNAL(scanFinished(bool)), this, SLOT(scanFinished(bool)));
+}
+
+int
+BT40DeviceConnectionDialog::exec()
+{
+    controller->start();
+    controller->resetCalibrationState();
+    return QDialog::exec();
+}
+
+void
+BT40DeviceConnectionDialog::okClicked()
+{
+    // Nothing to do. Just accept configuration
+    accept();
+}
+
+void
+BT40DeviceConnectionDialog::cancelClicked()
+{
+    // Cleanup and notify, that user does not want to start the workout
+    controller->stop();
+    reject();
+}
+
+void
+BT40DeviceConnectionDialog::retryClicked()
+{
+    /*
+     * ToDo: Only retry connection to "not connected", "disconnected" or "not found"
+    */
+
+    // avoid multiple concurrent retries
+    retryButton->setEnabled(false);
+
+    // Wait for scan to finish
+    okButton->setEnabled(false);
+
+    // reset bt40 controller
+    controller->stop();
+
+    for (int i=0; i< tree->invisibleRootItem()->childCount(); i++)
+    {
+        QTreeWidgetItem *item = tree->invisibleRootItem()->child(i);
+        QLabel* label = dynamic_cast<QLabel *>(tree->itemWidget(item,1));
+        updateLabel(label, searching, Qt::black);
+    }
+
+    // Give bluetooth manager some time to disconnect all devices.
+    // Five seconds was enough on a i5-450M from 2010. Even if it's
+    // still not enough time, this will only result in a incorrect
+    // connection status label.
+    QTime sleepTime = QTime::currentTime().addSecs(5);
+
+    // Allow UI to render and process evens during wait
+    while (QTime::currentTime() < sleepTime)
+    {
+        QCoreApplication::processEvents(QEventLoop::AllEvents, 100);
+        // Avoid 100% cpu
+        QThread::usleep(100);
+    }
+
+    controller->start();
+    controller->resetCalibrationState();
+}
+
+void
+BT40DeviceConnectionDialog::deviceConnecting(QString address, QString uuid)
+{
+    setDeviceStatus(
+        address,
+        uuid,
+        tr("Connecting..."),
+        Qt::black);
+}
+
+void
+BT40DeviceConnectionDialog::deviceConnected(QString address, QString uuid)
+{
+    setDeviceStatus(
+        address,
+        uuid,
+        tr("Connected"),
+        Qt::darkGreen);
+}
+
+void
+BT40DeviceConnectionDialog::deviceDisconnected(QString address, QString uuid)
+{
+    setDeviceStatus(
+        address,
+        uuid,
+        tr("Disconnected"),
+        Qt::darkRed);
+}
+
+void
+BT40DeviceConnectionDialog::deviceConnectionError(QString address, QString uuid)
+{
+    // Treat connection erros as "not found", since
+    // QBluetoothDeviceDiscoveryAgent also reports
+    // "trusted" or cached devices. This means, the Agent
+    // will also try to connect to devices, not found by
+    // the current scan. If this fails, we will receive a
+    // connection error. Just print "not found" to avoid
+    // confusion.
+    setDeviceStatus(
+        address,
+        uuid,
+        tr("Device not found"),
+        Qt::darkYellow);
+}
+
+void
+BT40DeviceConnectionDialog::scanFinished(bool /*foundAnyDevices*/)
+{
+    // Set all "searching" devices to "not found"
+    for (int i=0; i< tree->invisibleRootItem()->childCount(); i++)
+    {
+        QTreeWidgetItem *item = tree->invisibleRootItem()->child(i);
+        QLabel* label = dynamic_cast<QLabel *>(tree->itemWidget(item,1));
+        if (label->text() == searching)
+        {
+            updateLabel(label, tr("Device not found"), Qt::darkYellow);
+        }
+    }
+
+    // Scan finished, allow user to start workout or search again
+    retryButton->setEnabled(true);
+    okButton->setEnabled(true);
+}
+
+void
+BT40DeviceConnectionDialog::createSubTitle()
+{
+    QLabel* subTitle = new QLabel(this);
+    subTitle->setText("Searching for devices.\n\nPress OK to start your workout with the current configuration.");
+    subTitle->setMargin(4 * dpiXFactor);
+    mainLayout->addWidget(subTitle);
+}
+
+void
+BT40DeviceConnectionDialog::createTree()
+{
+    // Device status list
+    tree = new QTreeWidget(this);
+    tree->headerItem()->setText(0, tr("Device"));
+    tree->headerItem()->setText(1, tr("Status"));
+    tree->setColumnCount(2);
+    tree->setSelectionMode(QAbstractItemView::NoSelection);
+    tree->setUniformRowHeights(true);
+    tree->setIndentation(0);
+
+    tree->header()->resizeSection(0, 600 * dpiXFactor); // Device name
+    tree->header()->resizeSection(0, 200 * dpiXFactor); // status
+    mainLayout->addWidget(tree);
+}
+
+void
+BT40DeviceConnectionDialog::createButtons()
+{
+    // Buttons
+    QHBoxLayout *buttons = new QHBoxLayout;
+    buttons->addStretch();
+    mainLayout->addLayout(buttons);
+
+    cancelButton = new QPushButton(tr("Cancel"), this);
+    buttons->addWidget(cancelButton);
+
+    retryButton = new QPushButton(tr("Retry"), this);
+     // Disable until scan finished
+    retryButton->setEnabled(false);
+    buttons->addWidget(retryButton);
+
+    okButton = new QPushButton(tr("OK"), this);
+    // Disable until scan finished
+    okButton->setEnabled(false);
+    buttons->addWidget(okButton);
+
+    connect(cancelButton, SIGNAL(clicked()), this, SLOT(cancelClicked()));
+    connect(retryButton, SIGNAL(clicked()), this, SLOT(retryClicked()));
+    connect(okButton, SIGNAL(clicked()), this, SLOT(okClicked()));
+}
+
+void
+BT40DeviceConnectionDialog::addDevices()
+{
+    // Add available devices with "searching..." status
+    foreach(const DeviceInfo deviceInfo, controller->getAllowedDevices())
+    {
+        QTreeWidgetItem *add = new QTreeWidgetItem(tree->invisibleRootItem());
+        QLabel *name = new QLabel(this);
+        name->setText(deviceInfo.getName());
+
+        QLabel *status = new QLabel(this);
+        updateLabel(status, searching, Qt::black);
+
+        tree->setItemWidget(add, 0, name);
+        tree->setItemWidget(add, 1, status);
+
+        add->setData(0, AddressRole, deviceInfo.getAddress()); // other OS
+        add->setData(0, UuidRole, deviceInfo.getUuid()); // macOS
+    }
+}
+
+void
+BT40DeviceConnectionDialog::setDeviceStatus(const QString& address, const QString& uuid, const QString& status, QColor color)
+{
+    for (int i=0; i< tree->invisibleRootItem()->childCount(); i++)
+    {
+        QTreeWidgetItem *item = tree->invisibleRootItem()->child(i);
+
+        if (item->data(0, AddressRole).toString() == address
+                && item->data(0, UuidRole).toString() == uuid)
+        {
+            updateLabel(dynamic_cast<QLabel *>(tree->itemWidget(item,1)), status, color);
+        }
+    }
+}
+
+void BT40DeviceConnectionDialog::updateLabel(QLabel* label, const QString& status, QColor color)
+{
+    if (label)
+    {
+        QPalette palette = label->palette();
+        palette.setColor(label->foregroundRole(), color);
+        label->setPalette(palette);
+
+        label->setText(status);
+    }
+}

--- a/src/Train/BT40DeviceConnectionDialog.cpp
+++ b/src/Train/BT40DeviceConnectionDialog.cpp
@@ -18,6 +18,7 @@ BT40DeviceConnectionDialog::BT40DeviceConnectionDialog(BT40Controller *controlle
 
     mainLayout = new QVBoxLayout;
     searching = tr("Searching...");
+    connected = tr("Connected");
     setWindowTitle(tr("Connecting to Bluetooth devices"));
 
     createSubTitle();
@@ -114,8 +115,15 @@ BT40DeviceConnectionDialog::deviceConnected(QString address, QString uuid)
     setDeviceStatus(
         address,
         uuid,
-        tr("Connected"),
+        connected,
         Qt::darkGreen);
+
+    if (allConnected())
+    {
+        // Don't wait for scan to finish. All required devices
+        // already discovered and connected.
+        okButton->setEnabled(true);
+    }
 }
 
 void
@@ -262,4 +270,20 @@ void BT40DeviceConnectionDialog::updateLabel(QLabel* label, const QString& statu
 
         label->setText(status);
     }
+}
+
+bool
+BT40DeviceConnectionDialog::allConnected()
+{
+    for (int i=0; i< tree->invisibleRootItem()->childCount(); i++)
+    {
+        QTreeWidgetItem *item = tree->invisibleRootItem()->child(i);
+        QLabel *label = dynamic_cast<QLabel *>(tree->itemWidget(item,1));
+        if (label->text() != connected)
+        {
+            return false;
+        }
+    }
+
+    return true;
 }

--- a/src/Train/BT40DeviceConnectionDialog.h
+++ b/src/Train/BT40DeviceConnectionDialog.h
@@ -1,0 +1,54 @@
+#ifndef BT40DEVICECONNECTIONDIALOG_H
+#define BT40DEVICECONNECTIONDIALOG_H
+
+#include <QDialog>
+#include <QWidget>
+#include <QObject>
+#include <QStackedLayout>
+
+class BT40Controller;
+class QTreeWidget;
+class QLabel;
+
+class BT40DeviceConnectionDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    BT40DeviceConnectionDialog(BT40Controller *controller);
+    int exec() override;
+
+private slots:
+    void okClicked();
+    void cancelClicked();
+    void retryClicked();
+    void deviceConnecting(QString address, QString uuid);
+    void deviceConnected(QString address, QString uuid);
+    void deviceDisconnected(QString address, QString uuid);
+    void deviceConnectionError(QString address, QString uuid);
+    void scanFinished(bool foundAnyDevices);
+
+private:
+    void createSubTitle();
+    void createTree();
+    void createButtons();
+    void addDevices();
+    void setDeviceStatus(const QString& address, const QString& uuid, const QString& status, QColor color);
+    void updateLabel(QLabel* label, const QString& status, QColor color);
+
+private:
+    QVBoxLayout *mainLayout;
+    QTreeWidget *tree;
+    QPushButton *okButton;
+    QPushButton *retryButton;
+    QPushButton *cancelButton;
+
+    BT40Controller *controller;
+
+    QString searching;
+
+    static const int AddressRole = Qt::UserRole + 1;
+    static const int UuidRole = Qt::UserRole + 2;
+};
+
+#endif // BT40DEVICECONNECTIONDIALOG_H

--- a/src/Train/BT40DeviceConnectionDialog.h
+++ b/src/Train/BT40DeviceConnectionDialog.h
@@ -35,6 +35,7 @@ private:
     void addDevices();
     void setDeviceStatus(const QString& address, const QString& uuid, const QString& status, QColor color);
     void updateLabel(QLabel* label, const QString& status, QColor color);
+    bool allConnected();
 
 private:
     QVBoxLayout *mainLayout;
@@ -46,6 +47,7 @@ private:
     BT40Controller *controller;
 
     QString searching;
+    QString connected;
 
     static const int AddressRole = Qt::UserRole + 1;
     static const int UuidRole = Qt::UserRole + 2;

--- a/src/src.pro
+++ b/src/src.pro
@@ -766,7 +766,7 @@ HEADERS += Train/AddDeviceWizard.h Train/CalibrationData.h Train/ComputrainerCon
            Train/Library.h Train/LibraryParser.h Train/MeterWidget.h Train/NullController.h Train/RealtimeController.h \
            Train/RealtimeData.h Train/RealtimePlot.h Train/RealtimePlotWindow.h Train/RemoteControl.h Train/SpinScanPlot.h \
            Train/SpinScanPlotWindow.h Train/SpinScanPolarPlot.h Train/GarminServiceHelper.h Train/PhysicsUtility.h Train/BicycleSim.h \
-           Train/PolynomialRegression.h Train/MultiRegressionizer.h
+           Train/PolynomialRegression.h Train/MultiRegressionizer.h Train/BT40DeviceConnectionDialog.h
 
 greaterThan(QT_MAJOR_VERSION, 4) {
     HEADERS += Train/TodaysPlanWorkoutDownload.h
@@ -878,7 +878,7 @@ SOURCES += Train/AddDeviceWizard.cpp Train/CalibrationData.cpp Train/Computraine
            Train/Library.cpp Train/LibraryParser.cpp Train/MeterWidget.cpp Train/NullController.cpp Train/RealtimeController.cpp \
            Train/RealtimeData.cpp Train/RealtimePlot.cpp Train/RealtimePlotWindow.cpp Train/RemoteControl.cpp Train/SpinScanPlot.cpp \
            Train/SpinScanPlotWindow.cpp Train/SpinScanPolarPlot.cpp Train/GarminServiceHelper.cpp Train/PhysicsUtility.cpp Train/BicycleSim.cpp \
-           Train/PolynomialRegression.cpp
+           Train/PolynomialRegression.cpp Train/BT40DeviceConnectionDialog.cpp
 
 greaterThan(QT_MAJOR_VERSION, 4) {
     SOURCES  += Train/TodaysPlanWorkoutDownload.cpp


### PR DESCRIPTION
_This is a follow up to Bluetooth Pairing._

Connect now shows a dialog with the current connection status, if only one Bluetooth profile with allow list is selected.
I created this dialog because it is difficult to see which devices are connected.

This dialog offers to:
- accept the current connections and start a workout (available after scan)
- retry to establish connections to configured devices (available after scan)
- cancel connect and disconnect all devices (always available)

To get a fast overview, I decided to use colors for the connection status
- Green =  connected
- Yellow = not found
- Red = disconnected again
- Black = searching or connecting

We could achieve a generic dialog for Bluetooth/ANT+ and so on, but this would require a bigger refactoring and I only can test Bluetooth devices right now.

I also only support single device selection (the default setting)

These are real devices, with real connection states. I just changed the name for the screenshot.
![connection_dialog](https://github.com/GoldenCheetah/GoldenCheetah/assets/148800743/ca169417-0d01-4ba7-9c2e-0dc324b3c611)
