### PR TITLE
Qt6: Preventing crash in stacked LTMPlots

### DIFF
--- a/src/Charts/LTMWindow.cpp
+++ b/src/Charts/LTMWindow.cpp
@@ -785,8 +785,11 @@ LTMWindow::refreshCompare()
     int position = 0;
 
     // create ltmPlot with this
+    // Reserving space in list to prevent reallocations and reorderings that break the pointers
+    // to the LTMSettings
     if (plotSetting.metrics.count()) {
 
+        compareplotSettings.reserve(1 + settings.metrics.size());
         compareplotSettings << plotSetting;
 
         // create and setup the plot
@@ -797,6 +800,8 @@ LTMWindow::refreshCompare()
         // now add
         compareplotsLayout->addWidget(stacked);
         compareplots << stacked;
+    } else {
+        compareplotSettings.reserve(settings.metrics.size());
     }
 
     // OK, now one plot for each curve
@@ -888,8 +893,11 @@ LTMWindow::refreshStackPlots()
     int position = 0;
 
     // create ltmPlot with this
+    // Reserving space in list to prevent reallocations and reorderings that break the pointers
+    // to the LTMSettings
     if (plotSetting.metrics.count()) {
 
+        plotSettings.reserve(1 + settings.metrics.size());
         plotSettings << plotSetting;
 
         // create and setup the plot
@@ -900,6 +908,8 @@ LTMWindow::refreshStackPlots()
         // now add
         plotsLayout->addWidget(stacked);
         plots << stacked;
+    } else {
+        plotSettings.reserve(settings.metrics.size());
     }
 
     // OK, now one plot for each curve


### PR DESCRIPTION
In Qt6 the internal handling of QList (now actually a QVector) was changed compared to Qt5. This results in reallocations / recreations of the LTMSettings, destroying the objects whose pointers already have been set to the LTMPlots.
This commit reserves the required space upfront, preventing the reallocations thus keeping the pointers valid and preventing the crash