### PR TITLE
"Automated only"-flagging for DataProcessors

### DIFF
--- a/src/Core/DataFilter.cpp
+++ b/src/Core/DataFilter.cpp
@@ -7429,7 +7429,7 @@ Result Leaf::eval(DataFilterRuntime *df, Leaf *leaf, const Result &x, long it, R
                         QString dp_name = *(leaf->fparms[0]->lvalue.n);
 
                         // lookup processor
-                        DataProcessor* dp = DataProcessorFactory::instance().getProcessors().value(dp_name, NULL);
+                        DataProcessor* dp = DataProcessorFactory::instance().getProcessor(dp_name);
 
                         if (!dp) return Result(0); // No such data processor
 

--- a/src/Core/GcUpgrade.cpp
+++ b/src/Core/GcUpgrade.cpp
@@ -452,6 +452,21 @@ GcUpgrade::upgrade(const QDir &home)
 
             RideMetadata::serialize(filename, keywordDefinitions, fieldDefinitions, colorfield, defaultDefinitions);
         }
+
+        // Migrate Data Processor apply-values to new keys
+        {
+            QMap<QString, DataProcessor*> processors = DataProcessorFactory::instance().getProcessors();
+            for (auto it = processors.keyValueBegin(); it != processors.keyValueEnd(); ++it) {
+                QString legacyId = it->second->legacyId();
+                if (! legacyId.isNull()) {
+                    QString id = it->second->id();
+                    if (! appsettings->contains(DataProcessor::configKeyAutomation(id))) {
+                        QVariant data = appsettings->value(nullptr, DataProcessor::configKeyApply(legacyId));
+                        appsettings->setValue(DataProcessor::configKeyAutomation(id), data);
+                    }
+                }
+            }
+        }
     }
 
     //----------------------------------------------------------------------

--- a/src/Core/Settings.cpp
+++ b/src/Core/Settings.cpp
@@ -173,6 +173,31 @@ GSettings::setValue(QString key, QVariant value)
 
 }
 
+void
+GSettings::remove(const QString &key)
+{
+    QString keyVar = QString(key);
+    if (newFormat) {
+        int store;
+        int file;
+        keyVar = DetermineKey(keyVar, store, file);
+        switch (store) {
+        case SETTINGS_SYSTEM:
+            systemsettings->remove(keyVar);
+            break;
+        case SETTINGS_GLOBAL:
+            global->at(file)->remove(keyVar);
+            break;
+        case SETTINGS_ATHLETE:
+            qDebug() << "remove key, keyVar, store:" << key << ":" << keyVar  << ": " << store; // error cases on code configuration
+            break;
+        }
+    } else {
+        keyVar.remove(QRegularExpression("^<.*>"));
+        systemsettings->remove(keyVar);
+    }
+}
+
 // access to athlete specific config
 QVariant
 GSettings::cvalue(QString athleteName, QString key, QVariant def) {

--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -496,8 +496,9 @@ public:
     ~GSettings();
 
     // standard access to global config
-    QVariant value(const QObject *me, const QString key, const QVariant def = 0) ;
+    QVariant value(const QObject *me, const QString key, const QVariant def = 0);
     void setValue(QString key, QVariant value);
+    void remove(const QString &key);
 
     // access to athleteName specific config
     QVariant cvalue(QString athleteName, QString key, QVariant def = 0);

--- a/src/FileIO/FitRideFile.cpp
+++ b/src/FileIO/FitRideFile.cpp
@@ -4726,7 +4726,7 @@ genericnext:
 
             if (rideFile->xdata("SWIM")) {
                 // Build synthetic kph, km and cad sample data for Lap Swims
-                DataProcessor* fixLapDP = DataProcessorFactory::instance().getProcessors(true).value("Fix Lap Swim");
+                DataProcessor* fixLapDP = DataProcessorFactory::instance().getProcessors(true).value("::FixLapSwim");
                 if (fixLapDP) fixLapDP->postProcess(rideFile, NULL, "NEW");
                 else qDebug()<<"Fix Lap Swim Data Processor not found.";
             }

--- a/src/FileIO/FixAeroPod.cpp
+++ b/src/FileIO/FixAeroPod.cpp
@@ -33,11 +33,13 @@ class FixAeroPodConfig : public DataProcessorConfig
 
     friend class ::FixAeroPod;
     protected:
+#if 0
         QHBoxLayout *layout;
         QLabel *paLabel;
         QLabel *percentLabel;
         QLineEdit *pa;
         QCheckBox *hrConv;
+#endif
 
     public:
         FixAeroPodConfig(QWidget *parent) : DataProcessorConfig(parent) {
@@ -45,33 +47,27 @@ class FixAeroPodConfig : public DataProcessorConfig
             HelpWhatsThis *help = new HelpWhatsThis(parent);
             parent->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Edit_FixMoxy));
 
+#if 0
 	    layout = new QHBoxLayout(this);
-
 	    layout->setContentsMargins(0,0,0,0);
 	    setContentsMargins(0,0,0,0);
-        //paLabel = new QLabel(tr("Field Adjustment"));
 
-        //hrConv = new QCheckBox(tr("Heartrate to XData.CdA"));
+            paLabel = new QLabel(tr("Field Adjustment"));
+            hrConv = new QCheckBox(tr("Heartrate to XData.CdA"));
 
-        //layout->addWidget(paLabel);
-        //layout->addWidget(hrConv);
+            layout->addWidget(paLabel);
+            layout->addWidget(hrConv);
 	    layout->addStretch();
+#endif
 	}
 
         //~FixAeroPodConfig() {} // deliberately not declared since Qt will delete
                               // the widget and its children when the config pane is deleted
 
