### PR TITLE
Bound global action to QKeySequence::Quit

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -494,7 +494,11 @@ MainWindow::MainWindow(const QDir &home)
     fileMenu->addSeparator();
     fileMenu->addAction(tr("Save all modified activities"), this, SLOT(saveAllUnsavedRides()));
     fileMenu->addSeparator();
-    fileMenu->addAction(tr("Close Window"), this, SLOT(closeWindow()));
+    QAction *actionQuit = new QAction(tr("&Quit"), fileMenu);
+    actionQuit->setShortcuts(QKeySequence::Quit);
+    actionQuit->setShortcutContext(Qt::ApplicationShortcut);
+    connect(actionQuit, SIGNAL(triggered()), this, SLOT(closeWindow()));
+    fileMenu->addAction(actionQuit);
     //fileMenu->addAction(tr("&Close Tab"), this, SLOT(closeTab())); use athlete view
 
     HelpWhatsThis *fileMenuHelp = new HelpWhatsThis(fileMenu);
@@ -1131,6 +1135,7 @@ MainWindow::moveEvent(QMoveEvent*)
 void
 MainWindow::closeEvent(QCloseEvent* event)
 {
+    QGuiApplication::setOverrideCursor(Qt::WaitCursor);
     QList<AthleteTab*> closing = tabList;
     bool needtosave = false;
     bool importrunning = false;
@@ -1143,7 +1148,9 @@ MainWindow::closeEvent(QCloseEvent* event)
         if (tab->context->athlete->autoImport) {
             if (tab->context->athlete->autoImport->importInProcess() ) {
                 importrunning = true;
+                QGuiApplication::restoreOverrideCursor();
                 QMessageBox::information(this, tr("Activity Import"), tr("Closing of athlete window not possible while background activity import is in progress..."));
+                QGuiApplication::setOverrideCursor(Qt::WaitCursor);
             }
         }
 
@@ -1178,6 +1185,7 @@ MainWindow::closeEvent(QCloseEvent* event)
     }
     appsettings->setValue(GC_SETTINGS_MAIN_GEOM, saveGeometry());
     appsettings->setValue(GC_SETTINGS_MAIN_STATE, saveState());
+    QGuiApplication::restoreOverrideCursor();
 }
 
 MainWindow::~MainWindow()
@@ -1989,8 +1997,10 @@ MainWindow::newCyclistTab()
 void
 MainWindow::closeWindow()
 {
+    QGuiApplication::setOverrideCursor(Qt::WaitCursor);
     // just call close, we might do more later
     appsettings->syncQSettings();
+    QGuiApplication::restoreOverrideCursor();
     close();
 }
 

--- a/src/Gui/SaveDialogs.cpp
+++ b/src/Gui/SaveDialogs.cpp
@@ -105,7 +105,9 @@ MainWindow::saveRideExitDialog(Context *context)
     // we have some files to save...
     if (dirtyList.count() > 0) {
         SaveOnExitDialogWidget dialog(this, context, dirtyList);
+        QGuiApplication::setOverrideCursor(Qt::ArrowCursor);
         int result = dialog.exec();
+        QGuiApplication::restoreOverrideCursor();
         if (result == QDialog::Rejected) return false; // cancel that closeEvent!
     }
 
@@ -119,6 +121,7 @@ MainWindow::saveRideExitDialog(Context *context)
 void
 MainWindow::saveSilent(Context *context, RideItem *rideItem)
 {
+    QGuiApplication::setOverrideCursor(Qt::WaitCursor);
     QFile   currentFile(rideItem->path + QDir::separator() + rideItem->fileName);
     QFileInfo currentFI(currentFile);
     QString currentType =  currentFI.completeSuffix().toUpper();
@@ -201,6 +204,7 @@ MainWindow::saveSilent(Context *context, RideItem *rideItem)
 
     // model estimates (lazy refresh)
     context->athlete->rideCache->estimator->refresh();
+    QGuiApplication::restoreOverrideCursor();
 }
 
 
@@ -217,8 +221,7 @@ MainWindow::saveAllFilesSilent(Context *context)
     // we have some files to save...
     if (dirtyList.count() > 0) {
         for (int i=0; i<dirtyList.count(); i++) {
-                this->saveRideSingleDialog(context, dirtyList.at(i));
-
+            this->saveRideSingleDialog(context, dirtyList.at(i));
         }
     }
 }


### PR DESCRIPTION
This change allows to quit Golden Cheetah using a keyboard shortcut. QKeySequence::Quit is Ctrl+q on Linux and Cmd+q on MacOS but unbound on Windows, see https://doc.qt.io/qt-6/qkeysequence.html#standard-shortcuts

Additionally set Qt::WaitCursor while shutting down Golden Cheetah to indicate the application is blocked