### PR TITLE
Qt6: Fixed a crash related to drag & drop

### DIFF
--- a/src/Charts/LTMChartParser.cpp
+++ b/src/Charts/LTMChartParser.cpp
@@ -197,7 +197,7 @@ ChartTreeView::dropEvent(QDropEvent* event)
     }*/
 }
 
-QStringList 
+QStringList
 ChartTreeView::mimeTypes() const
 {
     QStringList returning;
@@ -207,7 +207,12 @@ ChartTreeView::mimeTypes() const
 }
 
 QMimeData *
-ChartTreeView::mimeData (const QList<QTreeWidgetItem *> items) const
+ChartTreeView::mimeData
+#if QT_VERSION < 0x060000
+(const QList<QTreeWidgetItem *> items) const
+#else
+(const QList<QTreeWidgetItem *> &items) const
+#endif
 {
     QMimeData *returning = new QMimeData;
 
@@ -216,7 +221,7 @@ ChartTreeView::mimeData (const QList<QTreeWidgetItem *> items) const
     QDataStream stream(&rawData, QIODevice::WriteOnly);
     stream.setVersion(QDataStream::Qt_4_6);
 
-    // pack data 
+    // pack data
     stream << (quint64)(context); // where did this come from?
     stream << items.count();
     foreach (QTreeWidgetItem *p, items) {

--- a/src/Charts/LTMChartParser.h
+++ b/src/Charts/LTMChartParser.h
@@ -61,8 +61,12 @@ class ChartTreeView : public QTreeWidget
         ChartTreeView(Context *);
 
         // for drag/drop
-        QStringList mimeTypes () const;
-        QMimeData * mimeData ( const QList<QTreeWidgetItem *> items ) const;
+        QStringList mimeTypes () const override;
+#if QT_VERSION < 0x060000
+        QMimeData *mimeData(const QList<QTreeWidgetItem *> items) const override;
+#else
+        QMimeData *mimeData(const QList<QTreeWidgetItem *> &items) const override;
+#endif
 
     signals:
         void itemMoved(QTreeWidgetItem* item, int previous, int actual);

--- a/src/Core/Season.cpp
+++ b/src/Core/Season.cpp
@@ -626,7 +626,7 @@ SeasonTreeView::mimeData
 
     // pack data
     stream << (quint64)(context); // where did this come from?
-    stream << items.count();
+    stream << int(items.count());
     foreach (QTreeWidgetItem *p, items) {
         int seasonIdx = -1;
         int phaseIdx = -1;

--- a/src/Core/Season.cpp
+++ b/src/Core/Season.cpp
@@ -610,7 +610,12 @@ SeasonTreeView::mimeTypes() const
 }
 
 QMimeData *
-SeasonTreeView::mimeData (const QList<QTreeWidgetItem *> items) const
+SeasonTreeView::mimeData
+#if QT_VERSION < 0x060000
+(const QList<QTreeWidgetItem *> items) const
+#else
+(const QList<QTreeWidgetItem *> &items) const
+#endif
 {
     QMimeData *returning = new QMimeData;
 

--- a/src/Core/Season.h
+++ b/src/Core/Season.h
@@ -264,15 +264,19 @@ class SeasonTreeView : public QTreeWidget
         SeasonTreeView(Context *);
 
         // for drag/drop
-        QStringList mimeTypes () const;
-        QMimeData * mimeData ( const QList<QTreeWidgetItem *> items ) const;
+        QStringList mimeTypes () const override;
+#if QT_VERSION < 0x060000
+        QMimeData *mimeData(const QList<QTreeWidgetItem *> items) const override;
+#else
+        QMimeData *mimeData(const QList<QTreeWidgetItem *> &items) const override;
+#endif
 
     signals:
         void itemMoved(QTreeWidgetItem* item, int previous, int actual);
 
     protected:
-        void dragEnterEvent(QDragEnterEvent* event);
-        void dropEvent(QDropEvent* event);
+        void dragEnterEvent(QDragEnterEvent* event) override;
+        void dropEvent(QDropEvent* event) override;
         Context *context;
 
 

--- a/src/Gui/AbstractView.h
+++ b/src/Gui/AbstractView.h
@@ -265,7 +265,7 @@ protected:
         return toggle;
     }
 
-    virtual void dragEnterEvent(QDragEnterEvent *event) {
+    virtual void dragEnterEvent(QDragEnterEvent *event) override {
 
         // we handle intervals or seasons
         if (event->mimeData()->formats().contains("application/x-gc-intervals") ||
@@ -279,7 +279,7 @@ protected:
         }
     }
 
-    virtual void dragLeaveEvent(QDragLeaveEvent *) {
+    virtual void dragLeaveEvent(QDragLeaveEvent *) override {
 
         int X = this->mapFromGlobal(QCursor::pos()).x();
         int Y = this->mapFromGlobal(QCursor::pos()).y();

--- a/src/Gui/IntervalTreeView.cpp
+++ b/src/Gui/IntervalTreeView.cpp
@@ -117,7 +117,12 @@ IntervalTreeView::mimeTypes() const
 }
 
 QMimeData *
-IntervalTreeView::mimeData (const QList<QTreeWidgetItem *> items) const
+IntervalTreeView::mimeData
+#if QT_VERSION < 0x060000
+(const QList<QTreeWidgetItem *> items) const
+#else
+(const QList<QTreeWidgetItem *> &items) const
+#endif
 {
     QMimeData *returning = new QMimeData;
 

--- a/src/Gui/IntervalTreeView.h
+++ b/src/Gui/IntervalTreeView.h
@@ -37,8 +37,12 @@ class IntervalTreeView : public QTreeWidget
         IntervalTreeView(Context *context);
 
         // for drag/drop
-        QStringList mimeTypes () const;
-        QMimeData * mimeData ( const QList<QTreeWidgetItem *> items ) const;
+        QStringList mimeTypes () const override;
+#if QT_VERSION < 0x060000
+        QMimeData *mimeData(const QList<QTreeWidgetItem *> items) const override;
+#else
+        QMimeData *mimeData(const QList<QTreeWidgetItem *> &items) const override;
+#endif
 
         // access protected members .. why do the Trolls do this to us?
         QTreeWidgetItem *itemFromIndexPublic(QModelIndex index) { return itemFromIndex(index); }
@@ -50,8 +54,8 @@ class IntervalTreeView : public QTreeWidget
     protected:
         Context *context;
 
-        void dragEnterEvent(QDragEnterEvent* event);
-        void dropEvent(QDropEvent* event);
+        void dragEnterEvent(QDragEnterEvent* event) override;
+        void dropEvent(QDropEvent* event) override;
 
 };
 

--- a/src/Gui/PerspectiveDialog.cpp
+++ b/src/Gui/PerspectiveDialog.cpp
@@ -451,7 +451,12 @@ ChartTableWidget::mimeTypes() const
 }
 
 QMimeData *
-ChartTableWidget::mimeData (const QList<QTableWidgetItem *> items) const
+ChartTableWidget::mimeData
+#if QT_VERSION < 0x060000
+(const QList<QTableWidgetItem *> items) const
+#else
+(const QList<QTableWidgetItem *> &items) const
+#endif
 {
     QMimeData *returning = new QMimeData;
 

--- a/src/Gui/PerspectiveDialog.h
+++ b/src/Gui/PerspectiveDialog.h
@@ -40,9 +40,9 @@ class PerspectiveTableWidget : public QTableWidget
         PerspectiveTableWidget(QWidget *parent) : QTableWidget(parent) { setMouseTracking(true); }
 
         // process drag and drop
-        virtual void dragEnterEvent(QDragEnterEvent *);
-        virtual void dragMoveEvent(QDragMoveEvent *);
-        virtual void dropEvent(QDropEvent *);
+        virtual void dragEnterEvent(QDragEnterEvent *) override;
+        virtual void dragMoveEvent(QDragMoveEvent *) override;
+        virtual void dropEvent(QDropEvent *) override;
 
     signals:
         void chartMoved(GcChartWindow*);
@@ -56,8 +56,12 @@ class ChartTableWidget : public QTableWidget
     public:
         ChartTableWidget(QWidget *parent) : QTableWidget(parent) {}
 
-        virtual QStringList mimeTypes() const;
-        virtual QMimeData *mimeData (const QList<QTableWidgetItem *> items) const;
+        virtual QStringList mimeTypes() const override;
+#if QT_VERSION < 0x060000
+        virtual QMimeData *mimeData (const QList<QTableWidgetItem *> items) const override;
+#else
+        virtual QMimeData *mimeData (const QList<QTableWidgetItem *> &items) const override;
+#endif
 };
 
 class PerspectiveDialog : public QDialog

--- a/src/Gui/RideNavigatorProxy.h
+++ b/src/Gui/RideNavigatorProxy.h
@@ -223,7 +223,7 @@ public:
         //}
     }
 
-    QStringList mimeTypes() const {
+    QStringList mimeTypes() const override {
 
         QStringList returning;
         returning << "application/x-gc-intervals";
@@ -231,7 +231,7 @@ public:
         return returning;
     }
 
-    QMimeData *mimeData (const QModelIndexList & /*indexes*/) const {
+    QMimeData *mimeData(const QModelIndexList & /*indexes*/) const override {
 
         QMimeData *returning = new QMimeData;
 
@@ -240,7 +240,7 @@ public:
         QDataStream stream(&rawData, QIODevice::WriteOnly);
         stream.setVersion(QDataStream::Qt_4_6);
 
-        // pack data 
+        // pack data
         stream << (quint64)(rideNavigator->context); // where did this come from?
 
         RideItem *ride = rideNavigator->context->ride;  // the currently selected ride


### PR DESCRIPTION
Qt6 changed the signature of the method mimeData in QTreeWidget and QTableWidget from
Q...::mimeData(const QList<...>) const
to
Q...::mimeData(const QList<...>&) const
therefore ignoring local implementations and falling back to the base-implementation with the default-serialization. This PR supports both Qt5 and Qt6 by a selecting the matching signature based on the Qt-version. Additionally the specifier override was added to Q...::mimeData, Q...::mimeTypes and some drag&drop-related event-handlers to prevent this kind of error for future versions.