### PR TITLE
Field colouring using expressions

### DIFF
--- a/src/Charts/TreeMapWindow.cpp
+++ b/src/Charts/TreeMapWindow.cpp
@@ -65,9 +65,8 @@ TreeMapWindow::TreeMapWindow(Context *context) :
 
     // read metadata.xml
     QString filename = QDir(gcroot).canonicalPath()+"/metadata.xml";
-    QString colorfield;
     if (!QFile(filename).exists()) filename = ":/xml/metadata.xml";
-    RideMetadata::readXML(filename, keywordDefinitions, fieldDefinitions, colorfield, defaultDefinitions);
+    RideMetadata::readXML(filename, keywordDefinitions, fieldDefinitions, defaultDefinitions);
 
     //title = new QLabel(this);
     //QFont font;

--- a/src/Core/Athlete.h
+++ b/src/Core/Athlete.h
@@ -57,7 +57,6 @@ class RideAutoImportConfig;
 class RideCache;
 class IntervalCache;
 class Context;
-class ColorEngine;
 class AnalysisSidebar;
 class AthleteTab;
 class Leaf;

--- a/src/Core/Context.cpp
+++ b/src/Core/Context.cpp
@@ -38,7 +38,6 @@ static QList<Context*> _contexts;
 GlobalContext::GlobalContext()
 {
     rideMetadata = NULL;
-    colorEngine = NULL;
     readConfig(0); // don't reread user metrics just yet
 }
 
@@ -66,7 +65,6 @@ GlobalContext::readConfig(qint32 state)
 {
     if (rideMetadata) {
         delete rideMetadata;
-        delete colorEngine;
     }
 
     // metric / non-metric
@@ -80,7 +78,6 @@ GlobalContext::readConfig(qint32 state)
 
     // redo
     rideMetadata = new RideMetadata(NULL);
-    colorEngine = new ColorEngine(this);
     specialFields = SpecialFields();
 
     if (state & CONFIG_USERMETRICS)  userMetricsConfigChanged();

--- a/src/Core/Context.h
+++ b/src/Core/Context.h
@@ -71,7 +71,6 @@ class MainWindow;
 class AthleteTab;
 class NavigationModel;
 class RideMetadata;
-class ColorEngine;
 
 
 class GlobalContext : public QObject
@@ -87,7 +86,6 @@ class GlobalContext : public QObject
         // metadata etc
         RideMetadata *rideMetadata;
         SpecialFields specialFields;
-        ColorEngine *colorEngine;
 
         // metric units
         bool useMetricUnits;

--- a/src/Core/DataFilter.h
+++ b/src/Core/DataFilter.h
@@ -243,7 +243,7 @@ class DataFilter : public QObject
         const gsl_rng_type *T;
         gsl_rng *r;
 
-        // RideItem always available and supplies th context
+        // RideItem always available and supplies the context
         Result evaluate(RideItem *rideItem, RideFilePoint *p);
         Result evaluate(DateRange dr, QString filter="");
         Result evaluate(Specification spec, DateRange dr);

--- a/src/Core/GcUpgrade.cpp
+++ b/src/Core/GcUpgrade.cpp
@@ -236,11 +236,10 @@ GcUpgrade::upgrade(const QDir &home)
 
             QList<KeywordDefinition> keywordDefinitions;
             QList<FieldDefinition>   fieldDefinitions;
-            QString colorfield;
             QList<DefaultDefinition> defaultDefinitions;
 
             // read em in
-            RideMetadata::readXML(filename, keywordDefinitions, fieldDefinitions, colorfield, defaultDefinitions);
+            RideMetadata::readXML(filename, keywordDefinitions, fieldDefinitions, defaultDefinitions);
 
             bool updated=false;
 
@@ -299,8 +298,8 @@ GcUpgrade::upgrade(const QDir &home)
             //
             int defaultIndex = -1, reverseIndex = -1;
             for(int i=0; i<keywordDefinitions.count(); i++) {
-                if (keywordDefinitions[i].name == "Default") defaultIndex = i;
-                if (keywordDefinitions[i].name == "Reverse") reverseIndex = i;
+                if (keywordDefinitions[i].filterExpression == "Default") defaultIndex = i;
+                if (keywordDefinitions[i].filterExpression == "Reverse") reverseIndex = i;
             }
 
             // no more default
@@ -313,14 +312,14 @@ GcUpgrade::upgrade(const QDir &home)
             if (reverseIndex < 0) {
                 updated = true;
                 KeywordDefinition add;
-                add.name = "Reverse";
+                add.filterExpression = "Reverse";
                 add.color = QColor(Qt::black);
                 keywordDefinitions << add;
             }
 
             if (updated) {
                 // write a new updated version
-                RideMetadata::serialize(filename, keywordDefinitions, fieldDefinitions, colorfield, defaultDefinitions);
+                RideMetadata::serialize(filename, keywordDefinitions, fieldDefinitions, defaultDefinitions);
             }
         }
 
