### PR TITLE
Correct the format of the "Start Date" and "Start Time" time in the activities summary text field.

### DIFF
--- a/src/Metrics/RideMetadata.cpp
+++ b/src/Metrics/RideMetadata.cpp
@@ -1622,10 +1622,12 @@ FieldDefinition::calendarText(QString value)
     if (value.isEmpty() || diary != true) return QString();
 
     switch (type) {
+        case FIELD_TIME:
+            return QString("%1: %2\n").arg(name).arg(QTime(0, 0, 0).addSecs(value.toInt()).toString());
+        case FIELD_DATE:
+            return QString("%1: %2\n").arg(name).arg(QDate(1900, 01, 01).addDays(value.toInt()).toString("dd MMM yyyy"));
         case FIELD_INTEGER:
         case FIELD_DOUBLE:
-        case FIELD_DATE:
-        case FIELD_TIME:
         case FIELD_CHECKBOX:
             return QString("%1: %2\n").arg(name).arg(value);
         case FIELD_TEXT:


### PR DESCRIPTION
Selecting the "Start Date" and "Start Time" as summary items in the options->fields page causes them to be displayed as integers:

![Start Date and Time error](https://github.com/user-attachments/assets/7e8eab7a-747e-42b0-8c14-450c74e881ed)

This PR corrects their format:

![Start Date and Time fixed](https://github.com/user-attachments/assets/22747523-9d10-47e5-8206-2fad58be74f2)

Note: The calendar text is only updated for existing activities when the items selected for summary display are changed and the options->fields page is saved.