### PR TITLE
Placeholder text & filter background color field fixes (simple version)

### DIFF
--- a/src/Core/NamedSearch.cpp
+++ b/src/Core/NamedSearch.cpp
@@ -302,6 +302,26 @@ EditNamedSearches::EditNamedSearches(QWidget *parent, Context *context) : QDialo
     deleteButton = new QPushButton(tr("Delete"), this);
     row4->addWidget(deleteButton);
 
+    // The QlineEdit & QTreeWidget pick up the style from the location they launched and
+    // as the popup diagloues do not follow the theme, in these cases a correction is required.
+    QColor color = QPalette().color(QPalette::Highlight);
+    QString qbaseStyle = QString(" {  background-color: rgbs(255,255,255,255); "
+                                 "    color: rgbs(0, 0, 0, 255); "
+                                 "    border-radius: 3px; "
+                                 "    border: 1px solid rgba(127,127,127,127); } ");
+
+    QString qfocusStyle = QString("   QLineEdit:focus { "
+                                 "    border-radius: 3px; "
+#ifdef WIN32
+                                 "    border: 1px solid rgba(%1,%2,%3,255);"
+#else
+                                 "    border: 2px solid rgba(%1,%2,%3,255);"
+#endif
+                                 "}" ).arg(color.red()).arg(color.green()).arg(color.blue());
+
+    editName->setStyleSheet(QString(" QLineEdit ") + qbaseStyle + qfocusStyle);
+    searchList->setStyleSheet(QString(" QTreeWidget ") + qbaseStyle);
+
     // Populate the list of named searches
     foreach(NamedSearch x, context->athlete->namedSearches->getList()) {
         QTreeWidgetItem *add = new QTreeWidgetItem(searchList->invisibleRootItem(), 0);

--- a/src/Gui/AnalysisSidebar.cpp
+++ b/src/Gui/AnalysisSidebar.cpp
@@ -424,7 +424,7 @@ AnalysisSidebar::showActivityMenu(const QPoint &pos)
 
         } else {
 
-            QMenu *groupByMenu = new QMenu(tr("Group By"), this);
+            QMenu *groupByMenu = new QMenu(tr("Group By"), rideNavigator);
             groupByMenu->setEnabled(true);
             menu.addMenu(groupByMenu);
 

--- a/src/Gui/AnalysisSidebar.cpp
+++ b/src/Gui/AnalysisSidebar.cpp
@@ -424,7 +424,7 @@ AnalysisSidebar::showActivityMenu(const QPoint &pos)
 
         } else {
 
-            QMenu *groupByMenu = new QMenu(tr("Group By"), rideNavigator);
+            QMenu *groupByMenu = new QMenu(tr("Group By"), this);
             groupByMenu->setEnabled(true);
             menu.addMenu(groupByMenu);
 

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -336,7 +336,7 @@ MainWindow::MainWindow(const QDir &home)
     HelpWhatsThis *helpPerspectiveSelector = new HelpWhatsThis(perspectiveSelector);
     perspectiveSelector->setWhatsThis(helpPerspectiveSelector->getWhatsThisText(HelpWhatsThis::ToolBar_PerspectiveSelector));
 
-    searchBox = new SearchFilterBox(this,context,false);
+    searchBox = new SearchFilterBox(this,context,false, true);
 
     searchBox->setStyle(toolStyle);
     searchBox->setFixedWidth(400 * dpiXFactor);

--- a/src/Gui/SearchBox.h
+++ b/src/Gui/SearchBox.h
@@ -42,7 +42,7 @@ public:
     enum searchboxmode { Search, Filter };
     typedef enum searchboxmode SearchBoxMode;
 
-    SearchBox(Context *context, QWidget *parent = 0, bool nochooser=true);
+    SearchBox(Context *context, QWidget *parent = 0, bool nochooser=true, bool useTheme=false);
 
     // either search box or filter box
     void setMode(SearchBoxMode mode);
@@ -94,6 +94,7 @@ private slots:
     void keyPressEvent(QKeyEvent *e);
 
     void configChanged(qint32);
+    void setSearchBoxStyle(const QColor& textColor, int alpha, bool configChange = false);
 
 signals:
     // text search mode
@@ -119,6 +120,9 @@ private:
     DataFilterCompleter *completer;
     bool active;
     bool fixed;
+    bool useTheme;
+    int currTextAplha;
+    QColor currTextColor;
 };
 
 class DataFilterCompleter : public QCompleter

--- a/src/Gui/SearchFilterBox.cpp
+++ b/src/Gui/SearchFilterBox.cpp
@@ -25,7 +25,7 @@
 #include "RideCache.h"
 #include "RideItem.h"
 
-SearchFilterBox::SearchFilterBox(QWidget *parent, Context *context, bool nochooser) : QWidget(parent), context(context)
+SearchFilterBox::SearchFilterBox(QWidget *parent, Context *context, bool nochooser, bool useTheme) : QWidget(parent), context(context)
 {
 
     setContentsMargins(0,0,0,0);
@@ -34,7 +34,7 @@ SearchFilterBox::SearchFilterBox(QWidget *parent, Context *context, bool nochoos
     contents->setContentsMargins(0,0,0,0);
 
     // no column chooser if my parent widget is a modal widget
-    searchbox = new SearchBox(context, this, nochooser);
+    searchbox = new SearchBox(context, this, nochooser, useTheme);
     searchbox->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed));
     contents->addWidget(searchbox);
 

--- a/src/Gui/SearchFilterBox.h
+++ b/src/Gui/SearchFilterBox.h
@@ -32,7 +32,7 @@ class SearchFilterBox : public QWidget
     Q_PROPERTY(int xwidth READ xwidth WRITE setXWidth USER true)
 
 public:
-    SearchFilterBox(QWidget *parent, Context *context, bool nochooser = true);
+    SearchFilterBox(QWidget *parent, Context *context, bool nochooser = true, bool useTheme = false);
     void setMode(SearchBox::SearchBoxMode x) { searchbox->setMode(x); }
 
     QString filter();


### PR DESCRIPTION
Placeholder text & filter background colour field fixes:

The placeholder text which disappears on dark themes now remains visible.
![image](https://github.com/GoldenCheetah/GoldenCheetah/assets/46629337/ce80dda1-aaef-4daa-9e2b-f1be90466613)

![image](https://github.com/GoldenCheetah/GoldenCheetah/assets/46629337/dda65719-1456-4711-9596-9e80dddfb26b)

The red text is now displayed (and removed) when invalid filter text is entered.
![image](https://github.com/GoldenCheetah/GoldenCheetah/assets/46629337/0cf59e80-fdde-475b-aabb-a73d1e6e3f3b)

![image](https://github.com/GoldenCheetah/GoldenCheetah/assets/46629337/9e6e1431-941f-488c-b420-438620d60d0c)

The backgrounds of the "Manage Filters" dialogue QLineEdit fields for the name, searchbox and filter list would pickup the theme (noticeable on dark themes) depending where they were launched from:

**From the mainWindow Toolbar:**

![image](https://github.com/GoldenCheetah/GoldenCheetah/assets/46629337/5a457c4e-9e67-43e7-8119-ea1c887c9b3c)

**From the Trends, Manage Filters:**

![image](https://github.com/GoldenCheetah/GoldenCheetah/assets/46629337/aea128a2-a173-480b-9c24-9e5dd9b3f1c9)

I have tested the above with most dark & light themes on Windows and all seems to work, so can it be tested on Linux & MacOs ?

Note: All popup windows and dialogues do not respect the selected theme, and use a default light theme, this this was part of the problem of hidden text, I expect it would a significant project to get them to adopt the theme colours.