### PR TITLE
SearchFilterBox background

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -336,7 +336,7 @@ MainWindow::MainWindow(const QDir &home)
     HelpWhatsThis *helpPerspectiveSelector = new HelpWhatsThis(perspectiveSelector);
     perspectiveSelector->setWhatsThis(helpPerspectiveSelector->getWhatsThisText(HelpWhatsThis::ToolBar_PerspectiveSelector));
 
-    searchBox = new SearchFilterBox(this,context,false);
+    searchBox = new SearchFilterBox(this,context,false, true);
 
     searchBox->setStyle(toolStyle);
     searchBox->setFixedWidth(400 * dpiXFactor);

--- a/src/Gui/SearchBox.cpp
+++ b/src/Gui/SearchBox.cpp
@@ -34,8 +34,8 @@
 
 const int BUTTON_SIZE = 12;
 
-SearchBox::SearchBox(Context *context, QWidget *parent, bool nochooser)
-    : QLineEdit(parent), context(context), parent(parent), filtered(false), nochooser(nochooser), active(false), fixed(false)
+SearchBox::SearchBox(Context *context, QWidget *parent, bool nochooser, bool useToolbarBkgd)
+    : QLineEdit(parent), context(context), parent(parent), filtered(false), nochooser(nochooser), active(false), fixed(false), useToolbarBkgd(useToolbarBkgd)
 {
     setFixedHeight(28*dpiYFactor);
     //clear button
@@ -106,11 +106,17 @@ SearchBox::configChanged(qint32)
     int frameWidth = style()->pixelMetric(QStyle::PM_DefaultFrameWidth);
     QColor color = QPalette().color(QPalette::Highlight);
 
+    // Override the default dialogue colours when the searchbox is located within the main window toolbar.
+    QColor bkgdColor = useToolbarBkgd ? GColor(CTOOLBAR) : palette().color(QPalette::Base);
+    QColor textColor = useToolbarBkgd ? GCColor::invertColor(bkgdColor) : palette().color(QPalette::Text);
+
     setStyleSheet(QString( //"QLineEdit { padding-right: %1px; } "
                       "QLineEdit#SearchBox {"
                       "    border-radius: 3px; "
                       "    border: 1px solid rgba(127,127,127,127);"
                       "    padding: 0px %1px;"
+                      "    color: rgba(%6,%7,%8,255);"
+                      "    background: rgba(%9,%10,%11,255);"
                       "}"
                       "QLineEdit#SearchBox:focus {"
                       "    border-radius: 3px; "
@@ -123,7 +129,9 @@ SearchBox::configChanged(qint32)
                       "}"
              ).arg(clearButton->sizeHint().width() + frameWidth + 12)
               .arg(color.red()).arg(color.green()).arg(color.blue())
-              .arg(clearButton->sizeHint().width() + frameWidth + 12));
+              .arg(clearButton->sizeHint().width() + frameWidth + 12)
+              .arg(textColor.red()).arg(textColor.green()).arg(textColor.blue())
+              .arg(bkgdColor.red()).arg(bkgdColor.green()).arg(bkgdColor.blue()));
 
     // get suitably formated list
     QList<QString> list;

--- a/src/Gui/SearchBox.h
+++ b/src/Gui/SearchBox.h
@@ -42,7 +42,7 @@ public:
     enum searchboxmode { Search, Filter };
     typedef enum searchboxmode SearchBoxMode;
 
-    SearchBox(Context *context, QWidget *parent = 0, bool nochooser=true);
+    SearchBox(Context *context, QWidget *parent = 0, bool nochooser=true, bool useToolbarBkgd=false);
 
     // either search box or filter box
     void setMode(SearchBoxMode mode);
@@ -119,6 +119,7 @@ private:
     DataFilterCompleter *completer;
     bool active;
     bool fixed;
+    bool useToolbarBkgd;
 };
 
 class DataFilterCompleter : public QCompleter

--- a/src/Gui/SearchFilterBox.cpp
+++ b/src/Gui/SearchFilterBox.cpp
@@ -25,7 +25,7 @@
 #include "RideCache.h"
 #include "RideItem.h"
 
-SearchFilterBox::SearchFilterBox(QWidget *parent, Context *context, bool nochooser) : QWidget(parent), context(context)
+SearchFilterBox::SearchFilterBox(QWidget *parent, Context *context, bool nochooser, bool useToolbarBkgd) : QWidget(parent), context(context)
 {
 
     setContentsMargins(0,0,0,0);
@@ -34,7 +34,7 @@ SearchFilterBox::SearchFilterBox(QWidget *parent, Context *context, bool nochoos
     contents->setContentsMargins(0,0,0,0);
 
     // no column chooser if my parent widget is a modal widget
-    searchbox = new SearchBox(context, this, nochooser);
+    searchbox = new SearchBox(context, this, nochooser, useToolbarBkgd);
     searchbox->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed));
     contents->addWidget(searchbox);
 

--- a/src/Gui/SearchFilterBox.h
+++ b/src/Gui/SearchFilterBox.h
@@ -32,7 +32,7 @@ class SearchFilterBox : public QWidget
     Q_PROPERTY(int xwidth READ xwidth WRITE setXWidth USER true)
 
 public:
-    SearchFilterBox(QWidget *parent, Context *context, bool nochooser = true);
+    SearchFilterBox(QWidget *parent, Context *context, bool nochooser = true, bool useToolbarBkgd = false);
     void setMode(SearchBox::SearchBoxMode x) { searchbox->setMode(x); }
 
     QString filter();


### PR DESCRIPTION
All the FilterSearchBox instances within dialog use a light theme independent of the GC theme except the FilterSearchBox located within the main window toolbar, this PR ensures the different instances have the correct colours.

![Screenshot 2024-05-20 194611 v2](https://github.com/GoldenCheetah/GoldenCheetah/assets/46629337/4f9eb71a-24bd-473b-a8c2-fcc94fc100ed)
