### PR TITLE
Metadata tile initial creation update fix and time & date field support

### DIFF
--- a/src/Charts/OverviewItems.cpp
+++ b/src/Charts/OverviewItems.cpp
@@ -1734,9 +1734,6 @@ TopNOverviewItem::setDateRange(DateRange dr)
 void
 MetaOverviewItem::setData(RideItem *item)
 {
-    // Ensure fieldtype & sparkline match the metadata symbol
-    configChanged(0);
-
     if (item == NULL || item->ride() == NULL) return;
 
     // non-numeric META

--- a/src/Charts/OverviewItems.cpp
+++ b/src/Charts/OverviewItems.cpp
@@ -3527,10 +3527,6 @@ MetaOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *,
         painter->drawText(QPointF((geometry().width() - rect.width()) / 2.0f,
                                   mid + (fm.ascent() / 3.0f)), value); // divided by 3 to account for "gap" at top of font
 
-
-
-
-
         // paint the range and mean if the chart is shown
         if (showrange && sparkline) {
 

--- a/src/Gui/AddTileWizard.cpp
+++ b/src/Gui/AddTileWizard.cpp
@@ -206,6 +206,7 @@ AddTileFinal::validatePage()
             // everthing else is a bit smaller
             wizard->item->parent->addItem(0,0,1,7, wizard->item);
         }
+        wizard->item->configChanged(0);
         wizard->item->parent->updateGeometry();
     }
     return true;


### PR DESCRIPTION
When metadata tiles are initially created they are blank, and only update when the config menu is opened and closed.

The reason for this is the AddTileWizard initially creates a default MetaOverviewItem which has fieldtype=-1, then it calls setData on the MetaOverviewItem when the wizard's tile creation is complete. But this wasn't updating the fieldtype and sparkline information leading to misconfiguration and a blank tile value. A work around was to open the tile's settings menu and close it which would cause its configChanged() to be called and the correct fieldtype/sparkline values to be calculated.


Additionally I have added metadata tile support to display Time and Date fields, so Start_Time & Start_Date fields now display correctly.

![image](https://github.com/GoldenCheetah/GoldenCheetah/assets/46629337/f3e40b2f-99b4-4e37-8ab3-aa4953c03f60)     ![image](https://github.com/GoldenCheetah/GoldenCheetah/assets/46629337/6844b6b1-b376-4103-a72c-70dbf8b4c37e)
