### PR TITLE
Error found in GColor function readConfig

### DIFF
--- a/src/Gui/Colors.cpp
+++ b/src/Gui/Colors.cpp
@@ -423,6 +423,7 @@ GCColor::readConfig()
     for (unsigned int i=0; ColorList[i].name != ""; i++) {
         QString colortext = appsettings->value(NULL, ColorList[i].setting, "").toString();
         if (colortext != "") {
+
             // color definitions are stored as "r:g:b"
             QStringList rgb = colortext.split(":");
             ColorList[i].color = QColor(rgb[0].toInt(),
@@ -431,14 +432,14 @@ GCColor::readConfig()
         } else {
 
             // set sensible defaults for any not set (as new colors are added)
-            if (ColorList[i].name == "CTOOLBAR") {
+            if (ColorList[i].setting == "CTOOLBAR") {
                 QPalette def;
                 ColorList[i].color = def.color(QPalette::Window);
             }
-            if (ColorList[i].name == "CCHARTBAR") {
+            if (ColorList[i].setting == "CCHARTBAR") {
                 ColorList[i].color = ColorList[CTOOLBAR].color;
             }
-            if (ColorList[i].name == "CCALCURRENT") {
+            if (ColorList[i].setting == "CCALCURRENT") {
                 QPalette def;
                 ColorList[i].color = def.color(QPalette::Highlight);
 


### PR DESCRIPTION
 Error found in GColor function readConfig, the name field is a text description of the gc color, but it is being compared against the setting value, therefore these defaults will never be applied:

        `// set sensible defaults for any not set (as new colors are added)`
        `if (ColorList[i].name == "CTOOLBAR") {`
        `    QPalette def;`
        `    ColorList[i].color = def.color(QPalette::Window);`
        `}`
        `if (ColorList[i].name == "CCHARTBAR") {`
        `    ColorList[i].color = ColorList[CTOOLBAR].color;`
        `}`
        `if (ColorList[i].name == "CCALCURRENT") {`
        `    QPalette def;`
        `    ColorList[i].color = def.color(QPalette::Highlight);`

Example names & settings:

ColorList[i].name = "Plot Background"                           ColorList[i].setting = COLORPLOTBACKGROUND
ColorList[i].name = "Performance Plot Background"     ColorList[i].setting = COLORRIDEPLOTBACKGROUND
ColorList[i].name = "Trend Plot Background"                 ColorList[i].setting = COLORTRENDPLOTBACKGROUND
etc....