### PR TITLE
Qt6: Fixed flickering MainWindow

### DIFF
--- a/src/Charts/RideMapWindow.cpp
+++ b/src/Charts/RideMapWindow.cpp
@@ -137,6 +137,7 @@ RideMapWindow::RideMapWindow(Context *context, int mapType) : GcChartWindow(cont
     view->setContentsMargins(0,0,0,0);
     view->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding);
     view->setAcceptDrops(false);
+    view->page()->setHtml("<html></html>");
     layout->addWidget(view);
 
     HelpWhatsThis *help = new HelpWhatsThis(view);

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -444,6 +444,7 @@ MainWindow::MainWindow(const QDir &home)
     tablayout->addWidget(viewStack);
     setCentralWidget(central);
 
+#if QT_VERSION >= 0x060000
     /*----------------------------------------------------------------------
      * Hack to avoid a flickering MainWindow when showing a QWebEngineView in a chart, e.g. a Map:
      * Temporarily add a dummy QWebEngineView with some random content before the MainWindow is shown
@@ -454,6 +455,7 @@ MainWindow::MainWindow(const QDir &home)
     mainLayout->addWidget(dummywev);
     mainLayout->removeWidget(dummywev);
     delete dummywev;
+#endif
 
     /*----------------------------------------------------------------------
      * Application Menus

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -445,6 +445,17 @@ MainWindow::MainWindow(const QDir &home)
     setCentralWidget(central);
 
     /*----------------------------------------------------------------------
+     * Hack to avoid a flickering MainWindow when showing a QWebEngineView in a chart, e.g. a Map:
+     * Temporarily add a dummy QWebEngineView with some random content before the MainWindow is shown
+     * https://forum.qt.io/topic/141398/qwebengineview-closes-reopens-window-when-added-dynamically
+     *--------------------------------------------------------------------*/
+    QWebEngineView *dummywev = new QWebEngineView();
+    dummywev->page()->setHtml("<html></html>");
+    mainLayout->addWidget(dummywev);
+    mainLayout->removeWidget(dummywev);
+    delete dummywev;
+
+    /*----------------------------------------------------------------------
      * Application Menus
      *--------------------------------------------------------------------*/
 #ifdef WIN32


### PR DESCRIPTION
When opening a Mapchart for the first time after start of GC, the MainWindow used to shrink and be maximized again afterwards automatically, matching the description in
https://forum.qt.io/topic/141398/qwebengineview-closes-reopens-window-when-added-dynamically

By adding and removing a QWebEngineView before showing MainWindow, this flicker can be avoided