### PR TITLE
Qt6: The signature of enterEvent changed

### DIFF
--- a/src/Charts/GcPane.cpp
+++ b/src/Charts/GcPane.cpp
@@ -173,7 +173,11 @@ GcPane::spotHotSpot(QMouseEvent *e)
 }
 
 void
+#if QT_VERSION >= 0x060000
+GcPane::enterEvent(QEnterEvent *)
+#else
 GcPane::enterEvent(QEvent *)
+#endif
 {
     repaint();
 }

--- a/src/Charts/GcPane.h
+++ b/src/Charts/GcPane.h
@@ -50,14 +50,18 @@ class GcPane : public QWidget
     private slots:
 
     protected:
-        virtual void paintEvent(QPaintEvent *);
-        virtual void mousePressEvent(QMouseEvent *);
-        virtual void mouseReleaseEvent(QMouseEvent *);
-        virtual void mouseMoveEvent(QMouseEvent *);
-        virtual void enterEvent(QEvent *);
-        virtual void leaveEvent(QEvent *);
-        bool eventFilter(QObject *object, QEvent *e);
-        virtual void resizeEvent (QResizeEvent * e);
+        virtual void paintEvent(QPaintEvent *) override;
+        virtual void mousePressEvent(QMouseEvent *) override;
+        virtual void mouseReleaseEvent(QMouseEvent *) override;
+        virtual void mouseMoveEvent(QMouseEvent *) override;
+#if QT_VERSION >= 0x060000
+        virtual void enterEvent(QEnterEvent *) override;
+#else
+        virtual void enterEvent(QEvent *) override;
+#endif
+        virtual void leaveEvent(QEvent *) override;
+        virtual bool eventFilter(QObject *object, QEvent *e) override;
+        virtual void resizeEvent (QResizeEvent * e) override;
         void flip();
 
     private:

--- a/src/Charts/GoldenCheetah.cpp
+++ b/src/Charts/GoldenCheetah.cpp
@@ -647,7 +647,11 @@ GcWindow::setCursorShape(DragState d)
 }
 
 void
+#if QT_VERSION >= 0x060000
+GcWindow::enterEvent(QEnterEvent *)
+#else
 GcWindow::enterEvent(QEvent *)
+#endif
 {
     if (_noevents) return;
 

--- a/src/Charts/GoldenCheetah.h
+++ b/src/Charts/GoldenCheetah.h
@@ -191,7 +191,7 @@ public:
     void setResizable(bool);
     bool resizable() const;
 
-    void moveEvent(QMoveEvent *); // we trap move events to ungrab during resize
+    void moveEvent(QMoveEvent *) override; // we trap move events to ungrab during resize
     void setGripped(bool);
     bool gripped() const;
 
@@ -206,7 +206,7 @@ public:
 
     // popover controls
     virtual bool hasReveal() { return false;}
-    virtual void reveal() {} 
+    virtual void reveal() {}
     virtual void unreveal() {}
     bool revealed;
 
@@ -224,11 +224,15 @@ public:
 
     // mouse actions -- resizing and dragging tiles
     //bool eventFilter(QObject *object, QEvent *e);
-    void mousePressEvent(QMouseEvent *);
-    void mouseReleaseEvent(QMouseEvent *);
-    void mouseMoveEvent(QMouseEvent *);
-    void enterEvent(QEvent *);
-    void leaveEvent(QEvent *);
+    void mousePressEvent(QMouseEvent *) override;
+    void mouseReleaseEvent(QMouseEvent *) override;
+    void mouseMoveEvent(QMouseEvent *) override;
+#if QT_VERSION >= 0x060000
+    void enterEvent(QEnterEvent *) override;
+#else
+    void enterEvent(QEvent *) override;
+#endif
+    void leaveEvent(QEvent *) override;
     void setDragState(DragState);
     void setCursorShape(DragState);
     DragState spotHotSpot(QMouseEvent *);


### PR DESCRIPTION
Adapted to the new signature of enterEvent when using Qt6 (before this change enterEvent was ignored with Qt6); added some additional override specifiers