### PR TITLE
Text in Trainbottom window is word wrapped (Training Window)

### DIFF
--- a/src/Train/TrainBottom.cpp
+++ b/src/Train/TrainBottom.cpp
@@ -181,7 +181,7 @@ TrainBottom::TrainBottom(TrainSidebar *trainSidebar, QWidget *parent) :
     notificationText->setVerticalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     notificationText->setHorizontalScrollBarPolicy(Qt::ScrollBarAlwaysOff);
     notificationText->setTextInteractionFlags(Qt::NoTextInteraction);
-    notificationText->setLineWrapMode(QPlainTextEdit::NoWrap);
+    notificationText->setLineWrapMode(QPlainTextEdit::WidgetWidth);
 
     //QCheckBox *hideOnIdle = new QCheckBox(tr("Auto Hide"), this);
     //intensityControlLayout->addWidget(hideOnIdle);


### PR DESCRIPTION
Messages can be seen in several lines if they are large, not truncated
Specially useful when training a workout with long text messages during the training