### PR TITLE
ActionButtons: Showing +- labels with Qt 6.8.2

### DIFF
--- a/src/Charts/AllPlotWindow.cpp
+++ b/src/Charts/AllPlotWindow.cpp
@@ -22,6 +22,7 @@
 #include "Context.h"
 #include "Athlete.h"
 #include "AbstractView.h"
+#include "ActionButtonBox.h"
 #include "AllPlotInterval.h"
 #include "AllPlotWindow.h"
 #include "AllPlot.h"
@@ -141,42 +142,16 @@ AllPlotWindow::AllPlotWindow(Context *context) :
     connect(customTable, SIGNAL(cellDoubleClicked(int, int)), this, SLOT(doubleClicked(int, int)));
 
     // custom buttons
-    editCustomButton = new QPushButton(tr("Edit"));
-    connect(editCustomButton, SIGNAL(clicked()), this, SLOT(editUserData()));
+    ActionButtonBox *customActionButtons = new ActionButtonBox(ActionButtonBox::UpDownGroup | ActionButtonBox::EditGroup | ActionButtonBox::AddDeleteGroup);
 
-    addCustomButton = new QPushButton("+");
-    connect(addCustomButton, SIGNAL(clicked()), this, SLOT(addUserData()));
+    customActionButtons->defaultConnect(customTable);
+    connect(customActionButtons, &ActionButtonBox::upRequested, this, &AllPlotWindow::moveUserDataUp);
+    connect(customActionButtons, &ActionButtonBox::downRequested, this, &AllPlotWindow::moveUserDataDown);
+    connect(customActionButtons, &ActionButtonBox::editRequested, this, &AllPlotWindow::editUserData);
+    connect(customActionButtons, &ActionButtonBox::addRequested, this, &AllPlotWindow::addUserData);
+    connect(customActionButtons, &ActionButtonBox::deleteRequested, this, &AllPlotWindow::deleteUserData);
 
-    deleteCustomButton = new QPushButton("-");
-    connect(deleteCustomButton, SIGNAL(clicked()), this, SLOT(deleteUserData()));
-
-#ifndef Q_OS_MAC
-    upCustomButton = new QToolButton(this);
-    downCustomButton = new QToolButton(this);
-    upCustomButton->setArrowType(Qt::UpArrow);
-    downCustomButton->setArrowType(Qt::DownArrow);
-    upCustomButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    downCustomButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    addCustomButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    deleteCustomButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-#else
-    upCustomButton = new QPushButton(tr("Up"));
-    downCustomButton = new QPushButton(tr("Down"));
-#endif
-    connect(upCustomButton, SIGNAL(clicked()), this, SLOT(moveUserDataUp()));
-    connect(downCustomButton, SIGNAL(clicked()), this, SLOT(moveUserDataDown()));
-
-
-    QHBoxLayout *customButtons = new QHBoxLayout;
-    customButtons->setSpacing(2 *dpiXFactor);
-    customButtons->addWidget(upCustomButton);
-    customButtons->addWidget(downCustomButton);
-    customButtons->addStretch();
-    customButtons->addWidget(editCustomButton);
-    customButtons->addStretch();
-    customButtons->addWidget(addCustomButton);
-    customButtons->addWidget(deleteCustomButton);
-    customLayout->addLayout(customButtons);
+    customLayout->addWidget(customActionButtons);
 
     // Main layout
     //QGridLayout *mainLayout = new QGridLayout();

--- a/src/Charts/AllPlotWindow.h
+++ b/src/Charts/AllPlotWindow.h
@@ -370,12 +370,6 @@ class AllPlotWindow : public GcChartWindow
         // User data tab
         QWidget *custom;
         QTableWidget *customTable;
-        QPushButton *editCustomButton, *addCustomButton, *deleteCustomButton;
-#ifndef Q_OS_MAC
-        QToolButton *upCustomButton, *downCustomButton;
-#else
-        QPushButton *upCustomButton, *downCustomButton;
-#endif
         void refreshCustomTable(int indexSelectedItem = -1); // refreshes the table from LTMSettings
 
     private:

--- a/src/Charts/LTMTool.cpp
+++ b/src/Charts/LTMTool.cpp
@@ -18,6 +18,7 @@
 
 #include "LTMTool.h"
 #include "MainWindow.h"
+#include "ActionButtonBox.h"
 #include "Context.h"
 #include "Athlete.h"
 #include "Settings.h"
