### PR TITLE
Qt6: Prevent the use of a deleted QVariant constructor

### DIFF
--- a/src/Gui/Pages.cpp
+++ b/src/Gui/Pages.cpp
@@ -631,7 +631,7 @@ QVariant deviceModel::data(const QModelIndex &index, int role) const
                 {
                 DeviceTypes all;
                 DeviceType lookupType = all.getType (Entry.type);
-                return lookupType.name;
+                return (const char*)(lookupType.name);
                 }
                 break;
             case 2 :


### PR DESCRIPTION
In Qt6.4++, the templated constructor QVariant(T) is marked as `= delete`, making compilation fail. By casting the return value to (const char*), the right QVariant constructor `QVariant const char *)` is explicitly selected instead of
`template <typename T,
              std::enable_if_t<std::disjunction_v<std::is_pointer<T>, std::is_member_pointer<T>>, bool> = false>
    QVariant(T) = delete;
`