### PR TITLE
Settings: Inline-editing for Measures

### DIFF
--- a/src/Gui/AthletePages.h
+++ b/src/Gui/AthletePages.h
@@ -57,19 +57,17 @@
 class MeasuresPage : public QWidget
 {
     Q_OBJECT
-    G_OBJECT
-
 
     public:
         MeasuresPage(QWidget *parent, Context *context, MeasuresGroup *measuresGroup);
+        ~MeasuresPage();
+
         qint32 saveClicked();
 
-    public slots:
-        void unitChanged(int currentIndex);
-        void addOReditClicked();
+    private slots:
+        void addClicked();
         void deleteClicked();
-        void rangeEdited();
-        void rangeSelectionChanged();
+        void rangeChanged(const QModelIndex &topLeft);
 
     private:
         Context *context;
@@ -77,23 +75,19 @@ class MeasuresPage : public QWidget
         bool metricUnits;
         QList<Measure> measures;
 
-        QLabel *dateLabel;
-        QDateTimeEdit *dateTimeEdit;
-
-        QVector<QLabel*> valuesLabel;
-        QVector<QDoubleSpinBox*> valuesEdit;
-
-        QLabel *commentlabel;
-        QLineEdit *comment;
+        QList<DoubleSpinBoxEditDelegate*> valueDelegates;
+        NoEditDelegate dateTimeDelegate;
+        NoEditDelegate sourceDelegate;
+        NoEditDelegate origSourceDelegate;
 
         QTreeWidget *measuresTree;
-        QPushButton *addButton, *updateButton, *deleteButton;
+        QPushButton *addButton, *deleteButton;
+
+        void fillItemFromMeasures(int rnum, QTreeWidgetItem *item) const;
 
     struct {
         unsigned long fingerprint;
     } b4;
-
-    private slots:
 };
 
 class WheelSizeCalculator : public QDialog

--- a/src/Gui/StyledItemDelegates.cpp
+++ b/src/Gui/StyledItemDelegates.cpp
@@ -82,6 +82,7 @@ ComboBoxDelegate::ComboBoxDelegate
 (QObject *parent)
 : QStyledItemDelegate(parent)
 {
+    fillSizeHint();
 }
 
 
@@ -90,6 +91,7 @@ ComboBoxDelegate::addItems
 (const QStringList &texts)
 {
     this->texts = texts;
+    fillSizeHint();
 }
 
 
@@ -162,9 +164,17 @@ ComboBoxDelegate::sizeHint
     Q_UNUSED(option)
     Q_UNUSED(index)
 
+    return _sizeHint;
+}
+
+
+void
+ComboBoxDelegate::fillSizeHint
+()
+{
     QComboBox widget;
     widget.addItems(texts);
-    return widget.sizeHint();
+    _sizeHint = widget.sizeHint();
 }
 
 
@@ -370,14 +380,16 @@ SpinBoxEditDelegate::SpinBoxEditDelegate
 (QObject *parent)
 : QStyledItemDelegate(parent)
 {
+    fillSizeHint();
 }
 
 
 void
-SpinBoxEditDelegate::setMininum
+SpinBoxEditDelegate::setMinimum
 (int minimum)
 {
     this->minimum = minimum;
+    fillSizeHint();
 }
 
 
@@ -386,6 +398,7 @@ SpinBoxEditDelegate::setMaximum
 (int maximum)
 {
     this->maximum = maximum;
+    fillSizeHint();
 }
 
 
@@ -395,6 +408,7 @@ SpinBoxEditDelegate::setRange
 {
     this->minimum = minimum;
     this->maximum = maximum;
+    fillSizeHint();
 }
 
 
@@ -411,6 +425,7 @@ SpinBoxEditDelegate::setSuffix
 (const QString &suffix)
 {
     this->suffix = suffix;
+    fillSizeHint();
 }
 
 
@@ -419,6 +434,7 @@ SpinBoxEditDelegate::setShowSuffixOnEdit
 (bool show)
 {
     showSuffixOnEdit = show;
+    fillSizeHint();
 }
 
 
