### PR TITLE
Prevent GC saving the perspectives twice

### DIFF
--- a/src/Gui/AthleteTab.cpp
+++ b/src/Gui/AthleteTab.cpp
@@ -123,11 +123,6 @@ AthleteTab::~AthleteTab()
 void
 AthleteTab::close()
 {
-    analysisView->saveState();
-    homeView->saveState();
-    trainView->saveState();
-    diaryView->saveState();
-
     analysisView->close();
     homeView->close();
     trainView->close();


### PR DESCRIPTION
The saveState() call results in the loaded perspectives being saved twice when GC exits, once in saveState() and again when the AbstractView's destructor is called.