### PR TITLE
Make the Workout Editor's Settings Persistent

### DIFF
--- a/src/Train/WorkoutWindow.cpp
+++ b/src/Train/WorkoutWindow.cpp
@@ -26,19 +26,6 @@ static int MINTOOLHEIGHT = 350; // smaller than this, lose the toolbar
 
 WorkoutWindow::WorkoutWindow(Context *context) :
     GcChartWindow(context), draw(true), context(context), active(false), recording(false)
-    //plotHr(true),
-    //plotPwr(true),
-    //plotCadence(true),
-    //plotWbal(true),
-    //plotVo2(true),
-    //plotVentilation(true),
-    //plotSpeed(true),
-    //plotHrAvg(1),
-    //plotPwrAvg(1),
-    //plotCadenceAvg(1),
-    //plotVo2Avg(1),
-    //plotVentilationAvg(1),
-    //plotSpeedAvg(1)
 {
     HelpWhatsThis *helpContents = new HelpWhatsThis(this);
     this->setWhatsThis(helpContents->getWhatsThisText(HelpWhatsThis::ChartTrain_WorkoutEditor));

--- a/src/Train/WorkoutWindow.cpp
+++ b/src/Train/WorkoutWindow.cpp
@@ -25,20 +25,20 @@
 static int MINTOOLHEIGHT = 350; // smaller than this, lose the toolbar
 
 WorkoutWindow::WorkoutWindow(Context *context) :
-    GcChartWindow(context), draw(true), context(context), active(false), recording(false),
-    plotHr(true),
-    plotPwr(true),
-    plotCadence(true),
-    plotWbal(true),
-    plotVo2(true),
-    plotVentilation(true),
-    plotSpeed(true),
-    plotHrAvg(1),
-    plotPwrAvg(1),
-    plotCadenceAvg(1),
-    plotVo2Avg(1),
-    plotVentilationAvg(1),
-    plotSpeedAvg(1)
+    GcChartWindow(context), draw(true), context(context), active(false), recording(false)
+    //plotHr(true),
+    //plotPwr(true),
+    //plotCadence(true),
+    //plotWbal(true),
+    //plotVo2(true),
+    //plotVentilation(true),
+    //plotSpeed(true),
+    //plotHrAvg(1),
+    //plotPwrAvg(1),
+    //plotCadenceAvg(1),
+    //plotVo2Avg(1),
+    //plotVentilationAvg(1),
+    //plotSpeedAvg(1)
 {
     HelpWhatsThis *helpContents = new HelpWhatsThis(this);
     this->setWhatsThis(helpContents->getWhatsThisText(HelpWhatsThis::ChartTrain_WorkoutEditor));
@@ -73,21 +73,15 @@ WorkoutWindow::WorkoutWindow(Context *context) :
     plotVentilationSB = new QSpinBox(); plotVentilationSB->setMinimum(1);
     plotSpeedSB = new QSpinBox(); plotSpeedSB->setMinimum(1);
 
-    plotHrCB->setCheckState(plotHr ? Qt::Checked : Qt::Unchecked);
-    plotPwrCB->setCheckState(plotPwr ? Qt::Checked : Qt::Unchecked);
-    plotCadenceCB->setCheckState(plotCadence ? Qt::Checked : Qt::Unchecked);
-    plotWbalCB->setCheckState(plotWbal ? Qt::Checked : Qt::Unchecked);
-    plotVo2CB->setCheckState(plotVo2 ? Qt::Checked : Qt::Unchecked);
-    plotVentilationCB->setCheckState(plotVentilation ? Qt::Checked : Qt::Unchecked);
-    plotSpeedCB->setCheckState(plotSpeed ? Qt::Checked : Qt::Unchecked);
-
-    connect(plotHrCB, SIGNAL(stateChanged(int)), this, SLOT(plotHrChanged(int)));
-    connect(plotPwrCB, SIGNAL(stateChanged(int)), this, SLOT(plotPwrChanged(int)));
-    connect(plotCadenceCB, SIGNAL(stateChanged(int)), this, SLOT(plotCadenceChanged(int)));
-    connect(plotWbalCB, SIGNAL(stateChanged(int)), this, SLOT(plotWbalChanged(int)));
-    connect(plotVo2CB, SIGNAL(stateChanged(int)), this, SLOT(plotVo2Changed(int)));
-    connect(plotVentilationCB, SIGNAL(stateChanged(int)), this, SLOT(plotVentilationChanged(int)));
-    connect(plotSpeedCB, SIGNAL(stateChanged(int)), this, SLOT(plotSpeedChanged(int)));
+    // enable all plots by default. gets overriden by the corresponding property
+    // stored in the layout xml.
+    plotHrCB->setChecked(true);
+    plotPwrCB->setChecked(true);
+    plotCadenceCB->setChecked(true);
+    plotWbalCB->setChecked(true);
+    plotVo2CB->setChecked(true);
+    plotVentilationCB->setChecked(true);
+    plotSpeedCB->setChecked(true);
 
     connect(plotHrSB, SIGNAL(valueChanged(int)), this, SLOT(plotHrAvgChanged(int)));
     connect(plotPwrSB, SIGNAL(valueChanged(int)), this, SLOT(plotPwrAvgChanged(int)));
@@ -688,86 +682,133 @@ WorkoutWindow::stop()
     workout->stop();
 }
 
-void
-WorkoutWindow::plotHrChanged(int value)
+void WorkoutWindow::setShouldPlotHr(bool value)
 {
-    plotHr = (value != Qt::Unchecked);
+    plotHrCB->setChecked(value);
+}
+
+void WorkoutWindow::setShouldPlotPwr(bool value)
+{
+    plotPwrCB->setChecked(value);
+}
+
+void WorkoutWindow::setShouldPlotCadence(bool value)
+{
+    plotCadenceCB->setChecked(value);
+}
+
+void WorkoutWindow::setShouldPlotWbal(bool value)
+{
+    plotWbalCB->setChecked(value);
+}
+
+void WorkoutWindow::setShouldPlotVo2(bool value)
+{
+    plotVo2CB->setChecked(value);
+}
+
+void WorkoutWindow::setShouldPlotVentilation(bool value)
+{
+    plotVentilationCB->setChecked(value);
+}
+
+void WorkoutWindow::setShouldPlotSpeed(bool value)
+{
+    plotSpeedCB->setChecked(value);
+}
+
+int WorkoutWindow::hrPlotAvgLength()
+{
+    return plotHrSB->value();
+}
+
+int WorkoutWindow::pwrPlotAvgLength()
+{
+    return plotPwrSB->value();
+}
+
+int WorkoutWindow::cadencePlotAvgLength()
+{
+    return plotCadenceSB->value();
+}
+
+int WorkoutWindow::vo2PlotAvgLength()
+{
+  return plotVo2SB->value();
+}
+
+int WorkoutWindow::ventilationPlotAvgLength()
+{
+  return plotVentilationSB->value();
+}
+
+int WorkoutWindow::speedPlotAvgLength()
+{
+    return plotSpeedSB->value();
+}
+
+void WorkoutWindow::setPlotHrAvgLength(int value)
+{
+    plotHrSB->setValue(value);
+}
+
+void WorkoutWindow::setPlotPwrAvgLength(int value)
+{
+    plotPwrSB->setValue(value);
+}
+
+void WorkoutWindow::setPlotCadenceAvgLength(int value)
+{
+    plotCadenceSB->setValue(value);
+}
+
+void WorkoutWindow::setPlotVo2AvgLength(int value)
+{
+    plotVo2SB->setValue(value);
+}
+
+void WorkoutWindow::setPlotVentilationAvgLength(int value)
+{
+    plotVentilationSB->setValue(value);
+}
+
+void WorkoutWindow::setPlotSpeedAvgLength(int value)
+{
+    plotSpeedSB->setValue(value);
 }
 
 void
-WorkoutWindow::plotPwrChanged(int value)
+WorkoutWindow::plotHrAvgChanged(int)
 {
-    plotPwr = (value != Qt::Unchecked);
-}
-
-void
-WorkoutWindow::plotCadenceChanged(int value)
-{
-    plotCadence = (value != Qt::Unchecked);
-}
-
-void
-WorkoutWindow::plotWbalChanged(int value)
-{
-    plotWbal = (value != Qt::Unchecked);
-}
-
-void
-WorkoutWindow::plotVo2Changed(int value)
-{
-    plotVo2 = (value != Qt::Unchecked);
-}
-
-void
-WorkoutWindow::plotVentilationChanged(int value)
-{
-    plotVentilation = (value != Qt::Unchecked);
-}
-
-void
-WorkoutWindow::plotSpeedChanged(int value)
-{
-    plotSpeed = (value != Qt::Unchecked);
-}
-
-void
-WorkoutWindow::plotHrAvgChanged(int value)
-{
-    plotHrAvg = value;
     workout->hrAvg.clear();
 }
 
 void
-WorkoutWindow::plotPwrAvgChanged(int value)
+WorkoutWindow::plotPwrAvgChanged(int)
 {
-    plotPwrAvg = value;
     workout->pwrAvg.clear();
 }
 
 void
-WorkoutWindow::plotCadenceAvgChanged(int value)
+WorkoutWindow::plotCadenceAvgChanged(int)
 {
-    plotCadenceAvg = value;
     workout->cadenceAvg.clear();
 }
 
 void
-WorkoutWindow::plotVo2AvgChanged(int value)
+WorkoutWindow::plotVo2AvgChanged(int)
 {
-    plotVo2Avg = value;
     workout->vo2Avg.clear();
 }
 
 void
-WorkoutWindow::plotVentilationAvgChanged(int value)
+WorkoutWindow::plotVentilationAvgChanged(int)
 {
-    plotVentilationAvg = value;
     workout->ventilationAvg.clear();
 }
 
 void
-WorkoutWindow::plotSpeedAvgChanged(int value)
+WorkoutWindow::plotSpeedAvgChanged(int)
 {
-    plotSpeedAvg = value;
     workout->speedAvg.clear();
 }

--- a/src/Train/WorkoutWindow.h
+++ b/src/Train/WorkoutWindow.h
@@ -210,8 +210,6 @@ class WorkoutWindow : public GcChartWindow
 
         bool active;
         bool recording;
-        //bool plotHr, plotPwr, plotCadence, plotWbal, plotVo2, plotVentilation, plotSpeed;
-        //int plotHrAvg, plotPwrAvg, plotCadenceAvg, plotVo2Avg, plotVentilationAvg, plotSpeedAvg;
 };
 
 #endif // _GC_WorkoutWindow_h

