### PR TITLE
Ergmode: Coloring by powerzones in ErgFilePlot

### DIFF
--- a/src/Train/ErgFile.cpp
+++ b/src/Train/ErgFile.cpp
@@ -1175,6 +1175,64 @@ ErgFile::Sections()
     return returning;
 }
 
+
+// convert points to set of sections, every section will be strictly in one zone
+QList<ErgFileZoneSection>
+ErgFile::ZoneSections()
+{
+    QList<ErgFileZoneSection> ret;
+
+    const Zones *zones = context->athlete->zones("Bike");
+    int zoneRange = zones->whichRange(QDate::currentDate());
+    QList<QString> zoneNames = zones->getZoneNames(zoneRange);
+    if (hasWatts() && Duration > 0) {
+        for (int i = 0; i < Points.size() - 1; ++i) {
+            const ErgFilePoint &pl = Points[i];
+            const ErgFilePoint &pr = Points[i + 1];
+            if (long(pl.x) != long(pr.x)) {
+                int zoneL = 0;
+                int zoneR = 0;
+                if (zoneRange >= 0) {
+                    zoneL = zones->whichZone(zoneRange, pl.y);
+                    zoneR = zones->whichZone(zoneRange, pr.y);
+                }
+                if (zoneL == zoneR) {
+                    ret << ErgFileZoneSection(pl.x, pl.y, pr.x, pr.y, zoneL);
+                } else {
+                    double m = (pr.y - pl.y) / (pr.x - pl.x);
+                    int oldZone = 0;
+                    if (zoneRange >= 0) {
+                        oldZone = zones->whichZone(zoneRange, pl.y);
+                    }
+                    double oldTime = pl.x;
+                    double oldWatts = pl.y;
+                    double sectionStartTime = pl.x;
+                    double sectionStartWatts = pl.y;
+                    for (double i = pl.x; i < pr.x; i += 1000) {
+                        double watts = m * (i - pl.x) + pl.y;
+                        int newZone = 0;
+                        if (zoneRange >= 0) {
+                            newZone = zones->whichZone(zoneRange, watts);
+                        }
+                        if (newZone != oldZone) {
+                            ret << ErgFileZoneSection(sectionStartTime, sectionStartWatts, oldTime, oldWatts, oldZone);
+                            sectionStartTime = oldTime;
+                            sectionStartWatts = watts;
+                            oldZone = newZone;
+                        }
+                        oldTime = i;
+                        oldWatts = watts;
+                    }
+                    ret << ErgFileZoneSection(sectionStartTime, sectionStartWatts, pr.x, pr.y, oldZone);
+                }
+            }
+        }
+    }
+
+    return ret;
+}
+
+
 bool
 ErgFile::save(QStringList &errors)
 {

--- a/src/Train/ErgFile.h
+++ b/src/Train/ErgFile.h
@@ -74,6 +74,20 @@ class ErgFileSection
         double start, end;
 };
 
