### PR TITLE
Fix regression caused by #4551

### DIFF
--- a/src/Resources/xml/train-perspectives.xml
+++ b/src/Resources/xml/train-perspectives.xml
@@ -36,7 +36,7 @@
 		<property name="showInstant" type="bool" value="1" />
 		<property name="avgsecs" type="int" value="1" />
 		<property name="avgType" type="int" value="32695" />
-		<property name="dataSeries" type="int" value="12" />
+		<property name="dataSeries" type="int" value="16" />
 		<property name="style" type="int" value="2" />
 	</chart>
 	<chart id="22" name="" title="W&apos; bal" >
@@ -109,7 +109,7 @@
 		<property name="showInstant" type="bool" value="0" />
 		<property name="avgsecs" type="int" value="1" />
 		<property name="avgType" type="int" value="32526" />
-		<property name="dataSeries" type="int" value="2" />
+		<property name="dataSeries" type="int" value="4" />
 		<property name="style" type="int" value="2" />
 	</chart>
 	<chart id="22" name="" title="Distance" >
@@ -122,7 +122,7 @@
 		<property name="showInstant" type="bool" value="0" />
 		<property name="avgsecs" type="int" value="1" />
 		<property name="avgType" type="int" value="1083336304" />
-		<property name="dataSeries" type="int" value="4" />
+		<property name="dataSeries" type="int" value="3" />
 		<property name="style" type="int" value="2" />
 	</chart>
 </layout>
@@ -163,7 +163,7 @@
 		<property name="showInstant" type="bool" value="1" />
 		<property name="avgsecs" type="int" value="1" />
 		<property name="avgType" type="int" value="32695" />
-		<property name="dataSeries" type="int" value="12" />
+		<property name="dataSeries" type="int" value="16" />
 		<property name="style" type="int" value="2" />
 	</chart>
 	<chart id="22" name="" title="W&apos; bal" >
@@ -236,7 +236,7 @@
 		<property name="showInstant" type="bool" value="0" />
 		<property name="avgsecs" type="int" value="1" />
 		<property name="avgType" type="int" value="32526" />
-		<property name="dataSeries" type="int" value="2" />
+		<property name="dataSeries" type="int" value="4" />
 		<property name="style" type="int" value="2" />
 	</chart>
 	<chart id="22" name="" title="Distance" >
@@ -249,7 +249,7 @@
 		<property name="showInstant" type="bool" value="0" />
 		<property name="avgsecs" type="int" value="1" />
 		<property name="avgType" type="int" value="1083336304" />
-		<property name="dataSeries" type="int" value="4" />
+		<property name="dataSeries" type="int" value="3" />
 		<property name="style" type="int" value="2" />
 	</chart>
 </layout>
@@ -290,7 +290,7 @@
 		<property name="showInstant" type="bool" value="1" />
 		<property name="avgsecs" type="int" value="1" />
 		<property name="avgType" type="int" value="32695" />
-		<property name="dataSeries" type="int" value="12" />
+		<property name="dataSeries" type="int" value="16" />
 		<property name="style" type="int" value="2" />
 	</chart>
 	<chart id="22" name="" title="W&apos; bal" >
@@ -372,7 +372,7 @@
 		<property name="showInstant" type="bool" value="0" />
 		<property name="avgsecs" type="int" value="1" />
 		<property name="avgType" type="int" value="32526" />
-		<property name="dataSeries" type="int" value="2" />
+		<property name="dataSeries" type="int" value="4" />
 		<property name="style" type="int" value="2" />
 	</chart>
 	<chart id="22" name="" title="Distance" >
@@ -385,7 +385,7 @@
 		<property name="showInstant" type="bool" value="0" />
 		<property name="avgsecs" type="int" value="1" />
 		<property name="avgType" type="int" value="1083336304" />
-		<property name="dataSeries" type="int" value="4" />
+		<property name="dataSeries" type="int" value="3" />
 		<property name="style" type="int" value="2" />
 	</chart>
 </layout>

