### PR TITLE
Compass widget for Video training and Bearing telemetry field

### DIFF
--- a/src/Train/DialWindow.cpp
+++ b/src/Train/DialWindow.cpp
@@ -522,6 +522,9 @@ DialWindow::telemetryUpdate(const RealtimeData &rtData)
     case RealtimeData::Altitude:
         valueLabel->setText(QString("%1").arg(value, 0, 'f', 1));
         break;
+    case RealtimeData::Bearing:
+        valueLabel->setText(QString("%1°").arg(value, 0, 'f', 0));
+        break;
 
     case RealtimeData::VO2:
     case RealtimeData::VCO2:
@@ -606,6 +609,7 @@ void DialWindow::seriesChanged()
     case RealtimeData::LapDistance:
     case RealtimeData::LapDistanceRemaining:
     case RealtimeData::RER:
+    case RealtimeData::Bearing:
     case RealtimeData::None:
             foreground = GColor(CDIAL);
             break;

--- a/src/Train/MeterWidget.cpp
+++ b/src/Train/MeterWidget.cpp
@@ -25,6 +25,8 @@
 #include "LocationInterpolation.h"
 #include <QWebEngineScriptCollection>
 #include <QWebEngineProfile>
+#include <qwt_compass_rose.h>
+#include <qwt_dial_needle.h>
 
 MeterWidget::MeterWidget(QString Name, QWidget *parent, QString Source) : QWidget(parent), m_Name(Name), m_container(parent), m_Source(Source)
 {
@@ -362,6 +364,34 @@ void NeedleMeterWidget::paintEvent(QPaintEvent* paintevent)
     painter.drawPath(my_painterPath);
     painter.restore();
 }
+
+CompassWidget::CompassWidget(QString Name, QWidget *parent, QString Source) : MeterWidget(Name, parent, Source)
+{
+    m_Compass.setAttribute(Qt::WA_TranslucentBackground, true);
+    m_Compass.setNeedle(new QwtCompassMagnetNeedle(QwtCompassMagnetNeedle::TriangleStyle, Qt::white, Qt::red));
+    m_Compass.setMode(QwtCompass::RotateScale);
+    QwtSimpleCompassRose *rose = new QwtSimpleCompassRose( 16, 2 );
+    rose->setWidth( 0.15 );
+    m_Compass.setRose(rose);
+}
+
+void CompassWidget::paintEvent(QPaintEvent* paintevent)
+{
+    MeterWidget::paintEvent(paintevent);
+
+
+    //painter
+    QPainter painter(this);
+    painter.setClipRegion(videoContainerRegion);
+    painter.setRenderHint(QPainter::Antialiasing);
+
+    painter.save();
+    m_Compass.setGeometry(0, 0, m_Width, m_Height);
+    m_Compass.setValue(Value);
+    m_Compass.render(&painter);
+    painter.restore();
+}
+
 
 ElevationMeterWidget::ElevationMeterWidget(QString Name, QWidget *parent, QString Source, Context *context) : MeterWidget(Name, parent, Source), context(context),
     m_minX(0.), m_maxX(0.), m_savedWidth(0), m_savedHeight(0), m_savedMinY(0), m_savedMaxY(0), gradientValue(0.)

--- a/src/Train/MeterWidget.h
+++ b/src/Train/MeterWidget.h
@@ -24,6 +24,7 @@
 #include <QtWebChannel>
 #include <QWebEnginePage>
 #include <QWebEngineView>
+#include <qwt_compass.h>
 
 class MeterWidget : public QWidget
 {
@@ -121,6 +122,17 @@ class NeedleMeterWidget : public MeterWidget
     explicit NeedleMeterWidget(QString name, QWidget *parent = 0, QString Source = QString("None"));
     virtual void paintEvent(QPaintEvent* paintevent);
 };
+
+class CompassWidget : public MeterWidget
+{
+  private:
+    QwtCompass  m_Compass;
+  public:
+    explicit CompassWidget(QString name, QWidget *parent = 0, QString Source = QString("None"));
+    virtual void paintEvent(QPaintEvent* paintevent);
+};
+
+
 
 class ElevationMeterWidget : public MeterWidget
 {

--- a/src/Train/RealtimeData.cpp
+++ b/src/Train/RealtimeData.cpp
@@ -40,6 +40,7 @@ RealtimeData::RealtimeData()
     trainerCalibRequired = false;
     trainerConfigRequired = false;
     trainerBrakeFault = false;
+    bearing = 0.0;
     memset(spinScan, 0, 24);
 }
 
@@ -167,6 +168,11 @@ void RealtimeData::setRPS(double x)
     this->rps = x;
 }
 
+void RealtimeData::setBearing(double x)
+{
+    this->bearing = x;
+}
+
 const char *
 RealtimeData::getName() const
 {
@@ -269,6 +275,10 @@ double RealtimeData::getLPS() const
 double RealtimeData::getRPS() const
 {
     return rps;
+}
+double RealtimeData::getBearing() const
+{
+    return bearing;
 }
 
 double RealtimeData::getTorque() const
@@ -449,6 +459,8 @@ double RealtimeData::value(DataSeries series) const
 
     case FeO2: return feo2;
         break;
+    case Bearing: return bearing;
+        break;
 
     case None:
     default:
@@ -522,6 +534,7 @@ const QList<RealtimeData::DataSeries> &RealtimeData::listDataSeries()
         seriesList << Altitude;
         seriesList << RouteDistance;
         seriesList << DistanceRemaining;
+        seriesList << Bearing;
     }
     return seriesList;
 }