@@ -422,12 +421,11 @@ GcUpgrade::upgrade(const QDir &home)
         // just add some very basic fields as an example
         QList<KeywordDefinition> keywordDefinitions;
         QList<FieldDefinition>   fieldDefinitions;
-        QString colorfield;
         QList<DefaultDefinition> defaultDefinitions;
 
         // read em in (should be in parent directory of athlete home)
         filename = home.canonicalPath()+"/../metadata.xml";
-        RideMetadata::readXML(filename, keywordDefinitions, fieldDefinitions, colorfield, defaultDefinitions);
+        RideMetadata::readXML(filename, keywordDefinitions, fieldDefinitions, defaultDefinitions);
 
         // just check we haven't already added Interval metadata
         bool hasIntervalMetadata=false;
@@ -450,7 +448,7 @@ GcUpgrade::upgrade(const QDir &home)
             add.name = "Interval Goal";
             fieldDefinitions << add;
 
-            RideMetadata::serialize(filename, keywordDefinitions, fieldDefinitions, colorfield, defaultDefinitions);
+            RideMetadata::serialize(filename, keywordDefinitions, fieldDefinitions, defaultDefinitions);
         }
 
         // Migrate Data Processor apply-values to new keys

--- a/src/Core/RideCache.cpp
+++ b/src/Core/RideCache.cpp
@@ -225,6 +225,12 @@ RideCache::configChanged(qint32 what)
         }
     }
 
+    if (what & CONFIG_NOTECOLOR) {
+        foreach(RideItem * item, rides()) {
+            item->color = GlobalContext::context()->rideMetadata->getColor(item);
+        }
+    }
+ 
     // if zones or weight has changed refresh metrics
     // will add more as they come
     qint32 want = CONFIG_ATHLETE | CONFIG_ZONES | CONFIG_NOTECOLOR | CONFIG_DISCOVERY | CONFIG_GENERAL | CONFIG_USERMETRICS;
@@ -243,6 +249,8 @@ RideCache::itemChanged()
     // NOTE ONLY CONNECT THIS TO RIDEITEMS !!!
     // BECAUSE IT IS ASSUMED BELOW THE SENDER IS A RIDEITEM
     RideItem *item = static_cast<RideItem*>(QObject::sender());
+
+    item->color = GlobalContext::context()->rideMetadata->getColor(item);
 
     // the model is particularly interested in ANY item that changes
     emit itemChanged(item);
