### PR TITLE
Changed the standard colors for compare-mode

### DIFF
--- a/src/Gui/Colors.cpp
+++ b/src/Gui/Colors.cpp
@@ -63,28 +63,6 @@ int pixelSizeForFont(QFont &font, int height)
     return pixelsize;
 }
 
-//
-// A selection of distinct colours, user can adjust also
-//
-QList<QColor> standardColors;
-static bool initStandardColors()
-{
-    standardColors << QColor(Qt::magenta);
-    standardColors << QColor(Qt::cyan);
-    standardColors << QColor(Qt::yellow);
-    standardColors << QColor(Qt::red);
-    standardColors << QColor(Qt::blue);
-    standardColors << QColor(Qt::gray);
-    standardColors << QColor(Qt::darkCyan);
-    standardColors << QColor(Qt::green);
-    standardColors << QColor(Qt::darkRed);
-    standardColors << QColor(Qt::darkGreen);
-    standardColors << QColor(Qt::darkBlue);
-    standardColors << QColor(Qt::darkMagenta);
-
-    return true;
-}
-static bool init = initStandardColors();
 
 // the standard themes, a global object
 static Themes allThemes;
@@ -554,13 +532,13 @@ GCColor::css(bool ridesummary)
 		   ".tooltip .tooltiptext { visibility: hidden; background-color: %2; color: %1; text-align: center; padding: %4px 0; border-radius: %5px; position: absolute; z-index: 1; width: %6px; margin-left: -%7px; top: 100%; left: 50%; opacity: 0; transition: opacity 0.3s; } "
 		   ".tooltip:hover .tooltiptext { visibility: visible; opacity: 1; } "
 #ifdef Q_OS_MAC
-                   "::-webkit-scrollbar-thumb { border-radius: 4px; background: rgba(0,0,0,0.5);  "
+                   "::-webkit-scrollbar-thumb { border-radius: 4px; background-color: rgba(0,0,0,0.5);  "
                    "-webkit-box-shadow: inset 0 0 1px rgba(255,255,255,0.6); }"
-                   "::-webkit-scrollbar { width: 9; background: %2; } "
+                   "::-webkit-scrollbar { width: 9; background-color: %2; } "
 #else
-                   "::-webkit-scrollbar-thumb { background: darkGray; } "
-                   "::-webkit-scrollbar-thumb:hover { background: lightGray; } "
-                   "::-webkit-scrollbar { width: %5px; background: %2; } "
+                   "::-webkit-scrollbar-thumb { background-color: darkGray; } "
+                   "::-webkit-scrollbar-thumb:hover { background-color: lightGray; } "
+                   "::-webkit-scrollbar { width: %5px; background-color: %2; } "
 #endif
                    "</style> ").arg(GColor(CPLOTMARKER).name())
                                .arg(bgColor.name())
@@ -584,7 +562,7 @@ GCColor::palette()
     return palette;
 }
 
-QString 
+QString
 GCColor::stylesheet(bool train)
 {
     // make it to order to reflect current config
@@ -592,16 +570,15 @@ GCColor::stylesheet(bool train)
     QColor fgColor = GCColor::invertColor(bgColor);
     QColor bgSelColor = selectedColor(bgColor);
     QColor fgSelColor = GCColor::invertColor(bgSelColor);
-    return QString("QTreeView { color: %2; background: %1; }"
-                   "%3"
-                   "QTableWidget { color: %2; background: %1; }"
+    return QString("QTreeView { color: %2; background-color: %1; }"
+                   "QTreeView::item:hover { color: black; background-color: lightGray; }"
+                   "QTreeView::item:selected { color: %4; background-color: %3; }"
+                   "QTableWidget { color: %2; background-color: %1; }"
+                   "QTableWidget::item:hover { color: black; background-color: lightGray; }"
 #ifndef Q_OS_MAC
                    "QHeaderView { background-color: %1; color: %2; }"
                    "QHeaderView::section { background-color: %1; color: %2; border: 0px ; }"
 #endif
-                   "QTableWidget::item:hover { color: black; background: lightGray; }"
-                   "QTreeView::item:hover { color: black; background: lightGray; }"
-                   "QTreeView::item:selected { color: %4; background-color: %3; }"
                   ).arg(bgColor.name()).arg(fgColor.name()).arg(bgSelColor.name()).arg(fgSelColor.name());
 }
 
@@ -660,6 +637,47 @@ GCColor::getConfigKeys() {
         result.append(ColorList[i].setting);
     }
     return result;
+}
+
+
+QColor
+standardColor
+(int index)
+{
+    static const QList<QColor> darkThemeColors = {
+        QColor(1,202,152),
+        QColor(208,100,166),
+        QColor(185,138,255),
+        QColor(156,143,0),
+        QColor(0,145,186),
+        QColor(163,87,39),
+        QColor(118,54,115),
+        QColor(124,85,0),
+        QColor(66,98,140),
+        QColor(147,32,47),
+        QColor(255,161,104),
+        QColor(167,245,171)
+    };
+    static const QList<QColor> lightThemeColors = {
+        QColor(117,162,0),
+        QColor(211,0,153),
+        QColor(69,13,120),
+        QColor(50,108,255),
+        QColor(210,99,0),
+        QColor(255,95,87),
+        QColor(1,85,154),
+        QColor(184,0,34),
+        QColor(121,154,242),
+        QColor(128,63,0),
+        QColor(224,119,207),
+        QColor(189,108,90)
+    };
+
+    if (GCColor::luminance(GColor(CPLOTBACKGROUND)) < 127) {
+        return darkThemeColors[index % darkThemeColors.size()];
+    } else {
+        return lightThemeColors[index % lightThemeColors.size()];
+    }
 }
 
 

