### PR TITLE
Add Zoom property to Live map chart

### DIFF
--- a/src/Train/LiveMapWebPageWindow.cpp
+++ b/src/Train/LiveMapWebPageWindow.cpp
@@ -82,11 +82,19 @@ LiveMapWebPageWindow::LiveMapWebPageWindow(Context *context) : GcChartWindow(con
     customUrl = new QLineEdit(this);
     customUrl->setFixedWidth(600);
 
+    customZoomLabel = new QLabel(tr("Initial Zoom"));
+    customZoom = new QSpinBox(this);
+    customZoom->setFixedWidth(60);
+    customZoom->setRange(0, 20); // Set the range for zoom levels
+
     if (customUrl->text().trimmed().isEmpty()) customUrl->setText("https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png");
     commonLayout->addRow(customUrlLabel, customUrl);
 
     connect(customUrl, SIGNAL(returnPressed()), this, SLOT(userUrl()));
 
+    if (customZoom->text().trimmed().isEmpty()) customZoom->setValue(15);
+    commonLayout->addRow(customZoomLabel, customZoom);
+    
     applyButton = new QPushButton(application->style()->standardIcon(QStyle::SP_ArrowRight), tr("Apply changes"), this);
     commonLayout->addRow(applyButton);
 
@@ -145,7 +153,8 @@ void LiveMapWebPageWindow::ergFileSelected(ErgFile* f)
         }
         else
         {
-            QString js = ("<div><script type=\"text/javascript\">initMap (" + startingLat + ", " + startingLon + ",13);</script></div>\n");
+            QString sZoom = QString::number(zoom());
+            QString js = ("<div><script type=\"text/javascript\">initMap (" + startingLat + ", " + startingLon + ", " + sZoom + ");</script></div>\n");
             routeLatLngs = "[";
             QString code = "";
 
@@ -230,7 +239,8 @@ void LiveMapWebPageWindow::telemetryUpdate(RealtimeData rtd)
         code = "";
         if (!markerIsVisible)
         {
-            code = QString("centerMap (" + sLat + ", " + sLon + ", " + "15" + ");");
+            QString sZoom = QString::number(zoom());
+            code += QString("centerMap (" + sLat + ", " + sLon + ", " + sZoom + ");");
             code += QString("showMyMarker (" + sLat + ", " + sLon + ");");
             markerIsVisible = true;
         }

--- a/src/Train/LiveMapWebPageWindow.h
+++ b/src/Train/LiveMapWebPageWindow.h
@@ -59,6 +59,7 @@ class LiveMapWebPageWindow : public GcChartWindow
 
     // properties can be saved/restored/set by the layout manager
     Q_PROPERTY(QString url READ url WRITE setUrl USER true)
+    Q_PROPERTY(int zoom READ zoom WRITE setZoom USER true)
 
     public:
         LiveMapWebPageWindow(Context *);
@@ -72,6 +73,8 @@ class LiveMapWebPageWindow : public GcChartWindow
         // set/get properties
         QString url() const { return customUrl->text(); }
         void setUrl(QString x) { customUrl->setText(x); }
+        int zoom() const { return customZoom->value(); }
+        void setZoom(int x) { customZoom->setValue(x); }
 
     public slots:
         void configChanged(qint32);
@@ -96,7 +99,7 @@ class LiveMapWebPageWindow : public GcChartWindow
         QLineEdit* rCustomUrl;
         QLineEdit* customLat;
         QLineEdit* customLon;
-        QLineEdit* customZoom;
+        QSpinBox* customZoom;
         QPushButton* rButton;
         QPushButton* applyButton;
 


### PR DESCRIPTION
Accidentally closed #4618; this is a replica of it.

This PR adds an initial zoom for Live map chart in train view. 'Initial' because it can be modified on the fly with the +/- buttons.

It has been discussed previously in [user forum](https://groups.google.com/g/golden-cheetah-users/c/v19Jsjd1Vqk).

You can see the map with your desired zoom. If not set, it defaults to 15, the same as it is now hardcoded.

![Settings](https://github.com/user-attachments/assets/25c16c33-42c0-4509-9fa5-79b09683ba41)


