### PR TITLE
Correction to 8eb96b2d6 (ElevationChartWidget): isHidden() is always 'false'

### DIFF
--- a/src/Train/ElevationChartWindow.cpp
+++ b/src/Train/ElevationChartWindow.cpp
@@ -303,7 +303,7 @@ void
 ElevationChartWindow::telemetryUpdate(const RealtimeData &rtData)
 {
     // If it is not visible, it saves time
-    if (isHidden())
+    if (!isVisible())
         return;
     m_rtData = rtData;
     bubbleWidget->setRealtimeData(&m_rtData);


### PR DESCRIPTION
Using `!isVisible()` instead behaves as expected, to avoid updating elevation chart widget in training being updated when it is not in the selected layout