--- a/src/Gui/Colors.h
+++ b/src/Gui/Colors.h
@@ -29,7 +29,6 @@
 
 
 // A selection of distinct colours, user can adjust also
-extern QList<QColor> standardColors;
 extern QIcon colouredIconFromPNG(QString filename, QColor color);
 extern QPixmap colouredPixmapFromPNG(QString filename, QColor color);
 
@@ -131,7 +130,7 @@ class GCColor : public QObject
         static QColor alternateColor(QColor); // return the alternate background
         static QColor selectedColor(QColor); // return the on select background color
         static QColor htmlCode(QColor x) { return x.name(); } // return the alternate background
-        static Themes &themes(); 
+        static Themes &themes();
         static void applyTheme(int index);
 
         // for styling things with current preferences
@@ -145,7 +144,6 @@ class GCColor : public QObject
 
         // for upgrade/migration of Config
         static QStringList getConfigKeys();
-
 };
 
 // color chooser that also supports the standard colors (CPLOTMARKER, CPOWER)

--- a/src/Gui/ComparePane.cpp
+++ b/src/Gui/ComparePane.cpp
@@ -38,11 +38,6 @@
 #include <QTextEdit>
 
 
-QColor standardColor(int num)
-{
-   return standardColors.at(num % standardColors.count());
-}
-
 // we need to fix the sort order! (fixed for time fields)
 class CTableWidgetItem : public QTableWidgetItem
 {
@@ -780,7 +775,7 @@ ComparePane::dropEvent(QDropEvent *event)
             // just use standard colors and cycle round
             // we will of course repeat, but the user can
             // just edit them using the button
-            add.color = standardColors.at((i + context->compareIntervals.count()) % standardColors.count());
+            add.color = standardColor(i + context->compareIntervals.count());
 
             // construct a fake RideItem, slightly hacky need to fix this later XXX fixme
             //                            mostly cut and paste from RideItem::refresh
@@ -962,7 +957,7 @@ ComparePane::dropEvent(QDropEvent *event)
                             // just use standard colors and cycle round
                             // we will of course repeat, but the user can
                             // just edit them using the button
-                            add.color = standardColors.at((newOnes.count()) % standardColors.count());
+                            add.color = standardColor(newOnes.count());
 
                             // now add but only if not empty
                             if (!add.data->dataPoints().empty()) newOnes << add;
@@ -1015,7 +1010,7 @@ ComparePane::dropEvent(QDropEvent *event)
             // just use standard colors and cycle round
             // we will of course repeat, but the user can
             // just edit them using the button
-            add.color = standardColors.at((i + context->compareDateRanges.count()) % standardColors.count());
+            add.color = standardColor(i + context->compareDateRanges.count());
 
             // even empty date ranges are valid
             newOnes << add;


### PR DESCRIPTION
Currently, the standard colors used for compare-mode do not blend harmonically into the other defaults. Also some of the (e.g. yellow) are hardly visible on a light background and had to be manually changed every time. This PR tries to address this issue.

Changed the standard colors, used for compare-mode:
* Nice looking and distinguishable colors
* Separate color-sets for light- and darkmode

Additional fix + refactoring:
* Fixed a typo that prevented the background-color of ComparePanes to follow the color-scheme (was always white on my machine)
* Moved the definition of standardColor(int) from ComparePane.cpp to Colors.cpp, matching the declaration in Colors.h

![Screenshot_20240420_231757](https://github.com/GoldenCheetah/GoldenCheetah/assets/20986896/c68ef1dd-185a-40bc-b02e-626931c6fd41)
![Screenshot_20240420_231932](https://github.com/GoldenCheetah/GoldenCheetah/assets/20986896/42f5813f-b1e4-472b-b91e-03180498dc58)
