### PR TITLE
Enable RLV for QT6 Video Window

### DIFF
--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -145,7 +145,7 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
     mediaTree->verticalScrollBar()->setStyle(cde);
 #endif
 
-#ifdef GC_HAVE_VLC  // RLV currently only support for VLC
+#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
     videosyncModel = trainDB->getVideoSyncModel();
 
     vssortModel = new QSortFilterProxyModel(this);
@@ -316,7 +316,7 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
     mediaTree->setWhatsThis(helpMediaTree->getWhatsThisText(HelpWhatsThis::SideBarTrainView_Media));
     trainSplitter->addWidget(mediaItem);
 
-#ifdef GC_HAVE_VLC  // RLV currently only support for VLC
+#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
     videosyncItem = new GcSplitterItem(tr("VideoSync"), iconFromPNG(":images/sidebar/sync.png"), this);
     QAction *moreVideoSyncAct = new QAction(iconFromPNG(":images/sidebar/extra.png"), tr("Menu"), this);
     videosyncItem->addAction(moreVideoSyncAct);
@@ -350,7 +350,7 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
     connect(mediaTree->selectionModel(), SIGNAL(selectionChanged(QItemSelection, QItemSelection)),
                             this, SLOT(mediaTreeWidgetSelectionChanged()));
     connect(context, SIGNAL(selectMedia(QString)), this, SLOT(selectVideo(QString)));
-#ifdef GC_HAVE_VLC  // RLV currently only support for VLC
+#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
     connect(videosyncTree->selectionModel(), SIGNAL(selectionChanged(QItemSelection, QItemSelection)),
                             this, SLOT(videosyncTreeWidgetSelectionChanged()));
     connect(context, SIGNAL(selectVideoSync(QString)), this, SLOT(selectVideoSync(QString)));
@@ -434,7 +434,7 @@ TrainSidebar::~TrainSidebar
     if (videoModel != nullptr) {
         delete videoModel;
     }
-#ifdef GC_HAVE_VLC  // RLV currently only support for VLC
+#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
     if (videosyncModel != nullptr) {
         delete videosyncModel;
     }
@@ -455,7 +455,7 @@ TrainSidebar::refresh()
     row = mediaTree->currentIndex().row();
     QString videoPath = mediaTree->model()->data(mediaTree->model()->index(row, TdbVideoModelIdx::filepath)).toString();
 
-#ifdef GC_HAVE_VLC  // RLV currently only support for VLC
+#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
     // refresh data
     QAbstractTableModel *oldVideoModel = videoModel;
     videoModel = trainDB->getVideoModel();
@@ -467,7 +467,7 @@ TrainSidebar::refresh()
     // restore selection
     selectVideo(videoPath);
 
-#ifdef GC_HAVE_VLC  // RLV currently only support for VLC
+#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
     // remember selection
     row = videosyncTree->currentIndex().row();
     QString videosyncPath = videosyncTree->model()->data(videosyncTree->model()->index(row, TdbVideosyncModelIdx::filepath)).toString();
@@ -691,7 +691,7 @@ TrainSidebar::configChanged(qint32 why)
     setProperty("color", GColor(CTRAINPLOTBACKGROUND));
 #if !defined GC_VIDEO_NONE
     mediaTree->setStyleSheet(GCColor::stylesheet(true));
-#ifdef GC_HAVE_VLC  // RLV currently only support for VLC
+#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
     videosyncTree->setStyleSheet(GCColor::stylesheet(true));
 #endif
 #endif
@@ -927,7 +927,7 @@ TrainSidebar::workoutTreeWidgetSelectionChanged()
             QString workoutName = QFileInfo(filename).baseName();
             mediaTree->setFocus();
             mediaTree->keyboardSearch(workoutName);
-#ifdef GC_HAVE_VLC  // RLV currently only support for VLC
+#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6) // RLV currently only support for VLC
             videosyncTree->setFocus();
             videosyncTree->keyboardSearch(workoutName);
 #endif
@@ -1298,7 +1298,7 @@ void TrainSidebar::Start()       // when start button is pressed
 
 #if !defined GC_VIDEO_NONE
         mediaTree->setEnabled(false);
-#ifdef GC_HAVE_VLC  // RLV currently only support for VLC
+#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
         videosyncTree->setEnabled(false);
 #endif
 #endif
@@ -1325,7 +1325,7 @@ void TrainSidebar::Start()       // when start button is pressed
 #if !defined GC_VIDEO_NONE
         // enable media tree so we can change movie - mid workout
         mediaTree->setEnabled(true);