--- a/src/Train/WorkoutWindow.h
+++ b/src/Train/WorkoutWindow.h
@@ -61,6 +61,21 @@ class WWTelemetry;
 class WorkoutWindow : public GcChartWindow
 {
     Q_OBJECT
+    G_OBJECT
+    Q_PROPERTY(bool plotHr READ shouldPlotHr WRITE setShouldPlotHr USER true)
+    Q_PROPERTY(bool plotPwr READ shouldPlotPwr WRITE setShouldPlotPwr USER true)
+    Q_PROPERTY(bool plotCadence READ shouldPlotCadence WRITE setShouldPlotCadence USER true)
+    Q_PROPERTY(bool plotWbal READ shouldPlotWbal WRITE setShouldPlotWbal USER true)
+    Q_PROPERTY(bool plotVo2 READ shouldPlotVo2 WRITE setShouldPlotVo2 USER true)
+    Q_PROPERTY(bool plotVentilation READ shouldPlotVentilation WRITE setShouldPlotVentilation USER true)
+    Q_PROPERTY(bool plotSpeed READ shouldPlotSpeed WRITE setShouldPlotSpeed USER true)
+
+    Q_PROPERTY(int hrPlotAvgLength READ hrPlotAvgLength WRITE setPlotHrAvgLength USER true)
+    Q_PROPERTY(int pwrPlotAvgLength READ pwrPlotAvgLength WRITE setPlotPwrAvgLength USER true)
+    Q_PROPERTY(int cadencePlotAvgLength READ cadencePlotAvgLength WRITE setPlotCadenceAvgLength USER true)
+    Q_PROPERTY(int vo2PlotAvgLength READ vo2PlotAvgLength WRITE setPlotVo2AvgLength USER true)
+    Q_PROPERTY(int ventilationPlotAvgLength READ ventilationPlotAvgLength WRITE setPlotVentilationAvgLength USER true)
+    Q_PROPERTY(int speedPlotAvgLength READ speedPlotAvgLength WRITE setPlotSpeedAvgLength USER true)
 
     public:
 
@@ -90,6 +105,7 @@ class WorkoutWindow : public GcChartWindow
         bool draw; // draw or select mode?
 
    public slots:
+        // set properties
 
         // toolbar functions
         void newErgFile();
@@ -127,14 +143,6 @@ class WorkoutWindow : public GcChartWindow
         // show hide toolbar if too small
         void resizeEvent(QResizeEvent * event);
 
-        // settings changes
-        void plotHrChanged(int value);
-        void plotPwrChanged(int value);
-        void plotCadenceChanged(int value);
-        void plotWbalChanged(int value);
-        void plotVo2Changed(int value);
-        void plotVentilationChanged(int value);
-        void plotSpeedChanged(int value);
         void plotHrAvgChanged(int value);
         void plotPwrAvgChanged(int value);
         void plotCadenceAvgChanged(int value);
@@ -142,21 +150,36 @@ class WorkoutWindow : public GcChartWindow
         void plotVentilationAvgChanged(int value);
         void plotSpeedAvgChanged(int value);
 
-        // get settings
-        bool shouldPlotHr() { return plotHr;}
-        bool shouldPlotPwr() { return plotPwr;}
-        bool shouldPlotCadence() { return plotCadence;}
-        bool shouldPlotWbal() { return plotWbal;}
-        bool shouldPlotVo2() { return plotVo2;}
-        bool shouldPlotVentilation() { return plotVentilation;}
-        bool shouldPlotSpeed() { return plotSpeed;}
+        void setShouldPlotHr(bool);
+        void setShouldPlotPwr(bool);
+        void setShouldPlotCadence(bool);
+        void setShouldPlotWbal(bool);
+        void setShouldPlotVo2(bool);
+        void setShouldPlotVentilation(bool);
+        void setShouldPlotSpeed(bool);
 
-        int hrPlotAvgLength() { return plotHrAvg; }
-        int pwrPlotAvgLength() { return plotPwrAvg; }
-        int cadencePlotAvgLength() { return plotCadenceAvg; }
-        int vo2PlotAvgLength() { return plotVo2Avg; }
-        int ventilationPlotAvgLength() { return plotVentilationAvg; }
-        int speedPlotAvgLength() { return plotSpeedAvg; }
+        void setPlotHrAvgLength(int);
+        void setPlotPwrAvgLength(int);
+        void setPlotCadenceAvgLength(int);
+        void setPlotVo2AvgLength(int);
+        void setPlotVentilationAvgLength(int);
+        void setPlotSpeedAvgLength(int);
+
+        // get settings
+        bool shouldPlotHr() { return plotHrCB->checkState() != Qt::Unchecked;}
+        bool shouldPlotPwr() { return plotPwrCB->checkState() != Qt::Unchecked;}
+        bool shouldPlotCadence() { return plotCadenceCB->checkState() != Qt::Unchecked;}
+        bool shouldPlotWbal() { return plotWbalCB->checkState() != Qt::Unchecked;}
+        bool shouldPlotVo2() { return plotVo2CB->checkState() != Qt::Unchecked;}
+        bool shouldPlotVentilation() { return plotVentilationCB->checkState() != Qt::Unchecked;}
+        bool shouldPlotSpeed() { return plotSpeedCB->checkState() != Qt::Unchecked;}
+
+        int hrPlotAvgLength();
+        int pwrPlotAvgLength();
+        int cadencePlotAvgLength();
+        int vo2PlotAvgLength();
+        int ventilationPlotAvgLength();
+        int speedPlotAvgLength();
 
     protected:
         bool eventFilter(QObject *obj, QEvent *event);
@@ -187,8 +210,8 @@ class WorkoutWindow : public GcChartWindow
 
         bool active;
         bool recording;
-        bool plotHr, plotPwr, plotCadence, plotWbal, plotVo2, plotVentilation, plotSpeed;
-        int plotHrAvg, plotPwrAvg, plotCadenceAvg, plotVo2Avg, plotVentilationAvg, plotSpeedAvg;
+        //bool plotHr, plotPwr, plotCadence, plotWbal, plotVo2, plotVentilation, plotSpeed;
+        //int plotHrAvg, plotPwrAvg, plotCadenceAvg, plotVo2Avg, plotVentilationAvg, plotSpeedAvg;
 };
 
 #endif // _GC_WorkoutWindow_h


### PR DESCRIPTION
### What changed?
The chart settings of the workout editor are now defined as `Q_PROPERTY`.
This way the settings are stored inside the perspective's layout xml and are restored after the app is restarted. Otherwise all settings get lost each time GC is closed.