### PR TITLE
Enable compiling VideoWindow with QT6 toolset

### DIFF
--- a/src/Gui/GcCrashDialog.cpp
+++ b/src/Gui/GcCrashDialog.cpp
@@ -286,6 +286,8 @@ QString GcCrashDialog::versionHTML()
             .arg("quicktime")
 #elif defined GC_VIDEO_QT5
             .arg("qt5")
+#elif defined GC_VIDEO_QT6
+            .arg("qt6")
 #elif defined GC_VIDEO_VLC
             .arg("vlc")
 #else

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -142,7 +142,7 @@ VideoWindow::VideoWindow(Context *context)  :
     }
 #endif
 
-#ifdef GC_VIDEO_QT5
+#if defined(GC_VIDEO_QT5)||defined(GC_VIDEO_QT6)
     // USE QT VIDEO PLAYER
     wd = new QVideoWidget(this);
     wd->show();
@@ -198,7 +198,7 @@ VideoWindow::~VideoWindow()
     vlcDispatch.Drain();
 #endif
 
-#ifdef GC_VIDEO_QT5
+#if defined(GC_VIDEO_QT5)||defined(GC_VIDEO_QT6)
     // QT MEDIA
     delete mp;
     delete wd;
@@ -223,6 +223,10 @@ bool VideoWindow::hasActiveVideo() const
 #endif
 #ifdef GC_VIDEO_QT5
     if (mp->state() != QMediaPlayer::StoppedState)
+        return true;
+#endif
+#ifdef GC_VIDEO_QT6
+    if (mp->playbackState() != QMediaPlayer::StoppedState)
         return true;
 #endif
 
@@ -342,7 +346,7 @@ void VideoWindow::startPlayback()
     m_MediaChanged = false;
 #endif
 
-#ifdef GC_VIDEO_QT5
+#if defined(GC_VIDEO_QT5)||defined(GC_VIDEO_QT6)
     // open the media object
     mp->play();
 #endif
@@ -398,7 +402,7 @@ void VideoWindow::startPlayback()
             }
         }
 #endif
-#ifdef GC_VIDEO_QT5
+#if defined(GC_VIDEO_QT5)||defined(GC_VIDEO_QT6)
         // QT doesn't expose media frame rate so make due with duration.
         double videoSyncDuration = currentVideoSyncFile->duration();
         if (videoSyncDuration > 0) {
@@ -455,7 +459,7 @@ void VideoWindow::stopPlayback()
     vlcDispatch.AsyncCall([capture_mp]{ libvlc_media_player_stop(capture_mp); });
 #endif
 
-#ifdef GC_VIDEO_QT5
+#if defined(GC_VIDEO_QT5)||defined(GC_VIDEO_QT6)
     mp->stop();
 #endif
 }
@@ -476,7 +480,7 @@ void VideoWindow::pausePlayback()
     vlcDispatch.AsyncCall([capture_mp]{libvlc_media_player_set_pause(capture_mp, true); });
 #endif
 
-#ifdef GC_VIDEO_QT5
+#if defined(GC_VIDEO_QT5)||defined(GC_VIDEO_QT6)
     mp->pause();
 #endif
 }
@@ -499,7 +503,7 @@ void VideoWindow::resumePlayback()
     }
 #endif
 
-#ifdef GC_VIDEO_QT5
+#if defined(GC_VIDEO_QT5)||defined(GC_VIDEO_QT6)
     mp->play();
 #endif
 
@@ -798,7 +802,7 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
     }
 #endif
 
-#ifdef GC_VIDEO_QT5
+#if defined(GC_VIDEO_QT5)||defined(GC_VIDEO_QT6)
 //TODO
 //    // seek to ms position in current file
 //    mp->setPosition(ms);
@@ -831,7 +835,7 @@ void VideoWindow::seekPlayback(long ms)
     }
 #endif
 
-#ifdef GC_VIDEO_QT5
+#if defined(GC_VIDEO_QT5)||defined(GC_VIDEO_QT6)
     Q_UNUSED(ms)
 //TODO
 //    // seek to ms position in current file
@@ -891,6 +895,10 @@ void VideoWindow::mediaSelected(QString filename)
     // QT MEDIA
     mc = QMediaContent(QUrl::fromLocalFile(filename));
     mp->setMedia(mc);
