### PR TITLE
Limit chart settings size

### DIFF
--- a/src/Charts/ChartSettings.cpp
+++ b/src/Charts/ChartSettings.cpp
@@ -18,6 +18,7 @@
  */
 
 #include "ChartSettings.h"
+#include "Colors.h"
 #include <QVBoxLayout>
 
 ChartSettings::ChartSettings(QWidget *parent, QWidget *contents) : QDialog(parent)
@@ -31,8 +32,11 @@ ChartSettings::ChartSettings(QWidget *parent, QWidget *contents) : QDialog(paren
   // Create the main layout box.
   QVBoxLayout *mainVBox = new QVBoxLayout(this);
 
-  // Set up the instructions field.
+  // Set up the instructions field, limiting heigth
+  // to avoid issues on lower resolution displays
   mainVBox->addWidget(contents);
+  contents->setMaximumWidth(650*dpiXFactor);
+  contents->setMaximumHeight(720*dpiYFactor);
 
   // "Done" button.
   QHBoxLayout *buttonHBox = new QHBoxLayout;

--- a/src/Gui/AthleteTab.cpp
+++ b/src/Gui/AthleteTab.cpp
@@ -93,8 +93,6 @@ AthleteTab::AthleteTab(Context *context) : QWidget(context->mainWindow), context
 
     // the dialog box for the chart settings
     chartSettings = new ChartSettings(this, masterControls);
-    chartSettings->setMaximumWidth(650);
-    chartSettings->setMaximumHeight(600);
     chartSettings->hide();
 
     // navigation model after main items as it uses the observer


### PR DESCRIPTION
Currently it is too tall for lower resolution displays, as discussed in the users forum, the size limit in AthleteTab has no effect so it is moved to ChartSettings and adjusted. The tallest seems to be CP chart settings.
I tested on Windows (Qt 5.15.2 and 6.5.3), Linux (Qt 6.5.3), and macOS (Qt 6.7.3).