### PR TITLE
Resolve msvc2022 and Qt6.8.3 max and min macro conflict

### DIFF
--- a/src/ANT/ANT.h
+++ b/src/ANT/ANT.h
@@ -64,6 +64,7 @@
 #include <stdint.h> //uint8_t
 
 #ifdef WIN32
+#define NOMINMAX // prevents windows.h defining max & min macros
 #include <windows.h>
 #include <winbase.h>
 #include "USBXpress.h" // for Garmin USB1 sticks

--- a/src/Core/WindowsCrashHandler.cpp
+++ b/src/Core/WindowsCrashHandler.cpp
@@ -28,6 +28,7 @@
 #include <string>
 #include <sstream>
 
+#define NOMINMAX // prevents windows.h defining max & min macros
 #include <windows.h>
 #include <dbghelp.h>
 #pragma comment(lib, "dbghelp.lib")

--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -152,6 +152,7 @@ void sigabort(int x)
 #include <iostream>
 
 #ifdef WIN32
+#define NOMINMAX // prevents windows.h defining max & min macros
 #include <windows.h>
 #include <io.h>
 #else

--- a/src/FileIO/D2XX.h
+++ b/src/FileIO/D2XX.h
@@ -22,7 +22,8 @@
 
 #include "CommPort.h"
 #ifdef WIN32
-    #include <windows.h>
+#define NOMINMAX // prevents windows.h defining max & min macros
+#include <windows.h>
 #endif
 #include <ftd2xx.h>
 

--- a/src/FileIO/Serial.cpp
+++ b/src/FileIO/Serial.cpp
@@ -21,6 +21,7 @@
 #ifdef Q_OS_WIN32
 
 // WIN32 includes
+#define NOMINMAX // prevents windows.h defining max & min macros
 #include <windows.h>
 #include <winbase.h>
 #else

--- a/src/FileIO/Serial.h
+++ b/src/FileIO/Serial.h
@@ -23,6 +23,7 @@
 #include "CommPort.h"
 
 #ifdef Q_OS_WIN32 // for HANDLE
+#define NOMINMAX // prevents windows.h defining max & min macros
 #include <windows.h>
 #include <winbase.h>
 #endif

--- a/src/Gui/Colors.cpp
+++ b/src/Gui/Colors.cpp
@@ -26,6 +26,7 @@
 #include "Settings.h"
 
 #ifdef Q_OS_WIN
+#define NOMINMAX // prevents windows.h defining max & min macros
 #include <windows.h>
 #ifdef GC_HAVE_DWM
 #include "dwmapi.h"

--- a/src/Train/Computrainer.h
+++ b/src/Train/Computrainer.h
@@ -41,6 +41,7 @@
 #include "RealtimeController.h"
 
 #ifdef WIN32
+#define NOMINMAX // prevents windows.h defining max & min macros
 #include <windows.h>
 #include <winbase.h>
 #else

--- a/src/Train/GarminServiceHelper.cpp
+++ b/src/Train/GarminServiceHelper.cpp
@@ -20,6 +20,7 @@
 #if defined(_MSC_VER)
 
 #pragma comment(lib, "advapi32.lib")
+#define NOMINMAX // prevents windows.h defining max & min macros
 #include <windows.h>
 
 class WindowsServiceHandle

--- a/src/Train/LibUsb.h
+++ b/src/Train/LibUsb.h
@@ -23,6 +23,7 @@
 #if defined GC_HAVE_LIBUSB
 
 #ifdef WIN32
+#define NOMINMAX // prevents windows.h defining max & min macros
 #include <windows.h>
 #endif
 

--- a/src/Train/USBXpress.h
+++ b/src/Train/USBXpress.h
@@ -21,6 +21,7 @@
 
 #if defined WIN32 
 
+#define NOMINMAX // prevents windows.h defining max & min macros
 #include <windows.h>
 
 #ifdef GC_HAVE_USBXPRESS


### PR DESCRIPTION
I'm building GC with msvc2022 and Qt6.8.3 but the VS compiler complains numerous times about the following errors:

C:\Coding\ext_pkgs\Qt\6.8.3\msvc2022_64\include\QtConcurrent/qtconcurrentreducekernel.h(120): error C2589: '(': illegal token on right side of '::'
C:\Coding\ext_pkgs\Qt\6.8.3\msvc2022_64\include\QtConcurrent/qtconcurrentreducekernel.h(120): note: the template instantiation context (the oldest one first) is
C:\Coding\ext_pkgs\Qt\6.8.3\msvc2022_64\include\QtConcurrent/qtconcurrentreducekernel.h(78): note: while compiling class template 'QtConcurrent::ReduceKernel'
C:\Coding\GC\GoldenCheetah\src\Charts\PowerHist.h(221): error C2589: '(': illegal token on right side of '::'
C:\Coding\GC\GoldenCheetah\src\Charts\PowerHist.h(221): error C2059: syntax error: ')'

Searching the internet the problem is that windows.h defines max & min macros that conflicts with the std::numeric_limits::max() definition.

https://github.com/microsoft/cppwinrt/issues/479
https://stackoverflow.com/questions/1394132/macro-and-member-function-conflict

There maybe a better way to fix this issue, but defining NOMINMAX above the windows.h includes works.