### PR TITLE
Add Morpheus M7 heart rate monitor

### DIFF
--- a/src/Resources/json/FITmetadata.json
+++ b/src/Resources/json/FITmetadata.json
@@ -51,6 +51,7 @@
         { "manu":95, "prod":-1, "name":"Stryd" },
         { "manu":98, "prod":-1, "name":"BSX" },
         { "manu":98, "prod":2, "name":"BSX Insight 2" },
+        { "manu":106, "prod":5, "name":"Morpheus M7" },
         { "manu":107, "prod":-1, "name":"Magene" },
         { "manu":108, "prod":-1, "name":"Giant" },
         { "manu":108, "prod":21845, "name":"Giant Power Pro" },


### PR DESCRIPTION
Adds the heart rate monitor from Morpheus Training System:

https://trainwithmorpheus.com/
https://trainwithmorpheus.com/m7-user-guide/

![IMG_2440](https://github.com/user-attachments/assets/e1679aaf-0151-401f-a91c-4af28370d501)
