### PR TITLE
Improve CoreTemp data

### DIFF
--- a/src/ANT/ANT.cpp
+++ b/src/ANT/ANT.cpp
@@ -162,7 +162,7 @@ ANT::ANT(QObject *parent, DeviceConfiguration *devConf, QString athlete) : QThre
         connect(antChannel[i], SIGNAL(posData(uint8_t)), this, SIGNAL(posData(uint8_t)));
 
         // Core temp data
-        connect(antChannel[i], SIGNAL(tcoreData(float, float, int)), this, SIGNAL(tcoreData(float, float, int)));
+        connect(antChannel[i], SIGNAL(tcoreData(float, float, float, int)), this, SIGNAL(tcoreData(float, float, float, int)));
 
         // timer for master channel broadcasts
         connect(antChannel[i], SIGNAL(broadcastTimerStart(int)), this, SLOT(slotStartBroadcastTimer(int)));
@@ -243,9 +243,9 @@ void ANT::setTemp(double temp)
     telemetry.setTemp(temp);
 }
 
-void ANT::setCoreTemp(double core, double skin)
+void ANT::setCoreTemp(double core, double skin, double strain)
 {
-    telemetry.setCoreTemp(core, skin);
+    telemetry.setCoreTemp(core, skin, strain);
 }
 
 /*======================================================================

--- a/src/ANT/ANT.h
+++ b/src/ANT/ANT.h
@@ -672,7 +672,7 @@ public:
     }
     void setHb(double smo2, double thb);
 
-    void setCoreTemp(double core, double skin);
+    void setCoreTemp(double core, double skin, double strain);
 
     void setLRBalance(double lrbalance) {
         telemetry.setLRBalance(lrbalance);

--- a/src/ANT/ANTChannel.cpp
+++ b/src/ANT/ANTChannel.cpp
@@ -1260,8 +1260,10 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
 
             case CHANNEL_TYPE_TEMPE:
             {
-                if (antMessage.tempValid)
-                    parent->setTemp(antMessage.temp/100.0);
+                if (antMessage.tempValid) {
+                    value = value2 = antMessage.temp/100.0;
+                    parent->setTemp(value);
+                }
             }
             break;
 

--- a/src/ANT/ANTChannel.cpp
+++ b/src/ANT/ANTChannel.cpp
@@ -911,9 +911,9 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                 value2 = antMessage.skinTemp;
 
                 // Store in XDATA
-                emit tcoreData(antMessage.coreTemp, antMessage.skinTemp, antMessage.tempQual);
+                emit tcoreData(antMessage.coreTemp, antMessage.skinTemp, antMessage.heatStrain, antMessage.tempQual);
                 // and forward to telemetry
-                parent->setCoreTemp(antMessage.coreTemp, antMessage.skinTemp);
+                parent->setCoreTemp(antMessage.coreTemp, antMessage.skinTemp, antMessage.heatStrain);
             }
         }
         break;

--- a/src/ANT/ANTChannel.h
+++ b/src/ANT/ANTChannel.h
@@ -258,7 +258,7 @@ class ANTChannel : public QObject {
         void posData(uint8_t position);
 
         // signal for core temp data
-        void tcoreData(float core, float skin, int qual);
+        void tcoreData(float core, float skin, int qual, float strain);
 
         // signal for passing remote control commands
         void antRemoteControl(uint16_t command);

--- a/src/ANT/ANTMessage.cpp
+++ b/src/ANT/ANTMessage.cpp
@@ -636,6 +636,9 @@ ANTMessage::ANTMessage(ANT *parent, const unsigned char *message) {
                     val=(message[10]+(message[11]<<8));
                     if (val>0  && val != 0x8000)
                         coreTemp = val/100.0;
+                    uint8_t hsi = message[5]; //Heat strain index
+                    if (hsi != 0xff)
+                        heatStrain = hsi/10.0;
                     break;
                 }
                 break;
@@ -969,7 +972,7 @@ void ANTMessage::init()
     fpodStrides=0;
     tempValid = false;
     temp=0;
-    coreTemp = skinTemp = 0.0;
+    coreTemp = skinTemp = heatStrain = 0.0;
     tempQual = 0;
 }
 

--- a/src/ANT/ANTMessage.h
+++ b/src/ANT/ANTMessage.h
@@ -162,7 +162,7 @@ class ANTMessage {
         bool utcTimeRequired; // moxy
         uint8_t moxyCapabilities; //moxy
         double tHb, oldsmo2, newsmo2; //moxy
-        double coreTemp, skinTemp;
+        double coreTemp, skinTemp, heatStrain;
         uint8_t tempQual;
         uint8_t leftTorqueEffectiveness, rightTorqueEffectiveness; // power - TE&PS
         uint8_t leftOrCombinedPedalSmoothness, rightPedalSmoothness; // power - TE&PS

--- a/src/ANT/ANTlocalController.cpp
+++ b/src/ANT/ANTlocalController.cpp
@@ -49,7 +49,7 @@ ANTlocalController::ANTlocalController(TrainSidebar *parent, DeviceConfiguration
     connect(myANTlocal, SIGNAL(rrData(uint16_t, uint8_t, uint8_t)), this, SIGNAL(rrData(uint16_t, uint8_t, uint8_t)));
 
     connect(myANTlocal, SIGNAL(posData(uint8_t)), this, SIGNAL(posData(uint8_t)));
-    connect(myANTlocal, SIGNAL(tcoreData(float, float, int)), this, SIGNAL(tcoreData(float, float, int)));
+    connect(myANTlocal, SIGNAL(tcoreData(float, float, float, int)), this, SIGNAL(tcoreData(float, float, float, int)));
 
     // connect slot receiving ANT remote control commands & translating to native
     connect(myANTlocal, SIGNAL(antRemoteControl(uint16_t)), this, SLOT(antRemoteControl(uint16_t)));

--- a/src/FileIO/CsvRideFile.cpp
+++ b/src/FileIO/CsvRideFile.cpp
@@ -1572,9 +1572,9 @@ RideFile *CsvFileReader::openRideFile(QFile &file, QStringList &errors, QList<Ri
     {
         // create the XDATA series
         tcoreSeries = new XDataSeries();
-        tcoreSeries->name = "CoreTemp Measurements";
-        tcoreSeries->valuename << "Core" << "Skin" << "Quality";
-        tcoreSeries->unitname << "C" << "C" << "q";
+        tcoreSeries->name = "TCORE";
+        tcoreSeries->valuename << "Core" << "Skin" << "HSI" << "Quality";
+        tcoreSeries->unitname << "C" << "C" << "%" << "q";
 
         // attempt to read and add the data
         lineno=1;
@@ -1612,7 +1612,8 @@ RideFile *CsvFileReader::openRideFile(QFile &file, QStringList &errors, QList<Ri
                     p->km = 0;
                     p->number[0] = values.at(1).toDouble();
                     p->number[1] = values.at(2).toDouble();
-                    p->number[2] = values.at(3).toInt();
+                    p->number[2] = values.at(3).toDouble();
+                    p->number[3] = values.at(4).toInt();
                     tcoreSeries->datapoints.append(p);
                 }
 

--- a/src/Train/RealtimeData.cpp
+++ b/src/Train/RealtimeData.cpp
@@ -35,6 +35,7 @@ RealtimeData::RealtimeData()
     rppb = rppe = rpppb = rpppe = 0.0;
     lppb = lppe = lpppb = lpppe = 0.0;
     coreTemp = skinTemp = 0.0;
+    heatStrain = 0.0;
     latitude = longitude = altitude = 0.0;
     rf = rmv = vo2 = vco2 = tv = feo2 = 0.0;
     routeDistance = distanceRemaining = 0.0;
@@ -173,9 +174,10 @@ void RealtimeData::setRPS(double x)
 }
 
 //Skin temp passed but not used elsewhere
-void RealtimeData::setCoreTemp(double core, double skin) {
+void RealtimeData::setCoreTemp(double core, double skin, double heatStrain) {
   this->coreTemp = core;
   this->skinTemp = skin;
+  this->heatStrain = heatStrain;
 }
 
 const char *
@@ -895,3 +897,5 @@ void RealtimeData::setTemp(double temp) { this->temp = temp; }
 double RealtimeData::getTemp() const { return temp; }
 
 double RealtimeData::getCoreTemp() const { return coreTemp; }
+double RealtimeData::getSkinTemp() const { return skinTemp; }
+double RealtimeData::getHeatStrain() const { return heatStrain; }

--- a/src/Train/RealtimeData.h
+++ b/src/Train/RealtimeData.h
@@ -56,7 +56,7 @@ public:
                       RightPowerPhasePeakBegin, RightPowerPhasePeakEnd,
                       Position, RightPCO, LeftPCO,
                       Temp,
-                      CoreTemp
+                      CoreTemp, SkinTemp, HeatStrain
                     };
 
     typedef enum dataseries DataSeries;
@@ -121,7 +121,7 @@ public:
     void setLatitude(double);
     void setLongitude(double);
     void setAltitude(double);
-    void setCoreTemp(double,double);
+    void setCoreTemp(double,double,double);
     const char *getName() const;
 
     // new muscle oxygen stuff
@@ -145,6 +145,8 @@ public:
     double getTv() const;
     double getFeO2() const;
     double getCoreTemp() const;
+    double getSkinTemp() const;
+    double getHeatStrain() const;
 
     double getWatts() const;
     double getAltWatts() const;
@@ -224,6 +226,7 @@ private:
     RealtimeData::riderPosition position;
     double temp;
     double skinTemp, coreTemp;
+    double heatStrain;
 
     std::chrono::high_resolution_clock::time_point wheelRpmSampleTime;
 

--- a/src/Train/TrainSidebar.h
+++ b/src/Train/TrainSidebar.h
@@ -219,7 +219,7 @@ class TrainSidebar : public GcWindow
         void rrData(uint16_t  rrtime, uint8_t heartrateBeats, uint8_t instantHeartrate);
 
         void posData(uint8_t position);
-        void tcoreData(float  core, float skin, int qual);
+        void tcoreData(float  core, float skin, float hsi, int qual);
 
         // VO2 measurement data to save
         void vo2Data(double rf, double rmv, double vo2, double vco2, double tv, double feo2);
@@ -268,7 +268,7 @@ class TrainSidebar : public GcWindow
         double displayDistance, displayWorkoutDistance;
         double displayLapDistance, displayLapDistanceRemaining;
         double displayLatitude, displayLongitude, displayAltitude; // geolocation
-        double displayCoreTemp;
+        double displayCoreTemp, displaySkinTemp, displayHeatStrain;
         long load;
         double slope;
         int displayWorkoutLap;     // which Lap in the workout are we at?


### PR DESCRIPTION
Adds support for new "heat strain index" data from CoreTemp ANT messages

Details: [Heat Strain](https://corebodytemp.com/blogs/news/examples-of-the-heat-strain-index)
Not sure if the GoldenCheetah graphing could be used to create something like this (the strain is shown in the background coloured bars):
![image](https://github.com/user-attachments/assets/0e46b317-d34b-42e5-b24a-5964f14959c8)
