### PR TITLE
Position tile config menu

### DIFF
--- a/src/Charts/Overview.cpp
+++ b/src/Charts/Overview.cpp
@@ -178,8 +178,7 @@ nodice:
 void
 OverviewWindow::configItem(ChartSpaceItem *item, QPoint pos)
 {
-    OverviewConfigDialog *p = new OverviewConfigDialog(item);
-    p->move(pos.x()+10, pos.y()+10);
+    OverviewConfigDialog *p = new OverviewConfigDialog(item, pos);
     p->exec(); // no mem leak as delete on close
 }
 
@@ -573,7 +572,7 @@ badconfig:
 //
 // Config dialog that pops up when you click on the config button
 //
-OverviewConfigDialog::OverviewConfigDialog(ChartSpaceItem*item) : QDialog(NULL), item(item)
+OverviewConfigDialog::OverviewConfigDialog(ChartSpaceItem*item, QPoint pos) : QDialog(NULL), item(item), pos(pos)
 {
     if (item->type == OverviewItemType::USERCHART) setWindowTitle(tr("Chart Settings"));
     else setWindowTitle(tr("Tile Settings"));
@@ -619,6 +618,21 @@ OverviewConfigDialog::OverviewConfigDialog(ChartSpaceItem*item) : QDialog(NULL),
     connect(ok, SIGNAL(clicked()), this, SLOT(close()));
     connect(remove, SIGNAL(clicked()), this, SLOT(removeItem()));
 
+}
+
+void
+OverviewConfigDialog::showEvent(QShowEvent* event)
+{
+    QSize gcWindowSize = item->parent->context->mainWindow->size();
+    QPoint gcWindowPosn = item->parent->context->mainWindow->pos();
+
+    int xLimit = gcWindowPosn.x() + gcWindowSize.width() - geometry().width() -10;
+    int yLimit = gcWindowPosn.y() + gcWindowSize.height() - geometry().height() -10;
+
+    int xDialog = (pos.x() > xLimit) ? xLimit : pos.x();
+    int yDialog = (pos.y() > yLimit) ? yLimit : pos.y();
+
+    move(xDialog, yDialog);
 }
 
 OverviewConfigDialog::~OverviewConfigDialog()

--- a/src/Charts/Overview.cpp
+++ b/src/Charts/Overview.cpp
@@ -89,7 +89,7 @@ OverviewWindow::OverviewWindow(Context *context, int scope, bool blank) : GcChar
     connect(importChart, SIGNAL(triggered(bool)), this, SLOT(importChart()));
     connect(settings, SIGNAL(triggered(bool)), this, SLOT(settings()));
     connect(mincolsEdit, SIGNAL(valueChanged(int)), this, SLOT(setMinimumColumns(int)));
-    connect(space, SIGNAL(itemConfigRequested(ChartSpaceItem*)), this, SLOT(configItem(ChartSpaceItem*)));
+    connect(space, SIGNAL(itemConfigRequested(ChartSpaceItem*, QPoint)), this, SLOT(configItem(ChartSpaceItem*, QPoint)));
 }
 
 void
@@ -176,9 +176,10 @@ nodice:
 }
 
 void
-OverviewWindow::configItem(ChartSpaceItem *item)
+OverviewWindow::configItem(ChartSpaceItem *item, QPoint pos)
 {
     OverviewConfigDialog *p = new OverviewConfigDialog(item);
+    p->move(pos.x()+10, pos.y()+10);
     p->exec(); // no mem leak as delete on close
 }
 

--- a/src/Charts/Overview.cpp
+++ b/src/Charts/Overview.cpp
@@ -621,7 +621,7 @@ OverviewConfigDialog::OverviewConfigDialog(ChartSpaceItem*item, QPoint pos) : QD
 }
 
 void