@@ -697,6 +710,9 @@ QString RealtimeData::seriesName(DataSeries series)
         break;
 
     case FeO2: return tr("Fraction O2 Expired");
+        break;
+
+    case Bearing: return tr("Bearing");
         break;
     }
 }

--- a/src/Train/RealtimeData.h
+++ b/src/Train/RealtimeData.h
@@ -47,7 +47,7 @@ public:
                       LeftPedalSmoothness, RightPedalSmoothness, Slope, 
                       LapDistance, LapDistanceRemaining, ErgTimeRemaining,
                       Latitude, Longitude, Altitude, RouteDistance,
-                      DistanceRemaining };
+                      DistanceRemaining, Bearing };
 
     typedef enum dataseries DataSeries;
 
@@ -93,6 +93,7 @@ public:
     void setLatitude(double);
     void setLongitude(double);
     void setAltitude(double);
+    void setBearing(double);
 
     const char *getName() const;
 
@@ -147,6 +148,7 @@ public:
     double getLatitude() const;
     double getLongitude() const;
     double getAltitude() const;
+    double getBearing() const;
 
     void setTrainerStatusAvailable(bool status);
     bool getTrainerStatusAvailable() const;
@@ -187,6 +189,7 @@ private:
     double wbal;
     double hhb, o2hb;
     double rer;
+    double bearing;
     long lap;
     long msecs;
     long lapMsecs;

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -1841,6 +1841,10 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
                     maintainLapDistanceState();
                 }
 
+                //  'Clone' of variables used below, to avoid modifications of original code. They are used later
+                bool fAltitudeSet4compass = false;
+                geolocation currentgeoloc;
+
                 rtData.setDistance(displayDistance);
                 rtData.setRouteDistance(displayWorkoutDistance);
                 rtData.setLapDistance(displayLapDistance);
@@ -1872,8 +1876,10 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
                                     rtData.setLongitude(displayLongitude);
                                 }
                                 fAltitudeSet = true;
+                                currentgeoloc = geoloc;
                             }
                         }
+                        fAltitudeSet4compass = fAltitudeSet;
 
                         if (ergFile->StrictGradient || !fAltitudeSet) {
                             slope = ergFileQueryAdapter.gradientAt(displayWorkoutDistance * 1000, curLap);
@@ -1894,6 +1900,21 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
                     double altitudeDeltaMeters = slope * (10 * distanceTick); // ((slope / 100) * distanceTick) * 1000
                     displayAltitude += altitudeDeltaMeters;
                     rtData.setAltitude(displayAltitude);
+                }
+
+                {
+                    //  Bearing (for the compass)
+                    if (fAltitudeSet4compass) {
+                        int lap;
+                        double gradient;
+                        geolocation geoloc2seconds;
+                        double dist2seconds = rtData.getSpeed() / 3.6 * 2;
+                        ergFileQueryAdapter.locationAt(displayWorkoutDistance * 1000. + dist2seconds, lap, geoloc2seconds, gradient);
+                        double displayBearing = currentgeoloc.BearingTo(geoloc2seconds);
+                        displayBearing = displayBearing/3.1415924536*180 + (displayBearing>0?0:360);
+                        rtData.setBearing(displayBearing);
+                    }
+
                 }
 
                 // time

--- a/src/Train/VideoLayoutParser.cpp
+++ b/src/Train/VideoLayoutParser.cpp
@@ -173,6 +173,10 @@ bool VideoLayoutParser::startElement( const QString&, const QString&,
         {
             meterWidget = new NeedleMeterWidget(meterName, containerWidget, source);
         }
+        else if (meterType == QString("Compass"))
+        {
+            meterWidget = new CompassWidget(meterName, containerWidget, source);
+        }
         else if (meterType == QString("CircularMeter"))
         {
             meterWidget = new CircularIndicatorMeterWidget(meterName, containerWidget, source);

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -664,6 +664,12 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
                 p_meterWidget->Text = tr("");
             }
         }
+        else if (p_meterWidget->Source() == QString("Bearing"))
+        {
+            p_meterWidget->Value = rtd.getBearing();
+            p_meterWidget->Text = QString::number((int) p_meterWidget->Value).rightJustified(p_meterWidget->textWidth);
+            p_meterWidget->AltText = tr(" °") + p_meterWidget->AltTextSuffix;
+        }
     }
 
     // The Meter Widgets need to follow the Video Window when it moves


### PR DESCRIPTION
I have developed the integration of a Compass to be used in the Video frame when training with a real time video.
I have always been curious about the bearing, when driving with the GPS, for example, and I found the same functionality nice for GoldenCheetah.

It uses the direction between the current position and the position within 2 seconds (with the current speed); it is a trade off between smoothness and accuracy of the bearing.

I am a complete ignorant about Qt, so maybe the code is not the best; I have copied code from other widgets and research a bit; in the end the code is rellay simple, but probably lacks some calls to QtPainter functions or some stuff.
If you consider that adding widgets is good for the app, I am happy to have the compass in the builds of GC.

[WorkoutVideo.webm](https://github.com/GoldenCheetah/GoldenCheetah/assets/19463568/f1e5acf6-de12-4745-9104-10a3271c04ed)

The configuration is simple; in _video-layout.xml_:
```
   <meter name="Compass" container="Video" source="Bearing" type="Compass">
       <RelativeSize Width="10.0" Height="10.0" />
       <RelativePosition X="60.0" Y="10.0" />
   </meter>
```
Also, a Telemetry field has been added: "Bearing". It can be seen as a numeric figure during the training.

It has been developed and tested with Qt5.15. the update to Qt6.2 is not ready in my environment, although there are no conflicts with the changes for 6.2