--- a/src/Train/DialWindow.h
+++ b/src/Train/DialWindow.h
@@ -72,7 +72,7 @@ class DialWindow : public GcChartWindow
         // get properties - the setters are below
         bool isInstant() const { return _instant; }
         int avgType() const { return _avgType; }
-        int dataSeries() const { return seriesSelector->currentIndex(); }
+        int dataSeries() const { return seriesSelector->itemData(seriesSelector->currentIndex()).toInt(); }
         int style() const { return _style; }
         int avgSecs() const { return average; }
 
@@ -92,7 +92,10 @@ class DialWindow : public GcChartWindow
         void setInstant(bool x) { _instant=x; }
         void setAvgSecs(int x) { average=x; averageSlider->setValue(x); setAverageFromSlider(); }
         void setAvgType(int x) { _avgType=x; }
-        void setDataSeries(int x) { seriesSelector->setCurrentIndex(x); }
+        void setDataSeries(int x) {
+          int index = seriesSelector->findData(x);
+          seriesSelector->setCurrentIndex(index); 
+        }
         void setStyle(int x) { _style=x; }
 
     private:

--- a/src/Train/RealtimeData.h
+++ b/src/Train/RealtimeData.h
@@ -35,6 +35,9 @@ public:
     ErgFileFormat mode;
 
     // abstract to dataseries
+    // the order matters. if we remove any entry, the corresponding layouts
+    // will break since the data series is defined by its enum value. new data
+    // series need to be appended.
     enum dataseries { None=0, Time, LapTime, Distance, Lap,
                       Watts, Speed, Cadence, HeartRate, Load,
                       XPower, BikeScore, RI, Joules, SkibaVI,
@@ -46,12 +49,12 @@ public:
                       VirtualSpeed, AltWatts, LRBalance, LapTimeRemaining,
                       LeftTorqueEffectiveness, RightTorqueEffectiveness,
                       LeftPedalSmoothness, RightPedalSmoothness, Slope, 
-                      RightPowerPhaseBegin, RightPowerPhaseEnd,
-                      RightPowerPhasePeakBegin, RightPowerPhasePeakEnd,
-                      Position, RightPCO, LeftPCO,
                       LapDistance, LapDistanceRemaining, ErgTimeRemaining,
                       Latitude, Longitude, Altitude, RouteDistance,
-                      DistanceRemaining };
+                      DistanceRemaining,
+                      RightPowerPhaseBegin, RightPowerPhaseEnd,
+                      RightPowerPhasePeakBegin, RightPowerPhasePeakEnd,
+                      Position, RightPCO, LeftPCO };
 
     typedef enum dataseries DataSeries;
 


### PR DESCRIPTION
Starting from #4551 the DialWindow's `dataSeries` property does not match the ``RealtimeData::Dataseries`` enum values.

The enum value has been stored as userdata for each dataseries item of the ``seriesSelector`` combobox. But the getter/setter for the `dataSeries` has stored/restored the currently/previously selected series' index. This has become a problem since #4551 as the data series are added in another order.

I also assume that #4337 might cause problems for some users, since new data series enum values have been inserted and all following data series enum values have been changed. Hence, I moved them to the end of the enum.

I also checked the default train perspectives and fixed all occurences, where the DialWindows' title did not match the corresponding data series.

Edit: Note that this will **not** solve the problems for layouts that have been created before #4551, if the `dataSeries` property had differed from the data series enum value.

Looking at https://github.com/GoldenCheetah/GoldenCheetah/blob/60f9033617996c30a7b18a608adea27e8e370153/src/Train/RealtimeData.cpp#L533
I can observe that not all data series are enlisted. I do not know if this is on purpose or by accident. Anyhow, this PR should make the layouts more robust, since regardless of the data series subset the function returns, each will be correctly associated with its enum value by the `DialWindow`.