@@ -427,6 +443,7 @@ SpinBoxEditDelegate::setShowSuffixOnDisplay
 (bool show)
 {
     showSuffixOnDisplay = show;
+    fillSizeHint();
 }
 
 
@@ -494,13 +511,21 @@ SpinBoxEditDelegate::sizeHint
     Q_UNUSED(option)
     Q_UNUSED(index)
 
+    return _sizeHint;
+}
+
+
+void
+SpinBoxEditDelegate::fillSizeHint
+()
+{
     QSpinBox widget;
     if ((showSuffixOnEdit || showSuffixOnDisplay) && ! suffix.isEmpty()) {
         widget.setSuffix(" " + suffix);
     }
     widget.setMaximum(maximum);
     widget.setValue(maximum);
-    return widget.sizeHint();
+    _sizeHint = widget.sizeHint();
 }
 
 
@@ -676,6 +701,7 @@ DateEditDelegate::DateEditDelegate
 (QObject *parent)
 : QStyledItemDelegate(parent)
 {
+    fillSizeHint();
 }
 
 
@@ -684,6 +710,7 @@ DateEditDelegate::setCalendarPopup
 (bool enable)
 {
     calendarPopup = enable;
+    fillSizeHint();
 }
 
 
@@ -738,8 +765,17 @@ DateEditDelegate::sizeHint
     Q_UNUSED(option)
     Q_UNUSED(index)
 
+    return _sizeHint;
+}
+
+
+void
+DateEditDelegate::fillSizeHint
+()
+{
     QDateEdit widget;
-    return widget.sizeHint();
+    widget.setCalendarPopup(calendarPopup);
+    _sizeHint = widget.sizeHint();
 }
 
 
@@ -749,6 +785,7 @@ TimeEditDelegate::TimeEditDelegate
 (QObject *parent)
 : QStyledItemDelegate(parent)
 {
+    fillSizeHint();
 }
 
 
@@ -757,6 +794,7 @@ TimeEditDelegate::setFormat
 (const QString &format)
 {
     this->format = format;
+    fillSizeHint();
 }
 
 
@@ -765,6 +803,7 @@ TimeEditDelegate::setSuffix
 (const QString &suffix)
 {
     this->suffix = suffix;
+    fillSizeHint();
 }
 
 
@@ -773,6 +812,7 @@ TimeEditDelegate::setShowSuffixOnEdit
 (bool show)
 {
     showSuffixOnEdit = show;
+    fillSizeHint();
 }
 
 
@@ -781,6 +821,7 @@ TimeEditDelegate::setShowSuffixOnDisplay
 (bool show)
 {
     showSuffixOnDisplay = show;
+    fillSizeHint();
 }
 
 
@@ -866,6 +907,14 @@ TimeEditDelegate::sizeHint
     Q_UNUSED(option)
     Q_UNUSED(index)
 
+    return _sizeHint;
+}
+
+
+void
+TimeEditDelegate::fillSizeHint
+()
+{
     QTimeEdit widget;
     widget.setTime(QTime(0, 0, 0));
     QString f = format;
@@ -876,5 +925,5 @@ TimeEditDelegate::sizeHint
         f += " '" + suffix + "'";
     }
     widget.setDisplayFormat(f);
-    return widget.sizeHint();
+    _sizeHint = widget.sizeHint();
 }

--- a/src/Gui/StyledItemDelegates.cpp
+++ b/src/Gui/StyledItemDelegates.cpp
@@ -510,14 +510,16 @@ DoubleSpinBoxEditDelegate::DoubleSpinBoxEditDelegate
 (QObject *parent)
 : QStyledItemDelegate(parent)
 {
+    fillSizeHint();
 }
 
 
 void
-DoubleSpinBoxEditDelegate::setMininum
+DoubleSpinBoxEditDelegate::setMinimum
 (double minimum)
 {
     this->minimum = minimum;
+    fillSizeHint();
 }
 
 
@@ -526,6 +528,7 @@ DoubleSpinBoxEditDelegate::setMaximum
 (double maximum)
 {
     this->maximum = maximum;
+    fillSizeHint();
 }
 
 
