### PR TITLE
Sort the Dial Window's Combobox by Name

### DIFF
--- a/src/Train/DialWindow.cpp
+++ b/src/Train/DialWindow.cpp
@@ -49,7 +49,15 @@ DialWindow::DialWindow(Context *context) :
     QLabel *seriesLabel = new QLabel(tr("Data Series"), this);
     seriesLabel->setAutoFillBackground(true);
     seriesSelector = new QComboBox(this);
-    foreach (RealtimeData::DataSeries x, RealtimeData::listDataSeries()) {
+    QList<RealtimeData::DataSeries> all_series = RealtimeData::listDataSeries();
+    // sort the data series by the translated name for a better usability, since
+    // we have a lot of data series in the combobox.
+    auto sortByNameFun = [](const RealtimeData::DataSeries s1, const RealtimeData::DataSeries s2) {
+      // make the sorting case insensitive
+      return RealtimeData::seriesName(s1).toLower() < RealtimeData::seriesName(s2).toLower();
+    };
+    std::sort(all_series.begin(), all_series.end(), sortByNameFun);
+    foreach (RealtimeData::DataSeries x, all_series) {
         seriesSelector->addItem(RealtimeData::seriesName(x), static_cast<int>(x));
     }
     controlsLayout->addRow(seriesLabel, seriesSelector);


### PR DESCRIPTION
### What changed?
The combobox for the data series selection of the training view's dial window is now sorted by name.
I checked the sorting for english and german and it looks correct to me.
### Why
There is quite an amount of data series to select from in the combobox. This makes finding the and selecting the desired data series quite tedious. If it is sorted by name, the desired series is much easier to find.
### Alternative
 For example group the items by their categories, like power related data, timing related data, etc. But I think these groups might quickly become non mutually exclusive so the group assignment gets ambiguous. Additionally, the QComboBox widget does not support grouping items. So more extensive changes would be needed. Probably not worth the effort.