### PR TITLE
Added 'Context' to VideoLayoutParser, resolving crash d18f24c, fixing #4484

### DIFF
--- a/src/Train/VideoLayoutParser.cpp
+++ b/src/Train/VideoLayoutParser.cpp
@@ -23,11 +23,13 @@
 #include <QString>
 #include <QDebug>
 
+#include "Context.h"
+
 #include "VideoLayoutParser.h"
 #include "MeterWidget.h"
 
-VideoLayoutParser::VideoLayoutParser (QList<MeterWidget*>* metersWidget, QList<QString>* layoutNames, QWidget* VideoContainer)
-    : metersWidget(metersWidget), layoutNames(layoutNames), VideoContainer(VideoContainer)
+VideoLayoutParser::VideoLayoutParser (QList<MeterWidget*>* metersWidget, QList<QString>* layoutNames, QWidget* VideoContainer, Context* context)
+    : metersWidget(metersWidget), layoutNames(layoutNames), VideoContainer(VideoContainer), context(context)
 {
     nonameindex = 0;
     skipLayout = false;
@@ -191,7 +193,7 @@ bool VideoLayoutParser::startElement( const QString&, const QString&,
         }
         else if (meterType == QString("LiveMap"))
         {
-            meterWidget = new LiveMapWidget(meterName, containerWidget, source);
+            meterWidget = new LiveMapWidget(meterName, containerWidget, source, context);
         }
         else
         {

--- a/src/Train/VideoLayoutParser.h
+++ b/src/Train/VideoLayoutParser.h
@@ -23,6 +23,7 @@
 #ifndef _VideoLayoutParser_h
 #define _VideoLayoutParser_h
 #include "GoldenCheetah.h"
+class Context;
 
 #include <QString>
 #include <QXmlDefaultHandler>
@@ -32,7 +33,7 @@
 class VideoLayoutParser : public QXmlDefaultHandler
 {
 public:
-    VideoLayoutParser(QList<MeterWidget*>* metersWidget, QList<QString>* layoutNames, QWidget* VideoContainer);
+    VideoLayoutParser(QList<MeterWidget*>* metersWidget, QList<QString>* layoutNames, QWidget* VideoContainer, Context* context);
 
     bool startElement( const QString&, const QString&, const QString&, const QXmlAttributes& );
     bool endElement( const QString&, const QString&, const QString& );
@@ -42,6 +43,8 @@ public:
     int  layoutPositionSelected;
 
 private:
+    Context *context;
+
     QList<MeterWidget*>* metersWidget;
     QList<QString>* layoutNames;
     QWidget*    VideoContainer;

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -267,7 +267,7 @@ void VideoWindow::readVideoLayout(int pos, bool useDefault)
         }
         layoutNames.clear();
 
-        VideoLayoutParser handler(&m_metersWidget, &layoutNames, container);
+        VideoLayoutParser handler(&m_metersWidget, &layoutNames, container, context);
         QXmlInputSource source(&file);
         QXmlSimpleReader reader;
         handler.layoutPositionSelected = pos;


### PR DESCRIPTION
Commit d18f24c (that fixes #4484) makes GC crash when switchin to Train window. This is the relevat part of the stack trace:

```
#5  0x00005a27ac7cbab8 in LiveMapWidget::LiveMapWidget (this=0x5a27e148d260, Name=..., parent=0x5a27e12907d0, Source=..., context=0x0) at Train/MeterWidget.cpp:548
#6  0x00005a27ac845013 in VideoLayoutParser::startElement (this=0x7ffdb97c9a20, qName=..., qAttributes=...) at Train/VideoLayoutParser.cpp:198
#7  0x00007acce03eb074 in ?? () from /opt/goldencheetah/lib/libQt5Xml.so.5
#8  0x00007acce03ea4e8 in ?? () from /opt/goldencheetah/lib/libQt5Xml.so.5
#9  0x00007acce03eae68 in ?? () from /opt/goldencheetah/lib/libQt5Xml.so.5
#10 0x00007acce03ea4e8 in ?? () from /opt/goldencheetah/lib/libQt5Xml.so.5
#11 0x00007acce03eae68 in ?? () from /opt/goldencheetah/lib/libQt5Xml.so.5
#12 0x00007acce03eda83 in ?? () from /opt/goldencheetah/lib/libQt5Xml.so.5
#13 0x00007acce03edf72 in QXmlSimpleReader::parse(QXmlInputSource const*, bool) () from /opt/goldencheetah/lib/libQt5Xml.so.5
#14 0x00005a27abe3c4a8 in VideoWindow::readVideoLayout (this=0x5a27e12589e0, pos=1, useDefault=false) at Train/VideoWindow.cpp:275
#15 0x00005a27abe3c04b in VideoWindow::layoutChanged (this=0x5a27e12589e0) at Train/VideoWindow.cpp:234
#16 0x00005a27ac8879a6 in VideoWindow::qt_static_metacall (_o=0x5a27e12589e0, _c=QMetaObject::InvokeMetaMethod, _id=0, _a=0x7ffdb97c9c50) at moc_VideoWindow.cpp:112
#17 0x00007accd7afa660 in ?? () from /opt/goldencheetah/lib/libQt5Core.so.5
#18 0x00007acce067ced5 in QComboBox::currentIndexChanged(int) () from /opt/goldencheetah/lib/libQt5Widgets.so.5
#19 0x00007acce067f3c6 in ?? () from /opt/goldencheetah/lib/libQt5Widgets.so.5
#20 0x00007acce0681e2d in ?? () from /opt/goldencheetah/lib/libQt5Widgets.so.5
#21 0x00007acce0682183 in QComboBox::setCurrentIndex(int) () from /opt/goldencheetah/lib/libQt5Widgets.so.5
#22 0x00005a27ac887d99 in VideoWindow::setVideoLayout (this=0x5a27e12589e0, x=1) at Train/VideoWindow.h:250
```
[LiveMapWidget::LiveMapWidget()](https://github.com/GoldenCheetah/GoldenCheetah/blob/20c97899797027ee081ff8c2a74bf31d1ed5fbaf/src/Train/MeterWidget.cpp#L512) is invoked with context defaulting to null, but commit d18f24c needs that context points to something, [(MeterWidget.cpp)](https://github.com/GoldenCheetah/GoldenCheetah/blob/20c97899797027ee081ff8c2a74bf31d1ed5fbaf/src/Train/MeterWidget.cpp#L518)

This PR solves it by adding the context to VideoLayoutParser, that is who is invoking to LiveMapWidget::LiveMapWidget() and then, can pass the context.