### PR TITLE
Use speed data from imported GPX files

### DIFF
--- a/src/FileIO/GpxParser.h
+++ b/src/FileIO/GpxParser.h
@@ -29,6 +29,8 @@
 #include <QXmlDefaultHandler>
 #include "Settings.h"
 
+#define GPX_SAMPLE_INTERVAL (1.0)
+
 class GpxParser : public QXmlDefaultHandler
 {
 public:
@@ -53,6 +55,7 @@ private:
     QDateTime   time;
     double      distance;
     double      lastLat, lastLon;
+    double      lastSpeed;
 
     double      alt;
     double      lat;
@@ -61,6 +64,7 @@ private:
     double      temp;
     double      cad;
     double      watts;
+    double      speed;
 
     // set to false after the first time element is seen (not in metadata)
     bool firstTime;

--- a/src/FileIO/GpxRideFile.cpp
+++ b/src/FileIO/GpxRideFile.cpp
@@ -32,7 +32,7 @@ RideFile *GpxFileReader::openRideFile(QFile &file, QStringList &errors, QList<Ri
 {
     (void) errors;
     RideFile *rideFile = new RideFile();
-    rideFile->setRecIntSecs(1.0);
+    rideFile->setRecIntSecs(GPX_SAMPLE_INTERVAL);
     //rideFile->setDeviceType("GPS Exchange Format");
     rideFile->setFileFormat("GPS Exchange Format (gpx)");
 


### PR DESCRIPTION
When importing a GPX file, prefer embedded speed data (if present) over GPS coordinates for calculating speed and distance.

The GPX file format supports providing the measured speed at each trackpoint as a TrackPointExtension. Some programs use this to report readings from dedicated speed sensors.

If no speed data is embedded or if data is missing from any trackpoints, Golden Cheetah calculates speed from the GPS coordinates. When using GPS, weak signal or low-quality receivers can result in irregular speed measurements due to location jitter, whereas dedicated speed sensors should be consistent in any environment.

Distance is additionally calculated from speed and time if available, falling back to GPS otherwise.