### PR TITLE
Qt6: Removed an unused timer

### DIFF
--- a/src/Train/Fortius.cpp
+++ b/src/Train/Fortius.cpp
@@ -420,9 +420,6 @@ void Fortius::run()
     if (openDevice()) return;
     isDeviceOpen = true;
 
-    QTime timer;
-    timer.start();
-
     while(1) {
 
         if (isDeviceOpen == true) {
@@ -574,8 +571,6 @@ void Fortius::run()
 
             if (openDevice()) return;
             isDeviceOpen = true;        
-                        
-            timer.restart();
         }
     }
 }


### PR DESCRIPTION
Removed a timer object of type QTime that only utilizes methods removed in Qt6, but is never read