-#ifdef GC_HAVE_VLC  // RLV currently only support for VLC
+#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
         videosyncTree->setEnabled(true);
 #endif
 #endif
@@ -1363,7 +1363,7 @@ void TrainSidebar::Start()       // when start button is pressed
         // media or workouts whilst a workout is in progress
 #if !defined GC_VIDEO_NONE
         mediaTree->setEnabled(false);
-#ifdef GC_HAVE_VLC  // RLV currently only support for VLC
+#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
         videosyncTree->setEnabled(false);
 #endif
 #endif
@@ -1486,7 +1486,7 @@ void TrainSidebar::Pause()        // pause capture to recalibrate
 
 #if !defined GC_VIDEO_NONE
         mediaTree->setEnabled(false);
-#ifdef GC_HAVE_VLC  // RLV currently only support for VLC
+#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
         videosyncTree->setEnabled(false);
 #endif
 #endif
@@ -1507,7 +1507,7 @@ void TrainSidebar::Pause()        // pause capture to recalibrate
         // enable media tree so we can change movie
 #if !defined GC_VIDEO_NONE
         mediaTree->setEnabled(true);
-#ifdef GC_HAVE_VLC  // RLV currently only support for VLC
+#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
         videosyncTree->setEnabled(true);
 #endif
 #endif
@@ -1532,7 +1532,7 @@ void TrainSidebar::Stop(int deviceStatus)        // when stop button is pressed
     // media or workouts whilst a workout is in progress
 #if !defined GC_VIDEO_NONE
     mediaTree->setEnabled(true);
-#ifdef GC_HAVE_VLC  // RLV currently only support for VLC
+#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
     videosyncTree->setEnabled(true);
 #endif
 #endif

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -80,6 +80,10 @@
 #include "TrainDB.h"
 #include "Library.h"
 
+#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6) // RLV currently only support for VLC
+#define USE_RLV
+#endif
+
 TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(context),
     bicycle(context)
 {
@@ -145,7 +149,7 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
     mediaTree->verticalScrollBar()->setStyle(cde);
 #endif
 
-#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
+#ifdef USE_RLV
     videosyncModel = trainDB->getVideoSyncModel();
 
     vssortModel = new QSortFilterProxyModel(this);
@@ -182,7 +186,7 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
     videosyncTree->verticalScrollBar()->setStyle(cdevideosync);
 #endif
 
-#endif //GC_HAVE_VLC
+#endif //USE_RLV
 
 #endif //GC_VIDEO_NONE
 
@@ -316,7 +320,7 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
     mediaTree->setWhatsThis(helpMediaTree->getWhatsThisText(HelpWhatsThis::SideBarTrainView_Media));
     trainSplitter->addWidget(mediaItem);
 
-#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
+#ifdef USE_RLV
     videosyncItem = new GcSplitterItem(tr("VideoSync"), iconFromPNG(":images/sidebar/sync.png"), this);
     QAction *moreVideoSyncAct = new QAction(iconFromPNG(":images/sidebar/extra.png"), tr("Menu"), this);
     videosyncItem->addAction(moreVideoSyncAct);
@@ -325,7 +329,7 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
     HelpWhatsThis *helpVideosyncTree = new HelpWhatsThis(videosyncTree);
     videosyncTree->setWhatsThis(helpVideosyncTree->getWhatsThisText(HelpWhatsThis::SideBarTrainView_VideoSync));
     trainSplitter->addWidget(videosyncItem);
-#endif //GC_HAVE_VLC
+#endif //USE_RLV
 #endif //GC_VIDEO_NONE
     trainSplitter->prepare(context->athlete->cyclist, "train");
 
@@ -350,11 +354,11 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
     connect(mediaTree->selectionModel(), SIGNAL(selectionChanged(QItemSelection, QItemSelection)),
                             this, SLOT(mediaTreeWidgetSelectionChanged()));
     connect(context, SIGNAL(selectMedia(QString)), this, SLOT(selectVideo(QString)));
-#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
+#ifdef USE_RLV
     connect(videosyncTree->selectionModel(), SIGNAL(selectionChanged(QItemSelection, QItemSelection)),
                             this, SLOT(videosyncTreeWidgetSelectionChanged()));
     connect(context, SIGNAL(selectVideoSync(QString)), this, SLOT(selectVideoSync(QString)));
-#endif //GC_HAVE_VLC
+#endif //USE_RLV
 #endif //GC_VIDEO_NONE
     connect(context, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));
     connect(context, SIGNAL(selectWorkout(QString)), this, SLOT(selectWorkout(QString)));
