### PR TITLE
Add Morpheus M7 heart rate monitor

### DIFF
--- a/util/fit/nongarmin.json
+++ b/util/fit/nongarmin.json
@@ -47,6 +47,7 @@
 { "manu":95, "prod":-1, "name":"Stryd" },
 { "manu":98, "prod":-1, "name":"BSX" },
 { "manu":98, "prod":2, "name":"BSX Insight 2" },
+{ "manu":106, "prod":5, "name":"Morpheus M7" },
 { "manu":107, "prod":-1, "name":"Magene" },
 { "manu":108, "prod":-1, "name":"Giant" },
 { "manu":108, "prod":21845, "name":"Giant Power Pro" },


### PR DESCRIPTION
Adds the [Morpheus M7](https://trainwithmorpheus.com/m7-user-guide/) heart rate monitor from[ Morpheus Training System](https://trainwithmorpheus.com/)

![IMG_2440](https://github.com/user-attachments/assets/7cbf6d4c-be00-44a2-8d84-2161cd302905)
