### PR TITLE
Fixed translated image filters

### DIFF
--- a/src/Resources/translations/gc_de.ts
+++ b/src/Resources/translations/gc_de.ts
@@ -208,7 +208,7 @@ Sie müssen diesen möglicherweise manuell deaktivieren.</translation>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="366"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>Bilder (*.png, *.jpg, *.bmp)</translation>
+        <translation>Bilder (*.png *.jpg *.bmp)</translation>
     </message>
 </context>
 <context>
@@ -21633,7 +21633,7 @@ Keine Aktivitäten zum Importieren gefunden.
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="220"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>Bilder (*.png, *.jpg, *.bmp)</translation>
+        <translation>Bilder (*.png *.jpg *.bmp)</translation>
     </message>
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="368"/>

--- a/src/Resources/translations/gc_sv.ts
+++ b/src/Resources/translations/gc_sv.ts
@@ -207,7 +207,7 @@ Det kan behövas göras manuellt.</translation>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="366"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>Bilder (*.png, *.jpg, *.bmp)</translation>
+        <translation>Bilder (*.png *.jpg *.bmp)</translation>
     </message>
 </context>
 <context>
@@ -21563,7 +21563,7 @@ Inga Aktiviteter att importera.
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="220"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>Bilder (*.png, *.jpg, *.bmp)</translation>
+        <translation>Bilder (*.png *.jpg *.bmp)</translation>
     </message>
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="368"/>


### PR DESCRIPTION
* Some translations (de, sv) for filters used in QFileDialogs contained commas to separate wildcards. As this is in violation with Qts syntax, the dialogs didn't show any files. These commas are removed by this PR
* No other translation contains these commas