### PR TITLE
Scale Line Width default values

### DIFF
--- a/src/Charts/Aerolab.cpp
+++ b/src/Charts/Aerolab.cpp
@@ -252,10 +252,10 @@ Aerolab::configChanged(qint32)
   // set colors
   setCanvasBackground(GColor(CPLOTBACKGROUND));
   QPen vePen = QPen(GColor(CAEROVE));
-  vePen.setWidth(appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble());
+  vePen.setWidth(appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble());
   veCurve->setPen(vePen);
   QPen altPen = QPen(GColor(CAEROEL));
-  altPen.setWidth(appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble());
+  altPen.setWidth(appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble());
   altCurve->setPen(altPen);
   QPen gridPen(GColor(CPLOTGRID));
   gridPen.setStyle(Qt::DotLine);

--- a/src/Charts/AllPlot.cpp
+++ b/src/Charts/AllPlot.cpp
@@ -1057,7 +1057,7 @@ AllPlot::configChanged(qint32 what)
 
     if (what & CONFIG_APPEARANCE) {
 
-        double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
+        double width = appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble();
         labelFont.fromString(appsettings->value(this, GC_FONT_CHARTLABELS, QFont().toString()).toString());
         labelFont.setPointSize(appsettings->value(NULL, GC_FONT_CHARTLABELS_SIZE, 8).toInt());
 

--- a/src/Charts/CPPlot.cpp
+++ b/src/Charts/CPPlot.cpp
@@ -533,7 +533,7 @@ CPPlot::plotLinearWorkModel()
 
         // curve cosmetics
         QPen pen(GColor(CCP));
-        double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
+        double width = appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble();
         pen.setWidth(width);
         if (showBest) pen.setStyle(Qt::DashLine);
         workModelCurve->setPen(pen);
@@ -632,7 +632,7 @@ CPPlot::plotModel()
 
             // curve cosmetics
             QPen pen(GColor(CCP));
-            double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
+            double width = appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble();
             pen.setWidth(width);
             if (showBest) pen.setStyle(Qt::DashLine);
             modelCurve->setPen(pen);
@@ -936,7 +936,7 @@ CPPlot::plotModel(QVector<double> vector, QColor plotColor, PDModel *baseline)
 
     // curve cosmetics
     QPen pen(plotColor);
-    double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
+    double width = appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble();
     pen.setWidth(width);
     if (showBest) pen.setStyle(Qt::DashLine);
     curve->setPen(pen);
@@ -1350,7 +1350,7 @@ CPPlot::plotBests(RideItem *rideItem)
             }
 
             fill.setAlpha(64);
-            line.setWidth(appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble());
+            line.setWidth(appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble());
 
             curve->setPen(line);
             if (criticalSeries == CriticalPowerWindow::work || rideSeries == RideFile::watts || rideSeries == RideFile::wattsKg || rideSeries == RideFile::aPower || rideSeries == RideFile::aPowerKg || rideSeries == RideFile::kph)
@@ -1530,7 +1530,7 @@ CPPlot::plotBests(RideItem *rideItem)
                     curve->setRenderHint(QwtPlotItem::RenderAntialiased);
                 QPen pen(color.darker(200));
                 pen.setColor(GColor(CCP)); //XXX color ?
-                double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
+                double width = appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble();
                 pen.setWidth(width);
                 curve->setPen(pen);
 
@@ -1618,7 +1618,7 @@ CPPlot::plotBests(RideItem *rideItem)
                     curve->setRenderHint(QwtPlotItem::RenderAntialiased);
                 QPen pen(color.darker(200));
                 pen.setColor(GColor(CCP)); //XXX color ?
-                double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
+                double width = appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble();
                 pen.setWidth(width);
                 curve->setPen(pen);
 
@@ -1884,7 +1884,7 @@ CPPlot::plotRide(RideItem *rideItem)
     // curve that gets any special colour treatment.
     QPen ridePen;
     ridePen.setColor(GColor(CRIDECP));
-    double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
+    double width = appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble();
     ridePen.setWidth(width);
     rideCurve->setPen(ridePen);
 
@@ -2435,7 +2435,7 @@ CPPlot::refreshReferenceLines(RideItem *rideItem)
                     QwtPlotMarker *referenceLine = new QwtPlotMarker;
                     QPen p;
                     p.setColor(GColor(CPLOTMARKER));
-                    double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
+                    double width = appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble();
                     p.setWidth(width);
                     p.setStyle(Qt::DashLine);
                     referenceLine->setLinePen(p);
@@ -2697,7 +2697,7 @@ CPPlot::plotCentile(RideItem *rideItem)
             QColor std = GColor(CRIDECP);
             QPen pen(QColor(250-(i*20),std.green(),std.blue()));
             pen.setStyle(Qt::DashLine); // Qt::SolidLine
-            double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
+            double width = appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble();
             pen.setWidth(width);
             rideCurve->setPen(pen);
             rideCurve->attach(this);
@@ -3136,7 +3136,7 @@ CPPlot::plotCache(QVector<double> vector, QColor intervalColor)
 
     // set its color - based upon index in intervals!
     QPen pen(intervalColor);
-    double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
+    double width = appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble();
     pen.setWidth(width);
     //pen.setStyle(Qt::DotLine);
     intervalColor.setAlpha(64);

