### PR TITLE
Revert "travis/linux: set QTWEBENGINE_DISABLE_SANDBOX=1 (#4216)"

### DIFF
--- a/travis/linux/after_success.sh
+++ b/travis/linux/after_success.sh
@@ -18,15 +18,6 @@ mkdir -p appdir
 # Executable
 cp GoldenCheetah appdir
 
-# AppRun file
-cat >appdir/AppRun <<EOF
-#!/bin/bash
-HERE="\$(dirname "\$(readlink -f "\${0}")")"
-export QTWEBENGINE_DISABLE_SANDBOX=1
-exec "\${HERE}/GoldenCheetah" "\$@"
-EOF
-chmod a+x appdir/AppRun
-
 # Desktop file
 cat >appdir/GoldenCheetah.desktop <<EOF
 [Desktop Entry]


### PR DESCRIPTION
This reverts commit 9b29fb2f8de05eb72cd1d30403533a09cdd24fa2.

Disabling the sandbox like this was a good workaround at the time. But we shouldn't stick with it for security reasons.
Ubuntu 20.04 is EOL in April 2025 and was the last version using the problematic glibc 2.34

This is not urgent. But maybe add it to the [3.7 milestone](https://github.com/GoldenCheetah/GoldenCheetah/milestone/13)  so it doesn't fall under the radar.