### PR TITLE
Fixed rounding error when loading and saving ERG files

### DIFF
--- a/src/Train/ErgFile.cpp
+++ b/src/Train/ErgFile.cpp
@@ -26,6 +26,7 @@
 #include <QXmlSimpleReader>
 
 #include <stdint.h>
+#include <cmath>
 #include "Units.h"
 #include "Utils.h"
 
@@ -599,13 +600,12 @@ void ErgFile::parseComputrainer(QString p)
                 switch (format) {
 
                 case ERG:       // its an absolute wattage
-                    if (Ftp) { // adjust if target FTP is set.
+                    if (Ftp && Ftp != CP) { // adjust if target FTP is set.
                         // if ftp is set then convert to the users CP
-
                         double watts = add.y;
                         double ftp = Ftp;
                         watts *= CP/ftp;
-                        add.y = add.val = int(watts);
+                        add.y = add.val = int(std::round(watts));
                     }
                     break;
                 case MRC:       // its a percent relative to CP (mrc file)
@@ -1264,7 +1264,9 @@ ErgFile::save(QStringList &errors)
             double minutes = double(p.x) / (1000.0f*60.0f);
 
             // we scale back if needed
-            if (Ftp && CP) watts = (double(p.y)/CP) * Ftp;
+            if (Ftp && CP && Ftp != CP) {
+                 watts = std::round(p.y / CP * Ftp);
+            }
 
             // check if a lap marker should be inserted
             foreach(ErgFileLap l, Laps) {


### PR DESCRIPTION
Conversion from double to int can result in lower values. 
Example:
```cpp
int Ftp = 293;
double point = 246;
int watt = point / Ftp * Ftp; // watt = 245
```

This bug is hard to notice, since saving a workout will store the incorrect value, but
the UI still shows the correct value. You have to restart GC to spot it. Changing the FTP
setting and editing workouts can increase the difference even further.

Fix
```cpp
int watt = std::round(point / Ftp * Ftp); // watt = 246
```
I also added a check if a conversion is necessary.



This PR will only fix ERG files (GC Standard file format). `ErgFile.cpp` contains more
errors of this kind, but I can't reproduce and test them due to lack of data.