@@ -273,6 +281,9 @@ RideCache::addRide(QString name, bool dosignal, bool select, bool useTempActivit
        last = new RideItem(plannedDirectory.canonicalPath(), name, dt, context, planned);
     else
        last = new RideItem(directory.canonicalPath(), name, dt, context, planned);
+
+    // set the navigator color
+    last->color = GlobalContext::context()->rideMetadata->getColor(last);
 
     connect(last, SIGNAL(rideDataChanged()), this, SLOT(itemChanged()));
     connect(last, SIGNAL(rideMetadataChanged()), this, SLOT(itemChanged()));

--- a/src/Core/RideDB.y
+++ b/src/Core/RideDB.y
@@ -916,10 +916,9 @@ APIWebService::listRides(QString athlete, HttpRequest &request, HttpResponse &re
 
         // params to readXML - we ignore them
         QList<KeywordDefinition> keywordDefinitions;
-        QString colorfield;
         QList<DefaultDefinition> defaultDefinitions;
 
-        RideMetadata::readXML(metaConfig, keywordDefinitions, settings.metafields, colorfield, defaultDefinitions);
+        RideMetadata::readXML(metaConfig, keywordDefinitions, settings.metafields, defaultDefinitions);
 
         SpecialFields sp;
 

--- a/src/Core/RideItem.cpp
+++ b/src/Core/RideItem.cpp
@@ -29,7 +29,7 @@
 #include "HrZones.h"
 #include "PaceZones.h"
 #include "Settings.h"
-#include "Colors.h" // for ColorEngine
+#include "Colors.h" // for standardColor
 #include "AddIntervalDialog.h" // till we fixup ridefilecache to have offsets
 #include "TimeUtils.h" // time_to_string()
 #include "WPrime.h" // for matches
@@ -473,9 +473,6 @@ RideItem::checkStale()
     // if we're marked stale already then just return that !
     if (isstale) return true;
 
-    // just change it .. its as quick to change as it is to check !
-    color = GlobalContext::context()->colorEngine->colorFor(getText(GlobalContext::context()->rideMetadata->getColorField(), ""));
-
     // upgraded metrics
     if (udbversion != UserMetricSchemaVersion || dbversion != DBSchemaVersion) {
 
@@ -602,7 +599,6 @@ RideItem::refresh()
         isSwim = f->isSwim();
         isXtrain = f->isXtrain();
         isAero = f->isAero();
-        color = GlobalContext::context()->colorEngine->colorFor(f->getTag(GlobalContext::context()->rideMetadata->getColorField(), ""));
         present = f->getTag("Data", "");
         samples = f->dataPoints().count() > 0;
 

--- a/src/Gui/Colors.cpp
+++ b/src/Gui/Colors.cpp
@@ -466,50 +466,6 @@ GCColor::themes()
     return allThemes;
 }
 
-ColorEngine::ColorEngine(GlobalContext *gc) : defaultColor(QColor(Qt::white)), gc(gc)
-{
-    configChanged(CONFIG_NOTECOLOR);
-    connect(gc, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));
-}
-
-void ColorEngine::configChanged(qint32)
-{
-    // clear existing
-    workoutCodes.clear();
-
-    // reverse
-    reverseColor = GColor(CPLOTBACKGROUND);
-
-    // setup the keyword/color combinations from config settings
-    foreach (KeywordDefinition keyword, gc->rideMetadata->getKeywords()) {
-        if (keyword.name == "Default")
-            defaultColor = keyword.color; // we actually ignore this now
-        else if (keyword.name == "Reverse")
-            reverseColor = keyword.color;  // to set the foreground when use as background is set
-        else {
-            workoutCodes[keyword.name] = keyword.color;
-
-            // alternative texts in notes
-            foreach (QString token, keyword.tokens) {
-                workoutCodes[token] = keyword.color;
-            }
-        }
-    }
-}
-
-QColor
-ColorEngine::colorFor(QString text)
-{
-    QColor color = QColor(1,1,1,1); // the default color has an alpha of 1, not possible otherwise
-
-    foreach(QString code, workoutCodes.keys()) {
-        if (text.contains(code, Qt::CaseInsensitive)) {
-           color = workoutCodes[code];
-        }
-    }
-    return color;
-}
-
 QString
 GCColor::css(bool ridesummary)
 {

--- a/src/Gui/Colors.h
+++ b/src/Gui/Colors.h
@@ -166,28 +166,6 @@ class GColorDialog : public QDialog
 };
 #endif
 
-// return a color for a ride file
-class GlobalContext;
-class ColorEngine : public QObject
-{
-    Q_OBJECT
-    G_OBJECT
-
-    public:
-        ColorEngine(GlobalContext *);
-
-        QColor colorFor(QString);
-        QColor defaultColor, reverseColor;
-
-    public slots:
-        void configChanged(qint32);
-
-    private:
-        QMap<QString, QColor> workoutCodes;
-        GlobalContext *gc; // bootstrapping
-};
-
-
 // shorthand
 #define GColor(x) GCColor::getColor(x)
 

--- a/src/Gui/Pages.h
+++ b/src/Gui/Pages.h
@@ -52,6 +52,7 @@
 #include "TagStore.h"
 #include "ActionButtonBox.h"
 #include "StyledItemDelegates.h"
+#include "SearchBox.h"
 #ifdef GC_WANT_PYTHON
 #include "FixPyScriptsDialog.h"
 #endif
@@ -404,22 +405,20 @@ class KeywordsPage : public QWidget
         QCheckBox *rideBG;
 
     public slots:
+        void updateClicked();
+
         void addClicked();
         void upClicked();
         void downClicked();
         void deleteClicked();
 
+        void currentItemChanged(QTreeWidgetItem* current, QTreeWidgetItem* previous);
         void pageSelected(); // reset the list of fields when we are selected...
-        void colorfieldChanged();
 
     private:
+        SearchBox* keywordFilter;
         QTreeWidget *keywords;
         ActionButtonBox *actionButtons;
-
-        QLabel *fieldLabel;
-        QComboBox *fieldChooser;
-        ListEditDelegate relatedDelegate;
-
         MetadataPage *parent;
 };
 
@@ -603,13 +602,11 @@ class MetadataPage : public QWidget
         QList<KeywordDefinition> keywordDefinitions;
         QList<FieldDefinition>   fieldDefinitions;
         QList<DefaultDefinition>  defaultDefinitions;
-        QString colorfield;
 
         // initial values
         struct {
             unsigned long fieldFingerprint;
             unsigned long keywordFingerprint;
-            QString colorfield;
         } b4;
 };
 