+class ErgFileZoneSection
+: public ErgFileSection
+{
+    public:
+        ErgFileZoneSection() : ErgFileSection(), startValue(0), endValue(0), zone(0) {}
+        ErgFileZoneSection(int startMSecs, int startValue, int endMSecs, int endValue, int zone)
+         : ErgFileSection(endMSecs - startMSecs, startMSecs, endMSecs), startValue(startValue), endValue(endValue), zone(zone)
+        {}
+
+        int startValue;
+        int endValue;
+        int zone;
+};
+
 class ErgFileText
 {
     public:
@@ -156,6 +170,7 @@ public:
         // turn the ergfile into a series of sections rather
         // than a list of points
         QList<ErgFileSection> Sections();
+        QList<ErgFileZoneSection> ZoneSections();
 
         QString Version,        // version number / identifer
                 Units,          // units used

--- a/src/Train/WorkoutPlotWindow.cpp
+++ b/src/Train/WorkoutPlotWindow.cpp
@@ -21,14 +21,45 @@
 #include "Context.h"
 #include "HelpWhatsThis.h"
 
+#include <QFormLayout>
+#include <QGroupBox>
+
+
 WorkoutPlotWindow::WorkoutPlotWindow(Context *context) :
     GcChartWindow(context), context(context)
 {
     HelpWhatsThis *helpContents = new HelpWhatsThis(this);
     this->setWhatsThis(helpContents->getWhatsThisText(HelpWhatsThis::ChartTrain_Workout));
 
+    // Chart settings
+    QWidget *settingsWidget = new QWidget(this);
+    settingsWidget->setContentsMargins(0, 0, 0, 0);
+
+    QVBoxLayout *commonLayout = new QVBoxLayout(settingsWidget);
+
+    ctrlsGroupBox = new QGroupBox(tr("Ergmode specific settings"));
+    commonLayout->addWidget(ctrlsGroupBox);
+    commonLayout->addStretch();
+
+    QFormLayout *ergmodeLayout = new QFormLayout(ctrlsGroupBox);
+
+    ctrlsSituationLabel = new QLabel(tr("Color power zones"));
+    ctrlsSituation = new QComboBox();
+    ctrlsSituation->addItem(tr("Never"));
+    ctrlsSituation->addItem(tr("Always"));
+    ctrlsSituation->addItem(tr("When stopped"));
+    connect(ctrlsSituation, SIGNAL(currentIndexChanged(int)), this, SLOT(setShowColorZones(int)));
+    ergmodeLayout->addRow(ctrlsSituationLabel, ctrlsSituation);
+
+    ctrlsShowTooltipLabel = new QLabel(tr("Show tooltip"));
+    ctrlsShowTooltip = new QComboBox();
+    ctrlsShowTooltip->addItem(tr("Never"));
+    ctrlsShowTooltip->addItem(tr("When stopped"));
+    connect(ctrlsShowTooltip, SIGNAL(currentIndexChanged(int)), this, SLOT(setShowTooltip(int)));
+    ergmodeLayout->addRow(ctrlsShowTooltipLabel, ctrlsShowTooltip);
+
     setContentsMargins(0,0,0,0);
-    setControls(NULL);
+    setControls(settingsWidget);
     setProperty("color", GColor(CTRAINPLOTBACKGROUND));
 
     QVBoxLayout *layout = new QVBoxLayout;
@@ -69,5 +100,50 @@ void
 WorkoutPlotWindow::configChanged(qint32)
 {
     setProperty("color", GColor(CTRAINPLOTBACKGROUND));
+
+    ctrlsGroupBox->setTitle(tr("Ergmode specific settings"));
+    ctrlsSituationLabel->setText(tr("Color power zones"));
+    ctrlsSituation->setItemText(0, tr("Never"));
+    ctrlsSituation->setItemText(1, tr("Always"));
+    ctrlsSituation->setItemText(2, tr("When stopped"));
+
+    ctrlsShowTooltipLabel->setText(tr("Show tooltip"));
+    ctrlsShowTooltip->setItemText(0, tr("Never"));
+    ctrlsShowTooltip->setItemText(1, tr("When stopped"));
+
     repaint();
+}
+
+
+int
+WorkoutPlotWindow::showColorZones
+() const
+{
+    return ctrlsSituation->currentIndex();
+}
+
+
+void
+WorkoutPlotWindow::setShowColorZones
+(int index)
+{
+    ctrlsSituation->setCurrentIndex(index);
+    ergPlot->setShowColorZones(index);
+}
+
+
+int
+WorkoutPlotWindow::showTooltip
+() const
+{
+    return ctrlsShowTooltip->currentIndex();
+}
+
+
+void
+WorkoutPlotWindow::setShowTooltip
+(int index)
+{
+    ctrlsShowTooltip->setCurrentIndex(index);
+    ergPlot->setShowTooltip(index);
 }

--- a/src/Train/WorkoutPlotWindow.h
+++ b/src/Train/WorkoutPlotWindow.h
@@ -32,26 +32,44 @@
 #include "Settings.h"
 #include "Colors.h"
 
+#include <QGroupBox>
+#include <QLabel>
+#include <QComboBox>
+
 class WorkoutPlotWindow : public GcChartWindow
 {
     Q_OBJECT
     G_OBJECT
 
+    Q_PROPERTY(int showColorZones READ showColorZones WRITE setShowColorZones USER true)
+    Q_PROPERTY(int showTooltip READ showTooltip WRITE setShowTooltip USER true)
+
     public:
 
         WorkoutPlotWindow(Context *context);
 
-   public slots:
+    public slots:
 
         // trap signals
         void setNow(long now);
         void ergFileSelected(ErgFile *);
         void configChanged(qint32);
 
+        int showColorZones() const;
+        void setShowColorZones(int index);
+        int showTooltip() const;
+        void setShowTooltip(int index);
+
     private:
 
         Context *context;
         ErgFilePlot *ergPlot;
+
+        QGroupBox *ctrlsGroupBox;
+        QLabel *ctrlsSituationLabel;
+        QComboBox *ctrlsSituation;
+        QLabel *ctrlsShowTooltipLabel;
+        QComboBox *ctrlsShowTooltip;
 };
 
 #endif // _GC_WorkoutPlotWindow_h


### PR DESCRIPTION
Added support to color sections according to their power zone
* Optional coloring: Never (default), Always, Workout is stopped
* Optional tooltip giving information about current section (independent of coloring): Never (default), Workout is stopped
* Single sections covering multiple zones are split (for coloring / tooltip only)
* Tooltip shows starttime, duration, power (range if applicable), zone, W'bal-range

![Screenshot_20240421_120727](https://github.com/GoldenCheetah/GoldenCheetah/assets/20986896/f1049544-425c-4e5a-a932-7ab1f5756247)
![Screenshot_20240421_121027](https://github.com/GoldenCheetah/GoldenCheetah/assets/20986896/0ba8159f-7442-42b6-9ce2-24cbd11762b3)
