### PR TITLE
RideNavigator: Always show colour bar

### DIFF
--- a/src/Gui/IntervalTreeView.cpp
+++ b/src/Gui/IntervalTreeView.cpp
@@ -160,41 +160,34 @@ IntervalTreeView::mimeData
     return returning;
 }
 
-void 
-IntervalColorDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option,
-               const QModelIndex &index) const 
+void
+IntervalColorDelegate::paint
+(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
-    //QStyledItemDelegate::paint(painter, option, index);
+    QTreeWidgetItem *item = nullptr;
+    if (index.isValid() && index.parent().isValid()) {
+        item = tree->itemFromIndexPublic(index);
+    }
 
     painter->save();
-
     // Only do this on items !
-    if(index.isValid() && index.parent().isValid()) {
-
-        // extract the state of item
-        bool hover = option.state & QStyle::State_MouseOver;
-        bool selected = option.state & QStyle::State_Selected;
-
-        QTreeWidgetItem *item = tree->itemFromIndexPublic(index);
-        QVariant v =  item->data(0, Qt::UserRole+1);
-        QColor color = v.value<QColor>();
-
-        // indicate color of interval in charts
-        if (!selected && !hover) {
-
-            // 7 pix wide mark on rhs
-            QRect high(option.rect.x()+option.rect.width() - (7*dpiXFactor),
-                       option.rect.y(), (7*dpiXFactor), tree->rowHeightPublic(index));
-
-            // use the interval colour
-            painter->fillRect(high, color);
-
-        }
-
+    if (item != nullptr) {
         // is it a performance test ?
-        QVariant t = item->data(0, Qt::UserRole+2);
+        QVariant t = item->data(0, Qt::UserRole + 2);
         const_cast<QStyleOptionViewItem&>(option).font.setBold(t.toInt() ? true : false);
     }
     QStyledItemDelegate::paint(painter, option, index);
+    if (item != nullptr) {
+        QVariant v =  item->data(0, Qt::UserRole + 1);
+        QColor color = v.value<QColor>();
+
+        // indicate color of interval in charts
+        // 7 pix wide mark on rhs
+        QRect high(option.rect.x() + option.rect.width() - 7 * dpiXFactor,
+                   option.rect.y(),
+                   7 * dpiXFactor,
+                   tree->rowHeightPublic(index));
+        painter->fillRect(high, color);
+    }
     painter->restore();
 }

--- a/src/Gui/RideNavigator.h
+++ b/src/Gui/RideNavigator.h
@@ -146,7 +146,7 @@ class RideNavigator : public GcChartWindow
 
         int groupBy() const { return _groupBy; }
         void setGroupBy(int x) { _groupBy = x; }
- 
+
         QString columns() const { return _columns; }
         void setColumns(QString x) { _columns = x; }
 
@@ -157,7 +157,7 @@ class RideNavigator : public GcChartWindow
         void noGroups() { currentColumn=-1; setGroupByColumn(); }
 
         QString widths() const { return _widths; }
-        void setWidths (QString x="") { _widths = x; resetView(); } // only reset once widths are set, witdths="" resets to default columns
+        void setWidths(QString x="") { _widths = x; resetView(); } // only reset once widths are set, widths="" resets to default columns
 
         void resetView(); // when columns/width changes
 
@@ -173,7 +173,7 @@ class RideNavigator : public GcChartWindow
         QList<QString> visualHeadings;
 
         // this maps friendly names to metric names
-        QMap <QString, QString> nameMap;
+        QMap<QString, QString> nameMap;
         QMap<QString, const RideMetric *> columnMetrics;
 
     private:
@@ -215,24 +215,22 @@ class RideNavigator : public GcChartWindow
 class NavigatorCellDelegate : public QItemDelegate
 {
     Q_OBJECT
-    G_OBJECT
-
 
 public:
-    NavigatorCellDelegate(RideNavigator *, QObject *parent = 0);
+    NavigatorCellDelegate(RideNavigator *, QObject *parent = nullptr);
 
     // These are all null since we don't allow editing
-    QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const;
-    void setEditorData(QWidget *editor, const QModelIndex &index) const;
-    void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const;
-    void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+    QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    void setEditorData(QWidget *editor, const QModelIndex &index) const override;
+    void setModelData(QWidget *editor, QAbstractItemModel *model, const QModelIndex &index) const override;
+    void updateEditorGeometry(QWidget *editor, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 
     // We increase the row height if there is a calendar text to display
-    QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const ;
+    QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 
     // override stanard painter to use color config to paint background
     // and perform correct level of rounding for each column before displaying
-    void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const;
+    void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 
     void setWidth(int x) { pwidth=x; }
 
@@ -246,8 +244,8 @@ private slots:
 private:
     RideNavigator *rideNavigator;
     int pwidth;
-
 };
+
 
 //
 // Column Chooser
@@ -297,7 +295,7 @@ class RideTreeView : public QTreeView
          void dragEnterEvent(QDragEnterEvent *e) {
             e->accept();
         }
- 
+
         void dragMoveEvent(QDragMoveEvent *e) {
             e->accept();
         }


### PR DESCRIPTION
* Show the colour bar (see Options > Data Fields > Colour Keywords) in RideNavigator even when an activity is selected
* Same for intervals
* Use contrasting colours for text (especially when using option "Use for Background")
* Replaced focus with active (QStyle::State) to avoid different text colors
* Remove trailing whitespaces from the code

![image](https://github.com/user-attachments/assets/4a6af29b-1d60-4ddd-bfb4-40040468dc54)
![image](https://github.com/user-attachments/assets/4610974c-c1fb-42e0-b3e9-402cb4597072)