@@ -265,42 +266,15 @@ LTMTool::LTMTool(Context *context, LTMSettings *settings) : QWidget(context->mai
     connect(customTable, SIGNAL(cellDoubleClicked(int, int)), this, SLOT(doubleClicked(int, int)));
 
     // custom buttons
-    editCustomButton = new QPushButton(tr("Edit"));
-    connect(editCustomButton, SIGNAL(clicked()), this, SLOT(editMetric()));
+    customActionButtons = new ActionButtonBox(ActionButtonBox::UpDownGroup | ActionButtonBox::EditGroup | ActionButtonBox::AddDeleteGroup);
+    customActionButtons->defaultConnect(customTable);
+    connect(customActionButtons, &ActionButtonBox::editRequested, this, &LTMTool::editMetric);
+    connect(customActionButtons, &ActionButtonBox::addRequested, this, &LTMTool::addMetric);
+    connect(customActionButtons, &ActionButtonBox::deleteRequested, this, &LTMTool::deleteMetric);
+    connect(customActionButtons, &ActionButtonBox::upRequested, this, &LTMTool::moveMetricUp);
+    connect(customActionButtons, &ActionButtonBox::downRequested, this, &LTMTool::moveMetricDown);
 
-    addCustomButton = new QPushButton("+");
-    connect(addCustomButton, SIGNAL(clicked()), this, SLOT(addMetric()));
-
-    deleteCustomButton = new QPushButton("-");
-    connect(deleteCustomButton, SIGNAL(clicked()), this, SLOT(deleteMetric()));
-
-#ifndef Q_OS_MAC
-    upCustomButton = new QToolButton(this);
-    downCustomButton = new QToolButton(this);
-    upCustomButton->setArrowType(Qt::UpArrow);
-    downCustomButton->setArrowType(Qt::DownArrow);
-    upCustomButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    downCustomButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    addCustomButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    deleteCustomButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-#else
-    upCustomButton = new QPushButton(tr("Up"));
-    downCustomButton = new QPushButton(tr("Down"));
-#endif
-    connect(upCustomButton, SIGNAL(clicked()), this, SLOT(moveMetricUp()));
-    connect(downCustomButton, SIGNAL(clicked()), this, SLOT(moveMetricDown()));
-
-
-    QHBoxLayout *customButtons = new QHBoxLayout;
-    customButtons->setSpacing(2 *dpiXFactor);
-    customButtons->addWidget(upCustomButton);
-    customButtons->addWidget(downCustomButton);
-    customButtons->addStretch();
-    customButtons->addWidget(editCustomButton);
-    customButtons->addStretch();
-    customButtons->addWidget(addCustomButton);
-    customButtons->addWidget(deleteCustomButton);
-    customLayout->addLayout(customButtons);
+    customLayout->addWidget(customActionButtons);
 
     //----------------------------------------------------------------------------------------------------------
     // setup the Tabs
@@ -1245,12 +1219,7 @@ LTMTool::hideBasic()
 void
 LTMTool::usePresetChanged()
 {
-    customTable->setEnabled(!usePreset->isChecked());
-    editCustomButton->setEnabled(!usePreset->isChecked());
-    addCustomButton->setEnabled(!usePreset->isChecked());
-    deleteCustomButton->setEnabled(!usePreset->isChecked());
-    upCustomButton->setEnabled(!usePreset->isChecked());
-    downCustomButton->setEnabled(!usePreset->isChecked());
+    customActionButtons->setEnabled(!usePreset->isChecked());
 
     // yuck .. this doesn't work nicely !
     //basic->setHidden(usePreset->isChecked());

--- a/src/Charts/LTMTool.h
+++ b/src/Charts/LTMTool.h
@@ -26,6 +26,7 @@
 #include "PDModel.h"
 
 #include "SearchFilterBox.h"
+#include "ActionButtonBox.h"
 
 #include <QDir>
 #include <QFileDialog>
@@ -140,12 +141,7 @@ class LTMTool : public QWidget
 
         // custom tab:
         QTableWidget *customTable;
-        QPushButton *editCustomButton, *addCustomButton, *deleteCustomButton;
-#ifndef Q_OS_MAC
-        QToolButton *upCustomButton, *downCustomButton;
-#else
-        QPushButton *upCustomButton, *downCustomButton;
-#endif
+        ActionButtonBox *customActionButtons;
         void refreshCustomTable(int indexSelectedItem = -1); // refreshes the table from LTMSettings
 };
 

--- a/src/Charts/UserChart.cpp
+++ b/src/Charts/UserChart.cpp
@@ -20,6 +20,7 @@
 
 #include "Colors.h"
 #include "AbstractView.h"
+#include "ActionButtonBox.h"
 #include "RideFileCommand.h"
 #include "Utils.h"
 #include "AthleteTab.h"
@@ -867,42 +868,15 @@ UserChartSettings::UserChartSettings(Context *context, bool rangemode, GenericCh
     connect(seriesTable, SIGNAL(cellDoubleClicked(int, int)), this, SLOT(seriesClicked(int, int)));
 
     // custom buttons
-    editSeriesButton = new QPushButton(tr("Edit"));
-    connect(editSeriesButton, SIGNAL(clicked()), this, SLOT(editSeries()));
+    ActionButtonBox *seriesActionButtons = new ActionButtonBox(ActionButtonBox::UpDownGroup | ActionButtonBox::EditGroup | ActionButtonBox::AddDeleteGroup);
+    seriesActionButtons->defaultConnect(seriesTable);
+    connect(seriesActionButtons, &ActionButtonBox::editRequested, this, &UserChartSettings::editSeries);
+    connect(seriesActionButtons, &ActionButtonBox::addRequested, this, &UserChartSettings::addSeries);
+    connect(seriesActionButtons, &ActionButtonBox::deleteRequested, this, &UserChartSettings::deleteSeries);
+    connect(seriesActionButtons, &ActionButtonBox::upRequested, this, &UserChartSettings::moveSeriesUp);
+    connect(seriesActionButtons, &ActionButtonBox::downRequested, this, &UserChartSettings::moveSeriesDown);
 
-    addSeriesButton = new QPushButton("+");
-    connect(addSeriesButton, SIGNAL(clicked()), this, SLOT(addSeries()));
-
-    deleteSeriesButton = new QPushButton("-");
-    connect(deleteSeriesButton, SIGNAL(clicked()), this, SLOT(deleteSeries()));
-
-#ifndef Q_OS_MAC
-    upSeriesButton = new QToolButton(this);
-    downSeriesButton = new QToolButton(this);
-    upSeriesButton->setArrowType(Qt::UpArrow);
-    downSeriesButton->setArrowType(Qt::DownArrow);
-    upSeriesButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    downSeriesButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    addSeriesButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    deleteSeriesButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-#else
-    upSeriesButton = new QPushButton(tr("Up"));
-    downSeriesButton = new QPushButton(tr("Down"));
-#endif
-    connect(upSeriesButton, SIGNAL(clicked()), this, SLOT(moveSeriesUp()));
-    connect(downSeriesButton, SIGNAL(clicked()), this, SLOT(moveSeriesDown()));
-
-
-    QHBoxLayout *seriesButtons = new QHBoxLayout;
-    seriesButtons->setSpacing(2 *dpiXFactor);
-    seriesButtons->addWidget(upSeriesButton);
-    seriesButtons->addWidget(downSeriesButton);
-    seriesButtons->addStretch();
-    seriesButtons->addWidget(editSeriesButton);
-    seriesButtons->addStretch();
-    seriesButtons->addWidget(addSeriesButton);
-    seriesButtons->addWidget(deleteSeriesButton);
-    seriesLayout->addLayout(seriesButtons);
+    seriesLayout->addWidget(seriesActionButtons);
 
     // Axes tab
     // axis tab
@@ -929,31 +903,15 @@ UserChartSettings::UserChartSettings(Context *context, bool rangemode, GenericCh
     connect(axisTable, SIGNAL(cellDoubleClicked(int, int)), this, SLOT(axisClicked(int, int)));
 
     // custom buttons
-    editAxisButton = new QPushButton(tr("Edit"));
-    connect(editAxisButton, SIGNAL(clicked()), this, SLOT(editAxis()));
+    ActionButtonBox *axisActionButtons = new ActionButtonBox(ActionButtonBox::EditGroup);
+    axisActionButtons->defaultConnect(axisTable);
+    connect(axisActionButtons, &ActionButtonBox::editRequested, this, &UserChartSettings::editAxis);
 
     // we don't allow axes to be created, since they are
     // implied by the data series that we add
     // this might change in the future
 
-    //addAxisButton = new QPushButton("+");
-    //connect(addAxisButton, SIGNAL(clicked()), this, SLOT(addAxis()));
-
-    //deleteAxisButton = new QPushButton("-");
-    //connect(deleteAxisButton, SIGNAL(clicked()), this, SLOT(deleteAxis()));
-
-    //addAxisButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-    //deleteAxisButton->setFixedSize(20*dpiXFactor,20*dpiYFactor);
-
-
-    QHBoxLayout *axisButtons = new QHBoxLayout;
-    axisButtons->setSpacing(2 *dpiXFactor);
-    axisButtons->addStretch();
-    axisButtons->addWidget(editAxisButton);
-    axisButtons->addStretch();
-    //axisButtons->addWidget(addAxisButton);
-    //axisButtons->addWidget(deleteAxisButton);
-    axisLayout->addLayout(axisButtons);
+    axisLayout->addWidget(axisActionButtons);
 
     // watch for chartinfo edits (the series/axis stuff is managed by separate dialogs)
     connect(title, SIGNAL(textChanged(QString)), this, SLOT(updateChartInfo()));

--- a/src/Charts/UserChart.h
+++ b/src/Charts/UserChart.h
@@ -153,16 +153,9 @@ class UserChartSettings : public QWidget {
 
         // series tab
         QTableWidget *seriesTable;
-        QPushButton *editSeriesButton, *addSeriesButton, *deleteSeriesButton;
-#ifndef Q_OS_MAC
-        QToolButton *upSeriesButton, *downSeriesButton;
-#else
-        QPushButton *upSeriesButton, *downSeriesButton;
-#endif
 
         // axes tab
         QTableWidget *axisTable;
-        QPushButton *editAxisButton, *addAxisButton, *deleteAxisButton;
 
     public slots:
 

--- a/src/Gui/ActionButtonBox.h
+++ b/src/Gui/ActionButtonBox.h
@@ -24,8 +24,7 @@
 #include <QToolButton>
 #endif
 #include <QHBoxLayout>
-#include <QTreeWidget>
-#include <QListWidget>
+#include <QAbstractItemView>
 
 
 class ActionButtonBox : public QWidget {
@@ -53,29 +52,31 @@ class ActionButtonBox : public QWidget {
             Right = 1
         };
 
-	ActionButtonBox(StandardButtonGroups standardButtonGroups, QWidget *parent = nullptr);
+        ActionButtonBox(StandardButtonGroups standardButtonGroups, QWidget *parent = nullptr);
 
         QAbstractButton *which(StandardButton which) const;
 
-	void setButtonHidden(StandardButton standardButton, bool hidden);
-	void setButtonEnabled(StandardButton standardButton, bool enabled);
+        void setButtonHidden(StandardButton standardButton, bool hidden);
+        void setButtonEnabled(StandardButton standardButton, bool enabled);
 
-	QPushButton *addButton(const QString &text, ActionPosition pos = ActionPosition::Left);
-	void addWidget(QWidget *widget);
-	void addStretch(ActionPosition pos = ActionPosition::Left);
+        QPushButton *addButton(const QString &text, ActionPosition pos = ActionPosition::Left);
+        void addWidget(QWidget *widget);
+        void addStretch(ActionPosition pos = ActionPosition::Left);
 
-        void defaultConnect(StandardButtonGroup group, QTreeWidget *tree);
-        void defaultConnect(StandardButtonGroup group, QListWidget *list);
+        void defaultConnect(QAbstractItemView *view);
+        void defaultConnect(StandardButtonGroup group, QAbstractItemView *view);
+
+        void setMaxViewItems(int maxItems);
 
     signals:
-	void upRequested();
-	void downRequested();
-	void addRequested();
-	void deleteRequested();
-	void editRequested();
+        void upRequested();
+        void downRequested();
+        void addRequested();
+        void deleteRequested();
+        void editRequested();
 
     private:
-	QHBoxLayout *layout;
+        QHBoxLayout *layout;
 #ifdef Q_OS_MAC
         QPushButton *up = nullptr;
         QPushButton *down = nullptr;
@@ -83,16 +84,16 @@ class ActionButtonBox : public QWidget {
         QToolButton *up = nullptr;
         QToolButton *down = nullptr;
 #endif
-	QPushButton *add = nullptr;
-	QPushButton *del = nullptr;
-	QPushButton *edit = nullptr;
+        QPushButton *add = nullptr;
+        QPushButton *del = nullptr;
+        QPushButton *edit = nullptr;
 
-	int leftOffset = 0;
-	int rightOffset = 0;
+        int maxViewItems = std::numeric_limits<int>::max();
 
-        void updateButtonState(StandardButtonGroup group, QTreeWidget *tree);
-        void updateButtonState(StandardButtonGroup group, QListWidget *list);
-        void defaultConnectInit(StandardButtonGroup group);
+        int leftOffset = 0;
+        int rightOffset = 0;
+
+        void updateButtonState(StandardButtonGroup group, QAbstractItemView *view);
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS(ActionButtonBox::StandardButtonGroups)

--- a/src/Gui/AthletePages.h
+++ b/src/Gui/AthletePages.h
@@ -80,7 +80,6 @@ class MeasuresPage : public QWidget
         NoEditDelegate origSourceDelegate;
 
         QTreeWidget *measuresTree;
-        QPushButton *addButton, *deleteButton;
 
         void fillItemFromMeasures(int rnum, QTreeWidgetItem *item) const;
 
@@ -219,7 +218,6 @@ class CredentialsPage : public QScrollArea
 
         Context *context;
         QTreeWidget *accounts;
-        QPushButton *addButton, *editButton, *deleteButton;
 
 };
 
@@ -239,12 +237,10 @@ class SchemePage : public QWidget
     private slots:
         void addClicked();
         void deleteClicked();
-        void updateButtons();
 
     private:
         Zones *zones;
         QTreeWidget *scheme;
-        QPushButton *addButton, *deleteButton;
         SpinBoxEditDelegate zoneFromDelegate;
 };
 
@@ -310,7 +306,6 @@ class CPPage : public QWidget
 #endif
 
         void review();
-        void updateButtons();
 
     private:
         bool active;
@@ -330,9 +325,8 @@ class CPPage : public QWidget
         SchemePage *schemePage;
         TreeWidget6 *ranges;
         QTreeWidget *zones;
-        QPushButton *addButton, *deleteButton;
         QPushButton *reviewButton;
-        QPushButton *addZoneButton, *deleteZoneButton, *defaultButton;
+        QPushButton *defaultButton;
         QPushButton *newZoneRequired;
 
         bool getValuesFor(const QDate &date, bool allowDefaults, int &cp, int &aetp, int &ftp, int &wprime, int &pmax, int &estOffset, bool &defaults, QDate *startDate = nullptr) const;
@@ -402,12 +396,10 @@ class HrSchemePage : public QWidget
     private slots:
         void addClicked();
         void deleteClicked();
-        void updateButtons();
 
     private:
         HrZones *hrZones;
         QTreeWidget *scheme;
-        QPushButton *addButton, *deleteButton;
 
         SpinBoxEditDelegate ltDelegate;
         DoubleSpinBoxEditDelegate trimpkDelegate;
@@ -430,7 +422,6 @@ class LTPage : public QWidget
         void addZoneClicked();
         void deleteZoneClicked();
         void zonesChanged();
-        void updateButtons();
 
     private:
         bool active;
@@ -449,8 +440,7 @@ class LTPage : public QWidget
         HrSchemePage *schemePage;
         QTreeWidget *ranges;
         QTreeWidget *zones;
-        QPushButton *addButton, *deleteButton;
-        QPushButton *addZoneButton, *deleteZoneButton, *defaultButton;
+        QPushButton *defaultButton;
 };
 
 class HrZonePage : public QWidget
@@ -497,12 +487,10 @@ class PaceSchemePage : public QWidget
     private slots:
         void addClicked();
         void deleteClicked();
-        void updateButtons();
 
     private:
         PaceZones* paceZones;
         QTreeWidget *scheme;
-        QPushButton *addButton, *deleteButton;
         SpinBoxEditDelegate fromDelegate;
 };
 
@@ -528,7 +516,6 @@ class CVPage : public QWidget
         void addZoneClicked();
         void deleteZoneClicked();
         void zonesChanged();
-        void updateButtons();
 
     private:
         bool active;
@@ -543,8 +530,7 @@ class CVPage : public QWidget
         PaceSchemePage *schemePage;
         QTreeWidget *ranges;
         QTreeWidget *zones;
-        QPushButton *addButton, *deleteButton;
-        QPushButton *addZoneButton, *deleteZoneButton, *defaultButton;
+        QPushButton *defaultButton;
         QLabel *per;
 };
 
@@ -648,14 +634,6 @@ class AutoImportPage : public QWidget
         QTreeWidget *fields;
         ComboBoxDelegate ruleDelegate;
         DirectoryPathDelegate dirDelegate;
-
-#ifndef Q_OS_MAC
-        QToolButton *upButton, *downButton;
-#else
-        QPushButton *upButton, *downButton;
-#endif
-        QPushButton *addButton, *renameButton, *deleteButton, *browseButton;
-
 };
 
 #endif


### PR DESCRIPTION
* With Qt 6.8.2 button-labels are not shown if widget is scaled too small
* Using ActionButtonBox throughout
* Set padding to 0px for +- buttons in ActionButtonBox
* Generalized ActionButtonBox to work with QAbstractItemView

See also https://groups.google.com/g/golden-cheetah-users/c/R-58f1LvwsM