### PR TITLE
Charts/PfPvPlot (QA): allow vertical scales up to 2500N

### DIFF
--- a/src/Charts/PfPvPlot.cpp
+++ b/src/Charts/PfPvPlot.cpp
@@ -1073,7 +1073,7 @@ PfPvPlot::recalc()
                 double aepf = (p1->watts * 60.0) / (p1->cad * cl_ * 2.0 * PI);
                 double cpv = (p1->cad * cl_ * 2.0 * PI) / 60.0;
 
-                if (aepf < 255 && aepf > maxAEPF) maxAEPF = aepf;
+                if (aepf < 2500 && aepf > maxAEPF) maxAEPF = aepf;
                 if (cpv > maxCPV) maxCPV = cpv;
             }
         }


### PR DESCRIPTION
The vertical axis on the QA plots (pedal force, Newtons) was stuck at 600N, even if the ride data exceeded it. The code that calculated the max force for the activity was apperently trying to throw out outliers (defined as "more than 2500N" -- 562 lbf)... but when finding the "max force" the value was seems to have accidentally been typed in as "255". This created logically dead code:

    maxAEPF = 600;
    ...
    if (aepf < 255 && aepf > maxAEPF) maxAEPF = aepf;

Thus, the max is never updated.

This patch changes the filter value from 255 to 2500 (as is indicated to be the intent elsewhere in the source file).