-        QString explain() {
-            return(QString(tr("When recording with an iBike AeroPod (in HR"
-                           " mode) the CdA data is sent as HR. This tool will"
-                           " update the activity file to move the values from HR"
-                           " into the XData.CdA series."
-                           )));
-        }
         void readConfig() {
         //bool isHr = appsettings->value(NULL, GC_HR2XDATACDA, Qt::Checked).toBool();
         //hrConv->setCheckState(isHr ? Qt::Checked : Qt::Unchecked);
-	    
+
 	}
         void saveConfig() {
         //appsettings->setValue(GC_CAD2SMO2, hrConv->checkState());
@@ -91,21 +87,36 @@ class FixAeroPod : public DataProcessor {
         ~FixAeroPod() {}
 
         // the processor
-        bool postProcess(RideFile *, DataProcessorConfig* config, QString op);
+        bool postProcess(RideFile *, DataProcessorConfig* config, QString op) override;
 
         // the config widget
-        DataProcessorConfig* processorConfig(QWidget *parent, const RideFile * ride = NULL) {
+        DataProcessorConfig* processorConfig(QWidget *parent, const RideFile * ride = NULL) const override {
             Q_UNUSED(ride);
             return new FixAeroPodConfig(parent);
         }
 
         // Localized Name
-        QString name() {
+        QString name() const override {
             return tr("Set XData.CdA from HR");
+        }
+
+        QString id() const override {
+            return "::FixAeroPod";
+        }
+
+        QString legacyId() const override {
+            return "FixAeroPod";
+        }
+
+        QString explain() const override {
+            return tr("When recording with an iBike AeroPod (in HR"
+                      " mode) the CdA data is sent as HR. This tool will"
+                      " update the activity file to move the values from HR"
+                      " into the XData.CdA series.");
         }
 };
 
-static bool FixAeroPodAdded = DataProcessorFactory::instance().registerProcessor(QString("FixAeroPod"), new FixAeroPod());
+static bool FixAeroPodAdded = DataProcessorFactory::instance().registerProcessor(new FixAeroPod());
 
 bool
 FixAeroPod::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")

--- a/src/FileIO/FixDeriveHeadwind.cpp
+++ b/src/FileIO/FixDeriveHeadwind.cpp
@@ -39,26 +39,16 @@ class FixDeriveHeadwindConfig : public DataProcessorConfig
     friend class ::FixDeriveHeadwind;
 
     protected:
-        QHBoxLayout *layout;
 
     public:
         FixDeriveHeadwindConfig(QWidget *parent) : DataProcessorConfig(parent) {
 
             HelpWhatsThis *help = new HelpWhatsThis(parent);
             parent->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Edit_EstimateHeadwindValues));
-
-            layout = new QHBoxLayout(this);
-
-            layout->setContentsMargins(0,0,0,0);
-            setContentsMargins(0,0,0,0);
         }
 
         //~FixDeriveHeadwindConfig() {} // deliberately not declared since Qt will delete
                               // the widget and its children when the config pane is deleted
-
-        QString explain() {
-            return(QString(tr("Use weather broadcasted data in FIT file to derive Headwind.")));
-        }
 
         void readConfig() { }
         void saveConfig() { }
@@ -72,21 +62,33 @@ class FixDeriveHeadwind : public DataProcessor {
         ~FixDeriveHeadwind() {}
 
         // the processor
-        bool postProcess(RideFile *, DataProcessorConfig* config, QString op);
+        bool postProcess(RideFile *, DataProcessorConfig* config, QString op) override;
 
         // the config widget
-        DataProcessorConfig* processorConfig(QWidget *parent, const RideFile * ride = NULL) {
+        DataProcessorConfig* processorConfig(QWidget *parent, const RideFile * ride = NULL) const override {
             Q_UNUSED(ride);
             return new FixDeriveHeadwindConfig(parent);
         }
 
         // Localized Name
-        QString name() {
+        QString name() const override {
             return tr("Estimate Headwind Values");
+        }
+
+        QString id() const override {
+            return "::FixDeriveHeadwind";
+        }
+
+        QString legacyId() const override {
+            return "Estimate Headwind Values";
+        }
+
+        QString explain() const override{
+            return tr("Use weather broadcasted data in FIT file to derive Headwind.");
         }
 };
 
-static bool FixDeriveHeadwindAdded = DataProcessorFactory::instance().registerProcessor(QString("Estimate Headwind Values"), new FixDeriveHeadwind());
+static bool FixDeriveHeadwindAdded = DataProcessorFactory::instance().registerProcessor(new FixDeriveHeadwind());
 
 bool
 FixDeriveHeadwind::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")

--- a/src/FileIO/FixDeriveTorque.cpp
+++ b/src/FileIO/FixDeriveTorque.cpp
@@ -59,10 +59,6 @@ class FixDeriveTorqueConfig : public DataProcessorConfig
         //~FixDeriveTorqueConfig() {} // deliberately not declared since Qt will delete
                               // the widget and its children when the config pane is deleted
 
-        QString explain() {
-            return(QString(tr("Derive torque when power and cadence data is available.")));
-        }
-
         void readConfig() {
             //ta->setText(appsettings->value(NULL, GC_DPTA, "0 nm").toString());
         }
@@ -85,21 +81,33 @@ class FixDeriveTorque : public DataProcessor {
         ~FixDeriveTorque() {}
 
         // the processor
-        bool postProcess(RideFile *, DataProcessorConfig* config, QString op);
+        bool postProcess(RideFile *, DataProcessorConfig* config, QString op) override;
 
         // the config widget
-        DataProcessorConfig* processorConfig(QWidget *parent, const RideFile * ride = NULL) {
+        DataProcessorConfig* processorConfig(QWidget *parent, const RideFile * ride = NULL) const override {
             Q_UNUSED(ride);
             return new FixDeriveTorqueConfig(parent);
         }
 
         // Localized Name
-        QString name() {
-            return (tr("Add Torque Values"));
+        QString name() const override {
+            return tr("Add Torque Values");
+        }
+
+        QString id() const override {
+            return "::FixDeriveTorque";
+        }
+
+        QString legacyId() const override {
+            return "Add Torque Values";
+        }
+
+        QString explain() const override{
+            return tr("Derive torque when power and cadence data is available.");
         }
 };
 
-static bool FixDeriveTorqueAdded = DataProcessorFactory::instance().registerProcessor(QString("Add Torque Values"), new FixDeriveTorque());
+static bool FixDeriveTorqueAdded = DataProcessorFactory::instance().registerProcessor(new FixDeriveTorque());
 
 bool
 FixDeriveTorque::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")
@@ -119,8 +127,7 @@ FixDeriveTorque::postProcess(RideFile *ride, DataProcessorConfig *config=0, QStr
     bool changed=false;
 
     for (int i=0; i< ride->dataPoints().count(); i++) {
-   
-        RideFilePoint *p = ride->dataPoints()[i]; 
+        RideFilePoint *p = ride->dataPoints()[i];
 
         // Estimate Power if not in data
         if (p->cad > 0 && p->watts > 0) {

--- a/src/FileIO/FixElevation.cpp
+++ b/src/FileIO/FixElevation.cpp
@@ -53,14 +53,6 @@ class FixElevationConfig : public DataProcessorConfig
             parent->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Edit_FixElevationErrors));
         }
 
-        QString explain() {
-            return tr("Fix or add elevation data. If elevation data is "
-                      "present it will be removed and overwritten."
-                      "\nElevation data is provided by Open-Elevation.com public API,"
-                      " consider a donation if you find it useful."
-                      "\n\nINTERNET CONNECTION REQUIRED.");
-        }
-
         void readConfig() {}
         void saveConfig() {}
 
@@ -79,24 +71,40 @@ class FixElevation : public DataProcessor {
         ~FixElevation() {}
 
         // the processor
-        bool postProcess(RideFile *, DataProcessorConfig* config, QString op);
+        bool postProcess(RideFile *, DataProcessorConfig* config, QString op) override;
 
         // the config widget
-        DataProcessorConfig* processorConfig(QWidget *parent, const RideFile * ride = NULL) {
+        DataProcessorConfig* processorConfig(QWidget *parent, const RideFile * ride = NULL) const override {
             Q_UNUSED(ride);
             return new FixElevationConfig(parent);
         }
 
         // Localized Name
-        QString name() {
+        QString name() const override {
             return tr("Fix Elevation errors");
+        }
+
+        QString id() const override {
+            return "::FixElevation";
+        }
+
+        QString legacyId() const override {
+            return "Fix Elevation errors";
+        }
+
+        QString explain() const override {
+            return tr("Fix or add elevation data. If elevation data is "
+                      "present it will be removed and overwritten."
+                      "\nElevation data is provided by Open-Elevation.com public API,"
+                      " consider a donation if you find it useful."
+                      "\n\nINTERNET CONNECTION REQUIRED.");
         }
 
     private:
         QList<double> FetchElevationData(QString latLngCollection);
 };
 
-static bool fixElevationAdded = DataProcessorFactory::instance().registerProcessor(QString("Fix Elevation errors"), new FixElevation());
+static bool fixElevationAdded = DataProcessorFactory::instance().registerProcessor(new FixElevation());
 
 bool
 FixElevation::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")

--- a/src/FileIO/FixFreewheeling.cpp
+++ b/src/FileIO/FixFreewheeling.cpp
@@ -43,14 +43,6 @@ class FixFreewheelingConfig : public DataProcessorConfig
         //~FixFreewheelingConfig() {} // deliberately not declared since Qt will delete
                               // the widget and its children when the config pane is deleted
 
-        QString explain() {
-            return(QString(tr("ANT+ crank based power meters will send "
-                           " 3 duplicate values for power and cadence when the "
-                           " rider starts to freewheel. The duplicates should "
-                           " not be retained. This tool removes the duplicates."
-                           )));
-        }
-
         void readConfig() { }
         void saveConfig() { }
 };
@@ -68,21 +60,36 @@ class FixFreewheeling : public DataProcessor {
         ~FixFreewheeling() {}
 
         // the processor
-        bool postProcess(RideFile *, DataProcessorConfig* config, QString op);
+        bool postProcess(RideFile *, DataProcessorConfig* config, QString op) override;
 
         // the config widget
-        DataProcessorConfig* processorConfig(QWidget *parent, const RideFile * ride = NULL) {
+        DataProcessorConfig* processorConfig(QWidget *parent, const RideFile * ride = NULL) const override {
             Q_UNUSED(ride);
             return new FixFreewheelingConfig(parent);
         }
 
         // Localized Name
-        QString name() {
+        QString name() const override {
             return tr("Fix freewheeling power/cadence.");
+        }
+
+        QString id() const override {
+            return "::FixFreewheeling";
+        }
+
+        QString legacyId() const override {
+            return "Fix Freewheeling";
+        }
+
+        QString explain() const override {
+            return tr("ANT+ crank based power meters will send "
+                      " 3 duplicate values for power and cadence when the "
+                      " rider starts to freewheel. The duplicates should "
+                      " not be retained. This tool removes the duplicates.");
         }
 };
 
-static bool FixFreewheelingAdded = DataProcessorFactory::instance().registerProcessor(QString("Fix Freewheeling"), new FixFreewheeling());
+static bool FixFreewheelingAdded = DataProcessorFactory::instance().registerProcessor(new FixFreewheeling());
 
 bool
 FixFreewheeling::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")
@@ -112,7 +119,7 @@ FixFreewheeling::postProcess(RideFile *ride, DataProcessorConfig *config=0, QStr
                 // set previous 2 back to zero
                 ride->command->setPointValue(i-2, RideFile::cad, 0.00f);
                 ride->command->setPointValue(i-1, RideFile::cad, 0.00f);
-                
+
                 ride->command->setPointValue(i-2, RideFile::watts, 0.00f);
                 ride->command->setPointValue(i-1, RideFile::watts, 0.00f);
             }

--- a/src/FileIO/FixGPS.cpp
+++ b/src/FileIO/FixGPS.cpp
@@ -19,6 +19,7 @@
 #include "DataProcessor.h"
 #include "Settings.h"
 #include "Units.h"
+#include "Colors.h"
 #include "HelpWhatsThis.h"
 #include <algorithm>
 #include <QVector>
@@ -113,10 +114,6 @@ class FixGPSConfig : public DataProcessorConfig
     Q_DECLARE_TR_FUNCTIONS(FixGPSConfig)
     friend class ::FixGPS;
     protected:
-        QVBoxLayout *mainLayout;
-        QHBoxLayout *simpleLayout;
-        QFormLayout *layout;
-
         // Altitude
         QCheckBox   *doSmoothAltitude;
 
@@ -174,7 +171,7 @@ class FixGPSConfig : public DataProcessorConfig
             {
                 QApplication::setOverrideCursor(QCursor(Qt::WaitCursor));
                 testButton->setEnabled(false);
-                
+
                 // PASS 0: ALTITUDE SMOOTHING TEST
 
                 AltitudeSmoothingStats altitudeSmoothingStats;
@@ -297,71 +294,22 @@ class FixGPSConfig : public DataProcessorConfig
 
     public:
         FixGPSConfig(QWidget *parent, const RideFile * rideFile) : DataProcessorConfig(parent) {
-
-            mainLayout = NULL;
-            simpleLayout = NULL;
-            layout = NULL;
-
-            // Altitude
-            doSmoothAltitude = NULL;
-
-            // Altitude smoothing degrees
-            degree0Label = NULL;
-            degree0SpinBox = NULL;
-            degree1Label = NULL;
-            degree1SpinBox = NULL;
-
-            // Altitude Outlier Criteria
-            outlierLabel = NULL;
-            outlierSpinBox = NULL;
-
-            // Altitude Stats
-            minSlopeLabel = NULL;
-            maxSlopeLabel = NULL;
-            avgSlopeLabel = NULL;
-            outlierCountLabel = NULL;
-
-            // Route
-            doSmoothRoute = NULL;
-
-            // Route smoothing degrees
-            degree0LabelRoute = NULL;
-            degree1LabelRoute = NULL;
-            degree0SpinBoxRoute = NULL;
-            degree1SpinBoxRoute = NULL;
-
-            // Route Outlier Criteria
-            outlierLabelRoute = NULL;
-            outlierSpinBoxRoute = NULL;
-
-            // Route Stats
-            stdDev0LabelRoute = NULL;
-            stdDev1LabelRoute = NULL;
-            outlierCountLabelRoute = NULL;
-
-            testButton = NULL;
-            stdDevLabel = NULL;
-
             ride = rideFile;
 
             HelpWhatsThis *help = new HelpWhatsThis(parent);
             parent->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Edit_FixGPSErrors));
 
-            // In import config there's no room for verbosity.
-            bool fUseShortDescription = (rideFile == NULL);
-
-
             // ALTITUDE SMOOTHING CONTROLS
 
             // Apply Altitude Smoothing Checkbox
 
-            doSmoothAltitude = new QCheckBox(fUseShortDescription ? tr("Altitude") : tr("Apply BSpline Altitude Smoothing"));
+            doSmoothAltitude = new QCheckBox(tr("Apply BSpline Altitude Smoothing"));
             doSmoothAltitude->setToolTip(tr("Apply B-Spline based altitude smoothing after running the GPS outlier pass."));
             doSmoothAltitude->setCheckState(appsettings->value(NULL, GC_FIXGPS_ALTITUDE_FIX_DOAPPLY, Qt::Unchecked).toBool() ? Qt::Checked : Qt::Unchecked);
 
             // Altitude Degree 0 SpinBox - First Pass
 
-            degree0Label= new QLabel(fUseShortDescription ? tr("P1 Deg") : tr("Pass 1 Altitude Smoothing Degree:"));
+            degree0Label= new QLabel(tr("Pass 1 Altitude Smoothing Degree"));
             degree0SpinBox = new QSpinBox();
             degree0SpinBox->setRange(0, 1000);
             degree0SpinBox->setSingleStep(10);
@@ -376,7 +324,7 @@ class FixGPSConfig : public DataProcessorConfig
 
             // Altitude Degree 1 SpinBox - Second Pass
 
-            degree1Label = new QLabel(fUseShortDescription ? tr("P2 Deg") : tr("Pass 2 Altitude Smoothing Degree:"));
+            degree1Label = new QLabel(tr("Pass 2 Altitude Smoothing Degree"));
             degree1SpinBox = new QSpinBox();
             degree1SpinBox->setRange(0, 1000);
             degree1SpinBox->setSingleStep(10);
@@ -391,11 +339,12 @@ class FixGPSConfig : public DataProcessorConfig
 
             // Altitude Outlier Criteria
 
-            outlierLabel = new QLabel(fUseShortDescription ? tr("Crit") : tr("Altitude Outlier Criteria - Centimeters:"));
+            outlierLabel = new QLabel(tr("Altitude Outlier Criteria"));
             outlierSpinBox = new QDoubleSpinBox();
             outlierSpinBox->setRange(0.001, 10000);
             outlierSpinBox->setSingleStep(10);
             outlierSpinBox->setDecimals(3);
+            outlierSpinBox->setSuffix(" " + tr("cm"));
             outlierSpinBox->setValue(appsettings->value(this, GC_FIXGPS_ALTITUDE_OUTLIER_PERCENT, s_Default_AltitudeOutlierPercent).toInt());
             outlierSpinBox->setToolTip(tr("ALTITUDE OUTLIER CRITERIA - CENTIMETERS:\n"
                                           "An outlier point is one so eggregiously out of range that it should not be used to\n"
@@ -407,13 +356,13 @@ class FixGPSConfig : public DataProcessorConfig
 
             // Apply Route Smoothing Checkbox
 
-            doSmoothRoute = new QCheckBox(fUseShortDescription ? tr("Route") : tr("Apply BSpline Route Smoothing"));
+            doSmoothRoute = new QCheckBox(tr("Apply BSpline Route Smoothing"));
             doSmoothRoute->setToolTip(tr("Apply B-Spline based location smoothing after running the altitude smoothing pass."));
             doSmoothRoute->setCheckState(appsettings->value(NULL, GC_FIXGPS_ROUTE_FIX_DOAPPLY, Qt::Unchecked).toBool() ? Qt::Checked : Qt::Unchecked);
 
             // Route Degree 0 SpinBox - PASS 1
 
-            degree0LabelRoute= new QLabel(fUseShortDescription ? tr("P1 Deg") : tr("Pass 1 Route Smoothing Degree:"));
+            degree0LabelRoute= new QLabel(tr("Pass 1 Route Smoothing Degree"));
             degree0SpinBoxRoute = new QSpinBox();
             degree0SpinBoxRoute->setRange(0, 1000);
             degree0SpinBoxRoute->setSingleStep(10);
@@ -426,7 +375,7 @@ class FixGPSConfig : public DataProcessorConfig
                                                "the ridefile and can vary by sample. This is the initial spline\n"
                                                "degree prior to outlier removal.\n"));
 
-            degree1LabelRoute = new QLabel(fUseShortDescription ? tr("P2 Deg") : tr("Pass 2 Route Smoothing Degree:"));
+            degree1LabelRoute = new QLabel(tr("Pass 2 Route Smoothing Degree"));
             degree1SpinBoxRoute = new QSpinBox();
             degree1SpinBoxRoute->setRange(0, 1000);
             degree1SpinBoxRoute->setSingleStep(10);
@@ -439,11 +388,12 @@ class FixGPSConfig : public DataProcessorConfig
                                                "the ridefile and can vary by sample. This is the degree to be\n"
                                                "used for the second pass spline made after outliers are removed.\n"));
 
-            outlierLabelRoute = new QLabel(fUseShortDescription ? tr("Crit") : tr("Route Outlier criteria - Centimeters:"));
+            outlierLabelRoute = new QLabel(tr("Route Outlier criteria"));
             outlierSpinBoxRoute = new QDoubleSpinBox();
             outlierSpinBoxRoute->setRange(0.001, 10000);
             outlierSpinBoxRoute->setSingleStep(10);
             outlierSpinBoxRoute->setDecimals(3);
+            outlierSpinBoxRoute->setSuffix(" " + tr("cm"));
             outlierSpinBoxRoute->setValue(appsettings->value(this, GC_FIXGPS_ROUTE_OUTLIER_PERCENT, s_Default_RouteOutlierPercent).toInt());
             outlierSpinBoxRoute->setToolTip(tr("ROUTE OUTLIER CRITERIA - CENTIMETERS"
                                                "An outlier point is one so eggregiously out of range that it should not be used to\n"
@@ -453,33 +403,21 @@ class FixGPSConfig : public DataProcessorConfig
                                                "final smoothing spline.\n"));
 
             // If no ridefile is provided then present simple dialog
-            if (rideFile == NULL)
-            {
-                simpleLayout = new QHBoxLayout(this);
+            QFormLayout *layout = newQFormLayout(this);
 
-                simpleLayout->addWidget(doSmoothAltitude);
-                simpleLayout->addWidget(degree0Label);
-                simpleLayout->addWidget(degree0SpinBox);
-                simpleLayout->addWidget(degree1Label);
-                simpleLayout->addWidget(degree1SpinBox);
-                simpleLayout->addWidget(outlierLabel);
-                simpleLayout->addWidget(outlierSpinBox);
+            layout->addRow("", doSmoothAltitude);
+            layout->addRow(degree0Label, degree0SpinBox);
+            layout->addRow(degree1Label, degree1SpinBox);
+            layout->addRow(outlierLabel, outlierSpinBox);
 
-                simpleLayout->addWidget(doSmoothRoute);
-                simpleLayout->addWidget(degree0LabelRoute);
-                simpleLayout->addWidget(degree0SpinBoxRoute);
-                simpleLayout->addWidget(degree1LabelRoute);
-                simpleLayout->addWidget(degree1SpinBoxRoute);
-                simpleLayout->addWidget(outlierLabelRoute);
-                simpleLayout->addWidget(outlierSpinBoxRoute);
+            layout->addRow("", doSmoothRoute);
+            layout->addRow(degree0LabelRoute, degree0SpinBoxRoute);
+            layout->addRow(degree1LabelRoute, degree1SpinBoxRoute);
+            layout->addRow(outlierLabelRoute, outlierSpinBoxRoute);
 
-                simpleLayout->setContentsMargins(0, 0, 0, 0);
-                setContentsMargins(0, 0, 0, 0);
-
-                simpleLayout->addStretch();
-            }
-            else
-            {
+            layout->setContentsMargins(0, 0, 0, 0);
+            setContentsMargins(0, 0, 0, 0);
+            if (rideFile != nullptr) {
                 // Determine min and max slope of original ride file.
                 AltitudeSmoothingStats altitudeSmoothingStats;
                 double routePass1StdDev = 0;
@@ -489,13 +427,6 @@ class FixGPSConfig : public DataProcessorConfig
                 if (fHasAlt) {
                     ComputeRideFileStats(ride, altitudeSmoothingStats);
                 }
-
-                mainLayout = new QVBoxLayout(this);
-                layout = new QFormLayout();
-                mainLayout->addLayout(layout);
-
-                mainLayout->setContentsMargins(0, 0, 0, 0);
-                setContentsMargins(0, 0, 0, 0);
 
                 // Create widgets
 
@@ -546,100 +477,30 @@ class FixGPSConfig : public DataProcessorConfig
                 testButton = new QPushButton(tr("Test Current Smoothing Setup"), this);
                 testButton->setToolTip(tr("Click this button to simulate behavior of current smoothing settings and update the statistics. NOTE: This simulation does not perform the Pass 0 outlier removal."));
 
-                // Create Rows of Widgets
-
-                std::vector<QHBoxLayout*> rows;
-
-                QHBoxLayout* row;
-                
-                // Altitude Smoothing
-                
-                row = new QHBoxLayout();
-                row->addWidget(doSmoothAltitude);
-                rows.push_back(row);
-
-                row = new QHBoxLayout();
-                row->addWidget(degree0Label);
-                row->addWidget(degree0SpinBox);
-                rows.push_back(row);
-
-                row = new QHBoxLayout();
-                row->addWidget(outlierLabel);
-                row->addWidget(outlierSpinBox);
-                row->addWidget(degree1Label);
-                row->addWidget(degree1SpinBox);
-                rows.push_back(row);
-
-                // Route Smoothing
-
-                row = new QHBoxLayout();
-                row->addWidget(doSmoothRoute);
-                rows.push_back(row);
-
-                row = new QHBoxLayout();
-                row->addWidget(degree0LabelRoute);
-                row->addWidget(degree0SpinBoxRoute);
-                rows.push_back(row);
-
-                row = new QHBoxLayout();
-                row->addWidget(outlierLabelRoute);
-                row->addWidget(outlierSpinBoxRoute);
-                row->addWidget(degree1LabelRoute);
-                row->addWidget(degree1SpinBoxRoute);
-                rows.push_back(row);
-
                 // Test Button
+                layout->addRow(testButton);
 
-                row = new QHBoxLayout();
-                row->addWidget(testButton);
-                rows.push_back(row);
+                QHBoxLayout *row;
 
                 // Altitude Stats
-
                 row = new QHBoxLayout();
                 row->addWidget(minSlopeLabel);
                 row->addWidget(maxSlopeLabel);
                 row->addWidget(avgSlopeLabel);
                 row->addWidget(outlierCountLabel);
                 row->addWidget(stdDevLabel);
-                rows.push_back(row);
+                layout->addRow(row);
 
                 // Route Stats
-
                 row = new QHBoxLayout();
                 row->addWidget(stdDev0LabelRoute);
                 row->addWidget(stdDev1LabelRoute);
                 row->addWidget(outlierCountLabelRoute);
-                rows.push_back(row);
-
-                // Insert rows into layout
-                for (int i = 0; i < rows.size(); i++)
-                    layout->insertRow(i, rows[i]);
+                layout->addRow(row);
 
                 // Hook up testButton to testClicked method.
-
                 connect(testButton, &QPushButton::clicked, this, &FixGPSConfig::testClicked);
             }
-        }
-        
-        QString explain() {
-            return(QString(tr("Multiple Pass GPS Repair:\n"
-                              "0 - Always: Remove GPS errors and interpolate positional\n"
-                              "    data where the GPS device did not record any data,\n"
-                              "    or the data that was recorded is invalid.\n"
-                              "1 - Optional: Altitude B-Spline smoothing will be applied\n"
-                              "    if checkbox is set. This is potentially two pass smoothing.\n"
-                              "    Spline is built with Pass 1 Degree, any original samples\n"
-                              "    that fail outlier criteria are discarded and then a final\n"
-                              "    smoothing is run with Pass 2 degree.\n"
-                              "2 - Optional: Route B-Spline smoothing will be applied\n"
-                              "    if checkbox is set. Again this is two pass smoothing where\n"
-                              "    outliers are determined by euclidean distance's stddev relative\n"
-                              "    to the smoothing spline. Again a final pass is run without\n"
-                              "    outliers using Pass 2 degree.\n\n"
-                              "Generally altitude data is noisiest and requires highest degree for\n"
-                              "reasonable smoothness. Route gps data gnerally requires a much\n"
-                              "lighter touch.\n")));
         }
 
         void readConfig() {
@@ -679,21 +540,50 @@ class FixGPS : public DataProcessor {
         ~FixGPS() {}
 
         // the processor
-        bool postProcess(RideFile *, DataProcessorConfig*settings=0, QString op="");
+        bool postProcess(RideFile *, DataProcessorConfig*settings=0, QString op="") override;
 
         // the config widget
-        DataProcessorConfig* processorConfig(QWidget *parent, const RideFile * ride = NULL) {
+        DataProcessorConfig* processorConfig(QWidget *parent, const RideFile * ride = NULL) const override {
             Q_UNUSED(ride);
             return new FixGPSConfig(parent, ride);
         }
 
         // Localized Name
-        QString name() {
-            return (tr("Fix GPS errors"));
+        QString name() const override {
+            return tr("Fix GPS errors");
         }
+
+        QString id() const override {
+            return "::FixGPS";
+        }
+
+        QString legacyId() const override {
+            return "Fix GPS errors";
+        }
+
+        QString explain() const override {
+            return tr("Multiple Pass GPS Repair:\n"
+                      "0 - Always: Remove GPS errors and interpolate positional\n"
+                      "    data where the GPS device did not record any data,\n"
+                      "    or the data that was recorded is invalid.\n"
+                      "1 - Optional: Altitude B-Spline smoothing will be applied\n"
+                      "    if checkbox is set. This is potentially two pass smoothing.\n"
+                      "    Spline is built with Pass 1 Degree, any original samples\n"
+                      "    that fail outlier criteria are discarded and then a final\n"
+                      "    smoothing is run with Pass 2 degree.\n"
+                      "2 - Optional: Route B-Spline smoothing will be applied\n"
+                      "    if checkbox is set. Again this is two pass smoothing where\n"
+                      "    outliers are determined by euclidean distance's stddev relative\n"
+                      "    to the smoothing spline. Again a final pass is run without\n"
+                      "    outliers using Pass 2 degree.\n\n"
+                      "Generally altitude data is noisiest and requires highest degree for\n"
+                      "reasonable smoothness. Route gps data gnerally requires a much\n"
+                      "lighter touch.\n");
+        }
+
 };
 
-static bool fixGPSAdded = DataProcessorFactory::instance().registerProcessor(QString("Fix GPS errors"), new FixGPS());
+static bool fixGPSAdded = DataProcessorFactory::instance().registerProcessor(new FixGPS());
 
 class SaveState
 {

--- a/src/FileIO/FixPyDataProcessor.cpp
+++ b/src/FileIO/FixPyDataProcessor.cpp
@@ -10,7 +10,6 @@ class FixPyDataProcessorConfig : public DataProcessorConfig
 public:
     // there is no config
     FixPyDataProcessorConfig(QWidget *parent) : DataProcessorConfig(parent) {}
-    QString explain() { return tr("Custom Python Data Processor"); }
     void readConfig() {}
     void saveConfig() {}
 };
@@ -41,8 +40,16 @@ bool FixPyDataProcessor::postProcess(RideFile *rideFile, DataProcessorConfig *se
     return pyRunner.run(pyScript->source, pyScript->iniKey, errText) == 0;
 }
 
-DataProcessorConfig *FixPyDataProcessor::processorConfig(QWidget *parent, const RideFile* ride)
+DataProcessorConfig *FixPyDataProcessor::processorConfig(QWidget *parent, const RideFile* ride) const
 {
     Q_UNUSED(ride);
     return new FixPyDataProcessorConfig(parent);
+}
+
+
+QString
+FixPyDataProcessor::explain
+() const
+{
+    return tr("Custom Python Data Processor");
 }

--- a/src/FileIO/FixPyDataProcessor.h
+++ b/src/FileIO/FixPyDataProcessor.h
@@ -6,12 +6,16 @@
 
 class FixPyDataProcessor : public DataProcessor
 {
+    Q_DECLARE_TR_FUNCTIONS(FixPyDataProcessor)
+
 public:
     FixPyDataProcessor(FixPyScript *pyScript);
-    bool postProcess(RideFile *rideFile, DataProcessorConfig *settings, QString op);
-    DataProcessorConfig *processorConfig(QWidget *parent, const RideFile* ride = NULL);
-    QString name() { return pyScript->name; }
-    bool isCoreProcessor() { return false; }
+    bool postProcess(RideFile *rideFile, DataProcessorConfig *settings, QString op) override;
+    DataProcessorConfig *processorConfig(QWidget *parent, const RideFile* ride = NULL) const override;
+    QString name() const override { return pyScript->name; }
+    QString id() const override { return pyScript->name; }
+    bool isCoreProcessor() const override { return false; }
+    QString explain() const override;
 
 private:
     FixPyScript *pyScript;

--- a/src/FileIO/FixPyScript.h
+++ b/src/FileIO/FixPyScript.h
@@ -4,7 +4,8 @@
 #include <QString>
 
 struct FixPyScript {
-    QString name, path, source, iniKey, oldPath;
+    QString name, path, source, iniKey;
+    QString oldName, oldPath;
     bool changed;
 };
 

--- a/src/FileIO/FixPyScriptsDialog.cpp
+++ b/src/FileIO/FixPyScriptsDialog.cpp
@@ -7,71 +7,69 @@
 #include "PythonEmbed.h"
 #include "PythonSyntax.h"
 
-ManageFixPyScriptsDialog::ManageFixPyScriptsDialog(Context *context)
-    : context(context)
+
+ManageFixPyScriptsWidget::ManageFixPyScriptsWidget
+(Context *context, QWidget *parent)
+: QGroupBox(tr("Select a Python Fix to manage"), parent), context(context)
 {
-    setWindowTitle(tr("Manage Python Fixes"));
-    setMinimumSize(QSize(700 * dpiXFactor, 600 * dpiYFactor));
-
-    QVBoxLayout *mainLayout = new QVBoxLayout(this);
-
-    QGroupBox *groupBox = new QGroupBox(tr("Select a Python Fix to manage"));
-    QHBoxLayout *manageBox = new QHBoxLayout();
-
     scripts = new QListWidget;
+    scripts->setAlternatingRowColors(true);
+
+    QDialogButtonBox *manageButtonBox = new QDialogButtonBox();
+    manageButtonBox->setOrientation(Qt::Vertical);
+    QPushButton *newButton = manageButtonBox->addButton(tr("New"), QDialogButtonBox::ActionRole);
+    edit = manageButtonBox->addButton(tr("Edit"), QDialogButtonBox::ActionRole);
+    del = manageButtonBox->addButton(tr("Delete"), QDialogButtonBox::ActionRole);
+
+    QHBoxLayout *manageBox = new QHBoxLayout(this);
     manageBox->addWidget(scripts);
+    manageBox->addWidget(manageButtonBox);
 
-    QVBoxLayout *manageButtons = new QVBoxLayout();
-    edit = new QPushButton(tr("Edit"));
-    del = new QPushButton(tr("Delete"));
-    manageButtons->addWidget(edit);
-    manageButtons->addWidget(del);
-    manageButtons->addStretch();
-    manageBox->addLayout(manageButtons);
-
-    groupBox->setLayout(manageBox);
-    mainLayout->addWidget(groupBox);
-
-    QPushButton *close = new QPushButton(tr("Close"));
-    QHBoxLayout *buttons = new QHBoxLayout();
-    buttons->addStretch();
-    buttons->addWidget(close);
-
-    mainLayout->addLayout(buttons);
+    connect(newButton, &QPushButton::clicked, this, &ManageFixPyScriptsWidget::newClicked);
+    connect(scripts, &QListWidget::itemDoubleClicked, this, &ManageFixPyScriptsWidget::editClicked);
+    connect(scripts, &QListWidget::itemSelectionChanged, this, &ManageFixPyScriptsWidget::scriptSelected);
+    connect(edit, &QPushButton::clicked, this, &ManageFixPyScriptsWidget::editClicked);
+    connect(del, &QPushButton::clicked, this, &ManageFixPyScriptsWidget::delClicked);
 
     reload(0);
-
-    connect(edit, SIGNAL(clicked()), this, SLOT(editClicked()));
-    connect(del, SIGNAL(clicked()), this, SLOT(delClicked()));
-    connect(close, SIGNAL(clicked()), this, SLOT(reject()));
 }
 
-void ManageFixPyScriptsDialog::editClicked()
+
+void
+ManageFixPyScriptsWidget::newClicked
+()
 {
-    QList<QListWidgetItem*> selItems = scripts->selectedItems();
-    if (selItems.length() == 0) {
+    EditFixPyScriptDialog editDlg(context, nullptr, this);
+    if (editDlg.exec() == QDialog::Accepted) {
+        reload(editDlg.getName());
+    }
+}
+
+
+void
+ManageFixPyScriptsWidget::editClicked
+()
+{
+    if (scripts->currentItem() == nullptr) {
         return;
     }
-
-    QListWidgetItem *selItem = selItems[0];
-    int selRow = scripts->row(selItem);
-    FixPyScript *script = fixPySettings->getScript(selItem->text());
+    FixPyScript *script = fixPySettings->getScript(scripts->currentItem()->text());
 
     EditFixPyScriptDialog editDlg(context, script, this);
     if (editDlg.exec() == QDialog::Accepted) {
-        reload(selRow);
+        reload(editDlg.getName());
     }
 }
 
-void ManageFixPyScriptsDialog::delClicked()
+
+void
+ManageFixPyScriptsWidget::delClicked
+()
 {
-    QList<QListWidgetItem*> selItems = scripts->selectedItems();
-    if (selItems.length() == 0) {
+    if (scripts->currentItem() == nullptr) {
         return;
     }
-
-    QListWidgetItem *selItem = selItems[0];
-    QString name = selItem->text();
+    QString name = scripts->currentItem()->text();
 
     QString msg = QString(tr("Are you sure you want to delete %1?")).arg(name);
     QMessageBox::StandardButtons result = QMessageBox::question(this, "GoldenCheetah", msg);
@@ -81,24 +79,77 @@ void ManageFixPyScriptsDialog::delClicked()
 
     fixPySettings->deleteScript(name);
 
-    reload(0);
+    reload(scripts->currentRow());
 }
 
-void ManageFixPyScriptsDialog::reload(int selRow)
+
+void
+ManageFixPyScriptsWidget::scriptSelected
+()
+{
+    edit->setEnabled(scripts->currentItem() != nullptr);
+    del->setEnabled(scripts->currentItem() != nullptr);
+}
+
+
+void
+ManageFixPyScriptsWidget::reload
+()
 {
     scripts->clear();
-    QList<FixPyScript *> fixes = fixPySettings->getScripts();
+    QList<FixPyScript*> fixes = fixPySettings->getScripts();
     for (int i = 0; i < fixes.size(); i++) {
-        scripts->addItem(fixes[i]->name);
+        QListWidgetItem *item = new QListWidgetItem();
+        item->setText(fixes[i]->name);
+        scripts->addItem(item);
     }
+    edit->setEnabled(false);
+    del->setEnabled(false);
+}
 
+
+void
+ManageFixPyScriptsWidget::reload
+(int selRow)
+{
+    reload();
+    QList<FixPyScript*> fixes = fixPySettings->getScripts();
     if (scripts->count() > 0) {
-        scripts->setCurrentRow(selRow);
-    } else {
-        edit->setEnabled(false);
-        del->setEnabled(false);
+        scripts->setCurrentRow(std::max(0, std::min(selRow, scripts->count() - 1)));
     }
 }
+
+
+void
+ManageFixPyScriptsWidget::reload
+(const QString &selName)
+{
+    reload();
+    QList<FixPyScript*> fixes = fixPySettings->getScripts();
+    for (int i = 0; i < fixes.size(); i++) {
+        if (fixes[i]->name == selName) {
+            scripts->setCurrentRow(i);
+            return;
+        }
+    }
+}
+
+
+
+ManageFixPyScriptsDialog::ManageFixPyScriptsDialog
+(Context *context)
+{
+    setWindowTitle(tr("Manage Python Fixes"));
+    setMinimumSize(QSize(700 * dpiXFactor, 600 * dpiYFactor));
+
+    QDialogButtonBox *buttonBox = new QDialogButtonBox(QDialogButtonBox::Close);
+
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    mainLayout->addWidget(new ManageFixPyScriptsWidget(context));
+    mainLayout->addWidget(buttonBox);
+    connect(buttonBox, &QDialogButtonBox::rejected, this, &QDialog::reject);
+}
+
 
 EditFixPyScriptDialog::EditFixPyScriptDialog(Context *context, FixPyScript *fix, QWidget *parent)
     : QDialog(parent), context(context), pyFixScript(fix)
@@ -119,16 +170,11 @@ EditFixPyScriptDialog::EditFixPyScriptDialog(Context *context, FixPyScript *fix,
     // LHS
     QFrame *scriptBox = new QFrame;
     scriptBox->setFrameStyle(QFrame::NoFrame);
-    QVBoxLayout *scriptLayout = new QVBoxLayout;
+    QFormLayout *scriptLayout = newQFormLayout();
     scriptLayout->setContentsMargins(0, 0, 0, 10);
     scriptBox->setLayout(scriptLayout);
 
-    QHBoxLayout *nameLayout = new QHBoxLayout;
-    QLabel *scriptNameLbl = new QLabel(tr("Name:"));
     scriptName = new QLineEdit(fix ? fix->name : "");
-    nameLayout->addWidget(scriptNameLbl);
-    nameLayout->addWidget(scriptName);
-    scriptLayout->addLayout(nameLayout);
 
     script = new QTextEdit;
     script->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding));
@@ -141,13 +187,15 @@ EditFixPyScriptDialog::EditFixPyScriptDialog(Context *context, FixPyScript *fix,
     p.setColor(QPalette::Text, GCColor::invertColor(GColor(CPLOTBACKGROUND)));
     script->setPalette(p);
     script->setStyleSheet(AbstractView::ourStyleSheet());
-    scriptLayout->addWidget(script);
 
     // syntax highlighter
     setScript(fix ? fix->source : "");
 
     QPushButton *run = new QPushButton(tr("Run"));
-    scriptLayout->addWidget(run);
+
+    scriptLayout->addRow(tr("Name"), scriptName);
+    scriptLayout->addRow(script);
+    scriptLayout->addRow(run);
 
     splitter->addWidget(scriptBox);
     console = new PythonConsole(context, this, this);
@@ -183,6 +231,19 @@ EditFixPyScriptDialog::EditFixPyScriptDialog(Context *context, FixPyScript *fix,
     connect(save, SIGNAL(clicked()), this, SLOT(saveClicked()));
     connect(cancel, SIGNAL(clicked()), this, SLOT(reject()));
 }
+
+
+QString
+EditFixPyScriptDialog::getName
+() const
+{
+    if (pyFixScript != nullptr) {
+        return pyFixScript->name;
+    } else {
+        return QString();
+    }
+}
+
 
 void EditFixPyScriptDialog::closeEvent(QCloseEvent *event)
 {
@@ -224,8 +285,8 @@ void EditFixPyScriptDialog::setScript(QString string)
 
 bool EditFixPyScriptDialog::isModified()
 {
-    return scriptName->isModified() ||
-           script->document()->isModified();
+    return    scriptName->isModified()
+           || script->document()->isModified();
 }
 
 void EditFixPyScriptDialog::saveClicked()
@@ -282,6 +343,11 @@ void EditFixPyScriptDialog::saveClicked()
     // remember old path, for clean up
     if (!pyFixScript->path.isEmpty() && pyFixScript->path != path) {
         pyFixScript->oldPath = pyFixScript->path;
+    }
+
+    // remember old name, for clean up
+    if (!pyFixScript->name.isEmpty() && pyFixScript->name != name) {
+        pyFixScript->oldName = pyFixScript->name;
     }
 
     pyFixScript->name = name;

--- a/src/FileIO/FixPyScriptsDialog.h
+++ b/src/FileIO/FixPyScriptsDialog.h
@@ -8,24 +8,39 @@
 #include "PythonChart.h"
 #include "FixPySettings.h"
 
-class ManageFixPyScriptsDialog : public QDialog
+
+class ManageFixPyScriptsWidget : public QGroupBox
 {
     Q_OBJECT
 
 public:
-    ManageFixPyScriptsDialog(Context *);
+    ManageFixPyScriptsWidget(Context *context, QWidget *parent = nullptr);
 
 private slots:
+    void newClicked();
     void editClicked();
     void delClicked();
+    void scriptSelected();
 
 private:
+    void reload();
     void reload(int selRow);
+    void reload(const QString &selName);
 
     Context *context;
     QListWidget *scripts;
     QPushButton *edit, *del;
 };
+
+
+class ManageFixPyScriptsDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    ManageFixPyScriptsDialog(Context *context);
+};
+
 
 class EditFixPyScriptDialog : public QDialog, public PythonHost
 {
@@ -36,6 +51,7 @@ public:
 
     PythonChart *chart() { return nullptr; }
     bool readOnly() { return false; }
+    QString getName() const;
 
 protected:
     void closeEvent(QCloseEvent *event);

--- a/src/FileIO/FixRunningCadence.cpp
+++ b/src/FileIO/FixRunningCadence.cpp
@@ -45,11 +45,6 @@ class FixRunningCadenceConfig : public DataProcessorConfig
         //~FixRunningCadenceConfig() {} // deliberately not declared since Qt will delete
                               // the widget and its children when the config pane is deleted
 
-        QString explain() {
-            return(QString(tr("Some file report cadence in steps per minutes.\n"
-                              "This tools convert to revolutions or cycles per minute")));
-        }
-
         void readConfig() { }
         void saveConfig() { }
 
@@ -64,21 +59,34 @@ class FixRunningCadence : public DataProcessor {
         ~FixRunningCadence() {}
 
         // the processor
-        bool postProcess(RideFile *, DataProcessorConfig* config, QString op);
+        bool postProcess(RideFile *, DataProcessorConfig* config, QString op) override;
 
         // the config widget
-        DataProcessorConfig* processorConfig(QWidget *parent, const RideFile * ride = NULL) {
+        DataProcessorConfig* processorConfig(QWidget *parent, const RideFile * ride = NULL) const override {
             Q_UNUSED(ride);
             return new FixRunningCadenceConfig(parent);
         }
 
         // Localized Name
-        QString name() {
+        QString name() const override {
             return (tr("Fix Running Cadence"));
+        }
+
+        QString id() const override {
+            return "::FixRunningCadence";
+        }
+
+        QString legacyId() const override {
+            return "Fix Running Cadence";
+        }
+
+        QString explain() const override {
+            return tr("Some file report cadence in steps per minutes.\n"
+                      "This tools convert to revolutions or cycles per minute");
         }
 };
 
-static bool FixRunningCadenceAdded = DataProcessorFactory::instance().registerProcessor(QString("Fix Running Cadence"), new FixRunningCadence());
+static bool FixRunningCadenceAdded = DataProcessorFactory::instance().registerProcessor(new FixRunningCadence());
 
 bool
 FixRunningCadence::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")

--- a/src/FileIO/FixTorque.cpp
+++ b/src/FileIO/FixTorque.cpp
@@ -20,6 +20,7 @@
 #include "LTMOutliers.h"
 #include "Settings.h"
 #include "Units.h"
+#include "Colors.h"
 #include "HelpWhatsThis.h"
 #include <algorithm>
 #include <QVector>
@@ -32,8 +33,6 @@ class FixTorqueConfig : public DataProcessorConfig
 
     friend class ::FixTorque;
     protected:
-        QHBoxLayout *layout;
-        QLabel *taLabel;
         QLineEdit *ta;
 
     public:
@@ -42,33 +41,16 @@ class FixTorqueConfig : public DataProcessorConfig
             HelpWhatsThis *help = new HelpWhatsThis(parent);
             parent->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Edit_AdjustTorqueValues));
 
-            layout = new QHBoxLayout(this);
-
+            QFormLayout *layout = newQFormLayout(this);
             layout->setContentsMargins(0,0,0,0);
             setContentsMargins(0,0,0,0);
 
-            taLabel = new QLabel(tr("Torque Adjust"));
-
             ta = new QLineEdit();
-
-            layout->addWidget(taLabel);
-            layout->addWidget(ta);
-            layout->addStretch();
+            layout->addRow(tr("Torque Adjust"), ta);
         }
 
         //~FixTorqueConfig() {} // deliberately not declared since Qt will delete
                               // the widget and its children when the config pane is deleted
-
-        QString explain() {
-            return(QString(tr("Adjusting torque values allows you to "
-                           "uplift or degrade the torque values when the calibration "
-                           "of your power meter was incorrect. It "
-                           "takes a single parameter:\n\n"
-                           "Torque Adjust - this defines an absolute value "
-                           "in poinds per square inch or newton meters to "
-                           "modify values by. Negative values are supported. (e.g. enter \"1.2 nm\" or "
-                           "\"-0.5 pi\").")));
-        }
 
         void readConfig() {
             ta->setText(appsettings->value(NULL, GC_DPTA, "0 nm").toString());
@@ -92,21 +74,40 @@ class FixTorque : public DataProcessor {
         ~FixTorque() {}
 
         // the processor
-        bool postProcess(RideFile *, DataProcessorConfig* config, QString op);
+        bool postProcess(RideFile *, DataProcessorConfig* config, QString op) override;
 
         // the config widget
-        DataProcessorConfig* processorConfig(QWidget *parent, const RideFile * ride = NULL) {
+        DataProcessorConfig* processorConfig(QWidget *parent, const RideFile * ride = NULL) const override {
             Q_UNUSED(ride);
             return new FixTorqueConfig(parent);
         }
 
         // Localized Name
-        QString name() {
-            return (tr("Adjust Torque Values"));
+        QString name() const override {
+            return tr("Adjust Torque Values");
+        }
+
+        QString id() const override {
+            return "::FixTorque";
+        }
+
+        QString legacyId() const override {
+            return "Adjust Torque Values";
+        }
+
+        QString explain() const override {
+            return tr("Adjusting torque values allows you to "
+                      "uplift or degrade the torque values when the calibration "
+                      "of your power meter was incorrect. It "
+                      "takes a single parameter:\n\n"
+                      "Torque Adjust - this defines an absolute value "
+                      "in poinds per square inch or newton meters to "
+                      "modify values by. Negative values are supported. (e.g. enter \"1.2 nm\" or "
+                      "\"-0.5 pi\").");
         }
 };
 
-static bool fixTorqueAdded = DataProcessorFactory::instance().registerProcessor(QString("Adjust Torque Values"), new FixTorque());
+static bool fixTorqueAdded = DataProcessorFactory::instance().registerProcessor(new FixTorque());
 
 bool
 FixTorque::postProcess(RideFile *ride, DataProcessorConfig *config=0, QString op="")

--- a/src/FileIO/Snippets.cpp
+++ b/src/FileIO/Snippets.cpp
@@ -42,10 +42,6 @@ class SnippetsConfig : public DataProcessorConfig
             //parent->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::MenuBar_Edit_SnippetsInRecording));
         }
 
-        QString explain() {
-            return(QString(tr("Dump metrics for the ride to Athlete_Home/Snippets")));
-        }
-
         void readConfig() {
         }
 
@@ -66,21 +62,33 @@ class Snippets : public DataProcessor {
         ~Snippets() {}
 
         // the processor
-        bool postProcess(RideFile *, DataProcessorConfig* config, QString op);
+        bool postProcess(RideFile *, DataProcessorConfig* config, QString op) override;
 
         // the config widget
-        DataProcessorConfig* processorConfig(QWidget *parent, const RideFile * ride = NULL) {
+        DataProcessorConfig* processorConfig(QWidget *parent, const RideFile * ride = NULL) const override {
             Q_UNUSED(ride);
             return new SnippetsConfig(parent);
         }
 
         // Localized Name
-        QString name() {
-            return (tr("Snippet export"));
+        QString name() const override {
+            return tr("Snippet export");
+        }
+
+        QString id() const override {
+            return "::Snippets";
+        }
+
+        QString legacyId() const override {
+            return "Snippet export";
+        }
+
+        QString explain() const override {
+            return tr("Dump metrics for the ride to Athlete_Home/Snippets");
         }
 };
 
-static bool SnippetsAdded = DataProcessorFactory::instance().registerProcessor(QString("Snippet export"), new Snippets());
+static bool SnippetsAdded = DataProcessorFactory::instance().registerProcessor(new Snippets());
 
 // how we write the ride time
 #define DATETIME_FORMAT "yyyy/MM/dd hh:mm:ss' UTC'"

--- a/src/Gui/BatchProcessingDialog.cpp
+++ b/src/Gui/BatchProcessingDialog.cpp
@@ -176,7 +176,9 @@ processed(0), fails(0), numFilesToProcess(0) {
     i.toFront();
     while (i.hasNext()) {
         i.next();
-        dataProcessorToRun->addItem(i.value()->name(), i.key());
+        if (! i.value()->isAutomatedOnly()) {
+            dataProcessorToRun->addItem(i.value()->name(), i.key());
+        }
     }
 
     dpButton = new QPushButton(tr("Edit"), this);

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -274,13 +274,7 @@ class MainWindow : public QMainWindow
         // autoload rides from athlete specific directory (preferences)
         void ridesAutoImport();
 
-#ifdef GC_WANT_PYTHON
-        // Python fix scripts
-        void onEditMenuAboutToShow();
-        void buildPyFixesMenu();
-        void showManageFixPyScriptsDlg();
-        void showCreateFixPyScriptDlg();
-#endif
+        void onProcessMenuAboutToShow();
 
 #ifdef GC_HAS_CLOUD_DB
         // CloudDB actions
@@ -307,6 +301,8 @@ class MainWindow : public QMainWindow
 #ifndef Q_OS_MAC
         QTFullScreen *fullScreen;
 #endif
+
+        QMenu *processMenu;
 
         QComboBox *perspectiveSelector;
         bool pactive; // when programmatically manipulating selector
@@ -354,11 +350,7 @@ class MainWindow : public QMainWindow
         QAction *checkAction;
 
         // Miscellany
-        QSignalMapper *toolMapper;
-
-#ifdef GC_WANT_PYTHON
-        QMenu *pyFixesMenu;
-#endif
+        QSignalMapper *toolMapper = nullptr;
 
 #ifdef GC_HAS_CLOUD_DB
         CloudDBVersionClient *versionClient;

--- a/src/Gui/Pages.h
+++ b/src/Gui/Pages.h
@@ -51,6 +51,10 @@
 #include "RemoteControl.h"
 #include "Measures.h"
 #include "TagStore.h"
+#include "StyledItemDelegates.h"
+#ifdef GC_WANT_PYTHON
+#include "FixPyScriptsDialog.h"
+#endif
 
 class QGroupBox;
 class QHBoxLayout;
@@ -559,28 +563,49 @@ class FieldsPage : public QWidget
 class ProcessorPage : public QWidget
 {
     Q_OBJECT
-    G_OBJECT
-
 
     public:
-
         ProcessorPage(Context *context);
         qint32 saveClicked();
 
-    public slots:
-
-        //void upClicked();
-        //void downClicked();
+    private slots:
+        void processorSelected(QTreeWidgetItem *selectedItem);
+        void reload();
+        void reload(const QString &selectName);
+        void reload(int selectRow);
+#ifdef GC_WANT_PYTHON
+        void addProcessor();
+        void delProcessor();
+        void editProcessor();
+        void dblClickProcessor(QTreeWidgetItem *item, int col);
+        void toggleCoreProcessors(bool checked);
+#endif
+        void automationChanged(int index);
+        void toggleAutomatedOnly(bool checked);
+        void dataChanged(const QModelIndex &topLeft);
 
     protected:
-
         Context *context;
-        QMap<QString, DataProcessor*> processors;
 
         QTreeWidget *processorTree;
-        //QPushButton *upButton, *downButton;
 
+    private:
+        NoEditDelegate processorDelegate;
+        ComboBoxDelegate automationDelegate;
+        QList<QComboBox*> automationCombos;
+        QList<QCheckBox*> automatedCheckBoxes;
+        QList<DataProcessorConfig*> configs;
+
+#ifdef GC_WANT_PYTHON
+        QPushButton *addButton = nullptr;
+        QPushButton *delButton = nullptr;
+        QPushButton *editButton = nullptr;
+        QCheckBox *hideButton = nullptr;
+#endif
+
+        QStackedWidget *settingsStack;
 };
+
 
 class DefaultsPage : public QWidget
 {
@@ -635,8 +660,8 @@ class MetadataPage : public QWidget
         QTabWidget *tabs;
         KeywordsPage *keywordsPage;
         FieldsPage *fieldsPage;
-        ProcessorPage *processorPage;
         DefaultsPage *defaultsPage;
+        ProcessorPage *processorPage;
 
         // local versions for modification
         QList<KeywordDefinition> keywordDefinitions;

--- a/src/Python/SIP/Bindings.cpp
+++ b/src/Python/SIP/Bindings.cpp
@@ -1625,7 +1625,7 @@ Bindings::postProcess(QString processor, PyObject *activity) const
     RideFile *f = selectRideFile(activity);
     if (f == nullptr) return false;
 
-    DataProcessor* dp = DataProcessorFactory::instance().getProcessors().value(processor, nullptr);
+    DataProcessor* dp = DataProcessorFactory::instance().getProcessor(processor);
     if (!dp) return false;
     return dp->postProcess(f, nullptr, "PYTHON");
 }


### PR DESCRIPTION
This PR provides a solution to mark all types of DataProcessors as "Automated execution only" and replaces #4572 

* Options > Data Fields > Processors & Automation (renamed from "Processing")
  * Modernized the UI
  * Added UI to set Automation (None, On Import, On Save) for all processors
  * Added UI to set Automated execution only for all processors
  * Showing the processors description
  * Showing the processors setting (if available) in a more userfriendly way
  * Added option to add / delete / edit custom Python processors
  * Enabled editing of Python processors via double click
  * Added option to hide code processors
* Removed the submenu to manage Python Fixes from the Edit-menu
* Renamed the Edit-menu to "Process"
* Hiding "automated only"-processors from Process-menu and Batchprocessing-dialog
* DataProcessors
  * Turned configuration of all core processors into forms
  * Changed the technical name of all core processors to match their classname
  * Added legacy technical name to all core processors to support existing scripts
  * Moved description from config-class to DataProcessor
  * Implemented a migration path for existing persisted processor configurations
* GSettings
  * Added method to remove settings by key