--- a/src/Gui/RideNavigator.cpp
+++ b/src/Gui/RideNavigator.cpp
@@ -47,7 +47,7 @@ RideNavigator::RideNavigator(Context *context, bool mainwindow) : GcChartWindow(
     this->mainwindow = mainwindow;
     _groupBy = -1;
     fontHeight = QFontMetrics(QFont()).height();
-    reverseColor = GlobalContext::context()->colorEngine->reverseColor;
+    reverseColor = GlobalContext::context()->rideMetadata->getReverseColor();
     currentItem = NULL;
     hasCalendarText = false;
 
@@ -168,7 +168,7 @@ void
 RideNavigator::configChanged(qint32 state)
 {
     fontHeight = QFontMetrics(QFont()).height();
-    reverseColor = GlobalContext::context()->colorEngine->reverseColor;
+    reverseColor = GlobalContext::context()->rideMetadata->getReverseColor();
     hasCalendarText = GlobalContext::context()->rideMetadata->hasCalendarText();
 
     // hide ride list scroll bar ?

--- a/src/Metrics/RideMetadata.h
+++ b/src/Metrics/RideMetadata.h
@@ -49,9 +49,9 @@ class RideEditor;
 class KeywordDefinition
 {
     public:
-        QString name;       // keyword for autocomplete
-        QColor  color;      // color to highlight with
-        QStringList tokens; // texts to find from notes
+
+        QString filterExpression;   // textual version of the keyword filter
+        QColor color;               // color to highlight if item matches keyword filter
 
         static unsigned long fingerprint(QList<KeywordDefinition>);
 };
@@ -179,8 +179,8 @@ class RideMetadata : public QWidget
 
     public:
         RideMetadata(Context *, bool singlecolumn = false);
-        static void serialize(QString filename, QList<KeywordDefinition>, QList<FieldDefinition>, QString colofield, QList<DefaultDefinition>defaultDefinitions);
-        static void readXML(QString filename, QList<KeywordDefinition>&, QList<FieldDefinition>&, QString &colorfield, QList<DefaultDefinition>&defaultDefinitions);
+        static void serialize(QString filename, QList<KeywordDefinition>, QList<FieldDefinition>, QList<DefaultDefinition>defaultDefinitions);
+        static void readXML(QString filename, QList<KeywordDefinition>&, QList<FieldDefinition>&, QList<DefaultDefinition>&defaultDefinitions);
         QList<KeywordDefinition> getKeywords() { return keywordDefinitions; }
         QList<FieldDefinition> getFields() { return fieldDefinitions; }
         QList<DefaultDefinition> getDefaults() { return defaultDefinitions; }
@@ -189,8 +189,8 @@ class RideMetadata : public QWidget
 
         QStringList sports();
 
-        QString getColorField() const { return colorfield; }
-        void setColorField(QString x) { colorfield = x; }
+        QColor getColor(RideItem* rideItem) const;
+        QColor getReverseColor() const;
 
         void setRideItem(RideItem *x);
         RideItem *rideItem() const;
@@ -234,7 +234,8 @@ class RideMetadata : public QWidget
 
     QVector<FormField*>   formFields;
 
-    QString colorfield;
+    QString colorfield; // support legacy format conversion
+    QColor reverseColor;
 
     RideEditor *editor;
 };
@@ -251,7 +252,6 @@ public:
 
     QList<KeywordDefinition> getKeywords() { return keywordDefinitions; }
     QList<FieldDefinition> getFields() { return fieldDefinitions; }
-    QString getColorField() { return colorfield; }
     QList<DefaultDefinition> getDefaults() { return defaultDefinitions; }
 
 protected:
@@ -260,7 +260,7 @@ protected:
     // ths results are here
     QList<KeywordDefinition> keywordDefinitions;
     QList<FieldDefinition>   fieldDefinitions;
-    QString colorfield;
+    QString colorfield; // legacy field for conversion
     QList<DefaultDefinition>   defaultDefinitions;
 
     // whilst parsing elements are stored here


### PR DESCRIPTION
Given the recent discussions on Sport & SubSport fields I intended to update my activities to use this structure, but this would prevent me having my existing activity navigator colouring scheme, as keyword colouring is based upon a single metadata item, not a combination of Sport & SubSport....

**Warning: Before testing this PR please backup your metadata.xml file, as the following PR will automatically convert your keyword definitions to expressions, and update the keyword section of the metadata.xml file to a new format.**

I have therefore created this PR which updates the keyword colouring to be based upon filter expressions, please test and let me know if a) it useful, b) it needs any changes/improvements.

![image](https://github.com/user-attachments/assets/477de4b7-1b66-44fd-aa56-2f2d7ae250a0)

Notes:
i) The existing "Reverse" keyword can be used in place of an expression, and when "Use for background" is checked it will set all the text to the colour defined for "Reverse"
ii) Tokens are not supported by this PR, as the expressions should support multiple keyword options.

		