### PR TITLE
Removed wildcard from translatable part

### DIFF
--- a/src/Gui/AthletePages.cpp
+++ b/src/Gui/AthletePages.cpp
@@ -363,7 +363,7 @@ void
 AboutRiderPage::chooseAvatar()
 {
     QString filename = QFileDialog::getOpenFileName(this, tr("Choose Picture"),
-                            "", tr("Images (*.png *.jpg *.bmp)"));
+                            "", tr("Images") + " (*.png *.jpg *.bmp)");
     if (filename != "") {
 
         avatar = QPixmap(filename);

--- a/src/Gui/NewCyclistDialog.cpp
+++ b/src/Gui/NewCyclistDialog.cpp
@@ -217,7 +217,7 @@ void
 NewCyclistDialog::chooseAvatar()
 {
     QString filename = QFileDialog::getOpenFileName(this, tr("Choose Picture"),
-                            "", tr("Images (*.png *.jpg *.bmp)"));
+                            "", tr("Images") + " (*.png *.jpg *.bmp)");
     if (filename != "") {
 
         avatar = QPixmap(filename);

--- a/src/Resources/translations/gc_cs.ts
+++ b/src/Resources/translations/gc_cs.ts
@@ -207,7 +207,7 @@ Může být nezbytné ji vypnout ručně.</translation>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="366"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>Obrázky (*.png *.jpg *.bmp)</translation>
+        <translation>Obrázky</translation>
     </message>
 </context>
 <context>
@@ -21451,7 +21451,7 @@ Nebyly nalezeny žádné jízdy k importu.
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="220"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>Obrázky (*.png *.jpg *.bmp)</translation>
+        <translation>Obrázky</translation>
     </message>
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="368"/>

--- a/src/Resources/translations/gc_de.ts
+++ b/src/Resources/translations/gc_de.ts
@@ -208,7 +208,7 @@ Sie müssen diesen möglicherweise manuell deaktivieren.</translation>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="366"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>Bilder (*.png, *.jpg, *.bmp)</translation>
+        <translation>Bilder</translation>
     </message>
 </context>
 <context>
@@ -21633,7 +21633,7 @@ Keine Aktivitäten zum Importieren gefunden.
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="220"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>Bilder (*.png, *.jpg, *.bmp)</translation>
+        <translation>Bilder</translation>
     </message>
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="368"/>

--- a/src/Resources/translations/gc_es.ts
+++ b/src/Resources/translations/gc_es.ts
@@ -207,7 +207,7 @@ Puede que sea necesario deshabilitarlo de forma manual.</translation>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="366"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>Imágenes (*.png *.jpg *.bmp)</translation>
+        <translation>Imágenes</translation>
     </message>
 </context>
 <context>
@@ -21563,7 +21563,7 @@ No se han encontrado actividades para importar.
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="220"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>Imágenes (*.png *.jpg *.bmp)</translation>
+        <translation>Imágenes</translation>
     </message>
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="368"/>

--- a/src/Resources/translations/gc_fr.ts
+++ b/src/Resources/translations/gc_fr.ts
@@ -209,7 +209,7 @@ Si non cochée, le stress de l&apos;entraînement d&apos;un jour donné sera pri
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="366"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>Images (*.png *.jpg *.bmp)</translation>
+        <translation>Images</translation>
     </message>
 </context>
 <context>
@@ -21712,7 +21712,7 @@ Pas d&apos;activité trouvée à importer.
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="220"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>Images (*.png *.jpg *.bmp)</translation>
+        <translation>Images</translation>
     </message>
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="368"/>

--- a/src/Resources/translations/gc_it.ts
+++ b/src/Resources/translations/gc_it.ts
@@ -207,7 +207,7 @@ Potrebbe essere necessario disabilitarlo manualmente.</translation>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="366"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>Immagini (*.png *.jpg *.bmp)</translation>
+        <translation>Immagini</translation>
     </message>
 </context>
 <context>
@@ -21559,7 +21559,7 @@ Nessuna uscita in bici trovata da importare.
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="220"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>Immagini (*.png *.jpg *.bmp)</translation>
+        <translation>Immagini</translation>
     </message>
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="368"/>

--- a/src/Resources/translations/gc_nl.ts
+++ b/src/Resources/translations/gc_nl.ts
@@ -208,7 +208,7 @@ Misschien is het handmatig stoppen hiervan nodig.</translation>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="366"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>Afbeeldingen (*.png *.jpg *.bmp)</translation>
+        <translation>Afbeeldingen</translation>
     </message>
 </context>
 <context>
@@ -21448,7 +21448,7 @@ Geen ritten gevonden om te importeren.
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="220"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>Afbeeldingen (*.png *.jpg *.bmp)</translation>
+        <translation>Afbeeldingen</translation>
     </message>
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="368"/>

--- a/src/Resources/translations/gc_ru.ts
+++ b/src/Resources/translations/gc_ru.ts
@@ -207,7 +207,7 @@ It might be necessary to manually disable it.</source>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="366"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>Изображения (*.png *.jpg *.bmp)</translation>
+        <translation>Изображения</translation>
     </message>
 </context>
 <context>
@@ -21466,7 +21466,7 @@ No rides found to import.
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="220"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>Изображения (*.png *.jpg *.bmp)</translation>
+        <translation>Изображения</translation>
     </message>
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="368"/>

--- a/src/Resources/translations/gc_sv.ts
+++ b/src/Resources/translations/gc_sv.ts
@@ -207,7 +207,7 @@ Det kan behövas göras manuellt.</translation>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="366"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>Bilder (*.png, *.jpg, *.bmp)</translation>
+        <translation>Bilder</translation>
     </message>
 </context>
 <context>
@@ -21563,7 +21563,7 @@ Inga Aktiviteter att importera.
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="220"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>Bilder (*.png, *.jpg, *.bmp)</translation>
+        <translation>Bilder</translation>
     </message>
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="368"/>

--- a/src/Resources/translations/gc_zh-cn.ts
+++ b/src/Resources/translations/gc_zh-cn.ts
@@ -207,7 +207,7 @@ It might be necessary to manually disable it.</source>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="366"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>图片(*.png *.jpg *.bmp)</translation>
+        <translation>图片</translation>
     </message>
 </context>
 <context>
@@ -21459,7 +21459,7 @@ No rides found to import.
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="220"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>图片 (*.png *.jpg *.bmp)</translation>
+        <translation>图片</translation>
     </message>
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="368"/>

--- a/src/Resources/translations/gc_zh-tw.ts
+++ b/src/Resources/translations/gc_zh-tw.ts
@@ -207,7 +207,7 @@ It might be necessary to manually disable it.</source>
     <message>
         <location filename="../../Gui/AthletePages.cpp" line="366"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>影像格式 (*.png *.jpg *.bmp)</translation>
+        <translation>影像格式</translation>
     </message>
 </context>
 <context>
@@ -21428,7 +21428,7 @@ No rides found to import.
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="220"/>
         <source>Images (*.png *.jpg *.bmp)</source>
-        <translation>影像格式 (*.png *.jpg *.bmp)</translation>
+        <translation>影像格式</translation>
     </message>
     <message>
         <location filename="../../Gui/NewCyclistDialog.cpp" line="368"/>


### PR DESCRIPTION
Some translations (de, sv) for filters used in QFileDialgos contained commas to separate wildcards. As this is in violation with Qts syntax, the dialogs didn't show any files.

The change separates the wildcards from the name of the filter so that only the name can be manipulated by translation. All affected translations are updated.

This PR replaces #4544