### PR TITLE
Fix crash caused by WorkoutFilterBox (see #4606)

### DIFF
--- a/src/Train/WorkoutFilterBox.cpp
+++ b/src/Train/WorkoutFilterBox.cpp
@@ -33,7 +33,6 @@ WorkoutFilterBox::WorkoutFilterBox(QWidget *parent, Context *context) : FilterEd
     this->setClearButtonEnabled(true);
     this->setPlaceholderText(tr("Filter..."));
     this->setFilterCommands(workoutFilterCommands());
-    connect(this, SIGNAL(textChanged(const QString&)), this, SLOT(textChanged(const QString&)));
     connect(this, SIGNAL(editingFinished()), this, SLOT(editingFinished()));
     connect(context, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));
 
@@ -46,31 +45,28 @@ WorkoutFilterBox::~WorkoutFilterBox()
 }
 
 void
-WorkoutFilterBox::textChanged(const QString &text)
+WorkoutFilterBox::editingFinished()
 {
     workoutFilterErrorAction->setVisible(false);
     bool ok = true;
     QString msg;
-    QString input(text.trimmed());
+    QString input(text().trimmed());
     while (input.length() > 0 && (input.back().isSpace() || input.back() == ',')) {
         input.chop(1);
     }
-    if (context && input.length() > 0) {
-	filters = parseWorkoutFilter(input, ok, msg);
-        if (! ok) {
-            workoutFilterErrorAction->setVisible(true);
-            workoutFilterErrorAction->setToolTip(tr("ERROR: %1").arg(msg));
+    if (context) {
+        if (input.length() > 0) {
+            QList<ModelFilter *> filters = parseWorkoutFilter(input, ok, msg);
+            if (ok) {
+                context->setWorkoutFilters(filters);
+            } else {
+                workoutFilterErrorAction->setVisible(true);
+                workoutFilterErrorAction->setToolTip(tr("ERROR: %1").arg(msg));
+                context->clearWorkoutFilters();
+            }
+        } else {
+            context->clearWorkoutFilters();
         }
-    }
-}
-
-void
-WorkoutFilterBox::editingFinished()
-{
-    if (context && text().trimmed().length() > 0) {
-        context->setWorkoutFilters(filters);
-    } else {
-        context->clearWorkoutFilters();
     }
 }
 

--- a/src/Train/WorkoutFilterBox.h
+++ b/src/Train/WorkoutFilterBox.h
@@ -36,14 +36,12 @@ public:
     void setContext(Context *ctx) { context = ctx; }
 
 private slots:
-    void textChanged(const QString &text);
     void editingFinished();
     void configChanged(qint32 topic);
 
 private:
     Context *context;
     QAction *workoutFilterErrorAction;
-    QList<ModelFilter *> filters;
 };
 
 #endif


### PR DESCRIPTION
Root cause of the issue:
* MultiFilterProxyModel takes ownership of the filterlist (QList<ModelFilter*>) and deletes the previously set version, including the contained ModelFilters when clearing or setting a new list
* WorkoutFilterBox parses the filter (i.e. creates the filterlist) on textChange and keeps it in a member, even after setting it to the MultiFilterProxyModel
* When the event editingFinished is triggered in WorkoutFilterBox without reparsing, the filterlist is set again to MultiFilterProxyModel with already deleted ModelFilter*