### PR TITLE
Qt6: Fixed connections

### DIFF
--- a/src/Charts/UserChart.cpp
+++ b/src/Charts/UserChart.cpp
@@ -958,9 +958,9 @@ UserChartSettings::UserChartSettings(Context *context, bool rangemode, GenericCh
     // watch for chartinfo edits (the series/axis stuff is managed by separate dialogs)
     connect(title, SIGNAL(textChanged(QString)), this, SLOT(updateChartInfo()));
     connect(description, SIGNAL(textChanged()), this, SLOT(updateChartInfo()));
-    connect(type, SIGNAL(currentIndexChanged(QString)), this, SLOT(updateChartInfo()));
+    connect(type, SIGNAL(currentIndexChanged(int)), this, SLOT(updateChartInfo()));
     connect(animate, SIGNAL(stateChanged(int)), this, SLOT(updateChartInfo()));
-    connect(legpos, SIGNAL(currentIndexChanged(QString)), this, SLOT(updateChartInfo()));
+    connect(legpos, SIGNAL(currentIndexChanged(int)), this, SLOT(updateChartInfo()));
     connect(stack, SIGNAL(stateChanged(int)), this, SLOT(updateChartInfo()));
     connect(intervalrefresh, SIGNAL(stateChanged(int)), this, SLOT(updateChartInfo()));
     connect(orientation, SIGNAL(currentIndexChanged(int)), this, SLOT(updateChartInfo()));

--- a/src/Gui/DownloadRideDialog.cpp
+++ b/src/Gui/DownloadRideDialog.cpp
@@ -50,7 +50,7 @@ DownloadRideDialog::DownloadRideDialog(Context *context, bool embedded) :
     int idx = deviceCombo->findText( defaultDevice );
     if( idx >= 0 )
         deviceCombo->setCurrentIndex( idx );
-    connect(deviceCombo, SIGNAL(currentIndexChanged(QString)), this, SLOT(deviceChanged(QString)));
+    connect(deviceCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(deviceChanged()));
 
     portCombo = new QComboBox(this);
 
@@ -270,10 +270,8 @@ DownloadRideDialog::updateProgress( const QString &progressText )
 
 
 void
-DownloadRideDialog::deviceChanged( QString deviceType )
+DownloadRideDialog::deviceChanged()
 {
-    (void)deviceType;
-
     updateAction(action); // adjust erase button visibility
     updatePort();
 }

--- a/src/Gui/DownloadRideDialog.h
+++ b/src/Gui/DownloadRideDialog.h
@@ -56,7 +56,7 @@ class DownloadRideDialog : public QDialog
         void closeClicked();
         void setReadyInstruct();
         void scanCommPorts();
-        void deviceChanged(QString);
+        void deviceChanged();
         void updateStatus(const QString &statusText);
         void updateProgress(const QString &progressText);
 


### PR DESCRIPTION
In UserChart, the (non-existant) signal QComboBox::currentIndexChanged(QString) was connected to a slot without parameters. In Qt6 this created a warning. Changed to signal QComboBox::currentIndexChanged(int)