@@ -434,7 +438,7 @@ TrainSidebar::~TrainSidebar
     if (videoModel != nullptr) {
         delete videoModel;
     }
-#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
+#ifdef USE_RLV
     if (videosyncModel != nullptr) {
         delete videosyncModel;
     }
@@ -455,7 +459,7 @@ TrainSidebar::refresh()
     row = mediaTree->currentIndex().row();
     QString videoPath = mediaTree->model()->data(mediaTree->model()->index(row, TdbVideoModelIdx::filepath)).toString();
 
-#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
+#ifdef USE_RLV
     // refresh data
     QAbstractTableModel *oldVideoModel = videoModel;
     videoModel = trainDB->getVideoModel();
@@ -467,7 +471,7 @@ TrainSidebar::refresh()
     // restore selection
     selectVideo(videoPath);
 
-#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
+#ifdef USE_RLV
     // remember selection
     row = videosyncTree->currentIndex().row();
     QString videosyncPath = videosyncTree->model()->data(videosyncTree->model()->index(row, TdbVideosyncModelIdx::filepath)).toString();
@@ -481,7 +485,7 @@ TrainSidebar::refresh()
 
     // restore selection
     selectVideoSync(videosyncPath);
-#endif // GC_HAVE_VLC
+#endif // USE_RLV
 
 #endif // GC_VIDEO_NONE
 
@@ -691,7 +695,7 @@ TrainSidebar::configChanged(qint32 why)
     setProperty("color", GColor(CTRAINPLOTBACKGROUND));
 #if !defined GC_VIDEO_NONE
     mediaTree->setStyleSheet(GCColor::stylesheet(true));
-#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
+#ifdef USE_RLV
     videosyncTree->setStyleSheet(GCColor::stylesheet(true));
 #endif
 #endif
@@ -927,7 +931,7 @@ TrainSidebar::workoutTreeWidgetSelectionChanged()
             QString workoutName = QFileInfo(filename).baseName();
             mediaTree->setFocus();
             mediaTree->keyboardSearch(workoutName);
-#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6) // RLV currently only support for VLC
+#ifdef USE_RLV
             videosyncTree->setFocus();
             videosyncTree->keyboardSearch(workoutName);
 #endif
@@ -1298,7 +1302,7 @@ void TrainSidebar::Start()       // when start button is pressed
 
 #if !defined GC_VIDEO_NONE
         mediaTree->setEnabled(false);
-#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
+#ifdef USE_RLV
         videosyncTree->setEnabled(false);
 #endif
 #endif
@@ -1325,7 +1329,7 @@ void TrainSidebar::Start()       // when start button is pressed
 #if !defined GC_VIDEO_NONE
         // enable media tree so we can change movie - mid workout
         mediaTree->setEnabled(true);
-#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
+#ifdef USE_RLV
         videosyncTree->setEnabled(true);
 #endif
 #endif
@@ -1363,7 +1367,7 @@ void TrainSidebar::Start()       // when start button is pressed
         // media or workouts whilst a workout is in progress
 #if !defined GC_VIDEO_NONE
         mediaTree->setEnabled(false);
-#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
+#ifdef USE_RLV
         videosyncTree->setEnabled(false);
 #endif
 #endif
@@ -1486,7 +1490,7 @@ void TrainSidebar::Pause()        // pause capture to recalibrate
 
 #if !defined GC_VIDEO_NONE
         mediaTree->setEnabled(false);
-#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
+#ifdef USE_RLV
         videosyncTree->setEnabled(false);
 #endif
 #endif
@@ -1507,7 +1511,7 @@ void TrainSidebar::Pause()        // pause capture to recalibrate
         // enable media tree so we can change movie
 #if !defined GC_VIDEO_NONE
         mediaTree->setEnabled(true);
-#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
+#ifdef USE_RLV
         videosyncTree->setEnabled(true);
 #endif
 #endif
@@ -1532,7 +1536,7 @@ void TrainSidebar::Stop(int deviceStatus)        // when stop button is pressed
     // media or workouts whilst a workout is in progress
 #if !defined GC_VIDEO_NONE
     mediaTree->setEnabled(true);
-#if defined(GC_HAVE_VLC)||defined(GC_VIDEO_QT6)  // RLV currently only support for VLC
+#ifdef USE_RLV
     videosyncTree->setEnabled(true);
 #endif
 #endif

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -852,7 +852,7 @@ void VideoWindow::telemetryUpdate(RealtimeData rtd)
     }
 #endif
 
