### PR TITLE
Search/filter placeholder text fix

### DIFF
--- a/src/Core/NamedSearch.cpp
+++ b/src/Core/NamedSearch.cpp
@@ -256,7 +256,7 @@ EditNamedSearches::EditNamedSearches(QWidget *parent, Context *context) : QDialo
     layout->addLayout(row2);
     QLabel *filter = new QLabel(tr("Filter"), this);
     row2->addWidget(filter);
-    editSearch = new SearchBox(context, this, true);
+    editSearch = new SearchBox(context, this, true, false);
     row2->addWidget(editSearch);
 
     // add/update buttons
@@ -301,6 +301,29 @@ EditNamedSearches::EditNamedSearches(QWidget *parent, Context *context) : QDialo
     row4->addStretch();
     deleteButton = new QPushButton(tr("Delete"), this);
     row4->addWidget(deleteButton);
+    row4->addStretch();
+    closeButton = new QPushButton(tr("Close"), this);
+    row4->addWidget(closeButton);
+
+    // The QlineEdit & QTreeWidget pick up the style from the location they launched and
+    // as the popup diagloues do not follow the theme, in these cases a correction is required.
+    QColor color = QPalette().color(QPalette::Highlight);
+    QString qbaseStyle = QString(" {  background-color: rgbs(255,255,255,255); "
+                                 "    color: rgbs(0, 0, 0, 255); "
+                                 "    border-radius: 3px; "
+                                 "    border: 1px solid rgba(127,127,127,127); } ");
+
+    QString qfocusStyle = QString("   QLineEdit:focus { "
+                                 "    border-radius: 3px; "
+#ifdef WIN32
+                                 "    border: 1px solid rgba(%1,%2,%3,255);"
+#else
+                                 "    border: 2px solid rgba(%1,%2,%3,255);"
+#endif
+                                 "}" ).arg(color.red()).arg(color.green()).arg(color.blue());
+
+    editName->setStyleSheet(QString(" QLineEdit ") + qbaseStyle + qfocusStyle);
+    searchList->setStyleSheet(QString(" QTreeWidget ") + qbaseStyle);
 
     // Populate the list of named searches
     foreach(NamedSearch x, context->athlete->namedSearches->getList()) {
@@ -319,6 +342,7 @@ EditNamedSearches::EditNamedSearches(QWidget *parent, Context *context) : QDialo
     // connect the buttons
     connect(addButton, SIGNAL(clicked()), this, SLOT(addClicked()));
     connect(deleteButton, SIGNAL(clicked()), this, SLOT(deleteClicked()));
+    connect(closeButton, SIGNAL(clicked()), this, SLOT(close()));
     connect(updateButton, SIGNAL(clicked()), this, SLOT(updateClicked()));
     connect(upButton, SIGNAL(clicked()), this, SLOT(upClicked()));
     connect(downButton, SIGNAL(clicked()), this, SLOT(downClicked()));

--- a/src/Core/NamedSearch.h
+++ b/src/Core/NamedSearch.h
@@ -115,7 +115,8 @@ class EditNamedSearches : public QDialog
                     *updateButton,
                     *upButton,
                     *downButton,
-                    *deleteButton;
+                    *deleteButton,
+                    *closeButton;
         QIcon searchIcon, filterIcon;
 
     private slots:

--- a/src/Gui/AnalysisSidebar.cpp
+++ b/src/Gui/AnalysisSidebar.cpp
@@ -424,7 +424,7 @@ AnalysisSidebar::showActivityMenu(const QPoint &pos)
 
         } else {
 
-            QMenu *groupByMenu = new QMenu(tr("Group By"), rideNavigator);
+            QMenu *groupByMenu = new QMenu(tr("Group By"), this);
             groupByMenu->setEnabled(true);
             menu.addMenu(groupByMenu);
 

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -336,7 +336,7 @@ MainWindow::MainWindow(const QDir &home)
     HelpWhatsThis *helpPerspectiveSelector = new HelpWhatsThis(perspectiveSelector);
     perspectiveSelector->setWhatsThis(helpPerspectiveSelector->getWhatsThisText(HelpWhatsThis::ToolBar_PerspectiveSelector));
 
-    searchBox = new SearchFilterBox(this,context,false);
+    searchBox = new SearchFilterBox(this,context, true, true, true);
 
     searchBox->setStyle(toolStyle);
     searchBox->setFixedWidth(400 * dpiXFactor);

--- a/src/Gui/SearchBox.cpp
+++ b/src/Gui/SearchBox.cpp
@@ -34,8 +34,10 @@
 
 const int BUTTON_SIZE = 12;
 
-SearchBox::SearchBox(Context *context, QWidget *parent, bool nochooser)
-    : QLineEdit(parent), context(context), parent(parent), filtered(false), nochooser(nochooser), active(false), fixed(false)
+SearchBox::SearchBox(Context *context, QWidget *parent, bool nochooser, bool manageFilters, bool useTheme) :
+    QLineEdit(parent), context(context), parent(parent), filtered(false),
+    nochooser(nochooser), active(false), fixed(false), currTextAplha(0),
+    manageFilters(manageFilters), useTheme(useTheme)
 {
     setFixedHeight(28*dpiYFactor);
     //clear button
@@ -103,27 +105,9 @@ static bool insensitiveLessThan(const QString &a, const QString &b)
 void
 SearchBox::configChanged(qint32)
 {
-    int frameWidth = style()->pixelMetric(QStyle::PM_DefaultFrameWidth);
-    QColor color = QPalette().color(QPalette::Highlight);
+    QColor bkgd = useTheme ? GColor(CTOOLBAR) : palette().color(QPalette::Base);
 
-    setStyleSheet(QString( //"QLineEdit { padding-right: %1px; } "
-                      "QLineEdit#SearchBox {"
-                      "    border-radius: 3px; "
-                      "    border: 1px solid rgba(127,127,127,127);"
-                      "    padding: 0px %1px;"
-                      "}"
-                      "QLineEdit#SearchBox:focus {"
-                      "    border-radius: 3px; "
-#ifdef WIN32
-                      "    border: 1px solid rgba(%2,%3,%4,255);"
-#else
-                      "    border: 2px solid rgba(%2,%3,%4,255);"
-#endif
-                      "    padding: 0px %5px;"
-                      "}"
-             ).arg(clearButton->sizeHint().width() + frameWidth + 12)
-              .arg(color.red()).arg(color.green()).arg(color.blue())
-              .arg(clearButton->sizeHint().width() + frameWidth + 12));
+    setSearchBoxStyle(GCColor::invertColor(bkgd), 128, true);
 
     // get suitably formated list
     QList<QString> list;
@@ -203,6 +187,44 @@ SearchBox::configChanged(qint32)
 
     // set new list
     completer->setList(list);
+}
+
+void
+SearchBox::setSearchBoxStyle(const QColor& textColor, int alpha, bool configChange /* = false */)
+{
+    // setSearchBoxStyle gets called numerous times, so limit the stylesheet updates 
+    if ((textColor != currTextColor) || (alpha != currTextAplha) || configChange) {
+
+        int frameWidth = style()->pixelMetric(QStyle::PM_DefaultFrameWidth);
+        QColor color = QPalette().color(QPalette::Highlight);
+        currTextColor = textColor;
+        currTextAplha = alpha;
+
+        QColor bkgd = useTheme ? GColor(CTOOLBAR) : palette().color(QPalette::Base);
+
+        setStyleSheet(QString(
+            "QLineEdit#SearchBox {"
+            "    color: rgba(%6,%7,%8,%9);"
+            "    background: rgba(%10,%11,%12,255);"
+            "    border-radius: 3px; "
+            "    border: 1px solid rgba(127,127,127,127);"
+            "    padding: 0px %1px;"
+            "}"
+            "QLineEdit#SearchBox:focus {"
+            "    border-radius: 3px; "
+#ifdef WIN32
+            "    border: 1px solid rgba(%2,%3,%4,255);"
+#else
+            "    border: 2px solid rgba(%2,%3,%4,255);"
+#endif
+            "    padding: 0px %5px;"
+            "}"
+        ).arg(clearButton->sizeHint().width() + frameWidth + 12)
+            .arg(color.red()).arg(color.green()).arg(color.blue())
+            .arg(clearButton->sizeHint().width() + frameWidth + 12)
+            .arg(textColor.red()).arg(textColor.green()).arg(textColor.blue()).arg(alpha)
+            .arg(bkgd.red()).arg(bkgd.green()).arg(bkgd.blue()));
+    }
 }
 
 void
@@ -299,10 +321,8 @@ void SearchBox::setMode(SearchBoxMode mode)
 void SearchBox::updateCloseButton(const QString& text)
 {
     if (clearButton->isVisible() && text.isEmpty()) mode == Search ? clearQuery() : clearFilter();
-    clearButton->setVisible(!text.isEmpty());
 
-    //REMOVED SINCE TOO HEAVY NOW AFFECTS CHARTS TOO
-    //if (mode == Search) searchSubmit(); // only do search as you type in search mode
+    clearButton->setVisible(!text.isEmpty());
 
     setGood(); // if user changing then don't stay red - wait till resubmitted
     checkMenu();
@@ -319,9 +339,10 @@ void SearchBox::searchSubmit()
 
 void SearchBox::clearClicked()
 {
-    setText("");
+    clear();
     filtered = false;
-    //mode == Search ? clearQuery() : clearFilter();
+    mode == Search ? clearQuery() : clearFilter();
+
     setGood();
 }
 
@@ -340,8 +361,10 @@ void SearchBox::setMenu()
         foreach(NamedSearch x, context->athlete->namedSearches->getList()) {
             dropMenu->addAction(x.name);
         }
-        dropMenu->addSeparator();
-        dropMenu->addAction(tr("Manage Filters"));
+        if (manageFilters) {
+            dropMenu->addSeparator();
+            dropMenu->addAction(tr("Manage Filters"));
+        }
     }
     if (!nochooser) dropMenu->addAction(tr("Column Chooser"));
 
@@ -374,23 +397,19 @@ void SearchBox::runMenu(QAction *x)
 
 void SearchBox::setBad(QStringList errors)
 {
-    QPalette pal;
-    pal.setColor(QPalette::Text, Qt::red);
-    setPalette(pal);
+    setSearchBoxStyle(QColor(Qt::red), 255);
 
     setToolTip(errors.join(tr(" and ")));
 }
 
 void SearchBox::setGood()
 {
-    QPalette pal;
-    pal.setColor(QPalette::Text, Qt::black);
-    setPalette(pal);
+    QColor bkgd = useTheme ? GColor(CTOOLBAR) : palette().color(QPalette::Base);
+
+    setSearchBoxStyle(GCColor::invertColor(bkgd), 255);
 
     setToolTip("");
 }
-
-
 
 // Drag and drop columns from the chooser...
 void

--- a/src/Gui/SearchBox.h
+++ b/src/Gui/SearchBox.h
@@ -42,7 +42,7 @@ public:
     enum searchboxmode { Search, Filter };
     typedef enum searchboxmode SearchBoxMode;
 
-    SearchBox(Context *context, QWidget *parent = 0, bool nochooser=true);
+    SearchBox(Context *context, QWidget *parent, bool nochooser = true, bool manageFilters = true, bool useTheme = false);
 
     // either search box or filter box
     void setMode(SearchBoxMode mode);
@@ -94,6 +94,7 @@ private slots:
     void keyPressEvent(QKeyEvent *e);
 
     void configChanged(qint32);
+    void setSearchBoxStyle(const QColor& textColor, int alpha, bool configChange = false);
 
 signals:
     // text search mode
@@ -119,6 +120,10 @@ private:
     DataFilterCompleter *completer;
     bool active;
     bool fixed;
+    bool useTheme;
+    bool manageFilters;
+    int currTextAplha;
+    QColor currTextColor;
 };
 
 class DataFilterCompleter : public QCompleter

--- a/src/Gui/SearchFilterBox.cpp
+++ b/src/Gui/SearchFilterBox.cpp
@@ -25,7 +25,7 @@
 #include "RideCache.h"
 #include "RideItem.h"
 
-SearchFilterBox::SearchFilterBox(QWidget *parent, Context *context, bool nochooser) : QWidget(parent), context(context)
+SearchFilterBox::SearchFilterBox(QWidget *parent, Context *context, bool nochooser, bool manageFilters, bool useTheme) : QWidget(parent), context(context)
 {
 
     setContentsMargins(0,0,0,0);
@@ -34,7 +34,7 @@ SearchFilterBox::SearchFilterBox(QWidget *parent, Context *context, bool nochoos
     contents->setContentsMargins(0,0,0,0);
 
     // no column chooser if my parent widget is a modal widget
-    searchbox = new SearchBox(context, this, nochooser);
+    searchbox = new SearchBox(context, this, nochooser, manageFilters, useTheme);
     searchbox->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed));
     contents->addWidget(searchbox);
 

--- a/src/Gui/SearchFilterBox.h
+++ b/src/Gui/SearchFilterBox.h
@@ -32,7 +32,7 @@ class SearchFilterBox : public QWidget
     Q_PROPERTY(int xwidth READ xwidth WRITE setXWidth USER true)
 
 public:
-    SearchFilterBox(QWidget *parent, Context *context, bool nochooser = true);
+    SearchFilterBox(QWidget *parent, Context *context, bool nochooser = true, bool manageFilters = true, bool useTheme = false);
     void setMode(SearchBox::SearchBoxMode x) { searchbox->setMode(x); }
 
     QString filter();


### PR DESCRIPTION
This PR fixes:

- The placeholder text which disappears on dark themes now remains visible.

![Screenshot 2024-04-16 201506](https://github.com/GoldenCheetah/GoldenCheetah/assets/46629337/90936ed4-38ee-482b-85ef-4f4d8754192c)

![Screenshot 2024-04-16 201546](https://github.com/GoldenCheetah/GoldenCheetah/assets/46629337/9ecc4af4-89bb-4f77-ade0-59eb0ca2e78d)

- The red text is now displayed (and removed) when invalid filter text is entered.

![Screenshot 2024-04-16 201724](https://github.com/GoldenCheetah/GoldenCheetah/assets/46629337/e88a1dd9-be54-4a80-88b5-d830ee329670)

![Screenshot 2024-04-16 201634](https://github.com/GoldenCheetah/GoldenCheetah/assets/46629337/48aa3444-3e16-4678-a232-ebe2b4fc5cd4)

- The colour of the group-by menu has now been fixed, previously on Windows it appeared as:

![Group-by menu](https://github.com/GoldenCheetah/GoldenCheetah/assets/46629337/544f157e-0f0a-4de5-8bc0-9fac4a4395c0)

- The backgrounds of the "Manage Filters" dialogue QLineEdit fields for the name, searchbox and filter list would pickup the theme (noticeable on dark themes) depending where they were launched from:

**From the mainWindow Toolbar:**

![Screenshot 2024-05-19 182832](https://github.com/GoldenCheetah/GoldenCheetah/assets/46629337/65d11a74-66a9-4fce-8e07-4387ae99049b)

**From the Trends, Manage Filters:**

![Screenshot 2024-05-19 184500](https://github.com/GoldenCheetah/GoldenCheetah/assets/46629337/9ebecfb7-32bd-4b51-8540-794e68b415ab)

- The "Manage Filters" option in the pull down menu has been removed from the "Manage Filters" dialogue, otherwise this just opens another instance of the dialogue for no benefit, and possible accidental filter overwrite problems.

- Added a close button to the bottom right of the "Manage Filters" dialogue, hopefully preventing accidentally deleted filters.

- Removed "column chooser" from  the "Manage Filters" pull down, as the option is already available from the ride navigator menu, and IMHO it is more logically associated with that location, I can add it back if you want it retained.

I have tested the above with most dark & light themes on Windows and all seems to work, so can it be tested on Linux & MacOs ?

Note: All popup windows and dialogues do not respect the selected theme, and use a default light theme, this this was part of the problem of hidden text, I expect it would a significant project to get them to adopt the theme colours.

 