### PR TITLE
Zoom property to Live map chart settings

### DIFF
--- a/src/Train/LiveMapWebPageWindow.h
+++ b/src/Train/LiveMapWebPageWindow.h
@@ -59,6 +59,7 @@ class LiveMapWebPageWindow : public GcChartWindow
 
     // properties can be saved/restored/set by the layout manager
     Q_PROPERTY(QString url READ url WRITE setUrl USER true)
+    Q_PROPERTY(int zoom READ zoom WRITE setZoom USER true)
 
     public:
         LiveMapWebPageWindow(Context *);
@@ -72,6 +73,8 @@ class LiveMapWebPageWindow : public GcChartWindow
         // set/get properties
         QString url() const { return customUrl->text(); }
         void setUrl(QString x) { customUrl->setText(x); }
+        int zoom() const { return customZoom->value(); }
+        void setZoom(int x) { customZoom->setValue(x); }
 
     public slots:
         void configChanged(qint32);
@@ -96,7 +99,7 @@ class LiveMapWebPageWindow : public GcChartWindow
         QLineEdit* rCustomUrl;
         QLineEdit* customLat;
         QLineEdit* customLon;
-        QLineEdit* customZoom;
+        QSpinBox* customZoom;
         QPushButton* rButton;
         QPushButton* applyButton;
 


### PR DESCRIPTION
This PR adds an initial zoom for Live map chart in train view. 'Initial' because it can be modified on the fly with the +/- buttons.

It has been discussed previously in [user forum](https://groups.google.com/g/golden-cheetah-users/c/v19Jsjd1Vqk).

You can see the map with your desired zoom. If not set, it defaults to 15, the same as it is now hardcoded.

![Settings](https://github.com/user-attachments/assets/25c16c33-42c0-4509-9fa5-79b09683ba41)

It allows a zoom equal to 0. In such case, the zoom is adapted to the boundaries of the route, and the map is not moved when the position changes to be centered on the position. It will show a static view of the route, and the marker will continue to move across the path.

As the zoom can be configured independently for each live mart, you can, for example, have two maps, one showing the general view, and other with a zoom to the current position:

![View](https://github.com/user-attachments/assets/da86126f-175e-4354-99be-a3ed9c093917)