+#endif
+#ifdef GC_VIDEO_QT6
+    // QT MEDIA
+    mp->setSource(QUrl::fromLocalFile(filename));
 #endif
     if(context->isRunning) startPlayback();
 }

--- a/src/Train/VideoWindow.h
+++ b/src/Train/VideoWindow.h
@@ -40,7 +40,7 @@
 #ifdef Q_OS_MAC
 
 // if we aint chosen one or the other then use quicktime
-#if !defined GC_VIDEO_QUICKTIME && !defined GC_VIDEO_NONE && !defined GC_VIDEO_QT5 && !defined GC_VIDEO_VLC
+#if !defined GC_VIDEO_QUICKTIME && !defined GC_VIDEO_NONE && !defined GC_VIDEO_QT5 && !defined GC_VIDEO_QT6 && !defined GC_VIDEO_VLC
 #define GC_VIDEO_QUICKTIME
 #endif
 
@@ -50,8 +50,8 @@
 #endif
 
 // but qt5 *is* supported, but use at your own risk!
-#if defined GC_VIDEO_QT5
-#warning "QT 5 video is supported experimentally in this version"
+#if defined (GC_VIDEO_QT5) || defined (GC_VIDEO_QT6)
+#warning "QT 5/6 video is supported experimentally in this version"
 #endif
 
 #endif //Q_OS_MAC
@@ -63,14 +63,14 @@
 #if defined Q_OS_LINUX || defined Q_OS_WIN
 
 // did the user specify location for VLC but not GC_VIDEO_XXXX
-#if defined GC_HAVE_VLC && !defined GC_VIDEO_NONE && !defined GC_VIDEO_QT5
+#if defined GC_HAVE_VLC && !defined GC_VIDEO_NONE && !defined GC_VIDEO_QT5 && !defined GC_VIDEO_QT6
 #if !defined GC_VIDEO_VLC
 #define GC_VIDEO_VLC
 #endif
 #endif
 
 // if we aint chosen one or the other then use QT5
-#if !defined GC_VIDEO_NONE && !defined GC_VIDEO_QT5 && !defined GC_VIDEO_VLC
+#if !defined GC_VIDEO_NONE && !defined GC_VIDEO_QT5 && !defined GC_VIDEO_QT6 && !defined GC_VIDEO_VLC
 #define GC_VIDEO_QT5
 #endif
 
@@ -103,9 +103,12 @@ extern "C" {
 
 #endif // VLC
 
-#ifdef GC_VIDEO_QT5 // QT5 Video Stuff
+#if defined(GC_VIDEO_QT5)||defined(GC_VIDEO_QT6) // QT5/6 Video Stuff
 #include <QVideoWidget>
 #include <QMediaPlayer>
+#endif
+
+#ifdef GC_VIDEO_QT5
 #include <QMediaContent>
 #endif
 
@@ -308,8 +311,10 @@ class VideoWindow : public GcChartWindow
 #endif
 
 #ifdef GC_VIDEO_QT5
-        // QT native
         QMediaContent mc;
+#endif
+#if defined(GC_VIDEO_QT5) || defined(GC_VIDEO_QT6)
+        // QT native
         QVideoWidget *wd;
         QMediaPlayer *mp;
 #endif

--- a/src/gcconfig.pri.in
+++ b/src/gcconfig.pri.in
@@ -246,6 +246,7 @@ macx {
 DEFINES += GC_VIDEO_NONE             # dont add any video playback support
 #DEFINES += GC_VIDEO_QUICKTIME       # mac only and the default
 #DEFINES += GC_VIDEO_QT5             # use QT5 qvideowidget if QT > 5.2.1
+#DEFINES += GC_VIDEO_QT6             # qt6 videowidget
 #DEFINES += GC_VIDEO_VLC             # use VideoLan library needs VLC_INSTALL defined above
 #DEFINES += GC_VIDEO_AV              # use AV Foundation on Mac now QTKit is deprecated
 


### PR DESCRIPTION
Qt6 has removed QMediaContent, so minor update, adds GC_VIDEO_QT6 flag to enable QT6 compilation with Qt video window.