@@ -535,6 +538,7 @@ DoubleSpinBoxEditDelegate::setRange
 {
     this->minimum = minimum;
     this->maximum = maximum;
+    fillSizeHint();
 }
 
 
@@ -551,6 +555,7 @@ DoubleSpinBoxEditDelegate::setDecimals
 (int prec)
 {
     this->prec = prec;
+    fillSizeHint();
 }
 
 
@@ -559,6 +564,7 @@ DoubleSpinBoxEditDelegate::setSuffix
 (const QString &suffix)
 {
     this->suffix = suffix;
+    fillSizeHint();
 }
 
 
@@ -567,6 +573,7 @@ DoubleSpinBoxEditDelegate::setShowSuffixOnEdit
 (bool show)
 {
     showSuffixOnEdit = show;
+    fillSizeHint();
 }
 
 
@@ -575,6 +582,7 @@ DoubleSpinBoxEditDelegate::setShowSuffixOnDisplay
 (bool show)
 {
     showSuffixOnDisplay = show;
+    fillSizeHint();
 }
 
 
@@ -643,6 +651,14 @@ DoubleSpinBoxEditDelegate::sizeHint
     Q_UNUSED(option)
     Q_UNUSED(index)
 
+    return _sizeHint;
+}
+
+
+void
+DoubleSpinBoxEditDelegate::fillSizeHint
+()
+{
     QDoubleSpinBox widget;
     if ((showSuffixOnEdit || showSuffixOnDisplay) && ! suffix.isEmpty()) {
         widget.setSuffix(" " + suffix);
@@ -650,7 +666,7 @@ DoubleSpinBoxEditDelegate::sizeHint
     widget.setMaximum(maximum);
     widget.setValue(maximum);
     widget.setDecimals(prec);
-    return widget.sizeHint();
+    _sizeHint = widget.sizeHint();
 }
 
 

--- a/src/Gui/StyledItemDelegates.h
+++ b/src/Gui/StyledItemDelegates.h
@@ -158,7 +158,7 @@ class DoubleSpinBoxEditDelegate: public QStyledItemDelegate
 public:
     DoubleSpinBoxEditDelegate(QObject *parent = nullptr);
 
-    void setMininum(double minimum);
+    void setMinimum(double minimum);
     void setMaximum(double maximum);
     void setRange(double minimum, double maximum);
     void setSingleStep(double val);
@@ -181,6 +181,9 @@ private:
     QString suffix;
     bool showSuffixOnEdit = true;
     bool showSuffixOnDisplay = true;
+    QSize _sizeHint;
+
+    void fillSizeHint();
 };
 
 

--- a/src/Gui/StyledItemDelegates.h
+++ b/src/Gui/StyledItemDelegates.h
@@ -68,6 +68,9 @@ private slots:
 
 private:
     QStringList texts;
+    QSize _sizeHint;
+
+    void fillSizeHint();
 };
 
 
@@ -128,7 +131,7 @@ class SpinBoxEditDelegate: public QStyledItemDelegate
 public:
     SpinBoxEditDelegate(QObject *parent = nullptr);
 
-    void setMininum(int minimum);
+    void setMinimum(int minimum);
     void setMaximum(int maximum);
     void setRange(int minimum, int maximum);
     void setSingleStep(int val);
@@ -149,6 +152,9 @@ private:
     QString suffix;
     bool showSuffixOnEdit = true;
     bool showSuffixOnDisplay = true;
+    QSize _sizeHint;
+
+    void fillSizeHint();
 };
 
 
@@ -203,6 +209,9 @@ public:
 
 private:
     bool calendarPopup = false;
+    QSize _sizeHint;
+
+    void fillSizeHint();
 };
 
 
@@ -231,6 +240,9 @@ private:
     bool showSuffixOnDisplay = true;
     QTime min;
     QTime max;
+    QSize _sizeHint;
+
+    void fillSizeHint();
 };
 
 #endif


### PR DESCRIPTION
* Implmented inline-editing in Measures-tab, similar to Zones (Power, HR, Pace)
* Disabled editing of columns Datetime, Source, Original-Source

![image](https://github.com/user-attachments/assets/de3b5d05-047d-4ea7-aef2-b6c5957e0f5a)
