### PR TITLE
Initializing AllPlot::isPanning to false

### DIFF
--- a/src/Charts/AllPlot.h
+++ b/src/Charts/AllPlot.h
@@ -734,7 +734,7 @@ class AllPlot : public QwtPlot
         RideFile::SeriesType secondaryScope;
 
         // mouse control
-        bool isPanning;
+        bool isPanning = false;
         int panOriginX;
 
     protected:


### PR DESCRIPTION
AllPlot::isPanning was uninitialized, leading to unwanted (i.e. without prior middleclick) panning.
This PR initializes AllPlot::isPanning explicitly to false.