### PR TITLE
Fixed crash on startup if no power zones for bikes are defined

### DIFF
--- a/src/Metrics/Zones.cpp
+++ b/src/Metrics/Zones.cpp
@@ -705,7 +705,7 @@ void Zones::setZonesFromCP(int rnum)
 // return the list of starting values of zones for a given range
 QList <int> Zones::getZoneLows(int rnum) const
 {
-    if (rnum >= ranges.size()) return QList <int>();
+    if (rnum < 0 || rnum >= ranges.size()) return QList <int>();
 
     const ZoneRange &range = ranges[rnum];
     QList <int> return_values;
@@ -721,7 +721,7 @@ QList <int> Zones::getZoneLows(int rnum) const
 QList <int> Zones::getZoneHighs(int rnum) const
 {
 
-    if (rnum >= ranges.size()) return QList <int>();
+    if (rnum < 0 || rnum >= ranges.size()) return QList <int>();
 
     const ZoneRange &range = ranges[rnum];
     QList <int> return_values;
@@ -736,7 +736,7 @@ QList <int> Zones::getZoneHighs(int rnum) const
 // return the list of zone names
 QList <QString> Zones::getZoneNames(int rnum) const
 {
-    if (rnum >= ranges.size()) return QList <QString>(); 
+    if (rnum < 0 || rnum >= ranges.size()) return QList <QString>(); 
 
     const ZoneRange &range = ranges[rnum];
     QList <QString> return_values;
@@ -751,7 +751,7 @@ QList <QString> Zones::getZoneNames(int rnum) const
 // return the list of zone names
 QList <QString> Zones::getZoneDescriptions(int rnum) const
 {
-    if (rnum >= ranges.size()) return QList <QString>();
+    if (rnum < 0 || rnum >= ranges.size()) return QList <QString>();
 
     const ZoneRange &range = ranges[rnum];
     QList <QString> return_values;

--- a/src/Train/PowerZonesWidget.cpp
+++ b/src/Train/PowerZonesWidget.cpp
@@ -100,7 +100,7 @@ void
 PowerZonesWidget::paintEvent
 (QPaintEvent *event)
 {
-    if (dominantZone == 0) {
+    if (zones.length() == 0 || dominantZone == 0) {
         event->accept();
         return;
     }

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -288,10 +288,12 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
 
 
     int zonerange = context->athlete->zones("Bike")->whichRange(QDateTime::currentDateTime().date());
-    int numZones = context->athlete->zones("Bike")->numZones(zonerange);
     QList<QColor> zoneColors;
-    for (int i = 0; i < numZones; ++i) {
-        zoneColors << zoneColor(i, numZones);
+    if (zonerange != -1) {
+        int numZones = context->athlete->zones("Bike")->numZones(zonerange);
+        for (int i = 0; i < numZones; ++i) {
+            zoneColors << zoneColor(i, numZones);
+        }
     }
     workoutInfo = new InfoWidget(zoneColors, context->athlete->zones("Bike")->getZoneDescriptions(zonerange));
     workoutInfo->setFrameStyle(QFrame::NoFrame);
@@ -700,10 +702,12 @@ TrainSidebar::configChanged(qint32 why)
     deviceTree->setStyleSheet(GCColor::stylesheet(true));
 
     int zonerange = context->athlete->zones("Bike")->whichRange(QDateTime::currentDateTime().date());
-    int numZones = context->athlete->zones("Bike")->numZones(zonerange);
     QList<QColor> zoneColors;
-    for (int i = 0; i < numZones; ++i) {
-        zoneColors << zoneColor(i, numZones);
+    if (zonerange != -1) {
+        int numZones = context->athlete->zones("Bike")->numZones(zonerange);
+        for (int i = 0; i < numZones; ++i) {
+            zoneColors << zoneColor(i, numZones);
+        }
     }
     workoutInfo->setPowerZoneColors(zoneColors);
     workoutInfo->setPowerZoneNames(context->athlete->zones("Bike")->getZoneDescriptions(zonerange));


### PR DESCRIPTION
Fix for #4508:
* Safeguarded reading zones in TrainSidebar.cpp
* Added additional check to prevent PowerZonesWidget from painting itself if zone list is empty
* Returning a empty list from multiple methods in class Zones if given range is out of allowed range (was: check only for range too high, below 0 was ignored):
  * Zones::getZoneLows(.)
  * Zones::getZoneHighs(.)
  * Zones::getZoneNames(.)
  * Zones::getZoneDescriptions(.)