-#if defined(GC_VIDEO_QT5)||defined(GC_VIDEO_QT6)
+#ifdef GC_VIDEO_QT5
 //TODO
 //    // seek to ms position in current file
 //    mp->setPosition(ms);
@@ -885,16 +885,13 @@ void VideoWindow::seekPlayback(long ms)
         libvlc_media_player_t* capture_mp = this->mp;
         vlcDispatch.AsyncCall([capture_mp, ms]{ libvlc_media_player_set_time(capture_mp, (libvlc_time_t)ms); });
 #else
+#if defined(GC_VIDEO_QT5)||defined(GC_VIDEO_QT6)
         mp->setPosition(ms);
+#else
+        Q_UNUSED(ms)
+#endif
 #endif
     }
-
-#if defined(GC_VIDEO_QT5)||defined(GC_VIDEO_QT6)
-    Q_UNUSED(ms)
-//TODO
-//    // seek to ms position in current file
-//    mp->setPosition(ms);
-#endif
 }
 
 void VideoWindow::mediaSelected(QString filename)

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -418,21 +418,21 @@ void VideoWindow::startPlayback()
         }
 #endif
 #if defined(GC_VIDEO_QT5)||defined(GC_VIDEO_QT6)
-//TODO
         double videoSyncFrameRate = currentVideoSyncFile->videoFrameRate();
         if (videoSyncFrameRate > 0.) {
-            auto md = mp->metaData();
             bool ok=false;
+#ifdef GC_VIDEO_QT6
+            auto md = mp->metaData();
             auto rate = md.value(QMediaMetaData::VideoFrameRate);
             
             double mediaFrameRate = rate.toReal(&ok);
             if (mediaFrameRate > 0.) {
                 videoSyncTimeAdjustFactor = videoSyncFrameRate / mediaFrameRate;
             }
-            
+#endif
             if (!ok) //fallback to duration
             {
-                // QT doesn't expose media frame rate so make due with duration.
+                // QT5 doesn't expose media frame rate so make due with duration.
                 double videoSyncDuration = currentVideoSyncFile->duration();
                 if (videoSyncDuration > 0) {
                     double mediaDuration = (double)mp->duration();

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -357,12 +357,14 @@ void VideoWindow::startPlayback()
     m_MediaChanged = false;
 #endif
 
-#if defined(GC_VIDEO_QT5)||defined(GC_VIDEO_QT6)
+#ifdef GC_VIDEO_QT5
+#ifdef GC_VIDEO_QT6
     // open the media object
     float rate = 1.0f;
     if (context->currentVideoSyncFile() && context->currentVideoSyncFile()->Points.count() > 1)
         rate = 0.1f;
     mp->setPlaybackRate(rate);
+#endif
     mp->play();
 #endif
 

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -358,13 +358,14 @@ void VideoWindow::startPlayback()
 #endif
 
 #ifdef GC_VIDEO_QT5
+    mp->play();
+#endif
 #ifdef GC_VIDEO_QT6
     // open the media object
     float rate = 1.0f;
     if (context->currentVideoSyncFile() && context->currentVideoSyncFile()->Points.count() > 1)
         rate = 0.1f;
     mp->setPlaybackRate(rate);
-#endif
     mp->play();
 #endif
 

--- a/src/Train/VideoWindow.h
+++ b/src/Train/VideoWindow.h
@@ -107,7 +107,9 @@ extern "C" {
 #include <QVideoWidget>
 #include <QMediaPlayer>
 #endif
-
+#ifdef GC_VIDEO_QT6
+#include <QAudioOutput>
+#endif
 #ifdef GC_VIDEO_QT5
 #include <QMediaContent>
 #endif
@@ -266,6 +268,8 @@ class VideoWindow : public GcChartWindow
         void mediaSelected(QString filename);
         bool hasActiveVideo() const;
 
+        void ChangedStatus(QMediaPlayer::MediaStatus);
+        
     protected:
 
         void resizeEvent(QResizeEvent *);

--- a/src/Train/VideoWindow.h
+++ b/src/Train/VideoWindow.h
@@ -268,8 +268,6 @@ class VideoWindow : public GcChartWindow
         void mediaSelected(QString filename);
         bool hasActiveVideo() const;
 
-        void ChangedStatus(QMediaPlayer::MediaStatus);
-        
     protected:
 
         void resizeEvent(QResizeEvent *);


### PR DESCRIPTION
Working smoothly for me on Qt6 in RLV with overlaid meters, needs more testing, plus checking qt5 support/build.

![Screenshot_20250126_183649](https://github.com/user-attachments/assets/fe196fcd-eee7-4479-bfda-a0489edf1eca)
