### PR TITLE
Store coretemp quality data

### DIFF
--- a/src/ANT/ANTChannel.cpp
+++ b/src/ANT/ANTChannel.cpp
@@ -904,7 +904,6 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
 
         case CHANNEL_TYPE_CORETEMP:
         {
-            // Quality alternates messages so will need to remember last quality message
             // only use core temp if data is 'good' or better (just use >0 for now)
             if ( antMessage.coreTemp > 0 )
             {

--- a/src/ANT/ANTMessage.cpp
+++ b/src/ANT/ANTMessage.cpp
@@ -621,12 +621,15 @@ ANTMessage::ANTMessage(ANT *parent, const unsigned char *message) {
 
             case ANTChannel::CHANNEL_TYPE_CORETEMP:
             {
+                static int tmpQual=0;
                 switch (data_page)
                 {
                 case 0:
-                    tempQual = (message[6]&0x3);
+                    // Quality only on intermittent messages so need to remember last quality message
+                    tmpQual = (message[6]&0x3);
                     break;
                 case 1:
+                    tempQual = tmpQual;
                     uint16_t val=(message[7]+((message[8] & 0xf0)<<4));
                     if (val>0 && val != 0x800) 
                         skinTemp = val/20.0;

--- a/src/Train/RealtimeData.cpp
+++ b/src/Train/RealtimeData.cpp
@@ -45,6 +45,7 @@ RealtimeData::RealtimeData()
     trainerConfigRequired = false;
     trainerBrakeFault = false;
     memset(spinScan, 0, 24);
+    temp = 0.0;
 }
 
 void RealtimeData::setName(char *name)
@@ -530,7 +531,7 @@ double RealtimeData::value(DataSeries series) const
 
     case Temp: return temp;
         break;
-        
+
     case CoreTemp: return coreTemp;
         break;
 


### PR DESCRIPTION
Tiny update, 
Currently not used but the core sensor provides a quality data value on a separate data page, this change holds onto the value so it can then be added into the XData.
also clear initial temp value to zero if not set, noticed this wasn't cleared when running a release build.