### PR TITLE
Changed the tab-order in the athlete selector

### DIFF
--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -744,7 +744,7 @@ main(int argc, char *argv[])
         // and the upgradeWarning was
         // lets ask the user which / create a new one
         if (!anyOpened) {
-            ChooseCyclistDialog d(home, true);
+            ChooseCyclistDialog d(home);
             d.setModal(true);
 
             // choose cancel?

--- a/src/Gui/ChooseCyclistDialog.cpp
+++ b/src/Gui/ChooseCyclistDialog.cpp
@@ -25,7 +25,7 @@
 #include <QtGui>
 
 static void recursiveDelete(QDir dir)
-{   
+{
     // delete the directory contents recursively before
     // removing the directory itself
     foreach(QString name, dir.entryList()) {
@@ -48,7 +48,7 @@ static void recursiveDelete(QDir dir)
 #endif
 }
 
-ChooseCyclistDialog::ChooseCyclistDialog(const QDir &home, bool allowNew) : home(home)
+ChooseCyclistDialog::ChooseCyclistDialog(const QDir &home) : home(home)
 {
     setWindowTitle(tr("Choose an Athlete"));
     setMinimumHeight(300 * dpiYFactor);
@@ -62,24 +62,23 @@ ChooseCyclistDialog::ChooseCyclistDialog(const QDir &home, bool allowNew) : home
 
     getList();
 
-    if (allowNew)
-        newButton = new QPushButton(tr("&New..."), this);
-    okButton = new QPushButton(tr("&Open"), this);
-    cancelButton = new QPushButton(tr("&Cancel"), this);
+    newButton = new QPushButton(tr("&New..."), this);
     deleteButton = new QPushButton(tr("Delete"), this);
+    cancelButton = new QPushButton(tr("&Cancel"), this);
+    okButton = new QPushButton(tr("&Open"), this);
 
     okButton->setEnabled(false);
     deleteButton->setEnabled(false);
 
     connect(okButton, SIGNAL(clicked()), this, SLOT(accept()));
     connect(deleteButton, SIGNAL(clicked()), this, SLOT(deleteClicked()));
-    if (allowNew) connect(newButton, SIGNAL(clicked()), this, SLOT(newClicked()));
+    connect(newButton, SIGNAL(clicked()), this, SLOT(newClicked()));
     connect(cancelButton, SIGNAL(clicked()), this, SLOT(cancelClicked()));
     connect(listWidget, SIGNAL(currentItemChanged(QListWidgetItem*,QListWidgetItem*)), this, SLOT(enableOkDelete(QListWidgetItem*)));
     connect(listWidget, SIGNAL(itemDoubleClicked(QListWidgetItem*)), this, SLOT(accept()));
 
     QHBoxLayout *buttonLayout = new QHBoxLayout;
-    if (allowNew) buttonLayout->addWidget(newButton);
+    buttonLayout->addWidget(newButton);
     buttonLayout->addWidget(deleteButton);
     buttonLayout->addStretch();
     buttonLayout->addWidget(cancelButton);
@@ -138,8 +137,13 @@ ChooseCyclistDialog::choice()
 void
 ChooseCyclistDialog::enableOkDelete(QListWidgetItem *item)
 {
-    okButton->setEnabled(item != NULL);
-    deleteButton->setEnabled(item != NULL);
+    okButton->setEnabled(item != nullptr);
+    if (listWidget->count() > 0) {
+        okButton->setDefault(item != nullptr);
+    } else {
+        newButton->setDefault(true);
+    }
+    deleteButton->setEnabled(item != nullptr);
 }
 
 void
@@ -196,7 +200,7 @@ ChooseCyclistDialog::newCyclistDialog(QDir &homeDir, QWidget *)
 
     // get new one..
     QString name;
-    if (newone->exec() == QDialog::Accepted) 
+    if (newone->exec() == QDialog::Accepted)
         name = newone->name->text();
     else
         name = "";

--- a/src/Gui/ChooseCyclistDialog.h
+++ b/src/Gui/ChooseCyclistDialog.h
@@ -40,7 +40,7 @@ class ChooseCyclistDialog : public QDialog
 
 
     public:
-        ChooseCyclistDialog(const QDir &home, bool allowNew);
+        ChooseCyclistDialog(const QDir &home);
         QString choice();
         void getList();
         static QString newCyclistDialog(QDir &homeDir, QWidget *parent);


### PR DESCRIPTION
On first start (or after crashes when developing), the ChooseCyclistDialog shows up. In this dialog, the order of the buttons when navigating with the tab-key feels random:
![Screenshot_20240719_220749](https://github.com/user-attachments/assets/7017a3c7-953c-4e99-b3ce-a7094cfc472a)
(Red: before this PR; green: after this PR)
Additionally, this PR changes the default button from "New" to "Open" if at least one athlete is available in the list. This feels more natural, opening is more frequently used than creating new users.
