### PR TITLE
Reworked the Options-Dialog

### DIFF
--- a/src/Gui/ActionButtonBox.cpp
+++ b/src/Gui/ActionButtonBox.cpp
@@ -1,0 +1,281 @@
+/*
+ * Copyright (c) 2024 Joachim Kohlhammer (joachim.kohlhammer@gmx.de)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "ActionButtonBox.h"
+
+#include "Colors.h"
+
+
+ActionButtonBox::ActionButtonBox
+(ActionButtonBox::StandardButtonGroups standardButtons, QWidget *parent)
+: QWidget(parent)
+{
+    layout = new QHBoxLayout(this);
+    layout->setSpacing(2 * dpiXFactor);
+    layout->setContentsMargins(0, 0, 0, 0);
+    if (standardButtons.testFlag(StandardButtonGroup::UpDownGroup)) {
+#ifdef Q_OS_MAC
+        up = new QPushButton(tr("Up"));
+        down = new QPushButton(tr("Down"));
+#else
+        up = new QToolButton(this);
+        up->setArrowType(Qt::UpArrow);
+        up->setFixedSize(20 * dpiXFactor, 20 * dpiYFactor);
+        down = new QToolButton(this);
+        down->setArrowType(Qt::DownArrow);
+        down->setFixedSize(20 * dpiXFactor, 20 * dpiYFactor);
+#endif
+        layout->addWidget(up, 0, Qt::AlignHCenter | Qt::AlignTop);
+        layout->addWidget(down, 0, Qt::AlignHCenter | Qt::AlignTop);
+
+        layout->addItem(new QSpacerItem(5 * dpiXFactor, 0));
+        leftOffset = 3;
+
+        connect(up, &QAbstractButton::clicked, this, &ActionButtonBox::upRequested);
+        connect(down, &QAbstractButton::clicked, this, &ActionButtonBox::downRequested);
+    }
+    layout->addStretch();
+    if (standardButtons.testFlag(StandardButtonGroup::EditGroup)) {
+        edit = new QPushButton(tr("Edit"));
+        int spacerWidth = 0;
+        if (standardButtons.testFlag(StandardButtonGroup::AddDeleteGroup)) {
+            spacerWidth = 5 * dpiXFactor;
+        }
+        layout->addItem(new QSpacerItem(spacerWidth, edit->sizeHint().height()));
+        layout->addWidget(edit);
+
+        connect(edit, &QPushButton::clicked, this, &ActionButtonBox::editRequested);
+        if (standardButtons.testFlag(StandardButtonGroup::AddDeleteGroup)) {
+            rightOffset += 2;
+        } else {
+            layout->addStretch();
+        }
+    }
+    if (standardButtons.testFlag(StandardButtonGroup::AddDeleteGroup)) {
+        add = new QPushButton(tr("+"));
+        del = new QPushButton(tr("-"));
+#ifdef Q_OS_MAC
+        add->setText(tr("Add"));
+        del->setText(tr("Delete"));
+#else
+        add->setFixedSize(20 * dpiXFactor, 20 * dpiYFactor);
+        del->setFixedSize(20 * dpiXFactor, 20 * dpiYFactor);
+#endif
+        layout->addItem(new QSpacerItem(5 * dpiXFactor, 0));
+        layout->addWidget(add, 0, Qt::AlignHCenter | Qt::AlignTop);
+        layout->addWidget(del, 0, Qt::AlignHCenter | Qt::AlignTop);
+        rightOffset += 3;
+
+        connect(add, &QPushButton::clicked, this, &ActionButtonBox::addRequested);
+        connect(del, &QPushButton::clicked, this, &ActionButtonBox::deleteRequested);
+    }
+}
+
+
+QAbstractButton*
+ActionButtonBox::which
+(ActionButtonBox::StandardButton which) const
+{
+    switch (which) {
+        case Up:
+            return up;
+        case Down:
+            return down;
+        case Add:
+            return add;
+        case Delete:
+            return del;
+        case Edit:
+            return edit;
+        default:
+            return nullptr;
+    }
+}
+
+
+void
+ActionButtonBox::setButtonHidden
+(ActionButtonBox::StandardButton standardButton, bool hidden)
+{
+    QAbstractButton *button = which(standardButton);
+    if (button != nullptr) {
+        button->setHidden(hidden);
+    }
+}
+
+
+void
+ActionButtonBox::setButtonEnabled
+(ActionButtonBox::StandardButton standardButton, bool enabled)
+{
+    QAbstractButton *button = which(standardButton);
+    if (button != nullptr) {
+        button->setEnabled(enabled);
+    }
+}
+
+
+QPushButton*
+ActionButtonBox::addButton
+(const QString &text, ActionButtonBox::ActionPosition pos)
+{
+    QPushButton *ret = new QPushButton(text);
+    if (pos == ActionButtonBox::Left) {
+        layout->insertWidget(leftOffset++, ret);
+        layout->insertItem(leftOffset++, new QSpacerItem(0, ret->sizeHint().height()));
+    } else {
+        layout->insertWidget(layout->count() - rightOffset++, ret);
+        layout->insertItem(layout->count() - rightOffset++, new QSpacerItem(0, ret->sizeHint().height()));
+    }
+    return ret;
+}
+
+
+void
+ActionButtonBox::addWidget
+(QWidget *widget)
+{
+    layout->insertWidget(leftOffset++, widget);
+    layout->insertItem(leftOffset++, new QSpacerItem(0, widget->sizeHint().height()));
+}
+
+
+void
+ActionButtonBox::addStretch
+(ActionPosition pos)
+{
+    if (pos == ActionButtonBox::Left) {
+        layout->insertStretch(leftOffset++);
+    } else {
+        layout->insertStretch(layout->count() - rightOffset++);
+    }
+}
+
+
+void
+ActionButtonBox::defaultConnect
+(StandardButtonGroup group, QTreeWidget *tree)
+{
+    defaultConnectInit(group);
+    connect(tree, &QTreeWidget::currentItemChanged, [=]() {
+            updateButtonState(group, tree);
+        });
+    // Also listen for rowsRemoved as currentItemChanged fires to early (count of tree not yet reduced)
+    connect(tree->model(), &QAbstractItemModel::rowsRemoved, [=]() {
+            updateButtonState(group, tree);
+        });
+}
+
+
+void
+ActionButtonBox::defaultConnect
+(StandardButtonGroup group, QListWidget *list)
+{
+    defaultConnectInit(group);
+    connect(list, &QListWidget::currentItemChanged, [=]()
+        {
+            updateButtonState(group, list);
+        }
+    );
+    // Also listen for rowsRemoved as currentItemChanged fires to early (count of list not yet reduced)
+    connect(list->model(), &QAbstractItemModel::rowsRemoved, [=]()
+        {
+            updateButtonState(group, list);
+        }
+    );
+}
+
+
+void
+ActionButtonBox::updateButtonState
+(StandardButtonGroup group, QTreeWidget *tree)
+{
+    QTreeWidgetItem *item = tree->currentItem();
+    switch (group) {
+    case UpDownGroup:
+        if (up != nullptr && down != nullptr) {
+            up->setEnabled(item != nullptr && tree->currentIndex().row() > 0);
+            down->setEnabled(item != nullptr && tree->currentIndex().row() < tree->invisibleRootItem()->childCount() - 1);
+        }
+        break;
+    case AddDeleteGroup:
+        if (add != nullptr && del != nullptr) {
+            add->setEnabled(true);
+            del->setEnabled(item != nullptr);
+        }
+        break;
+    case EditGroup:
+        if (edit != nullptr) {
+            edit->setEnabled(item != nullptr);
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+
+void
+ActionButtonBox::updateButtonState
+(StandardButtonGroup group, QListWidget *list)
+{
+    QListWidgetItem *item = list->currentItem();
+    switch (group) {
+    case UpDownGroup:
+        if (up != nullptr && down != nullptr) {
+            up->setEnabled(item != nullptr && list->row(item) > 0);
+            down->setEnabled(item != nullptr && list->row(item) < list->count() - 1);
+        }
+        break;
+    case AddDeleteGroup:
+        if (add != nullptr && del != nullptr) {
+            add->setEnabled(true);
+            del->setEnabled(item != nullptr);
+        }
+        break;
+    case EditGroup:
+        if (edit != nullptr) {
+            edit->setEnabled(item != nullptr);
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+
+void
+ActionButtonBox::defaultConnectInit
+(StandardButtonGroup group)
+{
+    switch (group) {
+    case UpDownGroup:
+        up->setEnabled(false);
+        down->setEnabled(false);
+        break;
+    case AddDeleteGroup:
+        add->setEnabled(true);
+        del->setEnabled(false);
+        break;
+    case EditGroup:
+        edit->setEnabled(false);
+        break;
+    default:
+        break;
+    }
+}

--- a/src/Gui/ActionButtonBox.h
+++ b/src/Gui/ActionButtonBox.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2024 Joachim Kohlhammer (joachim.kohlhammer@gmx.de)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef ACTIONBUTTONBOX_H
+#define ACTIONBUTTONBOX_H
+
+#include <QPushButton>
+#ifndef Q_OS_MAC
+#include <QToolButton>
+#endif
+#include <QHBoxLayout>
+#include <QTreeWidget>
+#include <QListWidget>
+
+
+class ActionButtonBox : public QWidget {
+    Q_OBJECT
+
+    public:
+        enum StandardButtonGroup {
+            NoGroup = 0x0,
+            UpDownGroup = 0x1,
+            AddDeleteGroup = 0x2,
+            EditGroup = 0x4
+        };
+        Q_DECLARE_FLAGS(StandardButtonGroups, StandardButtonGroup)
+
+        enum StandardButton {
+            Up = 0,
+            Down = 1,
+            Add = 2,
+            Delete = 3,
+            Edit = 4
+        };
+
+        enum ActionPosition {
+            Left = 0,
+            Right = 1
+        };
+
+	ActionButtonBox(StandardButtonGroups standardButtonGroups, QWidget *parent = nullptr);
+
+        QAbstractButton *which(StandardButton which) const;
+
+	void setButtonHidden(StandardButton standardButton, bool hidden);
+	void setButtonEnabled(StandardButton standardButton, bool enabled);
+
+	QPushButton *addButton(const QString &text, ActionPosition pos = ActionPosition::Left);
+	void addWidget(QWidget *widget);
+	void addStretch(ActionPosition pos = ActionPosition::Left);
+
+        void defaultConnect(StandardButtonGroup group, QTreeWidget *tree);
+        void defaultConnect(StandardButtonGroup group, QListWidget *list);
+
+    signals:
+	void upRequested();
+	void downRequested();
+	void addRequested();
+	void deleteRequested();
+	void editRequested();
+
+    private:
+	QHBoxLayout *layout;
+#ifdef Q_OS_MAC
+        QPushButton *up = nullptr;
+        QPushButton *down = nullptr;
+#else
+        QToolButton *up = nullptr;
+        QToolButton *down = nullptr;
+#endif
+	QPushButton *add = nullptr;
+	QPushButton *del = nullptr;
+	QPushButton *edit = nullptr;
+
+	int leftOffset = 0;
+	int rightOffset = 0;
+
+        void updateButtonState(StandardButtonGroup group, QTreeWidget *tree);
+        void updateButtonState(StandardButtonGroup group, QListWidget *list);
+        void defaultConnectInit(StandardButtonGroup group);
+};
+
+Q_DECLARE_OPERATORS_FOR_FLAGS(ActionButtonBox::StandardButtonGroups)
+
+#endif

--- a/src/Gui/Colors.cpp
+++ b/src/Gui/Colors.cpp
@@ -1154,3 +1154,28 @@ newQFormLayout
     }
     return form;
 }
+
+
+extern QLayout*
+centerLayout
+(QLayout *layout, bool margins)
+{
+    QHBoxLayout *centerLayout = new QHBoxLayout();
+    if (! margins) {
+        centerLayout->setContentsMargins(0, 0, 0, 0);
+    }
+    centerLayout->addStretch(1);
+    centerLayout->addLayout(layout, 3);
+    centerLayout->addStretch(1);
+    return centerLayout;
+}
+
+
+extern QWidget*
+centerLayoutInWidget
+(QLayout *layout, bool margins)
+{
+    QWidget *widget = new QWidget();
+    widget->setLayout(centerLayout(layout, margins));
+    return widget;
+}

--- a/src/Gui/Colors.h
+++ b/src/Gui/Colors.h
@@ -41,6 +41,8 @@ extern QFont baseFont;
 // layout and widget styling
 extern void basicTreeWidgetStyle(QTreeWidget *tree, bool editable = true);
 extern QFormLayout *newQFormLayout(QWidget *parent = nullptr);
+extern QLayout *centerLayout(QLayout *layout, bool margins = true);
+extern QWidget *centerLayoutInWidget(QLayout *layout, bool margins = true);
 
 // turn color to rgb, checks if a named color
 #define StandardColor(x) (QColor(1,1,x))

--- a/src/Gui/ConfigDialog.h
+++ b/src/Gui/ConfigDialog.h
@@ -64,7 +64,7 @@ class AppearanceConfig : public QWidget
 
     public slots:
         qint32 saveClicked();
-    
+
     private:
         QDir home;
         Context *context;
@@ -81,7 +81,7 @@ class DataConfig : public QWidget
 
     public slots:
         qint32 saveClicked();
-    
+
     private:
         QDir home;
         Context *context;
@@ -99,7 +99,7 @@ class MetricConfig : public QWidget
 
     public slots:
         qint32 saveClicked();
-    
+
     private:
         QDir home;
         Context *context;
@@ -118,7 +118,7 @@ class TrainConfig : public QWidget
 
     public slots:
         qint32 saveClicked();
-    
+
     private:
         QDir home;
         Context *context;
@@ -140,7 +140,7 @@ class IntervalConfig : public QWidget
 
     public slots:
         qint32 saveClicked();
-    
+
     private:
         QDir home;
         Context *context;
@@ -158,11 +158,11 @@ class MeasuresConfig : public QWidget
 
     public slots:
         qint32 saveClicked();
+        void resetClicked();
 
     private:
         QDir home;
         Context *context;
-
         MeasuresConfigPage *measuresPage;
 };
 
@@ -186,9 +186,7 @@ class ConfigDialog : public QMainWindow
         Context *context;
 
         QStackedWidget *pagesWidget;
-        QPushButton *saveButton;
-        QPushButton *closeButton;
-        QPushButton *resetAppearance;
+        QPushButton *reset;
 
         // the config pages
         GeneralConfig *general;

--- a/src/Gui/Pages.cpp
+++ b/src/Gui/Pages.cpp
@@ -52,25 +52,18 @@
 #include "MainWindow.h"
 extern ConfigDialog *configdialog_ptr;
 
+#define HLO "<h4>"
+#define HLC "</h4>"
+
+
 //
 // Main Config Page - tabs for each sub-page
 //
 GeneralPage::GeneralPage(Context *context) : context(context)
 {
-    // layout without too wide margins
-    QVBoxLayout *mainLayout = new QVBoxLayout(this);
-    QGridLayout *configLayout = new QGridLayout;
-    mainLayout->addLayout(configLayout);
-    mainLayout->addStretch();
-    setContentsMargins(0,0,0,0);
-    mainLayout->setSpacing(0);
-    mainLayout->setContentsMargins(0,0,0,0);
-    configLayout->setSpacing(10 *dpiXFactor);
-
     //
     // Language Selection
     //
-    langLabel = new QLabel(tr("Language"));
     langCombo = new QComboBox();
     langCombo->addItem(tr("English"));
     langCombo->addItem(tr("French"));
@@ -106,13 +99,9 @@ GeneralPage::GeneralPage(Context *context) : context(context)
     else if (lang.toString().startsWith("sv")) langCombo->setCurrentIndex(13);
     else langCombo->setCurrentIndex(0);
 
-    configLayout->addWidget(langLabel, 0,0, Qt::AlignRight);
-    configLayout->addWidget(langCombo, 0,1, Qt::AlignLeft);
-
     //
     // Units
     //
-    QLabel *unitlabel = new QLabel(tr("Unit"));
     unitCombo = new QComboBox();
     unitCombo->addItem(tr("Metric"));
     unitCombo->addItem(tr("Imperial"));
@@ -122,16 +111,11 @@ GeneralPage::GeneralPage(Context *context) : context(context)
     else
         unitCombo->setCurrentIndex(1);
 
-    configLayout->addWidget(unitlabel, 1,0, Qt::AlignRight);
-    configLayout->addWidget(unitCombo, 1,1, Qt::AlignLeft);
-
     metricRunPace = new QCheckBox(tr("Metric Run Pace"), this);
     metricRunPace->setCheckState(appsettings->value(this, GC_PACE, GlobalContext::context()->useMetricUnits).toBool() ? Qt::Checked : Qt::Unchecked);
-    configLayout->addWidget(metricRunPace, 2,1, Qt::AlignLeft);
 
     metricSwimPace = new QCheckBox(tr("Metric Swim Pace"), this);
     metricSwimPace->setCheckState(appsettings->value(this, GC_SWIMPACE, GlobalContext::context()->useMetricUnits).toBool() ? Qt::Checked : Qt::Unchecked);
-    configLayout->addWidget(metricSwimPace, 3,1, Qt::AlignLeft);
 
     //
     // Garmin crap
@@ -140,146 +124,165 @@ GeneralPage::GeneralPage(Context *context) : context(context)
     QVariant garminHWMark = appsettings->value(this, GC_GARMIN_HWMARK);
     garminSmartRecord = new QCheckBox(tr("Use Garmin Smart Recording"), this);
     QVariant isGarminSmartRecording = appsettings->value(this, GC_GARMIN_SMARTRECORD, Qt::Checked);
-    garminSmartRecord->setCheckState(isGarminSmartRecording.toInt() > 0 ? Qt::Checked : Qt::Unchecked);
 
     // by default, set the threshold to 25 seconds
     if (garminHWMark.isNull() || garminHWMark.toInt() == 0) garminHWMark.setValue(25);
-    QLabel *garminHWLabel = new QLabel(tr("Smart Recording Threshold (secs)"));
-    garminHWMarkedit = new QLineEdit(garminHWMark.toString(),this);
-    garminHWMarkedit->setInputMask("009");
+    garminHWMarkedit = new QSpinBox();
+    garminHWMarkedit->setSingleStep(1);
+    garminHWMarkedit->setRange(1, 300);
+    garminHWMarkedit->setSuffix(" " + tr("s"));
+    garminHWMarkedit->setValue(garminHWMark.toInt());
 
-    configLayout->addWidget(garminSmartRecord, 4,1, Qt::AlignLeft);
-    configLayout->addWidget(garminHWLabel, 5,0, Qt::AlignRight);
-    configLayout->addWidget(garminHWMarkedit, 5,1, Qt::AlignLeft);
+    connect(garminSmartRecord, &QCheckBox::stateChanged, [=](int state) { garminHWMarkedit->setEnabled(state); });
+    garminSmartRecord->setCheckState(! (isGarminSmartRecording.toInt() > 0) ? Qt::Checked : Qt::Unchecked);
+    garminSmartRecord->setCheckState(isGarminSmartRecording.toInt() > 0 ? Qt::Checked : Qt::Unchecked);
 
     // Elevation hysterisis  GC_ELEVATION_HYSTERISIS
     QVariant elevationHysteresis = appsettings->value(this, GC_ELEVATION_HYSTERESIS);
     if (elevationHysteresis.isNull() || elevationHysteresis.toFloat() == 0.0)
        elevationHysteresis.setValue(3.0);  // default is 1 meter
 
-    QLabel *hystlabel = new QLabel(tr("Elevation hysteresis (meters)"));
-    hystedit = new QLineEdit(elevationHysteresis.toString(),this);
-    hystedit->setInputMask("9.00");
-
-    configLayout->addWidget(hystlabel, 6,0, Qt::AlignRight);
-    configLayout->addWidget(hystedit, 6,1, Qt::AlignLeft);
-
+    hystedit = new QDoubleSpinBox();
+    hystedit->setDecimals(1);
+    hystedit->setSingleStep(0.1);
+    hystedit->setRange(0, 10);
+    hystedit->setSuffix(" " + tr("m"));
+    hystedit->setValue(elevationHysteresis.toFloat());
 
     // wbal formula preference
-    QLabel *wbalFormLabel = new QLabel(tr("W' bal formula"));
     wbalForm = new QComboBox(this);
     wbalForm->addItem(tr("Differential"));
     wbalForm->addItem(tr("Integral"));
     if (appsettings->value(this, GC_WBALFORM, "diff").toString() == "diff") wbalForm->setCurrentIndex(0);
     else wbalForm->setCurrentIndex(1);
 
-    configLayout->addWidget(wbalFormLabel, 7,0, Qt::AlignRight);
-    configLayout->addWidget(wbalForm, 7,1, Qt::AlignLeft);
-
-
     //
     // Warn to save on exit
     warnOnExit = new QCheckBox(tr("Warn for unsaved activities on exit"), this);
     warnOnExit->setChecked(appsettings->value(NULL, GC_WARNEXIT, true).toBool());
-    configLayout->addWidget(warnOnExit, 8,1, Qt::AlignLeft);
 
     //
     // Open last Athlete
     openLastAthlete = new QCheckBox(tr("Start with last opened Athlete"), this);
     openLastAthlete->setChecked(appsettings->value(NULL, GC_OPENLASTATHLETE, true).toBool());
-    configLayout->addWidget(openLastAthlete, 9,1, Qt::AlignLeft);
 
     //
     // Run API web services when running
     //
-    int offset=1;
 #ifdef GC_WANT_HTTP
-    startHttp = new QCheckBox(tr("Enable API Web Services"), this);
+    startHttp = new QCheckBox(tr("Enable API Web Services"));
     startHttp->setChecked(appsettings->value(NULL, GC_START_HTTP, false).toBool());
-    configLayout->addWidget(startHttp, 9+offset,1, Qt::AlignLeft);
-    offset += 1;
 #endif
 #ifdef GC_WANT_R
-    embedR = new QCheckBox(tr("Enable R"), this);
-    embedR->setChecked(appsettings->value(NULL, GC_EMBED_R, true).toBool());
-    configLayout->addWidget(embedR, 9+offset,1, Qt::AlignLeft);
-    offset += 1;
-    connect(embedR, SIGNAL(stateChanged(int)), this, SLOT(embedRchanged(int)));
-#endif
-
-#ifdef GC_WANT_PYTHON
-    embedPython = new QCheckBox(tr("Enable Python"), this);
-    embedPython->setChecked(appsettings->value(NULL, GC_EMBED_PYTHON, true).toBool());
-    configLayout->addWidget(embedPython, 9+offset,1, Qt::AlignLeft);
-    connect(embedPython, SIGNAL(stateChanged(int)), this, SLOT(embedPythonchanged(int)));
-    offset += 1;
-#endif
-
-    opendata = new QCheckBox(tr("Share to the OpenData project"), this);
-    QString grant = appsettings->cvalue(context->athlete->cyclist, GC_OPENDATA_GRANTED, "X").toString();
-    opendata->setChecked(grant == "Y");
-    configLayout->addWidget(opendata, 9+offset,1, Qt::AlignLeft);
-    if (grant == "X") opendata->hide();
-    offset += 1;
-
-    //
-    // Athlete directory (home of athletes)
-    //
-    QVariant athleteDir = appsettings->value(this, GC_HOMEDIR);
-    athleteLabel = new QLabel(tr("Athlete Library"));
-    athleteDirectory = new QLineEdit;
-    athleteDirectory->setText(athleteDir.toString() == "0" ? "" : athleteDir.toString());
-    athleteWAS = athleteDirectory->text(); // remember what we started with ...
-    athleteBrowseButton = new QPushButton(tr("Browse"));
-    //XXathleteBrowseButton->setFixedWidth(120);
-
-    configLayout->addWidget(athleteLabel, 9 + offset,0, Qt::AlignRight);
-    configLayout->addWidget(athleteDirectory, 9 + offset,1);
-    configLayout->addWidget(athleteBrowseButton, 9 + offset,2);
-
-    connect(athleteBrowseButton, SIGNAL(clicked()), this, SLOT(browseAthleteDir()));
-
-#ifdef GC_WANT_R
+    embedR = new QCheckBox(tr("Enable R"));
     //
     // R Home directory
     //
     QVariant rDir = appsettings->value(this, GC_R_HOME, "");
     // fix old bug..
     if (rDir == "0") rDir = "";
-    rLabel = new QLabel(tr("R Installation Directory"));
     rDirectory = new QLineEdit;
     rDirectory->setText(rDir.toString());
-    rBrowseButton = new QPushButton(tr("Browse"));
+    QPushButton *rBrowseButton = new QPushButton(tr("Browse"));
+    rDirectorySel = new QWidget();
+    QHBoxLayout *rDirectoryLayout = new QHBoxLayout(rDirectorySel);
+    rDirectoryLayout->setContentsMargins(0, 0, 0, 0);
+    rDirectoryLayout->addWidget(rDirectory);
+    rDirectoryLayout->addWidget(rBrowseButton);
     //XXrBrowseButton->setFixedWidth(120);
 
-    configLayout->addWidget(rLabel, 10 + offset,0, Qt::AlignRight);
-    configLayout->addWidget(rDirectory, 10 + offset,1);
-    configLayout->addWidget(rBrowseButton, 10 + offset,2);
-    offset++;
-
     connect(rBrowseButton, SIGNAL(clicked()), this, SLOT(browseRDir()));
+    connect(embedR, &QCheckBox::stateChanged, [=](int state) { rDirectorySel->setEnabled(state); });
+
+    embedR->setChecked(! appsettings->value(NULL, GC_EMBED_R, true).toBool());
+    embedR->setChecked(appsettings->value(NULL, GC_EMBED_R, true).toBool());
 #endif
+
 #ifdef GC_WANT_PYTHON
+    embedPython = new QCheckBox(tr("Enable Python"));
     //
     // Python Home directory
     //
     QVariant pythonDir = appsettings->value(this, GC_PYTHON_HOME, "");
     // fix old bug..
-    pythonLabel = new QLabel(tr("Python Home"));
     pythonDirectory = new QLineEdit;
     pythonDirectory->setText(pythonDir.toString());
-    pythonBrowseButton = new QPushButton(tr("Browse"));
-
-    configLayout->addWidget(pythonLabel, 10 + offset,0, Qt::AlignRight);
-    configLayout->addWidget(pythonDirectory, 10 + offset,1);
-    configLayout->addWidget(pythonBrowseButton, 10 + offset,2);
-    offset++;
-
-    bool embedPython = appsettings->value(NULL, GC_EMBED_PYTHON, true).toBool();
-    embedPythonchanged(embedPython);
+    QPushButton *pythonBrowseButton = new QPushButton(tr("Browse"));
+    pythonDirectorySel = new QWidget();
+    QHBoxLayout *pythonDirectoryLayout = new QHBoxLayout(pythonDirectorySel);
+    pythonDirectoryLayout->setContentsMargins(0, 0, 0, 0);
+    pythonDirectoryLayout->addWidget(pythonDirectory);
+    pythonDirectoryLayout->addWidget(pythonBrowseButton);
 
     connect(pythonBrowseButton, SIGNAL(clicked()), this, SLOT(browsePythonDir()));
+    connect(embedPython, &QCheckBox::stateChanged, [=](int state) { pythonDirectorySel->setEnabled(state); });
+
+    embedPython->setChecked(! appsettings->value(NULL, GC_EMBED_PYTHON, true).toBool());
+    embedPython->setChecked(appsettings->value(NULL, GC_EMBED_PYTHON, true).toBool());
 #endif
+
+    opendata = new QCheckBox(tr("Share to the OpenData project"), this);
+    QString grant = appsettings->cvalue(context->athlete->cyclist, GC_OPENDATA_GRANTED, "X").toString();
+    opendata->setChecked(grant == "Y");
+    if (grant == "X") opendata->hide();
+
+    //
+    // Athlete directory (home of athletes)
+    //
+    QVariant athleteDir = appsettings->value(this, GC_HOMEDIR);
+    athleteDirectory = new QLineEdit;
+    athleteDirectory->setPlaceholderText(tr("Deviate from default location"));
+    athleteDirectory->setText(athleteDir.toString() == "0" ? "" : athleteDir.toString());
+    athleteWAS = athleteDirectory->text(); // remember what we started with ...
+    QPushButton *athleteBrowseButton = new QPushButton(tr("Browse"));
+    QHBoxLayout *athleteDirectoryLayout = new QHBoxLayout();
+    athleteDirectoryLayout->addWidget(athleteDirectory);
+    athleteDirectoryLayout->addWidget(athleteBrowseButton);
+    //XXathleteBrowseButton->setFixedWidth(120);
+
+    connect(athleteBrowseButton, SIGNAL(clicked()), this, SLOT(browseAthleteDir()));
+
+    QFormLayout *form = newQFormLayout();
+    form->addRow(new QLabel(HLO + tr("Localization") + HLC));
+    form->addRow(tr("Language"), langCombo);
+    form->addRow(tr("Unit"), unitCombo);
+    form->addRow("", metricRunPace);
+    form->addRow("", metricSwimPace);
+    form->addItem(new QSpacerItem(0, 15 * dpiYFactor));
+    form->addRow(new QLabel(HLO + tr("Application Behaviour") + HLC));
+    form->addRow(tr("Athlete Library"), athleteDirectoryLayout);
+    form->addRow("", warnOnExit);
+    form->addRow("", openLastAthlete);
+    form->addRow("", opendata);
+
+    form->addItem(new QSpacerItem(0, 15 * dpiYFactor));
+    form->addRow(new QLabel(HLO + tr("Recording and Calculation") + HLC));
+    form->addRow("", garminSmartRecord);
+    form->addRow(tr("Smart Recording Threshold"), garminHWMarkedit);
+    form->addRow(tr("Elevation hysteresis"), hystedit);
+    form->addRow(tr("W' bal formula"), wbalForm);
+#if defined(GC_WANT_HTTP) || defined(GC_WANT_PYTHON) || defined(GC_WANT_R)
+    form->addItem(new QSpacerItem(0, 15 * dpiYFactor));
+    form->addRow(new QLabel(HLO + tr("Integration") + HLC));
+#endif
+#ifdef GC_WANT_HTTP
+    form->addRow("", startHttp);
+#endif
+#ifdef GC_WANT_PYTHON
+    form->addRow("", embedPython);
+    form->addRow(tr("Python Home"), pythonDirectorySel);
+#endif
+#ifdef GC_WANT_R
+    form->addRow("", embedR);
+    form->addRow(tr("R Installation Directory"), rDirectorySel);
+#endif
+
+    QScrollArea *scrollArea = new QScrollArea();
+    scrollArea->setWidget(centerLayoutInWidget(form, false));
+    scrollArea->setWidgetResizable(true);
+
+    QVBoxLayout *all = new QVBoxLayout(this);
+    all->addWidget(scrollArea);
 
     // save away initial values
     b4.unit = unitCombo->currentIndex();
@@ -292,25 +295,6 @@ GeneralPage::GeneralPage(Context *context) : context(context)
 #endif
 }
 
-#ifdef GC_WANT_R
-void
-GeneralPage::embedRchanged(int state)
-{
-    rBrowseButton->setVisible(state);
-    rDirectory->setVisible(state);
-    rLabel->setVisible(state);
-}
-#endif
-#ifdef GC_WANT_PYTHON
-void
-GeneralPage::embedPythonchanged(int state)
-{
-    pythonBrowseButton->setVisible(state);
-    pythonDirectory->setVisible(state);
-    pythonLabel->setVisible(state);
-}
-#endif
-
 qint32
 GeneralPage::saveClicked()
 {
@@ -321,7 +305,7 @@ GeneralPage::saveClicked()
     appsettings->setValue(GC_LANG, langs[langCombo->currentIndex()]);
 
     // Garmin and cranks
-    appsettings->setValue(GC_GARMIN_HWMARK, garminHWMarkedit->text().toInt());
+    appsettings->setValue(GC_GARMIN_HWMARK, garminHWMarkedit->value());
     appsettings->setValue(GC_GARMIN_SMARTRECORD, garminSmartRecord->checkState());
 
     // save on exit
@@ -344,7 +328,7 @@ GeneralPage::saveClicked()
     if (!opendata->isHidden()) appsettings->setCValue(context->athlete->cyclist, GC_OPENDATA_GRANTED, opendata->isChecked() ? "Y" : "N");
 
     // Elevation
-    appsettings->setValue(GC_ELEVATION_HYSTERESIS, hystedit->text());
+    appsettings->setValue(GC_ELEVATION_HYSTERESIS, hystedit->value());
 
     // wbal formula
     appsettings->setValue(GC_WBALFORM, wbalForm->currentIndex() ? "int" : "diff");
@@ -447,30 +431,15 @@ DevicePage::DevicePage(QWidget *parent, Context *context) : QWidget(parent), con
     HelpWhatsThis *help = new HelpWhatsThis(this);
     this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::Preferences_Training_TrainDevices));
 
-    QVBoxLayout *mainLayout = new QVBoxLayout(this);
-
     DeviceTypes all;
     devices = all.getList();
 
-    addButton = new QPushButton(tr("+"),this);
-    delButton = new QPushButton(tr("-"),this);
-
     deviceList = new QTableView(this);
-#ifdef Q_OS_MAC
-    addButton->setText(tr("Add"));
-    delButton->setText(tr("Delete"));
-    deviceList->setAttribute(Qt::WA_MacShowFocusRect, 0);
-#else
-    addButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    delButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-#endif
     deviceListModel = new deviceModel(this);
-
     // replace standard model with ours
     QItemSelectionModel *stdmodel = deviceList->selectionModel();
     deviceList->setModel(deviceListModel);
     delete stdmodel;
-
     deviceList->setSortingEnabled(false);
     deviceList->setSelectionBehavior(QAbstractItemView::SelectRows);
     deviceList->horizontalHeader()->setStretchLastSection(true);
@@ -478,16 +447,14 @@ DevicePage::DevicePage(QWidget *parent, Context *context) : QWidget(parent), con
     deviceList->setEditTriggers(QAbstractItemView::NoEditTriggers);
     deviceList->setSelectionMode(QAbstractItemView::SingleSelection);
 
-    mainLayout->addWidget(deviceList);
-    QHBoxLayout *bottom = new QHBoxLayout;
-    bottom->setSpacing(2 *dpiXFactor);
-    bottom->addStretch();
-    bottom->addWidget(addButton);
-    bottom->addWidget(delButton);
-    mainLayout->addLayout(bottom);
+    ActionButtonBox *actionButtons = new ActionButtonBox(ActionButtonBox::AddDeleteGroup);
 
-    connect(addButton, SIGNAL(clicked()), this, SLOT(devaddClicked()));
-    connect(delButton, SIGNAL(clicked()), this, SLOT(devdelClicked()));
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    mainLayout->addWidget(deviceList);
+    mainLayout->addWidget(actionButtons);
+
+    connect(actionButtons, &ActionButtonBox::addRequested, this, &DevicePage::devaddClicked);
+    connect(actionButtons, &ActionButtonBox::deleteRequested, this, &DevicePage::devdelClicked);
     connect(context, SIGNAL(configChanged(qint32)), deviceListModel, SLOT(doReset()));
 }
 
@@ -680,9 +647,7 @@ bool deviceModel::setData(const QModelIndex &index, const QVariant &value, int r
 {
         if (index.isValid() && role == Qt::EditRole) {
             int row = index.row();
-
             DeviceConfiguration p = Configuration.value(row);
-
             switch (index.column()) {
                 case 0 : //name
                     p.name = value.toString();
@@ -701,7 +666,7 @@ bool deviceModel::setData(const QModelIndex &index, const QVariant &value, int r
                     break;
             }
             Configuration.replace(row,p);
-                emit(dataChanged(index, index));
+            emit(dataChanged(index, index));
 
             return true;
         }
@@ -723,11 +688,8 @@ TrainOptionsPage::TrainOptionsPage(QWidget *parent, Context *context) : QWidget(
     QVariant workoutDir = appsettings->value(this, GC_WORKOUTDIR, "");
     // fix old bug..
     if (workoutDir == "0") workoutDir = "";
-    workoutLabel = new QLabel(tr("Workout and VideoSync Library"));
-    workoutDirectory = new QLineEdit;
-    workoutDirectory->setText(workoutDir.toString());
-    workoutBrowseButton = new QPushButton(tr("Browse"));
-    connect(workoutBrowseButton, SIGNAL(clicked()), this, SLOT(browseWorkoutDir()));
+    workoutDirectory = new DirectoryPathWidget();
+    workoutDirectory->setPath(workoutDir.toString());
 
     useSimulatedSpeed = new QCheckBox(tr("Simulate Speed From Power"), this);
     useSimulatedSpeed->setChecked(appsettings->value(this, TRAIN_USESIMULATEDSPEED, true).toBool());
@@ -759,13 +721,11 @@ TrainOptionsPage::TrainOptionsPage(QWidget *parent, Context *context) : QWidget(
     tooltips = new QCheckBox(tr("Enable Tooltips"), this);
     tooltips->setChecked(appsettings->value(this, TRAIN_TOOLTIPS, true).toBool());
 
-    telemetryScalingLabel = new QLabel(tr("Telemetry font scaling"));
     telemetryScaling = new QComboBox();
     telemetryScaling->addItem(tr("Fit to height only"), 0);
     telemetryScaling->addItem(tr("Fit to height and width"), 1);
     telemetryScaling->setCurrentIndex(appsettings->value(this, TRAIN_TELEMETRY_FONT_SCALING, 0).toInt());
 
-    delayLabel = new QLabel(tr("Start Countdown"));
     startDelay = new QSpinBox(this);
     startDelay->setMaximum(600);
     startDelay->setMinimum(0);
@@ -773,23 +733,20 @@ TrainOptionsPage::TrainOptionsPage(QWidget *parent, Context *context) : QWidget(
     startDelay->setValue(appsettings->value(this, TRAIN_STARTDELAY, 0).toUInt());
     startDelay->setToolTip(tr("Countdown for workout start"));
 
-    QFormLayout *all = newQFormLayout(this);
+    QFormLayout *form = newQFormLayout();
+    form->addRow(tr("Workout and VideoSync Library"), workoutDirectory);
+    form->addRow("", useSimulatedSpeed);
+    form->addRow("", useSimulatedHypoxia);
+    form->addRow("", multiCheck);
+    form->addRow("", autoConnect);
+    form->addRow("", autoHide);
+    form->addRow("", lapAlert);
+    form->addRow("", coalesce);
+    form->addRow("", tooltips);
+    form->addRow(tr("Start Countdown"), startDelay);
+    form->addRow(tr("Telemetry font scaling"), telemetryScaling);
 
-    QGridLayout *wdLayout = new QGridLayout;
-    wdLayout->addWidget(workoutDirectory, 0,1);
-    wdLayout->addWidget(workoutBrowseButton, 0,2);
-
-    all->addRow(workoutLabel, wdLayout);
-    all->addRow("", useSimulatedSpeed);
-    all->addRow("", useSimulatedHypoxia);
-    all->addRow("", multiCheck);
-    all->addRow("", autoConnect);
-    all->addRow("", autoHide);
-    all->addRow("", lapAlert);
-    all->addRow("", coalesce);
-    all->addRow("", tooltips);
-    all->addRow(delayLabel, startDelay);
-    all->addRow(telemetryScalingLabel, telemetryScaling);
+    setLayout(centerLayout(form));
 }
 
 
@@ -797,7 +754,7 @@ qint32
 TrainOptionsPage::saveClicked()
 {
     // Save the train view settings...
-    appsettings->setValue(GC_WORKOUTDIR, workoutDirectory->text());
+    appsettings->setValue(GC_WORKOUTDIR, workoutDirectory->getPath());
     appsettings->setValue(TRAIN_USESIMULATEDSPEED, useSimulatedSpeed->isChecked());
     appsettings->setValue(TRAIN_USESIMULATEDHYPOXIA, useSimulatedHypoxia->isChecked());
     appsettings->setValue(TRAIN_MULTI, multiCheck->isChecked());
@@ -812,16 +769,6 @@ TrainOptionsPage::saveClicked()
     return 0;
 }
 
-void
-TrainOptionsPage::browseWorkoutDir()
-{
-    QString currentDir = workoutDirectory->text();
-    if (!QDir(currentDir).exists()) currentDir = "";
-    QString dir = QFileDialog::getExistingDirectory(this, tr("Select Workout Library"),
-                            currentDir, QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks);
-    if (dir != "") workoutDirectory->setText(dir);  //only overwrite current dir, if a new was selected
-}
-
 
 //
 // Remote control page
@@ -832,95 +779,65 @@ RemotePage::RemotePage(QWidget *parent, Context *context) : QWidget(parent), con
     this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::Preferences_Training_RemoteControls));
 
     remote = new RemoteControl;
-
-    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    QList <RemoteCmd> nativeCmds = remote->getNativeCmds(); // Load the native command list
+    QList<RemoteCmd> antCmds = remote->getAntCmds(); // Load the ant command list
+    QList<CmdMap> cmdMaps = remote->getMappings(); // Load the remote control mappings
 
     fields = new QTreeWidget;
     fields->headerItem()->setText(0, tr("Action"));
     fields->headerItem()->setText(1, tr("ANT+ Command"));
-    fields->setColumnWidth(0,100 *dpiXFactor);
-    fields->setColumnWidth(1,200 *dpiXFactor);
     fields->setColumnCount(2);
-    fields->setSelectionMode(QAbstractItemView::SingleSelection);
-    fields->setIndentation(0);
+    basicTreeWidgetStyle(fields);
+    fields->setItemDelegateForColumn(0, &nativeCmdDelegate);
+    fields->setItemDelegateForColumn(1, &cmdDelegate);
 
-    fields->setCurrentItem(fields->invisibleRootItem()->child(0));
-
-    mainLayout->addWidget(fields, 0, Qt::Alignment());
-
-    // Load the native command list
-    QList <RemoteCmd> nativeCmds = remote->getNativeCmds();
-
-    // Load the ant command list
-    QList<RemoteCmd> antCmds = remote->getAntCmds();
-
-    // Load the remote control mappings
-    QList<CmdMap> cmdMaps = remote->getMappings();
+    QStringList cmds;
+    cmds << tr("<unset>");
+    for (const RemoteCmd &antCmd : antCmds) {
+        cmds << antCmd.getCmdStr();
+    }
+    cmdDelegate.addItems(cmds);
 
     // create a row for each native command
-    int index = 0;
-    foreach (RemoteCmd nativeCmd, nativeCmds) {
-
-        QComboBox *comboBox = new QComboBox(this);
-        comboBox->addItem(tr("<unset>"));
-
-        // populate the combo box with all possible ANT commands
-        foreach(RemoteCmd antCmd, antCmds) {
-            comboBox->addItem(antCmd.getCmdStr());
-        }
-
+    int selected = 0;
+    for (const RemoteCmd &nativeCmd : nativeCmds) {
+        selected = 0;
         // is this native command mapped to an ANT command?
-        foreach(CmdMap cmdMapping, cmdMaps) {
-            if (cmdMapping.getNativeCmdId() == nativeCmd.getCmdId()) {
-                if (cmdMapping.getAntCmdId() != 0xFFFF) {
-                    //qDebug() << "ANT remote mapping found:" << cmdMapping.getNativeCmdId() << cmdMapping.getAntCmdId();
-
-                    int i=0;
-                    foreach(RemoteCmd antCmd, antCmds) {
-                        i++; // increment first to skip <unset>
-                        if (cmdMapping.getAntCmdId() == antCmd.getCmdId()) {
-                            // set the default entry for the combo box
-                            comboBox->setCurrentIndex(i);
-                        }
+        for (const CmdMap &cmdMapping : cmdMaps) {
+            if (   cmdMapping.getNativeCmdId() == nativeCmd.getCmdId()
+                && cmdMapping.getAntCmdId() != 0xFFFF) {
+                int i = 0;
+                for (const RemoteCmd &antCmd : antCmds) {
+                    i++; // increment first to skip <unset>
+                    if (cmdMapping.getAntCmdId() == antCmd.getCmdId()) {
+                        selected = i;
                     }
                 }
             }
         }
 
-        QTreeWidgetItem *add = new QTreeWidgetItem;
-        fields->invisibleRootItem()->insertChild(index, add);
+        QTreeWidgetItem *add = new QTreeWidgetItem(fields);
         add->setFlags(add->flags() | Qt::ItemIsEditable);
-
-        add->setTextAlignment(0, Qt::AlignLeft | Qt::AlignVCenter);
-        add->setText(0, nativeCmd.getDisplayStr());
-
-        add->setTextAlignment(1, Qt::AlignHCenter | Qt::AlignVCenter);
-        fields->setItemWidget(add, 1, comboBox);
-        index++;
+        add->setData(0, Qt::DisplayRole, nativeCmd.getDisplayStr());
+        add->setData(1, Qt::DisplayRole, selected);
     }
+
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    mainLayout->addWidget(fields, 0, Qt::Alignment());
+
+    fields->setCurrentItem(fields->invisibleRootItem()->child(0));
 }
 
 qint32
 RemotePage::saveClicked()
 {
-    // Save the remote control code mappings...
+    QList<RemoteCmd> antCmds = remote->getAntCmds(); // Load the ant command list
+    QList<CmdMap> cmdMaps = remote->getMappings(); // Load the remote control mappings
 
-    //qDebug() << "RemotePage::saveClicked()";
-
-    // Load the ant command list
-    QList<RemoteCmd> antCmds = remote->getAntCmds();
-
-    // Load the remote control mappings
-    QList<CmdMap> cmdMaps = remote->getMappings();
-
-    for(int i=0; i < cmdMaps.size(); i++) {
-
-        QWidget *button = fields->itemWidget(fields->invisibleRootItem()->child(i),1);
-        int index = ((QComboBox*)button)->currentIndex();
-
-        if (index) {
-            cmdMaps[i].setAntCmdId(antCmds[index-1].getCmdId());
-
+    for (int i = 0; i < cmdMaps.size(); i++) {
+        int cmdIndex = fields->invisibleRootItem()->child(i)->data(1, Qt::DisplayRole).toInt();
+        if (cmdIndex) {
+            cmdMaps[i].setAntCmdId(antCmds[cmdIndex - 1].getCmdId());
         } else {
             cmdMaps[i].setAntCmdId(0xFFFF); // no command
         }
@@ -935,35 +852,35 @@ const SimBicyclePartEntry& SimBicyclePage::GetSimBicyclePartEntry(int e)
     // Bike mass values approximate a good current bike. Wheels are shimano c40 with conti tubeless tires.
 
     static const SimBicyclePartEntry arr[] = {
-          // SpinBox Title                              Path to athlete value                Default Value      Decimal      Tooltip                                                                              enum
-        { tr("Bicycle Mass Without Wheels (g)"     )  , GC_SIM_BICYCLE_MASSWITHOUTWHEELSG,   4000,              0,           tr("Mass of everything that isn't wheels, tires, skewers...")},                       // BicycleWithoutWheelsG
-        { tr("Front Wheel Mass (g)"                )  , GC_SIM_BICYCLE_FRONTWHEELG,          739,               0,           tr("Mass of front wheel excluding tires and skewers...")},                            // FrontWheelG
-        { tr("Front Spoke Count"                   )  , GC_SIM_BICYCLE_FRONTSPOKECOUNT,      24,                0,           tr("")},                                                                              // FrontSpokeCount
-        { tr("Front Spoke & Nipple Mass - Each (g)")  , GC_SIM_BICYCLE_FRONTSPOKENIPPLEG,    5.6,               1,           tr("Mass of a single spoke and nipple, washers, etc.")},                              // FrontSpokeNippleG
-        { tr("Front Rim Mass (g)"                  )  , GC_SIM_BICYCLE_FRONTRIMG,            330,               0,           tr("")},                                                                              // FrontRimG
-        { tr("Front Rotor Mass (g)"                )  , GC_SIM_BICYCLE_FRONTROTORG,          120,               0,           tr("Mass of rotor including bolts")},                                                 // FrontRotorG
-        { tr("Front Skewer Mass (g)"               )  , GC_SIM_BICYCLE_FRONTSKEWERG,         40,                0,           tr("")},                                                                              // FrontSkewerG
-        { tr("Front Tire Mass (g)"                 )  , GC_SIM_BICYCLE_FRONTTIREG,           220,               0,           tr("")},                                                                              // FrontTireG
-        { tr("Front Tube or Sealant Mass (g)"      )  , GC_SIM_BICYCLE_FRONTTUBESEALANTG,    26,                0,           tr("Mass of anything inside the tire: sealant, tube...")},                            // FrontTubeSealantG
-        { tr("Front Rim Outer Radius (m)"          )  , GC_SIM_BICYCLE_FRONTOUTERRADIUSM,    .35,               3,           tr("Functional outer radius of wheel, used for computing wheel circumference")},      // FrontOuterRadiusM
-        { tr("Front Rim Inner Radius (m)"          )  , GC_SIM_BICYCLE_FRONTRIMINNERRADIUSM, .3,                3,           tr("Inner radius of rim, for computing wheel inertia")},                              // FrontRimInnerRadiusM
-        { tr("Rear Wheel Mass (g)"                 )  , GC_SIM_BICYCLE_REARWHEELG,           739,               0,           tr("Mass of rear wheel excluding tires and skewers...")},                             // RearWheelG
-        { tr("Rear Spoke Count"                    )  , GC_SIM_BICYCLE_REARSPOKECOUNT,       24,                0,           tr("")},                                                                              // RearSpokeCount
-        { tr("Rear Spoke & Nipple Mass - Each (g)" )  , GC_SIM_BICYCLE_REARSPOKENIPPLEG,     5.6,               1,           tr("Mass of a single spoke and nipple, washers, etc.")},                              // RearSpokeNippleG
-        { tr("Rear Rim Mass (g)"                   )  , GC_SIM_BICYCLE_REARRIMG,             330,               0,           tr("")},                                                                              // RearRimG
-        { tr("Rear Rotor Mass (g)"                 )  , GC_SIM_BICYCLE_REARROTORG,           120,               0,           tr("Mass of rotor including bolts")},                                                 // RearRotorG
-        { tr("Rear Skewer Mass (g)"                )  , GC_SIM_BICYCLE_REARSKEWERG,           40,               0,           tr("Mass of skewer/axle/funbolts, etc...")},                                          // RearSkewerG
-        { tr("Rear Tire Mass (g)"                  )  , GC_SIM_BICYCLE_REARTIREG,            220,               0,           tr("Mass of tire not including tube or sealant")},                                    // RearTireG
-        { tr("Rear Tube or Sealant Mass (g)"       )  , GC_SIM_BICYCLE_REARTUBESEALANTG,      26,               0,           tr("Mass of anything inside the tire: sealant, tube...")},                            // RearTubeSealantG
-        { tr("Rear Rim Outer Radius (m)"           )  , GC_SIM_BICYCLE_REAROUTERRADIUSM,     .35,               3,           tr("Functional outer radius of wheel, used for computing wheel circumference")},      // RearOuterRadiusM
-        { tr("Rear Rim Inner Radius (m)"           )  , GC_SIM_BICYCLE_REARRIMINNERRADIUSM,  .3,                3,           tr("Inner radius of rim, for computing wheel inertia")},                              // RearRimInnerRadiusM
-        { tr("Rear Cassette Mass(g)"               )  , GC_SIM_BICYCLE_CASSETTEG,            190,               0,           tr("Mass of rear cassette, including lockring")},                                     // CassetteG
-        { tr("Coefficient of rolling resistance"   )  , GC_SIM_BICYCLE_CRR,                  0.004,             4,           tr("Total coefficient of rolling resistance for bicycle")},                           // CRR
-        { tr("Coefficient of power train loss"     )  , GC_SIM_BICYCLE_Cm,                   1.0,               3,           tr("Power train loss between reported watts and wheel. For direct drive trainer like kickr there is no relevant loss and value shold be 1.0.")},      // Cm
-        { tr("Coefficient of drag"                 )  , GC_SIM_BICYCLE_Cd,        (1.0 - 0.0045),               5,           tr("Coefficient of drag of rider and bicycle")},                                      // Cd
-        { tr("Frontal Area (m^2)"                  )  , GC_SIM_BICYCLE_Am2,                  0.5,               2,           tr("Effective frontal area of rider and bicycle")},                                   // Am2
-        { tr("Temperature (K)"                     )  , GC_SIM_BICYCLE_Tk,                 293.15,              2,           tr("Temperature in kelvin, used with altitude to compute air density")},              // Tk
-        { tr("ActualTrainerAltitude (m)"           )  , GC_SIM_BICYCLE_ACTUALTRAINERALTITUDEM, 0.,              0,           tr("Actual altitude of indoor trainer, in meters")}                                   // ActualTrainerAltitudeM
+          // SpinBox Title                              Path to athlete value                Default Value      Decimal Unit     Tooltip                                                                              enum
+        { tr("Bicycle Mass Without Wheels"      )  , GC_SIM_BICYCLE_MASSWITHOUTWHEELSG,   4000,              0,      "g",     tr("Mass of everything that isn't wheels, tires, skewers...")},                       // BicycleWithoutWheelsG
+        { tr("Front Wheel Mass"                 )  , GC_SIM_BICYCLE_FRONTWHEELG,          739,               0,      "g",     tr("Mass of front wheel excluding tires and skewers...")},                            // FrontWheelG
+        { tr("Front Spoke Count"                )  , GC_SIM_BICYCLE_FRONTSPOKECOUNT,      24,                0,      "",      tr("")},                                                                              // FrontSpokeCount
+        { tr("Front Spoke & Nipple Mass - Each" )  , GC_SIM_BICYCLE_FRONTSPOKENIPPLEG,    5.6,               1,      "g",     tr("Mass of a single spoke and nipple, washers, etc.")},                              // FrontSpokeNippleG
+        { tr("Front Rim Mass"                   )  , GC_SIM_BICYCLE_FRONTRIMG,            330,               0,      "g",     tr("")},                                                                              // FrontRimG
+        { tr("Front Rotor Mass"                 )  , GC_SIM_BICYCLE_FRONTROTORG,          120,               0,      "g",     tr("Mass of rotor including bolts")},                                                 // FrontRotorG
+        { tr("Front Skewer Mass"                )  , GC_SIM_BICYCLE_FRONTSKEWERG,         40,                0,      "g",     tr("")},                                                                              // FrontSkewerG
+        { tr("Front Tire Mass"                  )  , GC_SIM_BICYCLE_FRONTTIREG,           220,               0,      "g",     tr("")},                                                                              // FrontTireG
+        { tr("Front Tube or Sealant Mass"       )  , GC_SIM_BICYCLE_FRONTTUBESEALANTG,    26,                0,      "g",     tr("Mass of anything inside the tire: sealant, tube...")},                            // FrontTubeSealantG
+        { tr("Front Rim Outer Radius"           )  , GC_SIM_BICYCLE_FRONTOUTERRADIUSM,    .35,               3,      "m",     tr("Functional outer radius of wheel, used for computing wheel circumference")},      // FrontOuterRadiusM
+        { tr("Front Rim Inner Radius"           )  , GC_SIM_BICYCLE_FRONTRIMINNERRADIUSM, .3,                3,      "m",     tr("Inner radius of rim, for computing wheel inertia")},                              // FrontRimInnerRadiusM
+        { tr("Rear Wheel Mass"                  )  , GC_SIM_BICYCLE_REARWHEELG,           739,               0,      "g",     tr("Mass of rear wheel excluding tires and skewers...")},                             // RearWheelG
+        { tr("Rear Spoke Count"                 )  , GC_SIM_BICYCLE_REARSPOKECOUNT,       24,                0,      "",      tr("")},                                                                              // RearSpokeCount
+        { tr("Rear Spoke & Nipple Mass - Each"  )  , GC_SIM_BICYCLE_REARSPOKENIPPLEG,     5.6,               1,      "g",     tr("Mass of a single spoke and nipple, washers, etc.")},                              // RearSpokeNippleG
+        { tr("Rear Rim Mass"                    )  , GC_SIM_BICYCLE_REARRIMG,             330,               0,      "g",     tr("")},                                                                              // RearRimG
+        { tr("Rear Rotor Mass"                  )  , GC_SIM_BICYCLE_REARROTORG,           120,               0,      "g",     tr("Mass of rotor including bolts")},                                                 // RearRotorG
+        { tr("Rear Skewer Mass"                 )  , GC_SIM_BICYCLE_REARSKEWERG,           40,               0,      "g",     tr("Mass of skewer/axle/funbolts, etc...")},                                          // RearSkewerG
+        { tr("Rear Tire Mass"                   )  , GC_SIM_BICYCLE_REARTIREG,            220,               0,      "g",     tr("Mass of tire not including tube or sealant")},                                    // RearTireG
+        { tr("Rear Tube or Sealant Mass"        )  , GC_SIM_BICYCLE_REARTUBESEALANTG,      26,               0,      "g",     tr("Mass of anything inside the tire: sealant, tube...")},                            // RearTubeSealantG
+        { tr("Rear Rim Outer Radius"            )  , GC_SIM_BICYCLE_REAROUTERRADIUSM,     .35,               3,      "m",     tr("Functional outer radius of wheel, used for computing wheel circumference")},      // RearOuterRadiusM
+        { tr("Rear Rim Inner Radius"            )  , GC_SIM_BICYCLE_REARRIMINNERRADIUSM,  .3,                3,      "m",     tr("Inner radius of rim, for computing wheel inertia")},                              // RearRimInnerRadiusM
+        { tr("Rear Cassette Mass"               )  , GC_SIM_BICYCLE_CASSETTEG,            190,               0,      "g",     tr("Mass of rear cassette, including lockring")},                                     // CassetteG
+        { tr("Coefficient of rolling resistance")  , GC_SIM_BICYCLE_CRR,                  0.004,             4,      "",      tr("Total coefficient of rolling resistance for bicycle")},                           // CRR
+        { tr("Coefficient of power train loss"  )  , GC_SIM_BICYCLE_Cm,                   1.0,               3,      "",      tr("Power train loss between reported watts and wheel. For direct drive trainer like kickr there is no relevant loss and value shold be 1.0.")},      // Cm
+        { tr("Coefficient of drag"              )  , GC_SIM_BICYCLE_Cd,        (1.0 - 0.0045),               5,      "",      tr("Coefficient of drag of rider and bicycle")},                                      // Cd
+        { tr("Frontal Area"                     )  , GC_SIM_BICYCLE_Am2,                  0.5,               2,      "m^2",   tr("Effective frontal area of rider and bicycle")},                                   // Am2
+        { tr("Temperature"                      )  , GC_SIM_BICYCLE_Tk,                 293.15,              2,      "K",     tr("Temperature in kelvin, used with altitude to compute air density")},              // Tk
+        { tr("ActualTrainerAltitude"            )  , GC_SIM_BICYCLE_ACTUALTRAINERALTITUDEM, 0.,              0,      "m",     tr("Actual altitude of indoor trainer, in meters")}                                   // ActualTrainerAltitudeM
     };
 
     if (e < 0 || e >= LastPart) e = 0;
@@ -989,7 +906,7 @@ SimBicyclePage::AddSpecBox(int ePart)
 {
     const SimBicyclePartEntry & entry = GetSimBicyclePartEntry(ePart);
 
-    m_LabelArr[ePart] = new QLabel(entry.m_label);
+    m_LabelTextArr[ePart] = entry.m_label;
 
     QDoubleSpinBox * pSpinBox = new QDoubleSpinBox(this);
 
@@ -998,6 +915,9 @@ SimBicyclePage::AddSpecBox(int ePart)
     pSpinBox->setDecimals(entry.m_decimalPlaces);
     pSpinBox->setValue(GetBicyclePartValue(context, ePart));
     pSpinBox->setToolTip(entry.m_tooltip);
+    if (! entry.m_unit.isEmpty()) {
+        pSpinBox->setSuffix(" " + entry.m_unit);
+    }
     double singlestep = 1.;
     for (int i = 0; i < entry.m_decimalPlaces; i++)
         singlestep /= 10.;
@@ -1057,16 +977,24 @@ SimBicyclePage::SetStatsLabelArray(double )
 
     Bicycle bicycle(NULL, constants, riderMassKG, bicycleMassWithoutWheelsG / 1000., frontWheel, rearWheel);
 
-    m_StatsLabelArr[StatsLabel]              ->setText(QString(tr("------ Derived Statistics -------")));
-    m_StatsLabelArr[StatsTotalKEMass]        ->setText(QString(tr("Total KEMass:         \t%1g")).arg(bicycle.KEMass()));
-    m_StatsLabelArr[StatsFrontWheelKEMass]   ->setText(QString(tr("FrontWheel KEMass:    \t%1g")).arg(bicycle.FrontWheel().KEMass() * 1000));
-    m_StatsLabelArr[StatsFrontWheelMass]     ->setText(QString(tr("FrontWheel Mass:      \t%1g")).arg(bicycle.FrontWheel().MassKG() * 1000));
-    m_StatsLabelArr[StatsFrontWheelEquivMass]->setText(QString(tr("FrontWheel EquivMass: \t%1g")).arg(bicycle.FrontWheel().EquivalentMassKG() * 1000));
-    m_StatsLabelArr[StatsFrontWheelI]        ->setText(QString(tr("FrontWheel I:         \t%1")).arg(bicycle.FrontWheel().I()));
-    m_StatsLabelArr[StatsRearWheelKEMass]    ->setText(QString(tr("Rear Wheel KEMass:    \t%1g")).arg(bicycle.RearWheel().KEMass() * 1000));
-    m_StatsLabelArr[StatsRearWheelMass]      ->setText(QString(tr("Rear Wheel Mass:      \t%1g")).arg(bicycle.RearWheel().MassKG() * 1000));
-    m_StatsLabelArr[StatsRearWheelEquivMass] ->setText(QString(tr("Rear Wheel EquivMass: \t%1g")).arg(bicycle.RearWheel().EquivalentMassKG() * 1000));
-    m_StatsLabelArr[StatsRearWheelI]         ->setText(QString(tr("Rear Wheel I:         \t%1")).arg(bicycle.RearWheel().I()));
+    m_StatsTextArr[StatsTotalKEMass]         = tr("Total KEMass");
+    m_StatsLabelArr[StatsTotalKEMass]        ->setText(tr("%1 g").arg(bicycle.KEMass()));
+    m_StatsTextArr[StatsFrontWheelKEMass]    = tr("FrontWheel KEMass");
+    m_StatsLabelArr[StatsFrontWheelKEMass]   ->setText(tr("%1 g").arg(bicycle.FrontWheel().KEMass() * 1000));
+    m_StatsTextArr[StatsFrontWheelMass]      = tr("FrontWheel Mass");
+    m_StatsLabelArr[StatsFrontWheelMass]     ->setText(tr("%1 g").arg(bicycle.FrontWheel().MassKG() * 1000));
+    m_StatsTextArr[StatsFrontWheelEquivMass] = tr("FrontWheel EquivMass");
+    m_StatsLabelArr[StatsFrontWheelEquivMass]->setText(tr("%1 g").arg(bicycle.FrontWheel().EquivalentMassKG() * 1000));
+    m_StatsTextArr[StatsFrontWheelI]         = tr("FrontWheel I");
+    m_StatsLabelArr[StatsFrontWheelI]        ->setText(tr("%1").arg(bicycle.FrontWheel().I()));
+    m_StatsTextArr[StatsRearWheelKEMass]     = tr("Rear Wheel KEMass");
+    m_StatsLabelArr[StatsRearWheelKEMass]    ->setText(tr("%1 g").arg(bicycle.RearWheel().KEMass() * 1000));
+    m_StatsTextArr[StatsRearWheelMass]       = tr("Rear Wheel Mass");
+    m_StatsLabelArr[StatsRearWheelMass]      ->setText(tr("%1 g").arg(bicycle.RearWheel().MassKG() * 1000));
+    m_StatsTextArr[StatsRearWheelEquivMass]  = tr("Rear Wheel EquivMass");
+    m_StatsLabelArr[StatsRearWheelEquivMass] ->setText(tr("%1 g").arg(bicycle.RearWheel().EquivalentMassKG() * 1000));
+    m_StatsTextArr[StatsRearWheelI]          = tr("Rear Wheel I");
+    m_StatsLabelArr[StatsRearWheelI]         ->setText(tr("%1").arg(bicycle.RearWheel().I()));
 }
 
 SimBicyclePage::SimBicyclePage(QWidget *parent, Context *context) : QWidget(parent), context(context)
@@ -1074,108 +1002,66 @@ SimBicyclePage::SimBicyclePage(QWidget *parent, Context *context) : QWidget(pare
     HelpWhatsThis *help = new HelpWhatsThis(this);
     this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::Preferences_Training_VirtualBicycleSpecifications));
 
-    QVBoxLayout *all = new QVBoxLayout(this);
-    QGridLayout *grid = new QGridLayout;
-
-#ifdef Q_OS_MAX
-    setContentsMargins(10, 10, 10, 10);
-    grid->setSpacing(5 * dpiXFactor);
-    all->setSpacing(5 * dpiXFactor);
-#endif
-
-    // Populate m_LabelArr and m_SpinBoxArr
+    // Populate m_LabelTextArr and m_SpinBoxArr
     for (int e = 0; e < LastPart; e++) {
         AddSpecBox(e);
     }
 
-    Qt::Alignment alignment = Qt::AlignLeft;
-
     // Two sections. Bike mass properties are in two rows to the left.
     // Other properties like cd, ca and temp go in section to the right.
-
     int Section1Start = 0;
     int Section1End = BicycleParts::CRR;
     int Section2Start = Section1End;
     int Section2End = BicycleParts::LastPart;
 
-    // ------------------------------------------------------------------
-    // Column 0
-    int column = 0;
-    int row = 0;
-    grid->addWidget(new QLabel(tr("The values on this page inform the bicycle physics\n"
-                                  "models for simulating speed in trainer mode. These\n"
-                                  "values are used by smart trainers and also by the\n"
-                                  "speed simulation enabled by the 'Simulate Speed From\n"
-                                  "Power' option in the training preferences tab.")),
-                                  row, column,
-                                  4, // use 4 rows of grid
-                                  2, // span across 2 columns of grid (cols 0,2)
-                                  alignment);
+    QLabel *descLabel = new QLabel(tr("The values on this page inform the bicycle physics "
+                                      "models for simulating speed in trainer mode. These "
+                                      "values are used by smart trainers and also by the "
+                                      "speed simulation enabled by the <i>Simulate Speed From "
+                                      "Power</i> option in the <i>Training</i> &gt; "
+                                      "<i>Preferences</i> tab."));
+    descLabel->setWordWrap(true);
 
-    // Set first row +4 + 1 so there's a gap after title label.
-    int section2FirstRow = row + 5;
-
-    // Now add section 2 as a separate grid under above description text.
-    row = section2FirstRow;
+    QFormLayout *lForm = newQFormLayout();
+    lForm->addRow(new QLabel(HLO + tr("Resistance and Drag") + HLC));
     for (int i = Section2Start; i < Section2End; i++) {
-        grid->addWidget(m_LabelArr[i], row, column, alignment);
-        row++;
+        lForm->addRow(m_LabelTextArr[i], m_SpinBoxArr[i]);
     }
 
-    // There is still room below section 2... lets put in some useful stats
-    // about the virtual bicycle.
-
-    int statsFirstRow = row + 1;
-
-    // Create Stats Labels
-    for (int i = StatsLabel; i < StatsLastPart; i++) {
+    // Create and Populate Stats Labels
+    for (int i = StatsTotalKEMass; i < StatsLastPart; i++) {
         m_StatsLabelArr[i] = new QLabel();
     }
-
-    // Populate Stats Labels
     SetStatsLabelArray();
-
-    row = statsFirstRow;
-    for (int i = StatsLabel; i < StatsLastPart; i++) {
-        grid->addWidget(m_StatsLabelArr[i], row, column, 1, 2, alignment);
-        row++;
+    QFormLayout *rForm = newQFormLayout();
+    rForm->addRow(new QLabel(HLO + tr("Derived Statistics") + HLC));
+    for (int i = StatsTotalKEMass; i < StatsLastPart; i++) {
+        rForm->addRow(m_StatsTextArr[i], m_StatsLabelArr[i]);
     }
 
-
-    // ------------------------------------------------------------------
-    // Column 1 - physics spinboxes
-    column++;
-
-    row = section2FirstRow;
-    for (int i = Section2Start; i < Section2End; i++) {
-        grid->addWidget(m_SpinBoxArr[i], row, column, alignment);
-        row++;
-    }
-
-    // ------------------------------------------------------------------
-    // Column 2 - mass labels
-    column = 2;
-    row = 0;
+    lForm->addItem(new QSpacerItem(1, 15 * dpiYFactor));
+    lForm->addRow(new QLabel(HLO + tr("Bike & Wheels") + HLC));
     for (int i = Section1Start; i < Section1End; i++) {
-        grid->addWidget(m_LabelArr[i], row, column, alignment);
-        row++;
+        lForm->addRow(m_LabelTextArr[i], m_SpinBoxArr[i]);
     }
 
-    // ------------------------------------------------------------------
-    // Column 3 - mass spinboxes
-    column++;
-    row = 0;
-    for (int i = Section1Start; i < Section1End; i++) {
-        grid->addWidget(m_SpinBoxArr[i], row, column, alignment);
-        row++;
-    }
+    QScrollArea *scroller = new QScrollArea();
+    scroller->setWidget(centerLayoutInWidget(lForm));
+    scroller->setWidgetResizable(true);
 
-    all->addLayout(grid);
+    QHBoxLayout *dataLayout = new QHBoxLayout();
+    dataLayout->addWidget(scroller, 2);
+    dataLayout->addSpacing(10 * dpiXFactor);
+    dataLayout->addLayout(centerLayout(rForm), 1);
+
+    QVBoxLayout *all = new QVBoxLayout(this);
+    all->addWidget(descLabel);
+    all->addSpacing(10 * dpiYFactor);
+    all->addLayout(dataLayout);
 
     for (int i = 0; i < LastPart; i++) {
         connect(m_SpinBoxArr[i], SIGNAL(valueChanged(double)), this, SLOT(SetStatsLabelArray(double)));
     }
-
 }
 
 qint32
@@ -1200,27 +1086,15 @@ WorkoutTagManagerPage::WorkoutTagManagerPage
 (TagStore *tagStore, QWidget *parent)
 : QWidget(parent), tagStore(tagStore)
 {
-    UniqueLabelEditDelegate *labelEditDelegate = new UniqueLabelEditDelegate(0, this);
-    connect(labelEditDelegate, SIGNAL(closeEditor(QWidget*, QAbstractItemDelegate::EndEditHint)), this, SLOT(editorClosed(QWidget*, QAbstractItemDelegate::EndEditHint)));
-
-    QVBoxLayout *layout = new QVBoxLayout();
-    layout->setContentsMargins(0, 0, 0, 0);
     tw = new QTreeWidget();
     tw->setColumnCount(4);
-#if 1
     tw->hideColumn(2);
     tw->hideColumn(3);
-#endif
-    tw->setRootIsDecorated(false);
     tw->setSortingEnabled(true);
     tw->sortByColumn(0, Qt::AscendingOrder);
-    tw->setEditTriggers(  QAbstractItemView::DoubleClicked
-                        | QAbstractItemView::EditKeyPressed
-                        | QAbstractItemView::SelectedClicked);
-    tw->setColumnWidth(0, 240 * dpiXFactor);
-    tw->setItemDelegateForColumn(0, labelEditDelegate);
-    tw->setItemDelegateForColumn(1, new NoEditDelegate(this));
-    connect(tw, SIGNAL(currentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*)), this, SLOT(currentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*)));
+    basicTreeWidgetStyle(tw);
+    tw->setItemDelegateForColumn(0, &labelEditDelegate);
+    tw->setItemDelegateForColumn(1, &numDelegate);
 
     QStringList headers;
     headers << tr("Tag")
@@ -1239,32 +1113,21 @@ WorkoutTagManagerPage::WorkoutTagManagerPage
     }
     tw->insertTopLevelItems(0, items);
 
-    connect(tw->model(), SIGNAL(dataChanged(const QModelIndex&, const QModelIndex&, const QVector<int>&)), this, SLOT(dataChanged(const QModelIndex&, const QModelIndex&, const QVector<int>&)));
+    ActionButtonBox *actionButtons = new ActionButtonBox(ActionButtonBox::AddDeleteGroup);
+    actionButtons->defaultConnect(ActionButtonBox::AddDeleteGroup, tw);
 
-
+    QVBoxLayout *layout = new QVBoxLayout(this);
     layout->addWidget(tw);
+    layout->addWidget(actionButtons);
 
-    QHBoxLayout *buttonLayout = new QHBoxLayout();
-
-    QPushButton *addButton = new QPushButton(tr("+"),this);
-    QPushButton *delButton = new QPushButton(tr("-"),this);
-#ifdef Q_OS_MAC
-    addButton->setText(tr("Add"));
-    delButton->setText(tr("Delete"));
-#else
-    addButton->setFixedSize(20 * dpiXFactor, 20 * dpiYFactor);
-    delButton->setFixedSize(20 * dpiXFactor, 20 * dpiYFactor);
-#endif
-    connect(addButton, SIGNAL(released()), this, SLOT(addTag()));
-    connect(delButton, SIGNAL(released()), this, SLOT(deleteTag()));
-    buttonLayout->addStretch(100);
-    buttonLayout->addWidget(addButton);
-    buttonLayout->addWidget(delButton);
-    layout->addItem(buttonLayout);
-
-    setLayout(layout);
-
+    connect(actionButtons, &ActionButtonBox::addRequested, this, &WorkoutTagManagerPage::addTag);
+    connect(actionButtons, &ActionButtonBox::deleteRequested, this, &WorkoutTagManagerPage::deleteTag);
+    connect(&labelEditDelegate, SIGNAL(closeEditor(QWidget*, QAbstractItemDelegate::EndEditHint)), this, SLOT(editorClosed(QWidget*, QAbstractItemDelegate::EndEditHint)));
+    connect(tw, SIGNAL(currentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*)), this, SLOT(currentItemChanged(QTreeWidgetItem*, QTreeWidgetItem*)));
+    connect(tw->model(), SIGNAL(dataChanged(const QModelIndex&, const QModelIndex&, const QVector<int>&)), this, SLOT(dataChanged(const QModelIndex&, const QModelIndex&, const QVector<int>&)));
     connect(dynamic_cast<QObject*>(tagStore), SIGNAL(tagsChanged(int, int, int)), this, SLOT(tagStoreChanged(int, int, int)));
+
+    tw->setCurrentItem(tw->invisibleRootItem()->child(0));
 }
 
 
@@ -1412,6 +1275,7 @@ ColorsPage::ColorsPage(QWidget *parent) : QWidget(parent)
     themes->setUniformRowHeights(true); // causes height problems when adding - in case of non-text fields
     themes->setIndentation(0);
     //colors->header()->resizeSection(0,300);
+    themes->setAlternatingRowColors(true);
 
     QLabel *searchLabel = new QLabel(tr("Search"));
     searchEdit = new QLineEdit(this);
@@ -1424,13 +1288,8 @@ ColorsPage::ColorsPage(QWidget *parent) : QWidget(parent)
     colors->headerItem()->setText(1, tr("Color"));
     colors->headerItem()->setText(2, tr("Select"));
     colors->setColumnCount(3);
-    colors->setColumnWidth(0,70 *dpiXFactor);
-    colors->setColumnWidth(1,350 *dpiXFactor);
+    basicTreeWidgetStyle(colors, false);
     colors->setSelectionMode(QAbstractItemView::NoSelection);
-    //colors->setEditTriggers(QAbstractItemView::SelectedClicked); // allow edit
-    colors->setUniformRowHeights(true); // causes height problems when adding - in case of non-text fields
-    colors->setIndentation(0);
-    //colors->header()->resizeSection(0,300);
 
     antiAliased = new QCheckBox(tr("Antialias"));
     antiAliased->setChecked(appsettings->value(this, GC_ANTIALIAS, true).toBool());
@@ -1722,63 +1581,54 @@ FavouriteMetricsPage::FavouriteMetricsPage(QWidget *parent) :
 
     availList = new QListWidget;
     availList->setSortingEnabled(true);
+    availList->setAlternatingRowColors(true);
     availList->setSelectionMode(QAbstractItemView::SingleSelection);
+
     QVBoxLayout *availLayout = new QVBoxLayout;
-    availLayout->addWidget(new QLabel(tr("Available Metrics")));
+    availLayout->addWidget(new QLabel(HLO + tr("Available Metrics") + HLC));
     availLayout->addWidget(availList);
+
     selectedList = new QListWidget;
+    selectedList->setAlternatingRowColors(true);
     selectedList->setSelectionMode(QAbstractItemView::SingleSelection);
+
+    ActionButtonBox *actionButtons = new ActionButtonBox(ActionButtonBox::UpDownGroup);
+    actionButtons->defaultConnect(ActionButtonBox::UpDownGroup, selectedList);
+
     QVBoxLayout *selectedLayout = new QVBoxLayout;
-    selectedLayout->addWidget(new QLabel(tr("Favourites")));
+    selectedLayout->addWidget(new QLabel(HLO + tr("Favourites") + HLC));
     selectedLayout->addWidget(selectedList);
+    selectedLayout->addWidget(actionButtons);
+
 #ifndef Q_OS_MAC
-    upButton = new QToolButton(this);
-    downButton = new QToolButton(this);
     leftButton = new QToolButton(this);
-    rightButton = new QToolButton(this);
-    upButton->setArrowType(Qt::UpArrow);
-    downButton->setArrowType(Qt::DownArrow);
     leftButton->setArrowType(Qt::LeftArrow);
-    rightButton->setArrowType(Qt::RightArrow);
-    upButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    downButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
     leftButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
+    rightButton = new QToolButton(this);
+    rightButton->setArrowType(Qt::RightArrow);
     rightButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
 #else
-    upButton = new QPushButton(tr("Up"));
-    downButton = new QPushButton(tr("Down"));
     leftButton = new QPushButton("<");
     rightButton = new QPushButton(">");
 #endif
-    QVBoxLayout *buttonGrid = new QVBoxLayout;
-    QHBoxLayout *upLayout = new QHBoxLayout;
+    leftButton->setEnabled(false);
+    rightButton->setEnabled(false);
+
     QHBoxLayout *inexcLayout = new QHBoxLayout;
-    QHBoxLayout *downLayout = new QHBoxLayout;
-
-    upLayout->addStretch();
-    upLayout->addWidget(upButton);
-    upLayout->addStretch();
-
     inexcLayout->addStretch();
     inexcLayout->addWidget(leftButton);
     inexcLayout->addWidget(rightButton);
     inexcLayout->addStretch();
 
-    downLayout->addStretch();
-    downLayout->addWidget(downButton);
-    downLayout->addStretch();
-
+    QVBoxLayout *buttonGrid = new QVBoxLayout;
     buttonGrid->addStretch();
-    buttonGrid->addLayout(upLayout);
     buttonGrid->addLayout(inexcLayout);
-    buttonGrid->addLayout(downLayout);
     buttonGrid->addStretch();
 
-    QHBoxLayout *hlayout = new QHBoxLayout;
-    hlayout->addLayout(availLayout);
-    hlayout->addLayout(buttonGrid);
-    hlayout->addLayout(selectedLayout);
-    setLayout(hlayout);
+    QHBoxLayout *hlayout = new QHBoxLayout(this);;
+    hlayout->addLayout(availLayout, 2);
+    hlayout->addLayout(buttonGrid, 1);
+    hlayout->addLayout(selectedLayout, 2);
 
     QString s;
     if (appsettings->contains(GC_SETTINGS_FAVOURITE_METRICS))
@@ -1808,19 +1658,12 @@ FavouriteMetricsPage::FavouriteMetricsPage(QWidget *parent) :
         selectedList->addItem(item);
     }
 
-    upButton->setEnabled(false);
-    downButton->setEnabled(false);
-    leftButton->setEnabled(false);
-    rightButton->setEnabled(false);
-
-    connect(upButton, SIGNAL(clicked()), this, SLOT(upClicked()));
-    connect(downButton, SIGNAL(clicked()), this, SLOT(downClicked()));
+    connect(actionButtons, &ActionButtonBox::upRequested, this, &FavouriteMetricsPage::upClicked);
+    connect(actionButtons, &ActionButtonBox::downRequested, this, &FavouriteMetricsPage::downClicked);
     connect(leftButton, SIGNAL(clicked()), this, SLOT(leftClicked()));
     connect(rightButton, SIGNAL(clicked()), this, SLOT(rightClicked()));
-    connect(availList, SIGNAL(itemSelectionChanged()),
-            this, SLOT(availChanged()));
-    connect(selectedList, SIGNAL(itemSelectionChanged()),
-            this, SLOT(selectedChanged()));
+    connect(availList, SIGNAL(itemSelectionChanged()), this, SLOT(availChanged()));
+    connect(selectedList, SIGNAL(itemSelectionChanged()), this, SLOT(selectedChanged()));
 }
 
 void
@@ -1880,21 +1723,9 @@ void
 FavouriteMetricsPage::selectedChanged()
 {
     if (selectedList->selectedItems().isEmpty()) {
-        upButton->setEnabled(false);
-        downButton->setEnabled(false);
         leftButton->setEnabled(false);
         return;
     }
-    QListWidgetItem *item = selectedList->selectedItems().first();
-    int row = selectedList->row(item);
-    if (row == 0)
-        upButton->setEnabled(false);
-    else
-        upButton->setEnabled(true);
-    if (row == selectedList->count() - 1)
-        downButton->setEnabled(false);
-    else
-        downButton->setEnabled(true);
     leftButton->setEnabled(true);
 }
 
@@ -1935,58 +1766,57 @@ CustomMetricsPage::CustomMetricsPage(QWidget *parent, Context *context) :
     table->headerItem()->setText(0, tr("Symbol"));
     table->headerItem()->setText(1, tr("Name"));
     table->setColumnCount(2);
-    table->setColumnWidth(0,200 *dpiXFactor);
-    table->setSelectionMode(QAbstractItemView::SingleSelection);
-    table->setUniformRowHeights(true); // causes height problems when adding - in case of non-text fields
-    table->setIndentation(0);
+    basicTreeWidgetStyle(table);
 
-    refreshTable();
+    exportButton = new QPushButton(tr("Export"));
+    exportButton->setEnabled(false);
+    importButton = new QPushButton(tr("Import"));
+    importButton->setEnabled(false);
+#ifdef GC_HAS_CLOUD_DB
+    uploadButton = new QPushButton(tr("Upload"));
+    uploadButton->setEnabled(false);
+    downloadButton = new QPushButton(tr("Download"));
+    downloadButton->setEnabled(false);
+#endif
+
+    ActionButtonBox *actionButtons = new ActionButtonBox(ActionButtonBox::AddDeleteGroup | ActionButtonBox::EditGroup);
+    actionButtons->setButtonEnabled(ActionButtonBox::Edit, false);
+    actionButtons->defaultConnect(ActionButtonBox::AddDeleteGroup, table);
+
+    actionButtons->addWidget(exportButton);
+    actionButtons->addWidget(importButton);
+#ifdef GC_HAS_CLOUD_DB
+    actionButtons->addStretch();
+    actionButtons->addWidget(uploadButton);
+    actionButtons->addWidget(downloadButton);
+#endif
 
     QVBoxLayout *layout = new QVBoxLayout(this);
     layout->addWidget(table);
+    layout->addWidget(actionButtons);
+
     connect(table, SIGNAL(itemDoubleClicked(QTreeWidgetItem*, int)), this, SLOT(doubleClicked(QTreeWidgetItem*, int)));
-
-    editButton = new QPushButton(tr("Edit"));
-    exportButton = new QPushButton(tr("Export"));
-    importButton = new QPushButton(tr("Import"));
+    connect(table, &QTreeWidget::currentItemChanged, [=] (QTreeWidgetItem*) {
+            bool selected = table->currentItem() != nullptr;
+            actionButtons->setButtonEnabled(ActionButtonBox::Edit, selected);
+            exportButton->setEnabled(selected);
+            importButton->setEnabled(selected);
 #ifdef GC_HAS_CLOUD_DB
-    uploadButton = new QPushButton(tr("Upload"));
-    downloadButton = new QPushButton(tr("Download"));
+            uploadButton->setEnabled(selected);
+            downloadButton->setEnabled(selected);
 #endif
-    addButton = new QPushButton(tr("+"));
-    deleteButton = new QPushButton(tr("-"));
-#ifndef Q_OS_MAC
-    addButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    deleteButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-#else
-    addButton->setText(tr("Add"));
-    deleteButton->setText(tr("Delete"));
-#endif
-    QHBoxLayout *buttons = new QHBoxLayout();
-    buttons->addWidget(exportButton);
-    buttons->addWidget(importButton);
-    buttons->addStretch();
-#ifdef GC_HAS_CLOUD_DB
-    buttons->addWidget(uploadButton);
-    buttons->addWidget(downloadButton);
-    buttons->addStretch();
-#endif
-    buttons->addWidget(editButton);
-    buttons->addStretch();
-    buttons->addWidget(addButton);
-    buttons->addWidget(deleteButton);
-
-    layout->addLayout(buttons);
-
-    connect(addButton, SIGNAL(clicked()), this, SLOT(addClicked()));
-    connect(deleteButton, SIGNAL(clicked()), this, SLOT(deleteClicked()));
-    connect(editButton, SIGNAL(clicked()), this, SLOT(editClicked()));
+        });
+    connect(actionButtons, &ActionButtonBox::addRequested, this, &CustomMetricsPage::addClicked);
+    connect(actionButtons, &ActionButtonBox::deleteRequested, this, &CustomMetricsPage::deleteClicked);
+    connect(actionButtons, &ActionButtonBox::editRequested, this, &CustomMetricsPage::editClicked);
     connect(exportButton, SIGNAL(clicked()), this, SLOT(exportClicked()));
     connect(importButton, SIGNAL(clicked()), this, SLOT(importClicked()));
 #ifdef GC_HAS_CLOUD_DB
     connect(uploadButton, SIGNAL(clicked()), this, SLOT(uploadClicked()));
     connect(downloadButton, SIGNAL(clicked()), this, SLOT(downloadClicked()));
 #endif
+
+    refreshTable();
 }
 
 void
@@ -1994,8 +1824,8 @@ CustomMetricsPage::refreshTable()
 {
     table->clear();
     skipcompat=0;
+    bool first = true;
     foreach(UserMetricSettings m, metrics) {
-
         if (m.symbol.startsWith("compatibility_")) {
             skipcompat++;
             continue;
@@ -2014,6 +1844,10 @@ CustomMetricsPage::refreshTable()
         add->setToolTip(0, m.description);
         add->setText(1, m.name);
         add->setToolTip(1, m.description);
+        if (first) {
+            table->setCurrentItem(add);
+            first = false;
+        }
     }
 }
 
@@ -2063,26 +1897,24 @@ CustomMetricsPage::addClicked()
     here.unitsImperial = "watts";
     here.conversion = 1.00;
     here.conversionSum = 0.00;
-    here.program ="{\n\
-    # only calculate for rides containing power\n\
-    relevant { Data contains \"P\"; }\n\
-\n\
-    # initialise aggregating variables\n\
-    # does nothing, update as needed\n\
-    init { 0; }\n\
-\n\
-    # calculate metric value at end\n\
-    value { mean(samples(POWER)); }\n\
-    count { Duration; }\n\
-}";
+    here.program = R"({
+    # only calculate for rides containing power
+    relevant { Data contains P; }
+
+    # initialise aggregating variables
+    # does nothing, update as needed
+    init { 0; }
+
+    # calculate metric value at end
+    value { mean(samples(POWER)); }
+    count { Duration; }
+})";
 
     EditUserMetricDialog editor(this, context, here);
     if (editor.exec() == QDialog::Accepted) {
-
         // add to the list
         metrics.append(here);
         refreshTable();
-
     }
 }
 
@@ -2112,11 +1944,9 @@ CustomMetricsPage::doubleClicked(QTreeWidgetItem *item, int)
 
     EditUserMetricDialog editor(this, context, here);
     if (editor.exec() == QDialog::Accepted) {
-
         // add to the list
         metrics[row+skipcompat] = here;
         refreshTable();
-
     }
 }
 
@@ -2179,11 +2009,9 @@ CustomMetricsPage::importClicked()
 
     EditUserMetricDialog editor(this, context, here);
     if (editor.exec() == QDialog::Accepted) {
-
         // add to the list
         metrics.append(here);
         refreshTable();
-
     }
 }
 
@@ -2283,11 +2111,9 @@ CustomMetricsPage::downloadClicked()
 
                 EditUserMetricDialog editor(this, context, here);
                 if (editor.exec() == QDialog::Accepted) {
-
                     // add to the list
                     metrics.append(here);
                     refreshTable();
-
                 }
             }
         }
@@ -2375,20 +2201,6 @@ MetadataPage::saveClicked()
     return state;
 }
 
-// little helper since we create/recreate combos
-// for field types all over the place (init, move up, move down)
-void
-FieldsPage::addFieldTypes(QComboBox *p)
-{
-    p->addItem(tr("Text"));
-    p->addItem(tr("Textbox"));
-    p->addItem(tr("ShortText"));
-    p->addItem(tr("Integer"));
-    p->addItem(tr("Double"));
-    p->addItem(tr("Date"));
-    p->addItem(tr("Time"));
-    p->addItem(tr("Checkbox"));
-}
 
 //
 // Calendar coloring page
@@ -2398,6 +2210,8 @@ KeywordsPage::KeywordsPage(MetadataPage *parent, QList<KeywordDefinition>keyword
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
     HelpWhatsThis *help = new HelpWhatsThis(this);
     this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::Preferences_DataFields_Notes_Keywords));
+
+    relatedDelegate.setTitle(tr("<h3>Alternative Keywords</h3>Add additional keyword to have the same color"));
 
     QHBoxLayout *field = new QHBoxLayout();
     fieldLabel = new QLabel(tr("Field"),this);
@@ -2411,43 +2225,17 @@ KeywordsPage::KeywordsPage(MetadataPage *parent, QList<KeywordDefinition>keyword
     rideBG->setChecked(appsettings->value(this, GC_RIDEBG, false).toBool());
     field->addWidget(rideBG);
 
-    addButton = new QPushButton(tr("+"));
-    deleteButton = new QPushButton(tr("-"));
-#ifndef Q_OS_MAC
-    upButton = new QToolButton(this);
-    downButton = new QToolButton(this);
-    upButton->setArrowType(Qt::UpArrow);
-    downButton->setArrowType(Qt::DownArrow);
-    upButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    downButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    addButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    deleteButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-#else
-    addButton->setText(tr("Add"));
-    deleteButton->setText(tr("Delete"));
-    upButton = new QPushButton(tr("Up"));
-    downButton = new QPushButton(tr("Down"));
-#endif
-
-    QHBoxLayout *actionButtons = new QHBoxLayout;
-    actionButtons->setSpacing(2 *dpiXFactor);
-    actionButtons->addWidget(upButton);
-    actionButtons->addWidget(downButton);
-    actionButtons->addStretch();
-    actionButtons->addWidget(addButton);
-    actionButtons->addWidget(deleteButton);
-
     keywords = new QTreeWidget;
     keywords->headerItem()->setText(0, tr("Keyword"));
     keywords->headerItem()->setText(1, tr("Color"));
     keywords->headerItem()->setText(2, tr("Related Notes Words"));
     keywords->setColumnCount(3);
-    keywords->setSelectionMode(QAbstractItemView::SingleSelection);
-    keywords->setEditTriggers(QAbstractItemView::SelectedClicked); // allow edit
-    //keywords->setUniformRowHeights(true); // causes height problems when adding - in case of non-text fields
-    keywords->setIndentation(0);
-    //keywords->header()->resizeSection(0,100);
-    //keywords->header()->resizeSection(1,45);
+    keywords->setItemDelegateForColumn(2, &relatedDelegate);
+    basicTreeWidgetStyle(keywords);
+
+    actionButtons = new ActionButtonBox(ActionButtonBox::UpDownGroup | ActionButtonBox::AddDeleteGroup);
+    actionButtons->defaultConnect(ActionButtonBox::UpDownGroup, keywords);
+    actionButtons->defaultConnect(ActionButtonBox::AddDeleteGroup, keywords);
 
     foreach(KeywordDefinition keyword, keywordDefinitions) {
         QTreeWidgetItem *add;
@@ -2473,18 +2261,18 @@ KeywordsPage::KeywordsPage(MetadataPage *parent, QList<KeywordDefinition>keyword
         // notes texts
         add->setText(2, text);
     }
-    keywords->setCurrentItem(keywords->invisibleRootItem()->child(0));
 
     mainLayout->addWidget(keywords);
-    mainLayout->addLayout(actionButtons);
+    mainLayout->addWidget(actionButtons);
 
     // connect up slots
-    connect(upButton, SIGNAL(clicked()), this, SLOT(upClicked()));
-    connect(downButton, SIGNAL(clicked()), this, SLOT(downClicked()));
-    connect(addButton, SIGNAL(clicked()), this, SLOT(addClicked()));
-    connect(deleteButton, SIGNAL(clicked()), this, SLOT(deleteClicked()));
-
+    connect(actionButtons, &ActionButtonBox::upRequested, this, &KeywordsPage::upClicked);
+    connect(actionButtons, &ActionButtonBox::downRequested, this, &KeywordsPage::downClicked);
+    connect(actionButtons, &ActionButtonBox::addRequested, this, &KeywordsPage::addClicked);
+    connect(actionButtons, &ActionButtonBox::deleteRequested, this, &KeywordsPage::deleteClicked);
     connect(fieldChooser, SIGNAL(currentIndexChanged(int)), this, SLOT(colorfieldChanged()));
+
+    keywords->setCurrentItem(keywords->invisibleRootItem()->child(0));
 }
 
 void
@@ -2557,13 +2345,6 @@ KeywordsPage::downClicked()
 }
 
 void
-KeywordsPage::renameClicked()
-{
-    // which one is selected?
-    if (keywords->currentItem()) keywords->editItem(keywords->currentItem(), 0);
-}
-
-void
 KeywordsPage::addClicked()
 {
     int index = keywords->invisibleRootItem()->indexOfChild(keywords->currentItem());
@@ -2587,6 +2368,8 @@ KeywordsPage::addClicked()
 
     // notes texts
     add->setText(2, "");
+
+    keywords->setCurrentItem(add);
 }
 
 void
@@ -2623,34 +2406,15 @@ KeywordsPage::getDefinitions(QList<KeywordDefinition> &keywordList)
 //
 FieldsPage::FieldsPage(QWidget *parent, QList<FieldDefinition>fieldDefinitions) : QWidget(parent)
 {
-    QGridLayout *mainLayout = new QGridLayout(this);
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
     HelpWhatsThis *help = new HelpWhatsThis(this);
     this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::Preferences_DataFields_Fields));
 
-    addButton = new QPushButton(tr("+"));
-    deleteButton = new QPushButton(tr("-"));
-#ifndef Q_OS_MAC
-    upButton = new QToolButton(this);
-    downButton = new QToolButton(this);
-    upButton->setArrowType(Qt::UpArrow);
-    downButton->setArrowType(Qt::DownArrow);
-    upButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    downButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    addButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    deleteButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-#else
-    addButton->setText(tr("Add"));
-    deleteButton->setText(tr("Delete"));
-    upButton = new QPushButton(tr("Up"));
-    downButton = new QPushButton(tr("Down"));
-#endif
-    QHBoxLayout *actionButtons = new QHBoxLayout;
-    actionButtons->setSpacing(2 *dpiXFactor);
-    actionButtons->addWidget(upButton);
-    actionButtons->addWidget(downButton);
-    actionButtons->addStretch();
-    actionButtons->addWidget(addButton);
-    actionButtons->addWidget(deleteButton);
+    valueDelegate.setTitle(tr("<h3>Manage allowed values</h3>"
+                              "If the list is empty, any value is accepted. A list containing "
+                              "<tt>*</tt> as its only entry indicates previous values for the "
+                              "same field will be used to autocomplete input."));
+    valueDelegate.setDisplayLength(15, 2);
 
     fields = new QTreeWidget;
     fields->headerItem()->setText(0, tr("Screen Tab"));
@@ -2660,62 +2424,57 @@ FieldsPage::FieldsPage(QWidget *parent, QList<FieldDefinition>fieldDefinitions) 
     fields->headerItem()->setText(4, tr("Summary"));
     fields->headerItem()->setText(5, tr("Interval"));
     fields->headerItem()->setText(6, tr("Expression"));
-    fields->setColumnWidth(0,100 *dpiXFactor);
-    fields->setColumnWidth(1,100 *dpiXFactor);
-    fields->setColumnWidth(2,100 *dpiXFactor);
-    fields->setColumnWidth(3,100 *dpiXFactor);
-    fields->setColumnWidth(4,80 *dpiXFactor);
-    fields->setColumnWidth(5,80 *dpiXFactor);
-    fields->setColumnWidth(6,80 *dpiXFactor);
     fields->setColumnCount(7);
-    fields->setSelectionMode(QAbstractItemView::SingleSelection);
-    fields->setEditTriggers(QAbstractItemView::SelectedClicked); // allow edit
-    //fields->setUniformRowHeights(true); // causes height problems when adding - in case of non-text fields
-    fields->setIndentation(0);
+    fieldTypeDelegate.addItems( {
+        tr("Text"),
+        tr("Textbox"),
+        tr("ShortText"),
+        tr("Integer"),
+        tr("Double"),
+        tr("Date"),
+        tr("Time"),
+        tr("Checkbox")
+    } );
+    fields->setItemDelegateForColumn(0, &tabDelegate);
+    fields->setItemDelegateForColumn(1, &fieldDelegate);
+    fields->setItemDelegateForColumn(2, &fieldTypeDelegate);
+    fields->setItemDelegateForColumn(3, &valueDelegate);
+    basicTreeWidgetStyle(fields);
+
+    actionButtons = new ActionButtonBox(ActionButtonBox::UpDownGroup | ActionButtonBox::AddDeleteGroup);
+    actionButtons->defaultConnect(ActionButtonBox::UpDownGroup, fields);
+    actionButtons->defaultConnect(ActionButtonBox::AddDeleteGroup, fields);
 
     SpecialFields specials;
     SpecialTabs specialTabs;
     foreach(FieldDefinition field, fieldDefinitions) {
-        QTreeWidgetItem *add;
-        QComboBox *comboButton = new QComboBox(this);
         QCheckBox *checkBox = new QCheckBox("", this);
         checkBox->setChecked(field.diary);
 
         QCheckBox *checkBoxInt = new QCheckBox("", this);
         checkBoxInt->setChecked(field.interval);
 
-        addFieldTypes(comboButton);
-        comboButton->setCurrentIndex(field.type);
-
-        add = new QTreeWidgetItem(fields->invisibleRootItem());
+        QTreeWidgetItem *add = new QTreeWidgetItem(fields->invisibleRootItem());
         add->setFlags(add->flags() | Qt::ItemIsEditable);
-
-        // tab name
-        add->setText(0, specialTabs.displayName(field.tab));
-        // field name
-        add->setText(1, specials.displayName(field.name));
-        // values
-        add->setText(3, field.values.join(","));
-
-        // type button
-        add->setTextAlignment(2, Qt::AlignHCenter);
-        fields->setItemWidget(add, 2, comboButton);
+        add->setText(0, specialTabs.displayName(field.tab)); // tab name
+        add->setText(1, specials.displayName(field.name)); // field name
+        add->setData(2, Qt::DisplayRole, field.type);
+        add->setText(3, field.values.join(",")); // values
         fields->setItemWidget(add, 4, checkBox);
         fields->setItemWidget(add, 5, checkBoxInt);
-
-        // expression
-        add->setText(6, field.expression);
+        add->setText(6, field.expression); // expression
     }
-    fields->setCurrentItem(fields->invisibleRootItem()->child(0));
 
-    mainLayout->addWidget(fields, 0,0);
-    mainLayout->addLayout(actionButtons, 1,0);
+    mainLayout->addWidget(fields);
+    mainLayout->addWidget(actionButtons);
 
     // connect up slots
-    connect(upButton, SIGNAL(clicked()), this, SLOT(upClicked()));
-    connect(downButton, SIGNAL(clicked()), this, SLOT(downClicked()));
-    connect(addButton, SIGNAL(clicked()), this, SLOT(addClicked()));
-    connect(deleteButton, SIGNAL(clicked()), this, SLOT(deleteClicked()));
+    connect(actionButtons, &ActionButtonBox::upRequested, this, &FieldsPage::upClicked);
+    connect(actionButtons, &ActionButtonBox::downRequested, this, &FieldsPage::downClicked);
+    connect(actionButtons, &ActionButtonBox::addRequested, this, &FieldsPage::addClicked);
+    connect(actionButtons, &ActionButtonBox::deleteRequested, this, &FieldsPage::deleteClicked);
+
+    fields->setCurrentItem(fields->invisibleRootItem()->child(0));
 }
 
 void
@@ -2726,19 +2485,14 @@ FieldsPage::upClicked()
         if (index == 0) return; // its at the top already
 
         // movin on up!
-        QWidget *button = fields->itemWidget(fields->currentItem(),2);
         QWidget *check = fields->itemWidget(fields->currentItem(),4);
         QWidget *checkInt = fields->itemWidget(fields->currentItem(),5);
-        QComboBox *comboButton = new QComboBox(this);
-        addFieldTypes(comboButton);
-        comboButton->setCurrentIndex(((QComboBox*)button)->currentIndex());
         QCheckBox *checkBox = new QCheckBox("", this);
         checkBox->setChecked(((QCheckBox*)check)->isChecked());
         QCheckBox *checkBoxInt = new QCheckBox("", this);
         checkBoxInt->setChecked(((QCheckBox*)checkInt)->isChecked());
         QTreeWidgetItem* moved = fields->invisibleRootItem()->takeChild(index);
         fields->invisibleRootItem()->insertChild(index-1, moved);
-        fields->setItemWidget(moved, 2, comboButton);
         fields->setItemWidget(moved, 4, checkBox);
         fields->setItemWidget(moved, 5, checkBoxInt);
         fields->setCurrentItem(moved);
@@ -2752,19 +2506,14 @@ FieldsPage::downClicked()
         int index = fields->invisibleRootItem()->indexOfChild(fields->currentItem());
         if (index == (fields->invisibleRootItem()->childCount()-1)) return; // its at the bottom already
 
-        QWidget *button = fields->itemWidget(fields->currentItem(),2);
         QWidget *check = fields->itemWidget(fields->currentItem(),4);
         QWidget *checkInt = fields->itemWidget(fields->currentItem(),5);
-        QComboBox *comboButton = new QComboBox(this);
-        addFieldTypes(comboButton);
-        comboButton->setCurrentIndex(((QComboBox*)button)->currentIndex());
         QCheckBox *checkBox = new QCheckBox("", this);
         checkBox->setChecked(((QCheckBox*)check)->isChecked());
         QCheckBox *checkBoxInt = new QCheckBox("", this);
         checkBoxInt->setChecked(((QCheckBox*)checkInt)->isChecked());
         QTreeWidgetItem* moved = fields->invisibleRootItem()->takeChild(index);
         fields->invisibleRootItem()->insertChild(index+1, moved);
-        fields->setItemWidget(moved, 2, comboButton);
         fields->setItemWidget(moved, 4, checkBox);
         fields->setItemWidget(moved, 5, checkBoxInt);
         fields->setCurrentItem(moved);
@@ -2784,14 +2533,12 @@ FieldsPage::addClicked()
     int index = fields->invisibleRootItem()->indexOfChild(fields->currentItem());
     if (index < 0) index = 0;
     QTreeWidgetItem *add;
-    QComboBox *comboButton = new QComboBox(this);
-    addFieldTypes(comboButton);
     QCheckBox *checkBox = new QCheckBox("", this);
     QCheckBox *checkBoxInt = new QCheckBox("", this);
 
     add = new QTreeWidgetItem;
-    fields->invisibleRootItem()->insertChild(index, add);
     add->setFlags(add->flags() | Qt::ItemIsEditable);
+    fields->invisibleRootItem()->insertChild(index, add);
 
     // field
     QString text = tr("New");
@@ -2801,10 +2548,10 @@ FieldsPage::addClicked()
     add->setText(1, text);
 
     // type button
-    add->setTextAlignment(2, Qt::AlignHCenter);
-    fields->setItemWidget(add, 2, comboButton);
     fields->setItemWidget(add, 4, checkBox);
     fields->setItemWidget(add, 5, checkBoxInt);
+
+    fields->setCurrentItem(add);
 }
 
 void
@@ -2817,6 +2564,7 @@ FieldsPage::deleteClicked()
         delete fields->invisibleRootItem()->takeChild(index);
     }
 }
+
 
 void
 FieldsPage::getDefinitions(QList<FieldDefinition> &fieldList)
@@ -2847,7 +2595,7 @@ FieldsPage::getDefinitions(QList<FieldDefinition> &fieldList)
         if (sp.isMetric(add.name))
             add.type = 4;
         else
-            add.type = ((QComboBox*)fields->itemWidget(item, 2))->currentIndex();
+            add.type = item->data(2, Qt::DisplayRole).toInt();
 
         fieldList.append(add);
     }
@@ -2864,6 +2612,7 @@ FieldsPage::getDefinitions(QList<FieldDefinition> &fieldList)
 #define PROCESSORTREE_COL_AUTOMATEDONLY 4
 #define PROCESSORTREE_COL_ID 5
 #define PROCESSORTREE_NUM_COLS 6
+
 ProcessorPage::ProcessorPage(Context *context) : context(context)
 {
     automationDelegate.addItems({ tr("None"), tr("On Import"), tr("On Save") });
@@ -2888,42 +2637,29 @@ ProcessorPage::ProcessorPage(Context *context) : context(context)
 
     QWidget *leftWidget = new QWidget();
     QVBoxLayout *leftLayout = new QVBoxLayout(leftWidget);
+    leftLayout->setContentsMargins(0, 0, 5 * dpiXFactor, 0);
     leftLayout->addWidget(processorTree);
 #ifdef GC_WANT_PYTHON
     if (appsettings->value(nullptr, GC_EMBED_PYTHON, true).toBool()) {
-        addButton = new QPushButton(tr("+"));
-        delButton = new QPushButton(tr("-"));
-        editButton = new QPushButton(tr("Edit..."));
         hideButton = new QCheckBox(tr("Hide Core Processors"));
-#ifndef Q_OS_MAC
-        addButton->setFixedSize(20 * dpiXFactor, 20 * dpiYFactor);
-        delButton->setFixedSize(20 * dpiXFactor, 20 * dpiYFactor);
-#else
-        addButton->setText(tr("Add"));
-        delButton->setText(tr("Delete"));
-#endif
-        QHBoxLayout *actionButtons = new QHBoxLayout();
-        actionButtons->setSpacing(2 * dpiXFactor);
+        actionButtons = new ActionButtonBox(ActionButtonBox::EditGroup | ActionButtonBox::AddDeleteGroup);
         actionButtons->addWidget(hideButton);
-        actionButtons->addStretch();
-        actionButtons->addWidget(editButton);
-        actionButtons->addItem(new QSpacerItem(5 * dpiXFactor, editButton->sizeHint().height()));
-        actionButtons->addWidget(addButton, 0, Qt::AlignHCenter | Qt::AlignTop);
-        actionButtons->addWidget(delButton, 0, Qt::AlignHCenter | Qt::AlignTop);
 
-        leftLayout->addLayout(actionButtons);
+        leftLayout->addWidget(actionButtons);
 
-        connect(addButton, &QPushButton::clicked, this, &ProcessorPage::addProcessor);
-        connect(delButton, &QPushButton::clicked, this, &ProcessorPage::delProcessor);
-        connect(editButton, &QPushButton::clicked, this, &ProcessorPage::editProcessor);
+        connect(actionButtons, &ActionButtonBox::addRequested, this, &ProcessorPage::addProcessor);
+        connect(actionButtons, &ActionButtonBox::deleteRequested, this, &ProcessorPage::delProcessor);
+        connect(actionButtons, &ActionButtonBox::editRequested, this, &ProcessorPage::editProcessor);
         connect(hideButton, SIGNAL(toggled(bool)), this, SLOT(toggleCoreProcessors(bool)));
     }
 #endif
 
     settingsStack = new QStackedWidget();
+    settingsStack->setContentsMargins(5 * dpiXFactor, 0, 0, 0);
     settingsStack->addWidget(new QLabel(tr("<center><h1>No Processor selected</h1></center>")));
 
     QSplitter *splitter = new QSplitter();
+    splitter->setHandleWidth(0);
     splitter->addWidget(leftWidget);
     splitter->addWidget(settingsStack);
     splitter->setSizes(QList<int>({INT_MAX / 3, INT_MAX / 2}));
@@ -2974,10 +2710,10 @@ ProcessorPage::processorSelected
         int rownum = selectedItem->data(PROCESSORTREE_COL_ROWNUM, Qt::DisplayRole).toInt();
         if (rownum >= 0 && rownum < settingsStack->count() - 1) {
             settingsStack->setCurrentIndex(rownum + 1);
-            if (delButton != nullptr && editButton != nullptr) {
+            if (actionButtons != nullptr) {
                 bool isCoreProcessor = selectedItem->data(PROCESSORTREE_COL_CORE, Qt::DisplayRole).toBool();
-                delButton->setEnabled(! isCoreProcessor);
-                editButton->setEnabled(! isCoreProcessor);
+                actionButtons->setButtonEnabled(ActionButtonBox::Delete, ! isCoreProcessor);
+                actionButtons->setButtonEnabled(ActionButtonBox::Edit, ! isCoreProcessor);
             }
         }
     }
@@ -3033,7 +2769,7 @@ ProcessorPage::reload
             detailsHL->setText(QString("<center><h2>%1</h2></center>").arg((*iter)->name()));
         }
         detailsHL->setWordWrap(true);
-        QLabel *automationHL = new QLabel("<h3>" + tr("Automation") + "</h3>");
+        QLabel *automationHL = new QLabel(HLO + tr("Automation") + HLC);
 
         QFormLayout *setupLayout = newQFormLayout();
         QCheckBox *automatedOnly = new QCheckBox(tr("Automated execution only"));
@@ -3055,8 +2791,8 @@ ProcessorPage::reload
         connect(automationCombo, SIGNAL(currentIndexChanged(int)), this, SLOT(automationChanged(int)));
         connect(automatedOnly, SIGNAL(toggled(bool)), this, SLOT(toggleAutomatedOnly(bool)));
 
-        QLabel *configHL = new QLabel("<h3>" + tr("Default Settings") + "</h3>");
-        QLabel *descriptionHL = new QLabel("<h3>" + tr("Description") + "</h3>");
+        QLabel *configHL = new QLabel(HLO + tr("Default Settings") + HLC);
+        QLabel *descriptionHL = new QLabel(HLO + tr("Description") + HLC);
         QLabel *explainLabel = new QLabel((*iter)->explain());
         explainLabel->setWordWrap(true);
 
@@ -3083,6 +2819,7 @@ ProcessorPage::reload
 
         QWidget *details = new QWidget();
         QVBoxLayout *detailsLayout = new QVBoxLayout(details);
+        detailsLayout->setContentsMargins(0, 0, 0, 0);
         detailsLayout->addWidget(detailsHL);
         detailsLayout->addWidget(detailsScroller);
 
@@ -3091,9 +2828,11 @@ ProcessorPage::reload
         ++rownum;
     }
 
+#ifdef GC_WANT_PYTHON
     if (hideButton != nullptr) {
         toggleCoreProcessors(hideButton->isChecked());
     }
+#endif
     processorTree->model()->blockSignals(false);
 }
 
@@ -3278,51 +3017,30 @@ ProcessorPage::dataChanged
 //
 // Default values page
 //
-DefaultsPage::DefaultsPage(QWidget *parent, QList<DefaultDefinition>defaultDefinitions) : QWidget(parent)
+DefaultsPage::DefaultsPage
+(MetadataPage *parent, QList<DefaultDefinition>defaultDefinitions)
+: QWidget(parent), parent(parent)
 {
-    QGridLayout *mainLayout = new QGridLayout(this);
+    installEventFilter(this);
+    fieldDelegate.setDataSource(CompleterEditDelegate::External);
+    linkedDelegate.setDataSource(CompleterEditDelegate::External);
+
     HelpWhatsThis *help = new HelpWhatsThis(this);
     this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::Preferences_DataFields_Defaults));
 
-    addButton = new QPushButton(tr("+"));
-    deleteButton = new QPushButton(tr("-"));
-#ifndef Q_OS_MAC
-    upButton = new QToolButton(this);
-    downButton = new QToolButton(this);
-    upButton->setArrowType(Qt::UpArrow);
-    downButton->setArrowType(Qt::DownArrow);
-    upButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    downButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    addButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    deleteButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-#else
-    addButton->setText(tr("Add"));
-    deleteButton->setText(tr("Delete"));
-    upButton = new QPushButton(tr("Up"));
-    downButton = new QPushButton(tr("Down"));
-#endif
-    QHBoxLayout *actionButtons = new QHBoxLayout;
-    actionButtons->setSpacing(2 *dpiXFactor);
-    actionButtons->addWidget(upButton);
-    actionButtons->addWidget(downButton);
-    actionButtons->addStretch();
-    actionButtons->addWidget(addButton);
-    actionButtons->addWidget(deleteButton);
-
     defaults = new QTreeWidget;
-    defaults->headerItem()->setText(0, tr("Field"));
+    defaults->headerItem()->setText(0, tr("Field").leftJustified(30, ' '));
     defaults->headerItem()->setText(1, tr("Value"));
-    defaults->headerItem()->setText(2, tr("Linked field"));
+    defaults->headerItem()->setText(2, tr("Linked field").leftJustified(30, ' '));
     defaults->headerItem()->setText(3, tr("Default Value"));
-    defaults->setColumnWidth(0,80 *dpiXFactor);
-    defaults->setColumnWidth(1,100 *dpiXFactor);
-    defaults->setColumnWidth(2,80 *dpiXFactor);
-    defaults->setColumnWidth(3,100 *dpiXFactor);
     defaults->setColumnCount(4);
-    defaults->setSelectionMode(QAbstractItemView::SingleSelection);
-    defaults->setEditTriggers(QAbstractItemView::SelectedClicked); // allow edit
-    //defaults->setUniformRowHeights(true); // causes height problems when adding - in case of non-text fields
-    defaults->setIndentation(0);
+    defaults->setItemDelegateForColumn(0, &fieldDelegate);
+    defaults->setItemDelegateForColumn(2, &linkedDelegate);
+    basicTreeWidgetStyle(defaults);
+
+    ActionButtonBox *actionButtons = new ActionButtonBox(ActionButtonBox::UpDownGroup | ActionButtonBox::AddDeleteGroup);
+    actionButtons->defaultConnect(ActionButtonBox::UpDownGroup, defaults);
+    actionButtons->defaultConnect(ActionButtonBox::AddDeleteGroup, defaults);
 
     SpecialFields specials;
     foreach(DefaultDefinition adefault, defaultDefinitions) {
@@ -3340,16 +3058,18 @@ DefaultsPage::DefaultsPage(QWidget *parent, QList<DefaultDefinition>defaultDefin
         // Default Value
         add->setText(3, adefault.linkedValue);
     }
-    defaults->setCurrentItem(defaults->invisibleRootItem()->child(0));
 
-    mainLayout->addWidget(defaults, 0,0);
-    mainLayout->addLayout(actionButtons, 1,0);
+    QVBoxLayout *mainLayout = new QVBoxLayout(this);
+    mainLayout->addWidget(defaults);
+    mainLayout->addWidget(actionButtons);
 
     // connect up slots
-    connect(upButton, SIGNAL(clicked()), this, SLOT(upClicked()));
-    connect(downButton, SIGNAL(clicked()), this, SLOT(downClicked()));
-    connect(addButton, SIGNAL(clicked()), this, SLOT(addClicked()));
-    connect(deleteButton, SIGNAL(clicked()), this, SLOT(deleteClicked()));
+    connect(actionButtons, &ActionButtonBox::upRequested, this, &DefaultsPage::upClicked);
+    connect(actionButtons, &ActionButtonBox::downRequested, this, &DefaultsPage::downClicked);
+    connect(actionButtons, &ActionButtonBox::addRequested, this, &DefaultsPage::addClicked);
+    connect(actionButtons, &ActionButtonBox::deleteRequested, this, &DefaultsPage::deleteClicked);
+
+    defaults->setCurrentItem(defaults->invisibleRootItem()->child(0));
 }
 
 void
@@ -3430,25 +3150,38 @@ DefaultsPage::getDefinitions(QList<DefaultDefinition> &defaultList)
     }
 }
 
+
+bool
+DefaultsPage::eventFilter
+(QObject *obj, QEvent *event)
+{
+    if (event->type() == QEvent::Show && ! event->spontaneous()) {
+        SpecialFields sp;
+        QList<FieldDefinition> fromFieldsPage;
+        parent->fieldsPage->getDefinitions(fromFieldsPage);
+        QStringList fieldNames;
+        foreach(FieldDefinition x, fromFieldsPage) {
+            fieldNames << sp.displayName(x.name);
+        }
+        fieldDelegate.setCompletionList(fieldNames);
+        linkedDelegate.setCompletionList(fieldNames);
+        return false;
+    } else {
+        return QObject::eventFilter(obj, event);
+    }
+}
+
+
 IntervalsPage::IntervalsPage(Context *context) : context(context)
 {
     // get config
     b4.discovery = appsettings->cvalue(context->athlete->cyclist, GC_DISCOVERY, 57).toInt(); // 57 does not include search for PEAKs
 
-    QVBoxLayout *mainLayout = new QVBoxLayout(this);
-    QGridLayout *layout = new QGridLayout();
-    mainLayout->addLayout(layout);
-    mainLayout->addStretch();
-
-    QLabel *heading = new QLabel(tr("Enable interval auto-discovery"));
-    heading->setFixedHeight(QFontMetrics(heading->font()).height() + 4);
-
-    int row = 0;
-    layout->addWidget(heading, row, 0, Qt::AlignRight);
-
+    QFormLayout *form = newQFormLayout(this);
+    form->setFormAlignment(Qt::AlignHCenter | Qt::AlignTop);
+    form->addRow("", new QLabel(HLO + tr("Enable interval auto-discovery") + HLC));
     user = 99;
     for(int i=0; i<= static_cast<int>(RideFileInterval::last()); i++) {
-
         // ignore until we get past user interval type
         if (i == static_cast<int>(RideFileInterval::USER)) user=i;
 
@@ -3457,7 +3190,7 @@ IntervalsPage::IntervalsPage(Context *context) : context(context)
             QCheckBox *add = new QCheckBox(RideFileInterval::typeDescriptionLong(static_cast<RideFileInterval::IntervalType>(i)));
             checkBoxes << add;
             add->setChecked(b4.discovery & RideFileInterval::intervalTypeBits(static_cast<RideFileInterval::IntervalType>(i)));
-            layout->addWidget(add, row++, 1, Qt::AlignLeft);
+            form->addRow("", add);
         }
     }
 }
@@ -3484,23 +3217,27 @@ IntervalsPage::saveClicked()
 /// MeasuresConfigPage
 ///
 MeasuresConfigPage::MeasuresConfigPage(QWidget *parent, Context *context) :
-    QWidget(parent), context(context), measures(nullptr)
+    QWidget(parent), context(context)
 {
     // get config
     measures = new Measures();
 
     // create all the widgets
-    QLabel *mlabel = new QLabel(tr("Measures Groups"));
+    QLabel *mlabel = new QLabel(HLO + tr("Groups") + HLC);
     measuresTable = new QTreeWidget(this);
     measuresTable->headerItem()->setText(0, tr("Symbol"));
     measuresTable->headerItem()->setText(1, tr("Name"));
     measuresTable->setColumnCount(2);
-    measuresTable->setColumnWidth(0,200 *dpiXFactor);
-    measuresTable->setSelectionMode(QAbstractItemView::SingleSelection);
-    measuresTable->setUniformRowHeights(true); // causes height problems when adding - in case of non-text fields
-    measuresTable->setIndentation(0);
+    basicTreeWidgetStyle(measuresTable);
+    measuresTable->setItemDelegateForColumn(0, &meNameDelegate);
+    measuresTable->setItemDelegateForColumn(1, &meSymbolDelegate);
 
-    QLabel *mflabel = new QLabel(tr("Measures Fields"));
+    ActionButtonBox *measuresActions = new ActionButtonBox(ActionButtonBox::AddDeleteGroup);
+
+    meFiFactorDelegate.setDecimals(5);
+    meFiFactorDelegate.setSingleStep(0.1);
+
+    mflabel = new QLabel(QString(HLO) + HLC);
     measuresFieldsTable = new QTreeWidget(this);
     measuresFieldsTable->headerItem()->setText(0, tr("Symbol"));
     measuresFieldsTable->headerItem()->setText(1, tr("Name"));
@@ -3509,74 +3246,34 @@ MeasuresConfigPage::MeasuresConfigPage(QWidget *parent, Context *context) :
     measuresFieldsTable->headerItem()->setText(4, tr("Units Factor"));
     measuresFieldsTable->headerItem()->setText(5, tr("CSV Headers"));
     measuresFieldsTable->setColumnCount(6);
-    measuresFieldsTable->setColumnWidth(0,200 *dpiXFactor);
-    measuresFieldsTable->setSelectionMode(QAbstractItemView::SingleSelection);
-    measuresFieldsTable->setUniformRowHeights(true); // causes height problems when adding - in case of non-text fields
-    measuresFieldsTable->setIndentation(0);
+    basicTreeWidgetStyle(measuresFieldsTable);
+    measuresFieldsTable->setItemDelegateForColumn(0, &meFiNameDelegate);
+    measuresFieldsTable->setItemDelegateForColumn(1, &meFiSymbolDelegate);
+    measuresFieldsTable->setItemDelegateForColumn(4, &meFiFactorDelegate);
+    measuresFieldsTable->setItemDelegateForColumn(5, &meFiHeaderDelegate);
 
-    editMeasures = new QPushButton(tr("Edit"), this);
-    addMeasures = new QPushButton("+", this);
-    removeMeasures = new QPushButton("-", this);
+    ActionButtonBox *measureFieldsActions = new ActionButtonBox(ActionButtonBox::AddDeleteGroup);
 
-    editMeasuresField = new QPushButton(tr("Edit"), this);
-    addMeasuresField = new QPushButton("+", this);
-    removeMeasuresField = new QPushButton("-", this);
-
-#ifdef Q_OS_MAC
-    addMeasures->setText(tr("Add"));
-    removeMeasures->setText(tr("Delete"));
-    addMeasuresField->setText(tr("Add"));
-    removeMeasuresField->setText(tr("Delete"));
-#else
-    addMeasures->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    addMeasuresField->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    removeMeasures->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    removeMeasuresField->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-#endif
-
-    resetMeasures = new QPushButton(tr("Reset to Default"), this);
     QLabel *warningLabel = new QLabel(tr("Saved changes take effect after restart"));
+    QHBoxLayout *xr = new QHBoxLayout();
+    xr->addStretch();
+    xr->addWidget(warningLabel);
 
     // lay it out
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
-
     mainLayout->addWidget(mlabel);
     mainLayout->addWidget(measuresTable);
-    QHBoxLayout *xb = new QHBoxLayout();
-    xb->addStretch();
-    xb->addWidget(editMeasures);
-    xb->addStretch();
-    xb->addWidget(addMeasures);
-    xb->addWidget(removeMeasures);
-    mainLayout->addLayout(xb);
-
+    mainLayout->addWidget(measuresActions);
     mainLayout->addWidget(mflabel);
     mainLayout->addWidget(measuresFieldsTable);
-    QHBoxLayout *xs = new QHBoxLayout();
-    xs->addStretch();
-    xs->addWidget(editMeasuresField);
-    xs->addStretch();
-    xs->addWidget(addMeasuresField);
-    xs->addWidget(removeMeasuresField);
-    mainLayout->addLayout(xs);
-
-    QHBoxLayout *xr = new QHBoxLayout();
-    xr->addWidget(resetMeasures);
-    xr->addStretch();
-    xr->addWidget(warningLabel);
+    mainLayout->addWidget(measureFieldsActions);
     mainLayout->addLayout(xr);
 
     connect(measuresTable, SIGNAL(currentItemChanged(QTreeWidgetItem*,QTreeWidgetItem*)), this, SLOT(measuresSelected()));
-    connect(measuresTable, SIGNAL(itemDoubleClicked(QTreeWidgetItem*, int)), this, SLOT(measuresDoubleClicked(QTreeWidgetItem*, int)));
-    connect(resetMeasures, SIGNAL(clicked()), this, SLOT(resetMeasuresClicked()));
-    connect(editMeasures, SIGNAL(clicked()), this, SLOT(editMeasuresClicked()));
-    connect(removeMeasures, SIGNAL(clicked(bool)), this, SLOT(removeMeasuresClicked()));
-    connect(addMeasures, SIGNAL(clicked(bool)), this, SLOT(addMeasuresClicked()));
-
-    connect(measuresFieldsTable, SIGNAL(itemDoubleClicked(QTreeWidgetItem*, int)), this, SLOT(measuresFieldDoubleClicked(QTreeWidgetItem*, int)));
-    connect(editMeasuresField, SIGNAL(clicked()), this, SLOT(editMeasuresFieldClicked()));
-    connect(removeMeasuresField, SIGNAL(clicked(bool)), this, SLOT(removeMeasuresFieldClicked()));
-    connect(addMeasuresField, SIGNAL(clicked(bool)), this, SLOT(addMeasuresFieldClicked()));
+    connect(measuresActions, &ActionButtonBox::addRequested, this, &MeasuresConfigPage::addMeasuresClicked);
+    connect(measuresActions, &ActionButtonBox::deleteRequested, this, &MeasuresConfigPage::removeMeasuresClicked);
+    connect(measureFieldsActions, &ActionButtonBox::addRequested, this, &MeasuresConfigPage::addMeasuresFieldClicked);
+    connect(measureFieldsActions, &ActionButtonBox::deleteRequested, this, &MeasuresConfigPage::removeMeasuresFieldClicked);
 
     refreshMeasuresTable();
 }
@@ -3596,19 +3293,21 @@ MeasuresConfigPage::saveClicked()
 void
 MeasuresConfigPage::refreshMeasuresTable()
 {
+    disconnect(measuresTable->model(), &QAbstractItemModel::dataChanged, this, &MeasuresConfigPage::measureChanged);
     // remove existing rows
     measuresTable->clear();
 
     // add a row for each measures group
     foreach (MeasuresGroup* group, measures->getGroups()) {
-
         QTreeWidgetItem *add = new QTreeWidgetItem(measuresTable->invisibleRootItem());
-        add->setText(0, group->getSymbol());
-        add->setText(1, group->getName());
+        add->setFlags(add->flags() | Qt::ItemIsEditable);
+        add->setData(0, Qt::DisplayRole, group->getSymbol());
+        add->setData(1, Qt::DisplayRole, group->getName());
 
         measuresTable->setCurrentItem(add); // select the last added
     }
     measuresSelected();
+    connect(measuresTable->model(), &QAbstractItemModel::dataChanged, this, &MeasuresConfigPage::measureChanged);
 }
 
 void MeasuresConfigPage::measuresSelected()
@@ -3620,6 +3319,30 @@ void MeasuresConfigPage::measuresSelected()
     // update measures series table to reflect the selection
     refreshMeasuresFieldsTable();
 }
+
+
+void
+MeasuresConfigPage::measureChanged
+(const QModelIndex &topLeft)
+{
+    QTreeWidgetItem *item = measuresTable->currentItem();
+    if (item == nullptr) {
+        return;
+    }
+
+    MeasuresGroup *group = measures->getGroup(measuresTable->invisibleRootItem()->indexOfChild(item));
+    switch (topLeft.column()) {
+    case 0:
+        group->setSymbol(topLeft.data(Qt::DisplayRole).toString());
+        break;
+    case 1:
+        group->setName(topLeft.data(Qt::DisplayRole).toString());
+        break;
+    default:
+        break;
+    }
+}
+
 
 void
 MeasuresConfigPage::resetMeasuresClicked()
@@ -3643,61 +3366,38 @@ MeasuresConfigPage::resetMeasuresClicked()
     refreshMeasuresTable();
 }
 
-void
-MeasuresConfigPage::editMeasuresClicked()
-{
-    measuresDoubleClicked(measuresTable->currentItem(), 0);
-}
 
 void
-MeasuresConfigPage::measuresDoubleClicked(QTreeWidgetItem *item, int)
+MeasuresConfigPage::addMeasuresClicked
+()
 {
-    // nothing selected
-    if (item == nullptr) return;
-
-    // find group
-    MeasuresGroup* group = measures->getGroup(measuresTable->invisibleRootItem()->indexOfChild(item));
-
-    // edit
-    QString symbol = group->getSymbol();
-    QString name = group->getName();
-    MeasuresSettingsDialog *dialog = new MeasuresSettingsDialog(this, symbol, name);
-    if (dialog->exec() == QDialog::Accepted) {
-
-        group->setSymbol(symbol);
-        item->setText(0, symbol);
-        group->setName(name);
-        item->setText(1, name);
+    QString token = tr("New");
+    for (int i = 0; measuresTable->findItems(token, Qt::MatchExactly, 0).count() > 0 || measuresTable->findItems(token, Qt::MatchExactly, 1).count() > 0; i++) {
+        token = tr("New (%1)").arg(i + 1);
     }
+    measures->addGroup(new MeasuresGroup(token, token, QStringList(), QStringList(), QStringList(), QStringList(), QList<double>(), QList<QStringList>()));
+    refreshMeasuresTable();
 }
 
-void
-MeasuresConfigPage::addMeasuresClicked()
-{
-    QString symbol, name;
-    MeasuresSettingsDialog *dialog = new MeasuresSettingsDialog(this, symbol, name);
-    if (dialog->exec() == QDialog::Accepted) {
-
-        measures->addGroup(new MeasuresGroup(symbol, name, QStringList(), QStringList(), QStringList(), QStringList(), QList<double>(), QList<QStringList>()));
-        refreshMeasuresTable();
-    }
-}
 
 void
-MeasuresConfigPage::removeMeasuresClicked()
+MeasuresConfigPage::removeMeasuresClicked
+()
 {
     // lets find the one we have selected...
     int row = measuresTable->invisibleRootItem()->indexOfChild(measuresTable->currentItem());
-    if (row < 0) return; // nothing selected
-
+    if (row < 0) {
+        return;
+    }
     measures->removeGroup(row);
-
     refreshMeasuresTable();
 }
 
 void
 MeasuresConfigPage::refreshMeasuresFieldsTable()
 {
+    disconnect(measuresFieldsTable->model(), &QAbstractItemModel::dataChanged, this, &MeasuresConfigPage::measureFieldChanged);
+
     // find the current Measures Group
     MeasuresGroup* group = measures->getGroup(measuresTable->invisibleRootItem()->indexOfChild(measuresTable->currentItem()));
     if (group == nullptr) return; // just in case...
@@ -3705,73 +3405,94 @@ MeasuresConfigPage::refreshMeasuresFieldsTable()
     // remove existing rows
     measuresFieldsTable->clear();
 
+    mflabel->setText(HLO + tr("Fields in Group <i>%1</i>").arg(group->getName()) + HLC);
+
     // lets populate
     for (int i=0; i<group->getFieldSymbols().count(); i++) {
-
         QTreeWidgetItem *add = new QTreeWidgetItem(measuresFieldsTable->invisibleRootItem());
+        add->setFlags(add->flags() | Qt::ItemIsEditable);
         MeasuresField field = group->getField(i);
-        add->setText(0, field.symbol);
-        add->setText(1, field.name);
-        add->setText(2, field.metricUnits);
-        add->setText(3, field.imperialUnits);
-        add->setText(4, QString::number(field.unitsFactor));
-        add->setText(5, field.headers.join(","));
+        add->setData(0, Qt::DisplayRole, field.symbol);
+        add->setData(1, Qt::DisplayRole, field.name);
+        add->setData(2, Qt::DisplayRole, field.metricUnits);
+        add->setData(3, Qt::DisplayRole, field.imperialUnits);
+        add->setData(4, Qt::DisplayRole, QString::number(field.unitsFactor));
+        add->setData(5, Qt::DisplayRole, field.headers.join(","));
 
         measuresFieldsTable->setCurrentItem(add); // select the last added
     }
+
+    connect(measuresFieldsTable->model(), &QAbstractItemModel::dataChanged, this, &MeasuresConfigPage::measureFieldChanged);
 }
 
-void
-MeasuresConfigPage::editMeasuresFieldClicked()
-{
-    measuresFieldDoubleClicked(measuresFieldsTable->currentItem(), 0);
-}
 
 void
-MeasuresConfigPage::measuresFieldDoubleClicked(QTreeWidgetItem *item, int)
+MeasuresConfigPage::measureFieldChanged
+(const QModelIndex &topLeft)
 {
-    // nothing selected
-    if (item == nullptr) return;
-
-    // find group
-    MeasuresGroup* group = measures->getGroup(measuresTable->invisibleRootItem()->indexOfChild(measuresTable->currentItem()));
-
-    // find row
-    int row = measuresFieldsTable->invisibleRootItem()->indexOfChild(item);
-
-    // edit
-    MeasuresField field = group->getField(row);
-    MeasuresFieldSettingsDialog *dialog = new MeasuresFieldSettingsDialog(this, field);
-    if (dialog->exec() == QDialog::Accepted) {
-
-        group->setField(row, field);
-        item->setText(0, field.symbol);
-        item->setText(1, field.name);
-        item->setText(2, field.metricUnits);
-        item->setText(3, field.imperialUnits);
-        item->setText(4, QString::number(field.unitsFactor));
-        item->setText(5, field.headers.join(","));
+    if (measuresTable->currentItem() == nullptr) {
+        return;
     }
+    MeasuresGroup* group = measures->getGroup(measuresTable->invisibleRootItem()->indexOfChild(measuresTable->currentItem()));
+    if (group == nullptr) {
+        return;
+    }
+    int row = measuresFieldsTable->invisibleRootItem()->indexOfChild(measuresFieldsTable->currentItem());
+    if (row < 0) {
+        return;
+    }
+
+    // find the current Measures Group
+    MeasuresField field = group->getField(row);
+    switch (topLeft.column()) {
+    case 0:
+        field.symbol = topLeft.data(Qt::DisplayRole).toString();
+        break;
+    case 1:
+        field.name = topLeft.data(Qt::DisplayRole).toString();
+        break;
+    case 2:
+        field.metricUnits = topLeft.data(Qt::DisplayRole).toString();
+        break;
+    case 3:
+        field.imperialUnits = topLeft.data(Qt::DisplayRole).toString();
+        break;
+    case 4:
+        field.unitsFactor = topLeft.data(Qt::DisplayRole).toDouble();
+        break;
+    case 5:
+        field.headers = topLeft.data(Qt::DisplayRole).toString().split(',');
+        break;
+    default:
+        break;
+    }
+    group->setField(row, field);
 }
+
 
 void
 MeasuresConfigPage::addMeasuresFieldClicked()
 {
     // lets find the one we have selected...
-    int index=measuresTable->currentIndex().row();
-    if (index <0) return;
-
-    // find group
-    MeasuresGroup* group = measures->getGroup(measuresTable->invisibleRootItem()->indexOfChild(measuresTable->currentItem()));
-    if (group == nullptr) return;
-
-    MeasuresField field;
-    MeasuresFieldSettingsDialog *dialog = new  MeasuresFieldSettingsDialog(this, field);
-    if (dialog->exec() == QDialog::Accepted) {
-
-        group->addField(field);
-        refreshMeasuresFieldsTable();
+    int index = measuresTable->currentIndex().row();
+    if (index < 0) {
+        return;
     }
+
+    MeasuresGroup *group = measures->getGroup(measuresTable->invisibleRootItem()->indexOfChild(measuresTable->currentItem()));
+    if (group == nullptr) {
+        return;
+    }
+
+    QString token = tr("New");
+    for (int i = 0; measuresFieldsTable->findItems(token, Qt::MatchExactly, 0).count() > 0 || measuresFieldsTable->findItems(token, Qt::MatchExactly, 1).count() > 0; i++) {
+        token = tr("New (%1)").arg(i + 1);
+    }
+    MeasuresField field;
+    field.symbol = token;
+    field.name = token;
+    group->addField(field);
+    refreshMeasuresFieldsTable();
 }
 
 void
@@ -3786,140 +3507,4 @@ MeasuresConfigPage::removeMeasuresFieldClicked()
 
     group->removeField(row);
     refreshMeasuresFieldsTable();
-}
-
-///
-/// MeasuresSettingsDialog
-///
-MeasuresSettingsDialog::MeasuresSettingsDialog(QWidget *parent, QString &symbol, QString &name) : QDialog(parent), symbol(symbol), name(name)
-{
-    setWindowTitle(tr("Measures Group"));
-    setAttribute(Qt::WA_DeleteOnClose);
-    setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint | Qt::Tool);
-
-    QVBoxLayout *mainLayout = new QVBoxLayout(this);
-    QFormLayout *form = newQFormLayout();
-    mainLayout->addLayout(form);
-
-
-    QLabel *symbolLabel = new QLabel(tr("Symbol"), this);
-    symbolEdit = new QLineEdit(this);
-    symbolEdit->setText(symbol);
-    form->addRow(symbolLabel, symbolEdit);
-
-    QLabel *nameLabel = new QLabel(tr("Name"), this);
-    nameEdit = new QLineEdit(this);
-    nameEdit->setText(name);
-    form->addRow(nameLabel, nameEdit);
-
-    form->addRow(new QLabel("",this), new QLabel("", this));
-    mainLayout->addStretch();
-
-    cancelButton = new QPushButton(tr("Cancel"), this);
-    okButton = new QPushButton(tr("OK"), this);
-    QHBoxLayout *buttons = new QHBoxLayout();
-    buttons->addStretch();
-    buttons->addWidget(cancelButton);
-    buttons->addWidget(okButton);
-    mainLayout->addLayout(buttons);
-
-    connect(okButton, SIGNAL(clicked(bool)), this, SLOT(okClicked()));
-    connect(cancelButton, SIGNAL(clicked(bool)), this, SLOT(reject()));
-}
-
-void MeasuresSettingsDialog::okClicked()
-{
-    // lets just check we have something etc
-    if (symbolEdit->text() == "" || nameEdit->text() == "") {
-
-        QMessageBox::warning(this, tr("Error"), tr("Symbol/Name cannot be blank"));
-        return;
-    } else {
-
-        symbol = symbolEdit->text();
-        name = nameEdit->text();
-        accept();
-    }
-}
-
-
-///
-/// MeasuresFieldSettingsDialog
-///
-MeasuresFieldSettingsDialog::MeasuresFieldSettingsDialog(QWidget *parent, MeasuresField &field) : QDialog(parent), field(field)
-{
-    setWindowTitle(tr("Measures Field"));
-    setAttribute(Qt::WA_DeleteOnClose);
-    setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint | Qt::Tool);
-
-    QVBoxLayout *mainLayout = new QVBoxLayout(this);
-    QFormLayout *form = newQFormLayout();
-    mainLayout->addLayout(form);
-
-
-    QLabel *symbolLabel = new QLabel(tr("Symbol"), this);
-    symbolEdit = new QLineEdit(this);
-    symbolEdit->setText(field.symbol);
-    form->addRow(symbolLabel, symbolEdit);
-
-    QLabel *nameLabel = new QLabel(tr("Name"), this);
-    nameEdit = new QLineEdit(this);
-    nameEdit->setText(field.name);
-    form->addRow(nameLabel, nameEdit);
-
-    QLabel *metricUnitsLabel = new QLabel(tr("Metric Units"), this);
-    metricUnitsEdit = new QLineEdit(this);
-    metricUnitsEdit->setText(field.metricUnits);
-    form->addRow(metricUnitsLabel, metricUnitsEdit);
-
-    QLabel *imperialUnitsLabel = new QLabel(tr("Imperial Units"), this);
-    imperialUnitsEdit = new QLineEdit(this);
-    imperialUnitsEdit->setText(field.imperialUnits);
-    form->addRow(imperialUnitsLabel, imperialUnitsEdit);
-
-    QLabel *unitsFactorLabel = new QLabel(tr("Units Conversion"), this);
-    unitsFactorEdit = new QDoubleSpinBox(this);
-    unitsFactorEdit->setDecimals(5);
-    unitsFactorEdit->setValue(field.unitsFactor);
-    form->addRow(unitsFactorLabel, unitsFactorEdit);
-
-    QLabel *headersLabel = new QLabel(tr("CSV Headers"), this);
-    headersEdit = new QLineEdit(this);
-    headersEdit->setText(field.headers.join(","));
-    form->addRow(headersLabel, headersEdit);
-
-    form->addRow(new QLabel("",this), new QLabel("", this));
-    mainLayout->addStretch();
-
-    cancelButton = new QPushButton(tr("Cancel"), this);
-    okButton = new QPushButton(tr("OK"), this);
-    QHBoxLayout *buttons = new QHBoxLayout();
-    buttons->addStretch();
-    buttons->addWidget(cancelButton);
-    buttons->addWidget(okButton);
-    mainLayout->addLayout(buttons);
-
-    connect(okButton, SIGNAL(clicked(bool)), this, SLOT(okClicked()));
-    connect(cancelButton, SIGNAL(clicked(bool)), this, SLOT(reject()));
-}
-
-void MeasuresFieldSettingsDialog::okClicked()
-{
-    // lets just check we have something etc
-    if (symbolEdit->text() == "" || nameEdit->text() == "") {
-
-        QMessageBox::warning(this, tr("Error"), tr("Name/Symbol cannot be blank"));
-
-        return;
-    } else {
-
-        field.symbol = symbolEdit->text();
-        field.name = nameEdit->text();
-        field.metricUnits = metricUnitsEdit->text();
-        field.imperialUnits = imperialUnitsEdit->text();
-        field.unitsFactor = unitsFactorEdit->value();
-        field.headers = headersEdit->text().split(",");
-    }
-
-    accept();
 }

--- a/src/Gui/Pages.h
+++ b/src/Gui/Pages.h
@@ -51,6 +51,7 @@
 #include "RemoteControl.h"
 #include "Measures.h"
 #include "TagStore.h"
+#include "ActionButtonBox.h"
 #include "StyledItemDelegates.h"
 #ifdef GC_WANT_PYTHON
 #include "FixPyScriptsDialog.h"
@@ -76,7 +77,6 @@ class SimBicyclePage;
 class GeneralPage : public QWidget
 {
     Q_OBJECT
-    G_OBJECT
 
     public:
         GeneralPage(Context *context);
@@ -90,11 +90,9 @@ class GeneralPage : public QWidget
         void browseAthleteDir();
 #ifdef GC_WANT_PYTHON
         void browsePythonDir();
-        void embedPythonchanged(int);
 #endif
 #ifdef GC_WANT_R
         void browseRDir();
-        void embedRchanged(int);
 #endif
 
     private:
@@ -110,29 +108,23 @@ class GeneralPage : public QWidget
 #endif
 #ifdef GC_WANT_R
         QCheckBox *embedR;
+        QWidget *rDirectorySel;
 #endif
 #ifdef GC_WANT_PYTHON
         QCheckBox *embedPython;
+        QWidget *pythonDirectorySel;
 #endif
         QCheckBox *opendata;
-        QLineEdit *garminHWMarkedit;
-        QLineEdit *hystedit;
+        QSpinBox *garminHWMarkedit;
+        QDoubleSpinBox *hystedit;
         QLineEdit *athleteDirectory;
-        QPushButton *athleteBrowseButton;
 
 #ifdef GC_WANT_PYTHON
-        QPushButton *pythonBrowseButton;
         QLineEdit *pythonDirectory;
-        QLabel *pythonLabel;
 #endif
 #ifdef GC_WANT_R
-        QPushButton *rBrowseButton;
         QLineEdit *rDirectory;
-        QLabel *rLabel;
 #endif
-        QLabel *langLabel;
-        QLabel *warningLabel;
-        QLabel *athleteLabel;
 
         struct {
             int unit;
@@ -144,8 +136,6 @@ class GeneralPage : public QWidget
             bool starthttp;
 #endif
         } b4;
-
-
 };
 
 class deviceModel : public QAbstractTableModel
@@ -186,7 +176,6 @@ class deviceModel : public QAbstractTableModel
 class DevicePage : public QWidget
 {
     Q_OBJECT
-    G_OBJECT
 
     public:
         DevicePage(QWidget *parent, Context *context);
@@ -202,54 +191,35 @@ class DevicePage : public QWidget
         Context *context;
 
         QList<DeviceType> devices;
-
-        QPushButton *addButton;
-        QPushButton *delButton;
-
-        QGridLayout *leftLayout;
-        QVBoxLayout *rightLayout;
-
-        QGridLayout *inLayout;
-        QVBoxLayout *mainLayout;
-
         deviceModel *deviceListModel;
 };
 
 class TrainOptionsPage : public QWidget
 {
     Q_OBJECT
-    G_OBJECT
 
     public:
         TrainOptionsPage(QWidget *parent, Context *context);
         qint32 saveClicked();
 
-    public slots:
-        void browseWorkoutDir();
-
     private:
         Context     *context;
-        QLabel      *workoutLabel;
-        QLineEdit   *workoutDirectory;
-        QPushButton *workoutBrowseButton;
+        DirectoryPathWidget *workoutDirectory;
         QCheckBox   *useSimulatedSpeed;
         QCheckBox   *useSimulatedHypoxia;
         QCheckBox   *multiCheck;
         QCheckBox   *autoConnect;
-        QLabel      *delayLabel;
         QSpinBox    *startDelay;
         QCheckBox   *autoHide;
         QCheckBox   *lapAlert;
         QCheckBox   *coalesce;
         QCheckBox   *tooltips;
-        QLabel      *telemetryScalingLabel;
         QComboBox   *telemetryScaling;
 };
 
 class RemotePage : public QWidget
 {
     Q_OBJECT
-    G_OBJECT
 
     public:
         RemotePage(QWidget *parent, Context *context);
@@ -257,8 +227,10 @@ class RemotePage : public QWidget
 
     private:
         RemoteControl *remote;
-        Context       *context;
-        QTreeWidget   *fields;
+        Context *context;
+        QTreeWidget *fields;
+        NoEditDelegate nativeCmdDelegate;
+        ComboBoxDelegate cmdDelegate;
 };
 
 struct SimBicyclePartEntry
@@ -267,13 +239,13 @@ struct SimBicyclePartEntry
     const char*   m_path;
     double        m_defaultValue;
     double        m_decimalPlaces;
+    const QString m_unit;
     const QString m_tooltip;
 };
 
 class SimBicyclePage : public QWidget
 {
     Q_OBJECT
-    G_OBJECT
 
 public:
     SimBicyclePage(QWidget *parent, Context *context);
@@ -290,8 +262,7 @@ public:
     };
 
     enum BicycleStats {
-        StatsLabel = 0,
-        StatsTotalKEMass,
+        StatsTotalKEMass = 0,
         StatsFrontWheelKEMass,
         StatsFrontWheelMass,
         StatsFrontWheelEquivMass,
@@ -313,11 +284,11 @@ public slots:
 private:
     void AddSpecBox(int ePart);
 
-
     Context         *context;
 
-    QLabel          *m_LabelArr  [LastPart];
+    QString         m_LabelTextArr[LastPart];
     QDoubleSpinBox  *m_SpinBoxArr[LastPart];
+    QString         m_StatsTextArr[StatsLastPart];
     QLabel          *m_StatsLabelArr[StatsLastPart];
 };
 
@@ -347,6 +318,9 @@ private:
     TagStore *tagStore;
     QTreeWidget *tw;
     QList<int> deleted;
+
+    UniqueLabelEditDelegate labelEditDelegate;
+    NoEditDelegate numDelegate;
 };
 
 
@@ -354,14 +328,11 @@ private:
 class CustomMetricsPage : public QWidget
 {
     Q_OBJECT
-    G_OBJECT
 
     public:
-
-    CustomMetricsPage(QWidget *parent, Context *context);
+        CustomMetricsPage(QWidget *parent, Context *context);
 
     public slots:
-
         void refreshTable();
         qint32 saveClicked();
 
@@ -379,15 +350,12 @@ class CustomMetricsPage : public QWidget
     protected:
         Context *context;
 
-        QPushButton *addButton,
-                    *deleteButton,
-                    *editButton,
 #ifdef GC_HAS_CLOUD_DB
-                    *uploadButton,
-                    *downloadButton,
+        QPushButton *uploadButton;
+        QPushButton *downloadButton;
 #endif
-                    *exportButton,
-                    *importButton;
+        QPushButton *exportButton;
+        QPushButton *importButton;
         QTreeWidget *table;
         QList<UserMetricSettings> metrics;
 
@@ -401,15 +369,11 @@ class CustomMetricsPage : public QWidget
 class FavouriteMetricsPage : public QWidget
 {
     Q_OBJECT
-    G_OBJECT
-
 
     public:
-
         FavouriteMetricsPage(QWidget *parent = NULL);
 
     public slots:
-
         void upClicked();
         void downClicked();
         void leftClicked();
@@ -419,18 +383,13 @@ class FavouriteMetricsPage : public QWidget
         qint32 saveClicked();
 
     protected:
-
         bool changed;
         QListWidget *availList;
         QListWidget *selectedList;
 #ifndef Q_OS_MAC
-        QToolButton *upButton;
-        QToolButton *downButton;
         QToolButton *leftButton;
         QToolButton *rightButton;
 #else
-        QPushButton *upButton;
-        QPushButton *downButton;
         QPushButton *leftButton;
         QPushButton *rightButton;
 #endif
@@ -439,8 +398,6 @@ class FavouriteMetricsPage : public QWidget
 class KeywordsPage : public QWidget
 {
     Q_OBJECT
-    G_OBJECT
-
 
     public:
         KeywordsPage(MetadataPage *parent, QList<KeywordDefinition>);
@@ -451,24 +408,18 @@ class KeywordsPage : public QWidget
         void addClicked();
         void upClicked();
         void downClicked();
-        void renameClicked();
         void deleteClicked();
 
         void pageSelected(); // reset the list of fields when we are selected...
         void colorfieldChanged();
 
     private:
-
         QTreeWidget *keywords;
+        ActionButtonBox *actionButtons;
 
-#ifndef Q_OS_MAC
-        QToolButton *upButton, *downButton;
-#else
-        QPushButton *upButton, *downButton;
-#endif
-        QPushButton *addButton, *renameButton, *deleteButton;
         QLabel *fieldLabel;
         QComboBox *fieldChooser;
+        ListEditDelegate relatedDelegate;
 
         MetadataPage *parent;
 };
@@ -533,13 +484,10 @@ class ColorsPage : public QWidget
 class FieldsPage : public QWidget
 {
     Q_OBJECT
-    G_OBJECT
-
 
     public:
         FieldsPage(QWidget *parent, QList<FieldDefinition>);
         void getDefinitions(QList<FieldDefinition>&);
-        static void addFieldTypes(QComboBox *p);
 
     public slots:
         void addClicked();
@@ -549,15 +497,12 @@ class FieldsPage : public QWidget
         void deleteClicked();
 
     private:
-
         QTreeWidget *fields;
-
-#ifndef Q_OS_MAC
-        QToolButton *upButton, *downButton;
-#else
-        QPushButton *upButton, *downButton;
-#endif
-        QPushButton *addButton, *renameButton, *deleteButton;
+        ActionButtonBox *actionButtons;
+        CompleterEditDelegate tabDelegate;
+        UniqueLabelEditDelegate fieldDelegate;
+        ComboBoxDelegate fieldTypeDelegate;
+        ListEditDelegate valueDelegate;
 };
 
 class ProcessorPage : public QWidget
@@ -597,9 +542,7 @@ class ProcessorPage : public QWidget
         QList<DataProcessorConfig*> configs;
 
 #ifdef GC_WANT_PYTHON
-        QPushButton *addButton = nullptr;
-        QPushButton *delButton = nullptr;
-        QPushButton *editButton = nullptr;
+        ActionButtonBox *actionButtons = nullptr;
         QCheckBox *hideButton = nullptr;
 #endif
 
@@ -610,12 +553,9 @@ class ProcessorPage : public QWidget
 class DefaultsPage : public QWidget
 {
     Q_OBJECT
-    G_OBJECT
-
 
     public:
-
-        DefaultsPage(QWidget *parent, QList<DefaultDefinition>);
+        DefaultsPage(MetadataPage *parent, QList<DefaultDefinition>);
         void getDefinitions(QList<DefaultDefinition>&);
 
     public slots:
@@ -625,16 +565,12 @@ class DefaultsPage : public QWidget
         void deleteClicked();
 
     protected:
-
         QTreeWidget *defaults;
+        MetadataPage *parent;
+        CompleterEditDelegate fieldDelegate;
+        CompleterEditDelegate linkedDelegate;
 
-#ifndef Q_OS_MAC
-        QToolButton *upButton, *downButton;
-#else
-        QPushButton *upButton, *downButton;
-#endif
-        QPushButton *addButton, *deleteButton;
-
+        bool eventFilter(QObject *obj, QEvent *event) override;
 };
 
 class MetadataPage : public QWidget
@@ -643,6 +579,7 @@ class MetadataPage : public QWidget
     G_OBJECT
 
     friend class ::KeywordsPage;
+    friend class ::DefaultsPage;
 
     public:
 
@@ -706,7 +643,6 @@ class IntervalsPage : public QWidget
 class MeasuresConfigPage : public QWidget
 {
     Q_OBJECT
-    G_OBJECT
 
     public:
         MeasuresConfigPage(QWidget *parent, Context *context);
@@ -714,75 +650,37 @@ class MeasuresConfigPage : public QWidget
         qint32 saveClicked();
 
     public slots:
+        void resetMeasuresClicked();
 
     private:
         Context *context;
         Measures *measures;
 
         QTreeWidget *measuresTable;
-        QTreeWidget *measuresFieldsTable;
+        UniqueLabelEditDelegate meNameDelegate;
+        UniqueLabelEditDelegate meSymbolDelegate;
 
-        QPushButton *resetMeasures, *editMeasures, *addMeasures, *removeMeasures;
-        QPushButton *editMeasuresField, *addMeasuresField, *removeMeasuresField;
+        QLabel *mflabel;
+        QTreeWidget *measuresFieldsTable;
+        UniqueLabelEditDelegate meFiNameDelegate;
+        UniqueLabelEditDelegate meFiSymbolDelegate;
+        DoubleSpinBoxEditDelegate meFiFactorDelegate;
+        ListEditDelegate meFiHeaderDelegate;
 
         void refreshMeasuresTable();
         void refreshMeasuresFieldsTable();
 
     private slots:
         void measuresSelected();
-        void measuresDoubleClicked(QTreeWidgetItem *item, int column);
-        void measuresFieldDoubleClicked(QTreeWidgetItem *item, int column);
+        void measureChanged(const QModelIndex &topLeft);
 
-        void resetMeasuresClicked();
-        void editMeasuresClicked();
         void addMeasuresClicked();
         void removeMeasuresClicked();
 
-        void editMeasuresFieldClicked();
+        void measureFieldChanged(const QModelIndex &topLeft);
         void addMeasuresFieldClicked();
         void removeMeasuresFieldClicked();
 };
 
-class MeasuresSettingsDialog : public QDialog
-{
-    Q_OBJECT
-
-    public:
-        MeasuresSettingsDialog(QWidget *parent, QString &symbol, QString &name);
-
-    private slots:
-        void okClicked();
-
-    private:
-        QString &symbol, &name;
-
-        QLineEdit *symbolEdit;
-        QLineEdit *nameEdit;
-
-        QPushButton *cancelButton, *okButton;
-
-};
-
-class MeasuresFieldSettingsDialog : public QDialog
-{
-    Q_OBJECT
-
-    public:
-        MeasuresFieldSettingsDialog(QWidget *parent, MeasuresField &field);
-
-    private slots:
-        void okClicked();
-
-    private:
-        MeasuresField &field;
-        QLineEdit *symbolEdit;
-        QLineEdit *nameEdit;
-        QLineEdit *metricUnitsEdit;
-        QLineEdit *imperialUnitsEdit;
-        QDoubleSpinBox *unitsFactorEdit;
-        QLineEdit *headersEdit;
-
-        QPushButton *cancelButton, *okButton;
-};
 
 #endif

--- a/src/Train/RemoteControl.cpp
+++ b/src/Train/RemoteControl.cpp
@@ -23,7 +23,7 @@ void RemoteCmd::setCmdId(int id)
     cmdId = id;
 }
 
-int RemoteCmd::getCmdId()
+int RemoteCmd::getCmdId() const
 {
     return cmdId;
 }
@@ -33,7 +33,7 @@ void RemoteCmd::setCmdStr(QString string)
     cmdStr = string;
 }
 
-QString RemoteCmd::getCmdStr()
+QString RemoteCmd::getCmdStr() const
 {
     return cmdStr;
 }
@@ -43,7 +43,7 @@ void RemoteCmd::setDisplayStr(QString string)
     displayStr = string;
 }
 
-QString RemoteCmd::getDisplayStr()
+QString RemoteCmd::getDisplayStr() const
 {
     return displayStr;
 }
@@ -58,7 +58,7 @@ void CmdMap::setNativeCmdId(int id)
     nativeCmdId = id;
 }
 
-int CmdMap::getNativeCmdId()
+int CmdMap::getNativeCmdId() const
 {
     return nativeCmdId;
 }
@@ -68,7 +68,7 @@ void CmdMap::setAntCmdId(int id)
     antCmdId = id;
 }
 
-int CmdMap::getAntCmdId()
+int CmdMap::getAntCmdId() const
 {
     return antCmdId;
 }
@@ -237,7 +237,7 @@ RemoteControl::readConfig()
 }
 
 void
-RemoteControl::writeConfig(QList<CmdMap> mappings)
+RemoteControl::writeConfig(QList<CmdMap> mappings) const
 {
     QString key, value;
 
@@ -255,7 +255,7 @@ RemoteControl::writeConfig(QList<CmdMap> mappings)
 }
 
 QString
-RemoteControl::getCmdStr(int index, QList<RemoteCmd> cmdList)
+RemoteControl::getCmdStr(int index, QList<RemoteCmd> cmdList) const
 {
     foreach(RemoteCmd cmd, cmdList) {
         if (cmd.getCmdId() == index)
@@ -265,7 +265,7 @@ RemoteControl::getCmdStr(int index, QList<RemoteCmd> cmdList)
 }
 
 int
-RemoteControl::getNativeCmdId(int antCmd)
+RemoteControl::getNativeCmdId(int antCmd) const
 {
     foreach(CmdMap map, _cmdMaps) {
         if (map.getAntCmdId() == antCmd) {

--- a/src/Train/RemoteControl.h
+++ b/src/Train/RemoteControl.h
@@ -56,11 +56,11 @@ class RemoteCmd
 
     public:
         void    setCmdId(int);
-        int     getCmdId(void);
+        int     getCmdId(void) const;
         void    setCmdStr(QString);
-        QString getCmdStr(void);
+        QString getCmdStr(void) const;
         void    setDisplayStr(QString);
-        QString getDisplayStr(void);
+        QString getDisplayStr(void) const;
 };
 
 class CmdMap
@@ -72,9 +72,9 @@ class CmdMap
     public:
         CmdMap();
         void    setNativeCmdId(int);
-        int     getNativeCmdId(void);
+        int     getNativeCmdId(void) const;
         void    setAntCmdId(int);
-        int     getAntCmdId(void);
+        int     getAntCmdId(void) const;
 };
 
 class RemoteControl
@@ -88,14 +88,14 @@ class RemoteControl
 
     public:
         RemoteControl();
-        void             writeConfig(QList<CmdMap>);
+        void             writeConfig(QList<CmdMap>) const;
         QList<CmdMap>    readConfig();
-        QList<CmdMap>    getMappings()   { return _cmdMaps; }
-        QList<RemoteCmd> getAntCmds()    { return _antCmdList; }
-        QList<RemoteCmd> getNativeCmds() { return _nativeCmdList; }
+        QList<CmdMap>    getMappings() const   { return _cmdMaps; }
+        QList<RemoteCmd> getAntCmds() const    { return _antCmdList; }
+        QList<RemoteCmd> getNativeCmds() const { return _nativeCmdList; }
 
-        QString          getCmdStr(int, QList<RemoteCmd>);  // return the matching command string for an id
-        int              getNativeCmdId(int);               // return the matching native command id for an ant id
+        QString          getCmdStr(int, QList<RemoteCmd>) const;  // return the matching command string for an id
+        int              getNativeCmdId(int) const;               // return the matching native command id for an ant id
 };
 
 #endif // _GC_RemoteControl_h

--- a/src/src.pro
+++ b/src/src.pro
@@ -670,7 +670,7 @@ HEADERS += Gui/AboutDialog.h Gui/AddIntervalDialog.h Gui/AnalysisSidebar.h Gui/C
            Gui/Views.h Gui/BatchProcessingDialog.h Gui/DownloadRideDialog.h Gui/ManualRideDialog.h Gui/NewSideBar.h \
            Gui/MergeActivityWizard.h Gui/RideImportWizard.h Gui/SplitActivityWizard.h Gui/SolverDisplay.h Gui/MetricSelect.h \
            Gui/AddTileWizard.h Gui/NavigationModel.h Gui/AthleteView.h Gui/AthleteConfigDialog.h Gui/AthletePages.h Gui/Perspective.h \
-           Gui/PerspectiveDialog.h Gui/SplashScreen.h Gui/StyledItemDelegates.h Gui/MetadataDialog.h
+           Gui/PerspectiveDialog.h Gui/SplashScreen.h Gui/StyledItemDelegates.h Gui/MetadataDialog.h Gui/ActionButtonBox.h
 
 # metrics and models
 HEADERS += Metrics/Banister.h Metrics/CPSolver.h Metrics/Estimator.h Metrics/ExtendedCriticalPower.h Metrics/HrZones.h Metrics/PaceZones.h \
@@ -779,7 +779,7 @@ SOURCES += Gui/AboutDialog.cpp Gui/AddIntervalDialog.cpp Gui/AnalysisSidebar.cpp
            Gui/BatchProcessingDialog.cpp Gui/DownloadRideDialog.cpp Gui/ManualRideDialog.cpp Gui/EditUserMetricDialog.cpp Gui/NewSideBar.cpp \
            Gui/MergeActivityWizard.cpp Gui/RideImportWizard.cpp Gui/SplitActivityWizard.cpp Gui/SolverDisplay.cpp Gui/MetricSelect.cpp \
            Gui/AddTileWizard.cpp Gui/NavigationModel.cpp Gui/AthleteView.cpp Gui/AthleteConfigDialog.cpp Gui/AthletePages.cpp Gui/Perspective.cpp \
-           Gui/PerspectiveDialog.cpp Gui/SplashScreen.cpp Gui/StyledItemDelegates.cpp Gui/MetadataDialog.cpp
+           Gui/PerspectiveDialog.cpp Gui/SplashScreen.cpp Gui/StyledItemDelegates.cpp Gui/MetadataDialog.cpp Gui/ActionButtonBox.cpp
 
 ## Models and Metrics
 SOURCES += Metrics/aBikeScore.cpp Metrics/aCoggan.cpp Metrics/AerobicDecoupling.cpp Metrics/Banister.cpp Metrics/BasicRideMetrics.cpp \


### PR DESCRIPTION
* Added a new class ActionButtonBox, similar to QDialogButtonBox to reduce code duplication
* Created a new QStyledItemDelegate for inline editing of lists
* Marking the currently selected category (General, Appearance, ...)
* Using the same reset button for Appearance and Measures
* Using the same style and behaviour as in athlete settings for all QTreeWidgets
* Using QFormLayout as much as possible, including support for the setting Mac styled Forms
* General: Reordered the settings, grouped them and added a (optional) scrollbar
* Data Fields
  * Fields
    * Enabled inline editing
      * Added autocompletion to Screen Tab
      * Added a uniqueness validator to Field
      * Added the list-delegate to Values
  * Colour Keywords: Added the list-delegate to Related Notres Words
  * Defaults: Added autocompletion to Field and Linked field
* Metrics
  * Swapped the tab order
  * Favourites
    * Made the lists wider
    * Moved the up-/down-buttons below the Favourites list
* Training
  * Swapped the tab order of Preferences and Train Devices
  * Remote Controls
    * Switched to inline editing
    * Made the Action non-editable
  * Virtual Bicycle Specifications: Redesigned the dialog