-OverviewConfigDialog::showEvent(QShowEvent* event)
+OverviewConfigDialog::showEvent(QShowEvent*)
 {
     QSize gcWindowSize = item->parent->context->mainWindow->size();
     QPoint gcWindowPosn = item->parent->context->mainWindow->pos();

--- a/src/Charts/Overview.h
+++ b/src/Charts/Overview.h
@@ -93,7 +93,7 @@ class OverviewConfigDialog : public QDialog
 
     protected:
 
-        void showEvent(QShowEvent* event);
+        void showEvent(QShowEvent*) override;
 
     private:
         QPoint pos;

--- a/src/Charts/Overview.h
+++ b/src/Charts/Overview.h
@@ -63,7 +63,7 @@ class OverviewWindow : public GcChartWindow
         void settings();
 
         // config item requested
-        void configItem(ChartSpaceItem *);
+        void configItem(ChartSpaceItem *, QPoint);
 
     private:
 

--- a/src/Charts/Overview.h
+++ b/src/Charts/Overview.h
@@ -81,7 +81,7 @@ class OverviewConfigDialog : public QDialog
     Q_OBJECT
 
     public:
-        OverviewConfigDialog(ChartSpaceItem*);
+        OverviewConfigDialog(ChartSpaceItem*, QPoint pos);
         ~OverviewConfigDialog();
 
 
@@ -91,7 +91,12 @@ class OverviewConfigDialog : public QDialog
         void exportChart();
         void close();
 
+    protected:
+
+        void showEvent(QShowEvent* event);
+
     private:
+        QPoint pos;
         ChartSpaceItem *item;
         QVBoxLayout *main;
         QPushButton *remove, *ok, *exp;

--- a/src/Gui/AthleteView.cpp
+++ b/src/Gui/AthleteView.cpp
@@ -46,7 +46,7 @@ AthleteView::AthleteView(Context *context) : ChartSpace(context, OverviewScope::
     configChanged(0);
 
     // athlete config dialog...
-    connect(this, SIGNAL(itemConfigRequested(ChartSpaceItem*)), this, SLOT(configItem(ChartSpaceItem*)));
+    connect(this, SIGNAL(itemConfigRequested(ChartSpaceItem*, QPoint)), this, SLOT(configItem(ChartSpaceItem*, QPoint)));
     // new athlete
     connect(context->mainWindow, SIGNAL(newAthlete(QString)), this, SLOT(newAthlete(QString)));
     // delete athlete
@@ -93,7 +93,7 @@ AthleteView::configChanged(qint32)
 }
 
 void
-AthleteView::configItem(ChartSpaceItem*item)
+AthleteView::configItem(ChartSpaceItem*item, QPoint)
 {
     AthleteCard *card = static_cast<AthleteCard*>(item);
     card->configAthlete();

--- a/src/Gui/AthleteView.h
+++ b/src/Gui/AthleteView.h
@@ -1,5 +1,6 @@
 #include "ChartSpace.h"
 #include "OverviewItems.h"
+#include <QPoint>
 
 class AthleteView : public ChartSpace
 {
@@ -10,7 +11,7 @@ public:
 
 public slots:
     void configChanged(qint32);
-    void configItem(ChartSpaceItem*);
+    void configItem(ChartSpaceItem*, QPoint);
     void newAthlete(QString);
     void deleteAthlete(QString);
 

--- a/src/Gui/ChartSpace.cpp
+++ b/src/Gui/ChartSpace.cpp
@@ -940,7 +940,7 @@ ChartSpace::eventFilter(QObject *, QEvent *event)
             if (item && item->inCorner()) {
 
                 block = false; // reeentry is allowed
-                emit itemConfigRequested(item);
+                emit itemConfigRequested(item, static_cast<QGraphicsSceneMouseEvent*>(event)->screenPos());
                 return true;
             }
 

--- a/src/Gui/ChartSpace.h
+++ b/src/Gui/ChartSpace.h
@@ -241,7 +241,7 @@ class ChartSpace : public QWidget
 
 
     signals:
-        void itemConfigRequested(ChartSpaceItem*);
+        void itemConfigRequested(ChartSpaceItem*, QPoint);
 
     public slots:
 


### PR DESCRIPTION
This PR matches the functionality in the Editable metadata tile https://github.com/GoldenCheetah/GoldenCheetah/pull/4519 to position the popup menu close to the location from which it was launched.