### PR TITLE
Overview Metric Tile - support for metric overrides

### DIFF
--- a/src/Charts/OverviewItems.cpp
+++ b/src/Charts/OverviewItems.cpp
@@ -853,19 +853,23 @@ MetricOverviewItem::~MetricOverviewItem()
 void
 MetricOverviewItem::configChanged(qint32) {
 
-    // Update the value
+    // Update the value and override status
     value = rideItem ? rideItem->getStringForSymbol(symbol, GlobalContext::context()->useMetricUnits) : "";
+    overridden = rideItem ? (rideItem->ride()->metricOverrides.contains(symbol)) : false;
 }
 
 void MetricOverviewItem::displayTileEditMenu(const QPoint& pos) {
 
     RideMetricFactory& factory = RideMetricFactory::instance();
-    QString internalName = factory.rideMetric(symbol)->internalName();
-    double editValue = rideItem ? rideItem->getForSymbol(symbol, GlobalContext::context()->useMetricUnits) : 0.0;
+    const RideMetric* rideM = factory.rideMetric(symbol);
 
-    MetricOverrideDialog* metricOverrideDialog = new MetricOverrideDialog(parent->context, internalName, editValue, pos);
-    connect(metricOverrideDialog, SIGNAL(finished(int)), this, SLOT(updateTile(int)));
-    metricOverrideDialog->show(); // configured for delete on close
+    if (rideM && rideItem) {
+
+        double editValue = rideItem->getForSymbol(symbol, GlobalContext::context()->useMetricUnits);
+        MetricOverrideDialog* metricOverrideDialog = new MetricOverrideDialog(parent->context, rideM->internalName(), editValue, pos);
+        connect(metricOverrideDialog, SIGNAL(finished(int)), this, SLOT(updateTile(int)));
+        metricOverrideDialog->show(); // configured for delete on close
+    }
 }
 
 void MetricOverviewItem::updateTile(int ret) {

--- a/src/Charts/OverviewItems.h
+++ b/src/Charts/OverviewItems.h
@@ -25,6 +25,7 @@
 #include "DataFilter.h"
 #include <QGraphicsItem>
 #include "MetadataDialog.h"
+#include "MetricOverrideDialog.h"
 
 // qt charts for zone chart
 #include <QtCharts>
@@ -256,10 +257,14 @@ class MetricOverviewItem : public ChartSpaceItem
         void setData(RideItem *item);
         void setDateRange(DateRange);
 
+        virtual void displayTileEditMenu(const QPoint& pos) override;
+
         QWidget *config() { return configwidget; }
 
         // create and config
         static ChartSpaceItem *create(ChartSpace *parent) { return new MetricOverviewItem(parent, "PowerIndex", "power_index"); }
+
+        void configChanged(qint32) override;
 
         QString symbol;
         const RideMetric *metric;
@@ -267,6 +272,7 @@ class MetricOverviewItem : public ChartSpaceItem
 
         bool up;
         bool showrange = false;
+        bool overridden = false;
         QString value, upper, lower, mean;
 
         Sparkline *sparkline;
@@ -276,6 +282,15 @@ class MetricOverviewItem : public ChartSpaceItem
         QPixmap gold, silver, bronze; // medals
 
         OverviewItemConfig *configwidget;
+
+    protected slots:
+
+        void updateTile(int ret);
+        void metadataChanged();
+
+    protected:
+
+        RideItem* rideItem = nullptr;
 };
 
 // top N uses this to hold details for date range

