### PR TITLE
ErgFileplot: Updating the zone-coloring on changed intensity

### DIFF
--- a/src/Core/Context.h
+++ b/src/Core/Context.h
@@ -209,6 +209,7 @@ class Context : public QObject
         void notifyPause() { emit pause(); }
         void notifyStop() { emit stop(); }
         void notifySeek(long x) { emit seek(x); }
+        void notifyIntensityChanged(int intensity) { emit intensityChanged(intensity); };
 
         // date range selection
         void notifyDateRangeChanged(DateRange x) { dr_=x; emit dateRangeSelected(x); }
@@ -327,6 +328,7 @@ class Context : public QObject
         void unpause();
         void pause();
         void stop();
+        void intensityChanged(int intensity);
 
         // R messages
         void rMessage(QString);

--- a/src/Train/ErgFilePlot.h
+++ b/src/Train/ErgFilePlot.h
@@ -161,6 +161,7 @@ class ErgFilePlot : public QwtPlot
         void stopWorkout();
         void selectCurves();
         void selectTooltip();
+        void intensityChanged(int intensity);
 
         int showColorZones() const;
         void setShowColorZones(int index);
@@ -212,6 +213,8 @@ class ErgFilePlot : public QwtPlot
         penTooltip *tooltip;
         bool workoutActive = false;
 
+        void updateWBalCurvePredict();
+        void createSectionCurve();
         void highlightSectionCurve(QwtPlotCurve const * const highlightedCurve);
         QString secsToString(int fullSecs) const;
 };

--- a/src/Train/TrainBottom.cpp
+++ b/src/Train/TrainBottom.cpp
@@ -209,7 +209,7 @@ TrainBottom::TrainBottom(TrainSidebar *trainSidebar, QWidget *parent) :
     connect(loadUp, SIGNAL(clicked()), m_trainSidebar, SLOT(Higher()));
     connect(loadDown, SIGNAL(clicked()), m_trainSidebar, SLOT(Lower()));
     connect(intensitySlider, SIGNAL(valueChanged(int)), m_trainSidebar, SLOT(adjustIntensity(int)));
-    connect(m_trainSidebar, SIGNAL(intensityChanged(int)), intensitySlider, SLOT(setValue(int)));
+    connect(m_trainSidebar->context, SIGNAL(intensityChanged(int)), intensitySlider, SLOT(setValue(int)));
 
     connect(m_trainSidebar, SIGNAL(setNotification(QString, int)), this, SLOT(setNotification(QString, int)));
     connect(m_trainSidebar, SIGNAL(clearNotification(void)), this, SLOT(clearNotification(void)));

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -3002,7 +3002,7 @@ void TrainSidebar::adjustIntensity(int value)
     // force replot
     context->notifySetNow(context->getNow());
 
-    emit intensityChanged(lastAppliedIntensity);
+    context->notifyIntensityChanged(lastAppliedIntensity);
 }
 
 MultiDeviceDialog::MultiDeviceDialog(Context *, TrainSidebar *traintool) : traintool(traintool)

--- a/src/Train/TrainSidebar.h
+++ b/src/Train/TrainSidebar.h
@@ -137,7 +137,6 @@ class TrainSidebar : public GcWindow
         void start();
         void pause();
         void stop();
-        void intensityChanged(int value);
         void statusChanged(int status);
         void setNotification(QString msg, int timeout);
         void clearNotification(void);


### PR DESCRIPTION
This is a followup to #4479, taking care of manually changed intensity:
* Adjusting the coloring when sections change their power zone
* Adjusting the W'Balance prediction

![Screenshot_20240622_100417](https://github.com/GoldenCheetah/GoldenCheetah/assets/20986896/9a56d94d-f271-4452-9626-4f719878d900)
![Screenshot_20240622_100448](https://github.com/GoldenCheetah/GoldenCheetah/assets/20986896/82ae4b2d-5dfb-45fb-a836-733c1e1165c7)
