### PR TITLE
Respect the Line Width Setting Inside the Workout Editor's Realtime Plot

### DIFF
--- a/src/Train/WorkoutWidgetItems.h
+++ b/src/Train/WorkoutWidgetItems.h
@@ -220,7 +220,8 @@ class WWTelemetry : public WorkoutWidgetItem {
                              const WorkoutWidget::WwSeriesType& seriesType)
         {
             QPen linePen(color);
-            linePen.setWidth(1);
+            double width = appsettings->value(workoutWidget(), GC_LINEWIDTH, 1.0).toDouble();
+            linePen.setWidth(width);
             painter->setPen(linePen);
 
             int index = 0;


### PR DESCRIPTION
### What changed?
The realtime plot of the workout editor now applies the line width setting of the app. You can observe this in the screenshot below, the axis lines etc. have the hard coded with of 1 in comparison to the line width of 3 in my app's settings for the realtime data.

![07-10-2024_17-24-42](https://github.com/user-attachments/assets/dedfc765-c69b-4125-b27c-5f975cfa89b5)

### Why?

- The hard coded line width of 1 might be to small for large displays with a high resolution (like in my case)
- I think it is appropriate for the workout editor plot to respect the app's settings.

### Alternative
Have a dedicated line width setting for the workout editor. I do not see the use case of this option.