--- a/src/Gui/MetricOverrideDialog.cpp
+++ b/src/Gui/MetricOverrideDialog.cpp
@@ -1,0 +1,231 @@
+
+/*
+ * Metric Override Dialog Copyright (c) 2025 Paul Johnson (paulj49457@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "MetricOverrideDialog.h"
+#include "Context.h"
+#include "RideCache.h"
+#include "RideMetric.h"
+
+#include <QFormLayout>
+#include <QDebug>
+
+MetricOverrideDialog::MetricOverrideDialog(Context* context, const QString& fieldName, const double value, QPoint pos) :
+    QDialog(context->mainWindow), context_(context), fieldName_(fieldName), pos_(pos)
+{
+    setAttribute(Qt::WA_DeleteOnClose);
+    setWindowTitle(tr("Metric Override Editor"));
+
+    QString units = GlobalContext::context()->specialFields.rideMetric(fieldName_)->units(GlobalContext::context()->useMetricUnits);
+
+    if (GlobalContext::context()->specialFields.rideMetric(fieldName_)->isDate()) {
+        dlgMetricType_ = DialogMetricType::DATE;
+    } else if (units == "seconds" || units == tr("seconds")) {
+        dlgMetricType_ = DialogMetricType::SECS_TIME;
+    } else if (units == "minutes" || units == tr("minutes")) {
+        dlgMetricType_ = DialogMetricType::MINS_TIME;
+    } else {
+        dlgMetricType_ = DialogMetricType::DOUBLE;
+    }
+
+    // if metric is a time or date remove any units, since the field will be a QTimeEdit or QDateEdit field
+    units = (dlgMetricType_ == DialogMetricType::DOUBLE) ? QString(" (%1)").arg(units) : "";
+
+    // we need to show what units we use for weight...
+    if (fieldName_ == "Weight") {
+        units = GlobalContext::context()->useMetricUnits ? tr(" (kg)") : tr(" (lbs)");
+    }
+
+    metricLabel_ = new QLabel(QString("%1%2").arg(GlobalContext::context()->specialFields.displayName(fieldName_)).arg(units));
+
+    switch (dlgMetricType_) {
+        case DialogMetricType::DATE: {
+            metricEdit_ = new QDateEdit(this);
+            dynamic_cast<QDateEdit*>(metricEdit_)->setDisplayFormat("dd MMM yyyy"); // same format as metric tile
+            dynamic_cast<QDateEdit*>(metricEdit_)->setDate(QDate(1900,1,1).addDays(value));
+        } break;
+
+        case DialogMetricType::SECS_TIME: {
+            metricEdit_ = new QTimeEdit(this);
+            dynamic_cast<QTimeEdit*>(metricEdit_)->setDisplayFormat("h:mm:ss"); // same format as metric tile
+            dynamic_cast<QTimeEdit*>(metricEdit_)->setTime(QTime(0,0,0,0).addSecs(value));
+        } break;
+
+        case DialogMetricType::MINS_TIME: {
+
+            metricEdit_ = new QTimeEdit(this);
+            dynamic_cast<QTimeEdit*>(metricEdit_)->setDisplayFormat("mm:ss"); // same format as metric tile
+            dynamic_cast<QTimeEdit*>(metricEdit_)->setTime(QTime(0,0,0,0).addSecs(value*60));
+        } break;
+
+        case DialogMetricType::DOUBLE: {
+
+            metricEdit_ = new QDoubleSpinBox(this);
+            dynamic_cast<QDoubleSpinBox*>(metricEdit_)->setButtonSymbols(QAbstractSpinBox::NoButtons);
+            dynamic_cast<QDoubleSpinBox*>(metricEdit_)->setMinimum(-9999999.99);
+            dynamic_cast<QDoubleSpinBox*>(metricEdit_)->setMaximum(9999999.99);
+            dynamic_cast<QDoubleSpinBox*>(metricEdit_)->setMinimumWidth(150);
+            dynamic_cast<QDoubleSpinBox*>(metricEdit_)->setValue(value);
+        } break;
+        default: {
+            qDebug() << "Unsupported type in metric override dialog";
+        } break;
+    }
+
+    QHBoxLayout* metricDataLayout = new QHBoxLayout();
+    metricDataLayout->setContentsMargins(0, 0, 0, 0);
+    metricDataLayout->addSpacing(5);
+    metricDataLayout->addWidget(metricLabel_);
+    metricDataLayout->addSpacing(5);
+    metricDataLayout->addWidget(metricEdit_,10);
+    metricDataLayout->addStretch();
+
+    // buttons
+    QHBoxLayout* buttons = new QHBoxLayout;
+    QPushButton* cancel = new QPushButton(tr("Cancel"), this);
+    QPushButton* clear = new QPushButton(tr("Clear"), this);
+    QPushButton* set = new QPushButton(tr("Set"), this);
+    buttons->addStretch(75);
+    buttons->addWidget(cancel);
+    buttons->addWidget(clear);
+    buttons->addWidget(set);
+
+    // Layout
+    QFormLayout* layout = new QFormLayout(this);
+    layout->addRow(metricDataLayout);
+    layout->addRow(buttons);
+
+    adjustSize(); // Window to contents
+
+    connect(set, SIGNAL(clicked()), this, SLOT(setClicked()));
+    connect(clear, SIGNAL(clicked()), this, SLOT(clearClicked()));
+    connect(cancel, SIGNAL(clicked()), this, SLOT(cancelClicked()));
+}
+
+MetricOverrideDialog::~MetricOverrideDialog()
+{
+    delete metricLabel_;
+    delete metricEdit_; // QWidget destructor is virtual
+}
+
+void
+MetricOverrideDialog::showEvent(QShowEvent*)
+{
+
+    QSize gcWindowSize = context_->mainWindow->size();
+    QPoint gcWindowPosn = context_->mainWindow->pos();
+
+    int xLimit = gcWindowPosn.x() + gcWindowSize.width() - geometry().width() - 10;
+    int yLimit = gcWindowPosn.y() + gcWindowSize.height() - geometry().height() - 10;
+
+    int xDialog = (pos_.x() > xLimit) ? xLimit : pos_.x();
+    int yDialog = (pos_.y() > yLimit) ? yLimit : pos_.y();
+
+    move(xDialog, yDialog);
+}
+
+void
+MetricOverrideDialog::setClicked()
+{
+    // get the current value from the metricEdit_ into a string
+    QString text;
+    switch (dlgMetricType_) {
+        case DialogMetricType::DATE: {
+            text = QString("%1").arg(QDate(1900, 01, 01).daysTo(dynamic_cast<QDateEdit*>(metricEdit_)->date()));
+        } break;
+        case DialogMetricType::SECS_TIME: {
+            text = QString("%1").arg(QTime(0, 0, 0, 0).secsTo(dynamic_cast<QTimeEdit*>(metricEdit_)->time()));
+        } break;
+        case DialogMetricType::MINS_TIME: {
+            text = QString("%1").arg((QTime(0, 0, 0, 0).secsTo(dynamic_cast<QTimeEdit*>(metricEdit_)->time())) / 60.0);
+        } break;
+        case DialogMetricType::DOUBLE: {
+            text = QString("%1").arg(dynamic_cast<QDoubleSpinBox*>(metricEdit_)->value());
+
+            // convert from imperial to metric if needed
+            if (!GlobalContext::context()->useMetricUnits) {
+                double value = text.toDouble() * (1 / GlobalContext::context()->specialFields.rideMetric(fieldName_)->conversion());
+                value -= GlobalContext::context()->specialFields.rideMetric(fieldName_)->conversionSum();
+                text = QString("%1").arg(value);
+            }
+        } break;
+        default: {
+            qDebug() << "Unsupported type in metric override dialog";
+        } break;
+    }
+
+    // update metric override QMap!
+    QMap<QString, QString> override;
+    override.insert("value", text);
+
+    // check for compatability metrics
+    QString symbol = GlobalContext::context()->specialFields.metricSymbol(fieldName_);
+    if (fieldName_ == "TSS") symbol = "coggan_tss";
+    if (fieldName_ == "NP") symbol = "coggan_np";
+    if (fieldName_ == "IF") symbol = "coggan_if";
+    
+    RideItem* rideI = context_->rideItem();
+    if (!rideI) { qDebug() << "rideI error in metric override dialog"; done(QDialog::Rejected); return; }
+
+    // Update the metadata value in the ride item.
+    rideI->ride()->metricOverrides.insert(symbol, override);
+
+    // rideItem is now dirty!
+    rideI->setDirty(true);
+
+    // refresh as state has changed
+    rideI->notifyRideMetadataChanged();
+
+    done(QDialog::Accepted); // our work is done!
+}
+
+void
+MetricOverrideDialog::clearClicked() {
+
+    QString symbol = GlobalContext::context()->specialFields.metricSymbol(fieldName_);
+    if (fieldName_ == "TSS") symbol = "coggan_tss";
+    if (fieldName_ == "NP") symbol = "coggan_np";
+    if (fieldName_ == "IF") symbol = "coggan_if";
+
+    RideItem* rideI = context_->rideItem();
+    if (!rideI) { qDebug() << "rideI error in metric override dialog"; done(QDialog::Rejected); return; }
+
+    if (rideI->ride()->metricOverrides.contains(symbol)) {
+
+        // remove existing override for this metric
+        rideI->ride()->metricOverrides.remove(symbol);
+
+        // rideItem is now dirty!
+        rideI->setDirty(true);
+
+        // get refresh done, coz overrides state has changed
+        rideI->notifyRideMetadataChanged();
+
+        done(QDialog::Accepted); // our work is done!
+
+    } else {
+
+        done(QDialog::Rejected); // our work is done!
+    }
+}
+
+void
+MetricOverrideDialog::cancelClicked()
+{
+    done(QDialog::Rejected); // no work to do
+}

--- a/src/Gui/MetricOverrideDialog.cpp
+++ b/src/Gui/MetricOverrideDialog.cpp
@@ -29,11 +29,18 @@ MetricOverrideDialog::MetricOverrideDialog(Context* context, const QString& fiel
     QDialog(context->mainWindow), context_(context), fieldName_(fieldName), pos_(pos)
 {
     setAttribute(Qt::WA_DeleteOnClose);
+
+    const RideMetric* metric = GlobalContext::context()->specialFields.rideMetric(fieldName_);
+
+    // Metric Override Dialog should only be created for metrics that exist, if not exit.
+    if (metric == nullptr) { done(QDialog::Rejected); return; }
+
     setWindowTitle(tr("Metric Override Editor"));
 
-    QString units = GlobalContext::context()->specialFields.rideMetric(fieldName_)->units(GlobalContext::context()->useMetricUnits);
+    bool useMetricUnits = GlobalContext::context()->useMetricUnits;
+    QString units = metric->units(useMetricUnits);
 
-    if (GlobalContext::context()->specialFields.rideMetric(fieldName_)->isDate()) {
+    if (metric->isDate()) {
         dlgMetricType_ = DialogMetricType::DATE;
     } else if (units == "seconds" || units == tr("seconds")) {
         dlgMetricType_ = DialogMetricType::SECS_TIME;
@@ -47,9 +54,7 @@ MetricOverrideDialog::MetricOverrideDialog(Context* context, const QString& fiel
     units = (dlgMetricType_ == DialogMetricType::DOUBLE) ? QString(" (%1)").arg(units) : "";
 
     // we need to show what units we use for weight...
-    if (fieldName_ == "Weight") {
-        units = GlobalContext::context()->useMetricUnits ? tr(" (kg)") : tr(" (lbs)");
-    }
+    if (fieldName_ == "Weight") { units = useMetricUnits ? tr(" (kg)") : tr(" (lbs)"); }
 
     metricLabel_ = new QLabel(QString("%1%2").arg(GlobalContext::context()->specialFields.displayName(fieldName_)).arg(units));
 

--- a/src/Gui/MetricOverrideDialog.h
+++ b/src/Gui/MetricOverrideDialog.h
@@ -1,0 +1,62 @@
+
+/*
+ * Metric Override Dialog Copyright (c) 2025 Paul Johnson (paulj49457@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef _MetricOverrideDialog_h
+#define _MetricOverrideDialog_h
+
+#include "GoldenCheetah.h"
+#include "Context.h"
+
+#include <QDialog>
+#include <QLabel>
+
+// Dialog class to allow overriding of metric data items
+class MetricOverrideDialog : public QDialog
+{
+    Q_OBJECT
+        G_OBJECT
+
+    public:
+        MetricOverrideDialog(Context *context, const QString& fieldName, const double value, QPoint pos);
+        virtual ~MetricOverrideDialog();
+
+    protected:
+
+        void showEvent(QShowEvent*) override;
+
+    private slots:
+
+        void cancelClicked();
+        void clearClicked();
+        void setClicked();
+
+    private:
+
+        enum class DialogMetricType { DATE, SECS_TIME, MINS_TIME, DOUBLE };
+
+        QPoint pos_;
+        QString fieldName_;
+        DialogMetricType dlgMetricType_ = DialogMetricType::DOUBLE;
+        Context* context_ = nullptr;
+
+        QLabel* metricLabel_ = nullptr;
+        QWidget* metricEdit_ = nullptr;
+};
+
+#endif // _MetricOverrideDialog_h

--- a/src/Metrics/SpecialFields.cpp
+++ b/src/Metrics/SpecialFields.cpp
@@ -138,7 +138,7 @@ SpecialFields::metricSymbol(QString name) const
 }
 
 const RideMetric *
-SpecialFields::rideMetric(QString&name) const
+SpecialFields::rideMetric(const QString &name) const
 {
     return metricmap.value(name, NULL);
 }

--- a/src/Metrics/SpecialFields.h
+++ b/src/Metrics/SpecialFields.h
@@ -38,7 +38,7 @@ class SpecialFields
 
         QString makeTechName(QString) const;        // return a SQL friendly name
         QString metricSymbol(QString) const;        // return symbol for user friendly name
-        const RideMetric *rideMetric(QString&) const; // retuen metric ptr for user friendly name
+        const RideMetric *rideMetric(const QString&) const; // return metric ptr for user friendly name
         QString displayName(QString &) const;         // return display (localized) name for name
         QString internalName(QString) const;          // return internal (english) Name for display
 

--- a/src/src.pro
+++ b/src/src.pro
@@ -649,7 +649,8 @@ HEADERS += Gui/AboutDialog.h Gui/AddIntervalDialog.h Gui/AnalysisSidebar.h Gui/C
            Gui/Views.h Gui/BatchProcessingDialog.h Gui/DownloadRideDialog.h Gui/ManualRideDialog.h Gui/NewSideBar.h \
            Gui/MergeActivityWizard.h Gui/RideImportWizard.h Gui/SplitActivityWizard.h Gui/SolverDisplay.h Gui/MetricSelect.h \
            Gui/AddTileWizard.h Gui/NavigationModel.h Gui/AthleteView.h Gui/AthleteConfigDialog.h Gui/AthletePages.h Gui/Perspective.h \
-           Gui/PerspectiveDialog.h Gui/SplashScreen.h Gui/StyledItemDelegates.h Gui/MetadataDialog.h Gui/ActionButtonBox.h
+           Gui/PerspectiveDialog.h Gui/SplashScreen.h Gui/StyledItemDelegates.h Gui/MetadataDialog.h Gui/ActionButtonBox.h \
+           Gui/MetricOverrideDialog.h
 
 # metrics and models
 HEADERS += Metrics/Banister.h Metrics/CPSolver.h Metrics/Estimator.h Metrics/ExtendedCriticalPower.h Metrics/HrZones.h Metrics/PaceZones.h \
@@ -759,7 +760,8 @@ SOURCES += Gui/AboutDialog.cpp Gui/AddIntervalDialog.cpp Gui/AnalysisSidebar.cpp
            Gui/BatchProcessingDialog.cpp Gui/DownloadRideDialog.cpp Gui/ManualRideDialog.cpp Gui/EditUserMetricDialog.cpp Gui/NewSideBar.cpp \
            Gui/MergeActivityWizard.cpp Gui/RideImportWizard.cpp Gui/SplitActivityWizard.cpp Gui/SolverDisplay.cpp Gui/MetricSelect.cpp \
            Gui/AddTileWizard.cpp Gui/NavigationModel.cpp Gui/AthleteView.cpp Gui/AthleteConfigDialog.cpp Gui/AthletePages.cpp Gui/Perspective.cpp \
-           Gui/PerspectiveDialog.cpp Gui/SplashScreen.cpp Gui/StyledItemDelegates.cpp Gui/MetadataDialog.cpp Gui/ActionButtonBox.cpp
+           Gui/PerspectiveDialog.cpp Gui/SplashScreen.cpp Gui/StyledItemDelegates.cpp Gui/MetadataDialog.cpp Gui/ActionButtonBox.cpp \
+           Gui/MetricOverrideDialog.cpp
 
 ## Models and Metrics
 SOURCES += Metrics/aBikeScore.cpp Metrics/aCoggan.cpp Metrics/AerobicDecoupling.cpp Metrics/Banister.cpp Metrics/BasicRideMetrics.cpp \


### PR DESCRIPTION
The following PR allows metrics to be overridden from the Overview tile page.

The Metric tile now has an editable icon:

![m1](https://github.com/user-attachments/assets/7b6b37fb-b24c-40f4-bd5b-cb12e2395e90)

This allows access to the metric override dialog:

![m2](https://github.com/user-attachments/assets/d719aef4-6316-4369-ae78-b4793a88e835)

Setting a Metric override via the dialog is displayed on the Metric tile as follows. I'm not sure an equals sign is the best symbol, but there probably needs to be some indication on the tile that the calculated value has been overridden by the user.

![m3](https://github.com/user-attachments/assets/db681a11-3b9e-4f46-8043-0fccdb9c744a)
