### PR TITLE
Corrections to qt colors passed to GColor macro

### DIFF
--- a/src/Charts/OverviewItems.h
+++ b/src/Charts/OverviewItems.h
@@ -552,7 +552,7 @@ class IntervalOverviewItem : public ChartSpaceItem
 class BPointF {
 public:
 
-    BPointF() : x(0), y(0), z(0), xoff(0), yoff(0), fill(GColor(Qt::gray)), item(NULL) {}
+    BPointF() : x(0), y(0), z(0), xoff(0), yoff(0), fill(GColor(CRIDEPLOTXAXIS)), item(NULL) {}
 
     double score(BPointF &other);
 

--- a/src/Metrics/ExtendedCriticalPower.cpp
+++ b/src/Metrics/ExtendedCriticalPower.cpp
@@ -1216,7 +1216,7 @@ ExtendedCriticalPower::getPlotLevelForExtendedCP_5_3(TestModel model)
     QwtPlotCurve *extendedCPCurve2 = new QwtPlotCurve("level_eCP_5_3");
     if (appsettings->value(NULL, GC_ANTIALIAS, true).toBool() == true)
         extendedCPCurve2->setRenderHint(QwtPlotItem::RenderAntialiased);
-    QPen e2pen(GColor(Qt::lightGray)); // Qt::cyan
+    QPen e2pen(GColor(CRIDEPLOTYAXIS));
     e2pen.setWidth(1);
     e2pen.setStyle(Qt::SolidLine);
     extendedCPCurve2->setPen(e2pen);


### PR DESCRIPTION
QT colors ( https://doc.qt.io/qt-6/qt.html#GlobalColor-enum ) being used in GColor macro when GC Color references are expected:

**OverviewItems.h**

    `BPointF() : x(0), y(0), z(0), xoff(0), yoff(0), fill(GColor(Qt::gray)), item(NULL) {}`
A gc color should be passed to the GColor macro not a qt color, so this is now:

    `BPointF() : x(0), y(0), z(0), xoff(0), yoff(0), fill(GColor(CRIDEPLOTXAXIS)), item(NULL) {}`
as Qt::gray has the value of 5, so its replaced with RIDEPLOTXAXIS which has the same value.

**ExtendedCriticalPower.cpp**

    `QPen e2pen(GColor(Qt::lightGray));`
A gc color should be passed to the GColor macro not a qt color, so this is now:

    `QPen e2pen(GColor(CRIDEPLOTYAXIS));`
as Qt::lightGray has the value of 6, so its replaced with RIDEPLOTYAXIS which has the same value.