--- a/src/Charts/CriticalPowerWindow.cpp
+++ b/src/Charts/CriticalPowerWindow.cpp
@@ -1219,7 +1219,7 @@ CriticalPowerWindow::intervalHover(IntervalItem* x)
         for (size_t i=0; i<intervalCurves[index]->data()->size(); i++) array << intervalCurves[index]->data()->sample(i);
 
         QPen pen(Qt::gray);
-        double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
+        double width = appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble();
         pen.setWidth(width);
 
         // create the hover curve
@@ -1308,7 +1308,7 @@ CriticalPowerWindow::showIntervalCurve(IntervalItem *current, int index)
     int count=myRideItem->intervals().count();
     intervalColor.setHsv(index * (255/count), 255,255);
     QPen pen(intervalColor);
-    double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
+    double width = appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble();
     pen.setWidth(width);
     //pen.setStyle(Qt::DotLine);
     intervalColor.setAlpha(64);

--- a/src/Charts/LTMPlot.cpp
+++ b/src/Charts/LTMPlot.cpp
@@ -410,7 +410,7 @@ LTMPlot::setData(LTMSettings *set)
     //qDebug()<<"Created curve data.."<<timer.elapsed();
 
     // setup the curves
-    double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
+    double width = appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble();
     bool donestack = false;
 
     // now we iterate over the metric details AGAIN
@@ -1601,7 +1601,7 @@ LTMPlot::setCompareData(LTMSettings *set)
         //qDebug()<<"Created curve data.."<<timer.elapsed();
 
         // setup the curves
-        double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
+        double width = appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble();
 
         // now we iterate over the metric details AGAIN
         // but this time in reverse and only plot the

--- a/src/Charts/PowerHist.cpp
+++ b/src/Charts/PowerHist.cpp
@@ -185,7 +185,7 @@ PowerHist::configChanged(qint32)
         }
     }
 
-    double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
+    double width = appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble();
     if (appsettings->value(this, GC_ANTIALIAS, true).toBool()==true) {
         curve->setRenderHint(QwtPlotItem::RenderAntialiased);
         curveSelected->setRenderHint(QwtPlotItem::RenderAntialiased);
@@ -1443,7 +1443,7 @@ PowerHist::setDataFromCompare()
     // not for metric plots sonny
     if (source == Metric) return;
 
-    double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
+    double width = appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble();
 
     // set all the curves based upon whats in the compare intervals array
     // first lets clear the old data
@@ -1590,7 +1590,7 @@ PowerHist::setComparePens()
     if ((!rangemode && !context->isCompareIntervals) ||
         (rangemode && !context->isCompareDateRanges)) return;
 
-    double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
+    double width = appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble();
     for (int i=0; (!rangemode && i<context->compareIntervals.count()) ||
                   (rangemode && i<context->compareDateRanges.count()); i++) {
 
@@ -1627,7 +1627,7 @@ PowerHist::setDataFromCompare(QString totalMetric, QString distMetric)
     // set the data for each compare date range using
     // the metric results in the compare data range
     // and create the HistData and curves associated
-    double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
+    double width = appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble();
 
     // remove old data and curves
     compareData.clear();

--- a/src/Gui/Pages.cpp
+++ b/src/Gui/Pages.cpp
@@ -1449,7 +1449,7 @@ ColorsPage::ColorsPage(QWidget *parent) : QWidget(parent)
     lineWidth->setMinimum(0.5);
     lineWidth->setSingleStep(0.5);
     applyTheme = new QPushButton(tr("Apply Theme"));
-    lineWidth->setValue(appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble());
+    lineWidth->setValue(appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble());
 
     QLabel *lineWidthLabel = new QLabel(tr("Line Width"));
     QLabel *defaultLabel = new QLabel(tr("Font"));

--- a/src/Train/RealtimePlot.cpp
+++ b/src/Train/RealtimePlot.cpp
@@ -385,7 +385,7 @@ RealtimePlot::setAxisTitle(int axis, QString label)
 void
 RealtimePlot::configChanged(qint32)
 {
-    double width = appsettings->value(this, GC_LINEWIDTH, 0.5).toDouble();
+    double width = appsettings->value(this, GC_LINEWIDTH, 0.5*dpiXFactor).toDouble();
 
     setCanvasBackground(GColor(CTRAINPLOTBACKGROUND));
     QPen pwr30pen = QPen(GColor(CPOWER), width, Qt::DashLine);

--- a/src/Train/WorkoutWidgetItems.h
+++ b/src/Train/WorkoutWidgetItems.h
@@ -220,7 +220,7 @@ class WWTelemetry : public WorkoutWidgetItem {
                              const WorkoutWidget::WwSeriesType& seriesType)
         {
             QPen linePen(color);
-            double width = appsettings->value(workoutWidget(), GC_LINEWIDTH, 1.0).toDouble();
+            double width = appsettings->value(workoutWidget(), GC_LINEWIDTH, 1.0*dpiXFactor).toDouble();
             linePen.setWidth(width);
             painter->setPen(linePen);
 


### PR DESCRIPTION
This is a follow up of a discussion in #4550: since configurable GC_LINEWIDTH is not scaled on use, it is convenient to scale fixed default values so they adapt to display configuration on first use, to make an easier setup for new users without affecting existing ones.