### PR TITLE
Remove Qt deprecation warnings

### DIFF
--- a/contrib/kmeans/kmeans.cpp
+++ b/contrib/kmeans/kmeans.cpp
@@ -30,7 +30,7 @@ void Kmeans::free() {
 
 
 
-void Kmeans::initialize(Dataset const *aX, unsigned short aK, unsigned short *initialAssignment, int aNumThreads) {
+void Kmeans::initialize(Dataset const *aX, unsigned short aK, unsigned short *initialAssignment, [[maybe_unused]] int aNumThreads) {
     free();
 
     converged = false;
@@ -82,7 +82,7 @@ struct ThreadInfo {
 };
 #endif
 
-void *Kmeans::runner(void *args) {
+void *Kmeans::runner([[maybe_unused]] void *args) {
     #ifdef USE_THREADS
     ThreadInfo *ti = (ThreadInfo *)args;
     ti->numIterations = ti->km->runThread(ti->threadId, ti->maxIterations);
@@ -125,7 +125,7 @@ double Kmeans::getSSE() const {
     return sse;
 }
 
-void Kmeans::verifyAssignment(int iteration, int startNdx, int endNdx) const {
+void Kmeans::verifyAssignment([[maybe_unused]] int iteration, [[maybe_unused]] int startNdx, [[maybe_unused]] int endNdx) const {
     #ifdef VERIFY_ASSIGNMENTS
     for (int i = startNdx; i < endNdx; ++i) {
         // keep track of the squared distance and identity of the closest-seen

--- a/contrib/qtsolutions/flowlayout/flowlayout.cpp
+++ b/contrib/qtsolutions/flowlayout/flowlayout.cpp
@@ -155,7 +155,7 @@ QSize FlowLayout::sizeHint() const
 QSize FlowLayout::minimumSize() const
 {
     QSize size;
-    for (const QLayoutItem *item : qAsConst(itemList))
+    for (const QLayoutItem *item : std::as_const(itemList))
         size = size.expandedTo(item->minimumSize());
 
     const QMargins margins = contentsMargins();
@@ -176,7 +176,7 @@ int FlowLayout::doLayout(const QRect &rect, bool testOnly) const
 //! [9]
 
     QList<int> lineHeights;
-    for (QLayoutItem *item : qAsConst(itemList)) {
+    for (QLayoutItem *item : std::as_const(itemList)) {
         const QWidget *wid = item->widget();
         int spaceX = horizontalSpacing();
         if (spaceX == -1)
@@ -207,7 +207,7 @@ int FlowLayout::doLayout(const QRect &rect, bool testOnly) const
     int row = 0;
 
 //! [10]
-    for (QLayoutItem *item : qAsConst(itemList)) {
+    for (QLayoutItem *item : std::as_const(itemList)) {
         lineHeight = lineHeights.value(row, item->sizeHint().height());
         const QWidget *wid = item->widget();
         int spaceX = horizontalSpacing();

--- a/contrib/qzip/zip.cpp
+++ b/contrib/qzip/zip.cpp
@@ -739,7 +739,7 @@ void ZipWriterPrivate::addEntry(EntryType type, const QString &fileName, const Q
 */
 ZipReader::ZipReader(const QString &archive, QIODevice::OpenMode mode)
 {
-    QScopedPointer<QFile> f(new QFile(archive));
+    std::unique_ptr<QFile> f = std::make_unique<QFile>(archive);
     f->open(mode);
     ZipReader::Status status;
     if (f->error() == QFile::NoError)
@@ -755,8 +755,7 @@ ZipReader::ZipReader(const QString &archive, QIODevice::OpenMode mode)
             status = FileError;
     }
 
-    d = new ZipReaderPrivate(f.data(), /*ownDevice=*/true);
-    f.take();
+    d = new ZipReaderPrivate(&(*f), /*ownDevice=*/true);
     d->status = status;
 }
 
@@ -1024,7 +1023,7 @@ void ZipReader::close()
 */
 ZipWriter::ZipWriter(const QString &fileName, QIODevice::OpenMode mode)
 {
-    QScopedPointer<QFile> f(new QFile(fileName));
+    std::unique_ptr<QFile> f = std::make_unique<QFile>(fileName);
     f->open(mode);
     ZipWriter::Status status;
     if (f->error() == QFile::NoError)
@@ -1040,8 +1039,7 @@ ZipWriter::ZipWriter(const QString &fileName, QIODevice::OpenMode mode)
             status = ZipWriter::FileError;
     }
 
-    d = new ZipWriterPrivate(f.data(), /*ownDevice=*/true);
-    f.take();
+    d = new ZipWriterPrivate(&(*f), /*ownDevice=*/true);
     d->status = status;
 }
 

--- a/contrib/voronoi/Voronoi.cpp
+++ b/contrib/voronoi/Voronoi.cpp
@@ -778,12 +778,12 @@ Voronoi::line(float ax, float ay, float bx, float by)
     }
 
 void
-Voronoi::circle(float ax, float ay, float radius)
+Voronoi::circle([[maybe_unused]] float ax, [[maybe_unused]] float ay, [[maybe_unused]] float radius)
     {
     }
 
 void
-Voronoi::range(float pxmin, float pxmax, float pymin, float pymax)
+Voronoi::range([[maybe_unused]] float pxmin, [[maybe_unused]] float pxmax, [[maybe_unused]] float pymin, [[maybe_unused]] float pymax)
     {
     }
 

--- a/src/ANT/ANT.cpp
+++ b/src/ANT/ANT.cpp
@@ -1302,7 +1302,7 @@ int ANT::rawWrite(uint8_t *bytes, int size) // unix!!
 
 }
 
-int ANT::rawRead(uint8_t bytes[], int size)
+int ANT::rawRead([[maybe_unused]] uint8_t bytes[], [[maybe_unused]] int size)
 {
 #ifdef WIN32
 #ifdef GC_HAVE_LIBUSB

--- a/src/ANT/ANTMessage.cpp
+++ b/src/ANT/ANTMessage.cpp
@@ -375,7 +375,7 @@ ANTMessage::ANTMessage(ANT *parent, const unsigned char *message) {
             {
 
                 // page no is first 7 bits, page change toggle is bit 8
-                bool page_toggle = data_page&128;
+                // bool page_toggle = data_page&128;
                 data_page &= 127;
 
                 // Heartrate is fairly simple. Although
@@ -577,8 +577,8 @@ ANTMessage::ANTMessage(ANT *parent, const unsigned char *message) {
 
                 case POWER_MANUFACTURER_ID:
                 {
-                    uint16_t manuf_id = (message[8] + (static_cast<uint16_t>(message[9])<<8));
-                    uint16_t product_id = (message[10] + (static_cast<uint16_t>(message[11])<<8));
+                    // uint16_t manuf_id = (message[8] + (static_cast<uint16_t>(message[9])<<8));
+                    // uint16_t product_id = (message[10] + (static_cast<uint16_t>(message[11])<<8));
                     // qDebug()<<channel<<"Received power sensor info: Manufacturer id:" << manuf_id << ", Product id:" << product_id;
                     break;
                 }

--- a/src/Charts/AllPlot.cpp
+++ b/src/Charts/AllPlot.cpp
@@ -7185,7 +7185,7 @@ AllPlot::eventFilter(QObject *obj, QEvent *event)
         if (mouseEvent->button() == Qt::MouseButton::MiddleButton)
         {
             isPanning = true;
-            panOriginX = mouseEvent->globalX();
+            panOriginX = mouseEvent->globalPosition().x();
         }
     }
     else if (event->type() == QEvent::MouseButtonRelease)
@@ -7198,7 +7198,7 @@ AllPlot::eventFilter(QObject *obj, QEvent *event)
     {
         // the actual panning logic
         QMouseEvent* mouseEvent = static_cast<QMouseEvent*>(event);
-        int diffX = mouseEvent->globalX() - panOriginX;
+        int diffX = mouseEvent->globalPosition().x() - panOriginX;
         QxtSpanSlider* slider = window->spanSlider;
 
         // ride length in seconds
@@ -7206,7 +7206,7 @@ AllPlot::eventFilter(QObject *obj, QEvent *event)
         int movement = (int)(diffX * (total / 1000.0));
         if (movement != 0)
         {
-            panOriginX = mouseEvent->globalX();
+            panOriginX = mouseEvent->globalPosition().x();
             int newLower = slider->lowerValue() + movement;
             int newUpper = slider->upperValue() + movement;
             if (newUpper <= slider->maximum() && newLower >= slider->minimum())
@@ -7272,18 +7272,18 @@ AllPlot::eventFilter(QObject *obj, QEvent *event)
 
         if (axis == QwtAxis::YLeft && event->type() == QEvent::MouseButtonDblClick) {
             QMouseEvent *m = static_cast<QMouseEvent*>(event);
-            confirmTmpReference(invTransform(axis, m->y()),axis, RideFile::watts, true); // do show delete stuff
+            confirmTmpReference(invTransform(axis, m->position().y()),axis, RideFile::watts, true); // do show delete stuff
             return false;
         }
         if (axis == QwtAxis::YLeft && event->type() == QEvent::MouseMove) {
             QMouseEvent *m = static_cast<QMouseEvent*>(event);
-            plotTmpReference(axis, m->x()-axisWidget(axis)->width(), m->y(), RideFile::watts);
+            plotTmpReference(axis, m->position().x()-axisWidget(axis)->width(), m->position().y(), RideFile::watts);
             return false;
         }
         if (axis == QwtAxis::YLeft && event->type() == QEvent::MouseButtonRelease) {
             QMouseEvent *m = static_cast<QMouseEvent*>(event);
-            if (m->x()>axisWidget(axis)->width()) {
-                confirmTmpReference(invTransform(axis, m->y()),axis, RideFile::watts, false); // don't show delete stuff
+            if (m->position().x()>axisWidget(axis)->width()) {
+                confirmTmpReference(invTransform(axis, m->position().y()),axis, RideFile::watts, false); // don't show delete stuff
                 return false;
             } else  if (standard->tmpReferenceLines.count()) {
                 plotTmpReference(axis, 0, 0, RideFile::watts); //unplot
@@ -7303,18 +7303,18 @@ AllPlot::eventFilter(QObject *obj, QEvent *event)
 
         if (axis != QwtAxisId(-1,-1) && event->type() == QEvent::MouseButtonDblClick) {
             QMouseEvent *m = static_cast<QMouseEvent*>(event);
-            confirmTmpReference(invTransform(axis, m->y()),axis.id, RideFile::hr, true); // do show delete stuff
+            confirmTmpReference(invTransform(axis, m->position().y()),axis.id, RideFile::hr, true); // do show delete stuff
             return false;
         }
         if (axis != QwtAxisId(-1,-1) && event->type() == QEvent::MouseMove) {
             QMouseEvent *m = static_cast<QMouseEvent*>(event);
-            plotTmpReference(axis, m->x()-axisWidget(axis)->width(), m->y(), RideFile::hr);
+            plotTmpReference(axis, m->position().x()-axisWidget(axis)->width(), m->position().y(), RideFile::hr);
             return false;
         }
         if (axis != QwtAxisId(-1,-1) && event->type() == QEvent::MouseButtonRelease) {
             QMouseEvent *m = static_cast<QMouseEvent*>(event);
-            if (m->x()>axisWidget(axis)->width()) {
-                confirmTmpReference(invTransform(axis, m->y()),axis.id, RideFile::hr, false); // don't show delete stuff
+            if (m->position().x()>axisWidget(axis)->width()) {
+                confirmTmpReference(invTransform(axis, m->position().y()),axis.id, RideFile::hr, false); // don't show delete stuff
                 return false;
             } else  if (standard->tmpReferenceLines.count()) {
                 plotTmpReference(axis.id, 0, 0, RideFile::hr); //unplot
@@ -7334,23 +7334,23 @@ AllPlot::eventFilter(QObject *obj, QEvent *event)
 
         if (event->type() == QEvent::MouseButtonDblClick) {
 
-            confirmTmpExhaustion(m->x(), true); // do show delete stuff
+            confirmTmpExhaustion(m->position().x(), true); // do show delete stuff
             return false;
 
         } else if (event->type() == QEvent::MouseMove) {
 
             // plot a temporary marker
-            plotTmpExhaustion(m->x());
+            plotTmpExhaustion(m->position().x());
             return true;
 
         } else if (event->type() == QEvent::MouseButtonRelease) {
 
             // only respond if we are on the plot, which is above so
             // therefore has a y-value that is negative
-            if (m->y() < 0) {
+            if (m->position().y() < 0) {
 
                 // confirm and add to references + intervals
-                confirmTmpExhaustion(m->x());
+                confirmTmpExhaustion(m->position().x());
                 return true;
 
             } else {

--- a/src/Charts/ChartBar.cpp
+++ b/src/Charts/ChartBar.cpp
@@ -556,8 +556,8 @@ ChartBarItem::event(QEvent *e)
 
             // selected with a click (not release)
             state = Click;
-            clickpos.setX(static_cast<QMouseEvent*>(e)->x());
-            clickpos.setY(static_cast<QMouseEvent*>(e)->y());
+            clickpos.setX(static_cast<QMouseEvent*>(e)->position().x());
+            clickpos.setY(static_cast<QMouseEvent*>(e)->position().y());
             emit clicked(checked);
         }
     }
@@ -606,21 +606,21 @@ ChartBarItem::event(QEvent *e)
             dragging->checked = checked;
             dragging->setFixedWidth(geometry().width());
             dragging->setFixedHeight(geometry().height());
-            QPoint newpos = chartbar->mapFromGlobal(static_cast<QMouseEvent*>(e)->globalPos());
+            QPoint newpos = chartbar->mapFromGlobal(static_cast<QMouseEvent*>(e)->globalPosition().toPoint());
             dragging->move(QPoint(newpos.x()-clickpos.x(),0));
             dragging->show();
 
         } else if (state == Drag) {
 
             // move the clone tab for visual feedback
-            QPoint newpos = chartbar->mapFromGlobal(static_cast<QMouseEvent*>(e)->globalPos());
+            QPoint newpos = chartbar->mapFromGlobal(static_cast<QMouseEvent*>(e)->globalPosition().toPoint());
             dragging->move(QPoint(newpos.x()-clickpos.x(),0));
 
             // where are we currently?
             int cindex = chartbar->layout->indexOf(this);
 
             // work out where we should have dragged to
-            int indexpos = indexPos(static_cast<QMouseEvent*>(e)->x());
+            int indexpos = indexPos(static_cast<QMouseEvent*>(e)->position().x());
 
             // if moving left, just do it...
             if (cindex > indexpos) {

--- a/src/Charts/GcOverlayWidget.cpp
+++ b/src/Charts/GcOverlayWidget.cpp
@@ -268,7 +268,7 @@ bool GcOverlayWidget::eventFilter( QObject *obj, QEvent *evt )
  
 void GcOverlayWidget::mousePressEvent(QMouseEvent *e) 
 {
-    position = QPoint(e->globalX()-geometry().x(), e->globalY()-geometry().y());
+    position = QPoint(e->globalPosition().x()-geometry().x(), e->globalPosition().y()-geometry().y());
     if (!m_isEditing) return;
     if (!m_infocus) return;
     //QWidget::mouseMoveEvent(e);
@@ -387,13 +387,13 @@ void GcOverlayWidget::mouseMoveEvent(QMouseEvent *e)
     if (!m_isEditing) return;
     if (!m_infocus) return;
     if (!(e->buttons() & Qt::LeftButton)) {
-        QPoint p = QPoint(e->x()+geometry().x(), e->y()+geometry().y());
+        QPoint p = QPoint(e->position().x()+geometry().x(), e->position().y()+geometry().y());
         setCursorShape(p);
         return;
     }
  
     if (mode == moving && (e->buttons() & Qt::LeftButton)) {
-        QPoint toMove = e->globalPos() - position;
+        QPoint toMove = e->globalPosition().toPoint() - position;
         if (toMove.x() < 0) return;
         if (toMove.y() < 0) return;
         if (toMove.x() > parentWidget()->width()-width()) return;
@@ -405,47 +405,47 @@ void GcOverlayWidget::mouseMoveEvent(QMouseEvent *e)
     if ((mode != moving) && (e->buttons() & Qt::LeftButton)) {
         switch (mode){
             case resizetl: {  //Left-Top
-                int newwidth = e->globalX() - position.x() - geometry().x();
-                int newheight = e->globalY() - position.y() - geometry().y();
-                QPoint toMove = e->globalPos() - position;
+                int newwidth = e->globalPosition().x() - position.x() - geometry().x();
+                int newheight = e->globalPosition().y() - position.y() - geometry().y();
+                QPoint toMove = e->globalPosition().toPoint() - position;
                 resize(geometry().width()-newwidth,geometry().height()-newheight);
                 move(toMove.x(),toMove.y());
                 break;
             }
             case resizetr: {  //Right-Top
-                int newheight = e->globalY() - position.y() - geometry().y();
-                QPoint toMove = e->globalPos() - position;
-                resize(e->x(),geometry().height()-newheight);
+                int newheight = e->globalPosition().y() - position.y() - geometry().y();
+                QPoint toMove = e->globalPosition().toPoint() - position;
+                resize(e->position().x(),geometry().height()-newheight);
                 move(x(),toMove.y());
                 break;
             }
             case resizebl: {  //Left-Bottom
-                int newwidth = e->globalX() - position.x() - geometry().x();
-                QPoint toMove = e->globalPos() - position;
-                resize(geometry().width()-newwidth,e->y());
+                int newwidth = e->globalPosition().x() - position.x() - geometry().x();
+                QPoint toMove = e->globalPosition().toPoint() - position;
+                resize(geometry().width()-newwidth,e->position().y());
                 move(toMove.x(),y());
                 break;
             }
             case resizeb: {   //Bottom
-                resize(width(),e->y()); break;}
+                resize(width(),e->position().y()); break;}
             case resizel:  {  //Left
-                int newwidth = e->globalX() - position.x() - geometry().x();
-                QPoint toMove = e->globalPos() - position;
+                int newwidth = e->globalPosition().x() - position.x() - geometry().x();
+                QPoint toMove = e->globalPosition().toPoint() - position;
                 resize(geometry().width()-newwidth,height());
                 move(toMove.x(),y());
                 break;
             }
             case resizet:  {  //Top
-                int newheight = e->globalY() - position.y() - geometry().y();
-                QPoint toMove = e->globalPos() - position;
+                int newheight = e->globalPosition().y() - position.y() - geometry().y();
+                QPoint toMove = e->globalPosition().toPoint() - position;
                 resize(width(),geometry().height()-newheight);
                 move(x(),toMove.y());
                 break;
             }
             case resizer:  {  //Right
-                resize(e->x(),height()); break;}
+                resize(e->position().x(),height()); break;}
             case resizebr: {  //Right-Bottom
-                resize(e->x(),e->y()); break;}
+                resize(e->globalPosition().x(),e->position().y()); break;}
         }
         parentWidget()->repaint();
     }

--- a/src/Charts/GcPane.cpp
+++ b/src/Charts/GcPane.cpp
@@ -150,16 +150,16 @@ GcPane::spotHotSpot(QMouseEvent *e)
     int corner = closeImage.width()/2;
 
     // account for offset
-    int _y = e->y() - (closeImage.height()/2);
-    int _x = e->x();
+    int _y = e->position().y() - (closeImage.height()/2);
+    int _x = e->position().x();
     int _height = height() - (closeImage.height()/2);
     int _width = width() - (closeImage.width()/2);
 
-    if (e->x() > (width() - (closeImage.width()+10)) && e->y() < (closeImage.height()+12))
+    if (e->position().x() > (width() - (closeImage.width()+10)) && e->position().y() < (closeImage.height()+12))
         return Close;
-    else if (e->x() > (width() - 5 - closeImage.width() - flipImage.width()) &&
-             e->x() < (width() - 5 - closeImage.width()) &&
-             e->y() < (closeImage.height()-2))
+    else if (e->position().x() > (width() - 5 - closeImage.width() - flipImage.width()) &&
+             e->position().x() < (width() - 5 - closeImage.width()) &&
+             e->position().y() < (closeImage.height()-2))
         return Flip;
     else if (_x <= corner && _y <= corner) return (TLCorner);
     else if (_x >= (_width-corner) && _y <= corner) return (TRCorner);
@@ -214,8 +214,8 @@ GcPane::mousePressEvent(QMouseEvent *e)
     oHeight = height();
     oX = pos().x();
     oY = pos().y();
-    mX = e->globalX();
-    mY = e->globalY();
+    mX = e->globalPosition().x();
+    mY = e->globalPosition().y();
 
     setDragState(h); // set drag state then!
 
@@ -239,8 +239,8 @@ GcPane::mouseMoveEvent(QMouseEvent *e)
     }
 
     // work out the relative move x and y
-    int relx = e->globalX() - mX;
-    int rely = e->globalY() - mY;
+    int relx = e->globalPosition().x() - mX;
+    int rely = e->globalPosition().y() - mY;
 
     switch (dragState) {
 

--- a/src/Charts/GenericPlot.cpp
+++ b/src/Charts/GenericPlot.cpp
@@ -1278,7 +1278,7 @@ GenericPlot::configureAxis(QString name, bool visible, int align, double min, do
             if (series->type() == QAbstractSeries::SeriesType::SeriesTypeScatter ||
                 series->type() == QAbstractSeries::SeriesType::SeriesTypeBar ||
                 series->type() == QAbstractSeries::SeriesType::SeriesTypeLine) {
-                foreach(QPointF point, static_cast<QXYSeries*>(series)->pointsVector()) {
+                foreach(QPointF point, static_cast<QXYSeries*>(series)->points()) {
                     if (usey) {
                         if (setmin && point.y() < min) min=point.y();
                         else if (!setmin) { min=point.y(); setmin=true; }
@@ -1307,7 +1307,7 @@ GenericPlot::configureAxis(QString name, bool visible, int align, double min, do
                 if (series->type() == QAbstractSeries::SeriesType::SeriesTypeScatter ||
                     series->type() == QAbstractSeries::SeriesType::SeriesTypeBar ||
                     series->type() == QAbstractSeries::SeriesType::SeriesTypeLine) {
-                    foreach(QPointF point, static_cast<QXYSeries*>(series)->pointsVector()) {
+                    foreach(QPointF point, static_cast<QXYSeries*>(series)->points()) {
                         if (usey) {
                             if (setmax && point.y() > max) max=point.y();
                             else if (!setmax) { max=point.y(); setmax=true; }

--- a/src/Charts/GenericSelectTool.cpp
+++ b/src/Charts/GenericSelectTool.cpp
@@ -702,14 +702,14 @@ GenericSelectTool::moved(QPointF pos)
                 if (series->type() == QAbstractSeries::SeriesTypeLine || series->type() == QAbstractSeries::SeriesTypeArea) {
 
                     // we take a copy, would love to avoid this.
-                    QVector<QPointF> p = series->type() == QAbstractSeries::SeriesTypeLine ? static_cast<QLineSeries*>(series)->pointsVector() :
-                                                                              static_cast<QAreaSeries*>(series)->upperSeries()->pointsVector();
+                    QList<QPointF> p = series->type() == QAbstractSeries::SeriesTypeLine ? static_cast<QLineSeries*>(series)->points() :
+                                                                              static_cast<QAreaSeries*>(series)->upperSeries()->points();
 
                     // value we want
                     QPointF x= QPointF(xvalue,0);
 
                     // lower_bound to value near x
-                    QVector<QPointF>::const_iterator i = std::lower_bound(p.begin(), p.end(), x, CompareQPointFX());
+                    QList<QPointF>::const_iterator i = std::lower_bound(p.begin(), p.end(), x, CompareQPointFX());
 
                     if (i != p.end()) {
                         // collect them away

--- a/src/Charts/GoldenCheetah.cpp
+++ b/src/Charts/GoldenCheetah.cpp
@@ -416,8 +416,8 @@ GcWindow::spotHotSpot(QMouseEvent *e)
     int borderWidth = 3;
 
     // account for offset by mapping to GcWindow geom
-    int _y = e->y();
-    int _x = e->x();
+    int _y = e->position().y();
+    int _x = e->position().x();
     int _height = height();
     int _width = width();
 

--- a/src/Charts/LTMChartParser.cpp
+++ b/src/Charts/LTMChartParser.cpp
@@ -158,7 +158,7 @@ ChartTreeView::ChartTreeView(Context *context) : context(context)
 void
 ChartTreeView::dropEvent(QDropEvent* event)
 {
-    QTreeWidgetItem* target = (QTreeWidgetItem *)itemAt(event->pos());
+    QTreeWidgetItem* target = (QTreeWidgetItem *)itemAt(event->position().toPoint());
     int idxTo = indexFromItem(target).row();
 
     // when dragging to past the last one, we get -1, so lets

--- a/src/Charts/Overview.cpp
+++ b/src/Charts/Overview.cpp
@@ -402,13 +402,13 @@ badconfig:
 
         QVector<int> widths;
         QJsonArray w = root["widths"].toArray();
-        foreach(const QJsonValue width, w) widths << width.toInt();
+        for(const QJsonValue &width : w) widths << width.toInt();
         space->setColumnWidths(widths);
     }
 
     // cards
     QJsonArray CHARTS = root["CHARTS"].toArray();
-    foreach(const QJsonValue val, CHARTS) {
+    for(const QJsonValue &val : CHARTS) {
 
         // convert so we can inspect
         QJsonObject obj = val.toObject();

--- a/src/Charts/RideMapWindow.cpp
+++ b/src/Charts/RideMapWindow.cpp
@@ -1708,7 +1708,7 @@ MapWebBridge::drawOverlays()
             QString wNameEx = tr("Selection #");
             if (wNameItr.contains(wNameEx, Qt::CaseSensitive))
             {
-                int wSelCount = wNameItr.count() - wNameEx.count();
+                int wSelCount = wNameItr.length() - wNameEx.length();
                 wNameSelectionIndexList.append(wNameItr.right(wSelCount).toInt());
             }
         }

--- a/src/Charts/UserChart.cpp
+++ b/src/Charts/UserChart.cpp
@@ -682,7 +682,7 @@ UserChart::applySettings(QString x)
             delete static_cast<UserChartData*>(series.user1);
 
     seriesinfo.clear();
-    foreach(QJsonValue it, obj["SERIES"].toArray()) {
+    for(const QJsonValue &it : obj["SERIES"].toArray()) {
 
         // should be an array of objects
         QJsonObject series=it.toObject();
@@ -714,7 +714,7 @@ UserChart::applySettings(QString x)
 
     // array of axes
     axisinfo.clear();
-    foreach(QJsonValue it, obj["AXES"].toArray()) {
+    for(const QJsonValue &it : obj["AXES"].toArray()) {
 
         // should be an array of objects
         QJsonObject axis=it.toObject();

--- a/src/Cloud/CyclingAnalytics.cpp
+++ b/src/Cloud/CyclingAnalytics.cpp
@@ -132,7 +132,7 @@ CyclingAnalytics::readdir(QString path, QStringList &errors, QDateTime, QDateTim
     QTimer::singleShot(30000,&loop, SLOT(quit())); // timeout after 30 seconds
 
     // if successful, lets unpack
-    int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    //int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
     printd("fetch response: %d: %s\n", reply->error(), reply->errorString().toStdString().c_str());
 
     if (reply->error() == 0) {
@@ -246,7 +246,7 @@ CyclingAnalytics::readdir(QString path, QStringList &errors, QDateTime, QDateTim
 
 
     // all good ?
-    printd("returning count(%d), errors(%s)\n", returning.count(), errors.join(",").toStdString().c_str());
+    printd("returning count(%lld), errors(%s)\n", returning.count(), errors.join(",").toStdString().c_str());
     return returning;
 }
 
@@ -402,7 +402,6 @@ CyclingAnalytics::readFileCompleted()
             add.secs = index;
 
             // move through tracks if they're waiting for this point
-            bool updated=false;
             for(int t=0; t<data.count(); t++) {
 
                // hr, distance et al

--- a/src/Cloud/Nolio.cpp
+++ b/src/Cloud/Nolio.cpp
@@ -342,7 +342,7 @@ QByteArray* Nolio::prepareResponse(QByteArray* data){
         if (laps.size() > 0){
             double start = 0.0;
             double end = 0.0;
-            foreach (QJsonValue value, laps) {
+            for (const QJsonValue &value : laps) {
                 QJsonObject lap = value.toObject();
                 double duration = lap["duration"].toDouble();
                 if (start > 0.0){

--- a/src/Cloud/OpenData.cpp
+++ b/src/Cloud/OpenData.cpp
@@ -278,7 +278,7 @@ OpenData::run()
     postingdata = zip.readAll();
     zip.close();
 
-    printd("Compressed to %s, size %d\n", zipFile.fileName().toStdString().c_str(), postingdata.size());
+    printd("Compressed to %s, size %lld\n", zipFile.fileName().toStdString().c_str(), postingdata.size());
 
     // ----------------------------------------------------------------
     // STEP FOUR: Sending data to server

--- a/src/Cloud/SixCycle.cpp
+++ b/src/Cloud/SixCycle.cpp
@@ -258,7 +258,7 @@ SixCycle::readdir(QString path, QStringList &errors, QDateTime from, QDateTime t
         // results ?
         QJsonArray results = document.array();
 
-        printd("items found: %d\n", results.size());
+        printd("items found: %lld\n", results.size());
 
         // lets look at that then
         for(int i=0; i<results.size(); i++) {

--- a/src/Cloud/Strava.cpp
+++ b/src/Cloud/Strava.cpp
@@ -973,7 +973,7 @@ Strava::prepareResponse(QByteArray* data)
                 QJsonArray laps = each["laps"].toArray();
 
                 double last_lap = 0.0;
-                foreach (QJsonValue value, laps) {
+                for (const QJsonValue &value : laps) {
                     QJsonObject lap = value.toObject();
 
                     double start = starttime.secsTo(QDateTime::fromString(lap["start_date_local"].toString(), Qt::ISODate));

--- a/src/Cloud/Xert.cpp
+++ b/src/Cloud/Xert.cpp
@@ -200,7 +200,7 @@ Xert::readdir(QString path, QStringList &errors, QDateTime from, QDateTime to)
     loop.exec();
 
     // if successful, lets unpack
-    int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    //int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
     printd("fetch response: %d: %s\n", reply->error(), reply->errorString().toStdString().c_str());
 
     if (reply->error() == 0) {
@@ -259,7 +259,7 @@ Xert::readdir(QString path, QStringList &errors, QDateTime from, QDateTime to)
     }
 
     // all good ?
-    printd("returning count(%d), errors(%s)\n", returning.count(), errors.join(",").toStdString().c_str());
+    printd("returning count(%lld), errors(%s)\n", returning.count(), errors.join(",").toStdString().c_str());
     return returning;
 }
 
@@ -309,7 +309,7 @@ Xert::readActivityDetail(QString path, bool withSessionData)
     loop.exec();
 
     // if successful, lets unpack
-    int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
+    //int statusCode = reply->attribute(QNetworkRequest::HttpStatusCodeAttribute).toInt();
     printd("fetch response: %d: %s\n", reply->error(), reply->errorString().toStdString().c_str());
 
     if (reply->error() == 0) {

--- a/src/Core/WindowsCrashHandler.cpp
+++ b/src/Core/WindowsCrashHandler.cpp
@@ -43,7 +43,10 @@ static std::string getCrashFileName()
     if (installation_crash_path.length() > 0 ) {
       ret << installation_crash_path << "\\";
     }
-    ret << "crash_" << std::put_time(std::localtime(&nowTimeT), "%H%M_%d%m%y");
+
+    struct tm timeInfo;
+    localtime_s(&timeInfo, &nowTimeT);
+    ret << "crash_" << std::put_time(&timeInfo, "%H%M_%d%m%y");
     return ret.str();
 }
 

--- a/src/FileIO/BinRideFile.cpp
+++ b/src/FileIO/BinRideFile.cpp
@@ -290,7 +290,7 @@ struct BinFileReaderState
         QString deviceInfo = "";
         QDateTime t;
 
-        foreach(const BinField &field, def.fields) {
+        for(const BinField &field : def.fields) {
             if (!global_format_identifiers.contains(field.id)) {
                 unknown_format_identifiers.insert(field.id);
             } else {
@@ -408,7 +408,7 @@ struct BinFileReaderState
         double temperature = RideFile::NA;
         double lrbalance = RideFile::NA;
 
-        foreach(const BinField &field, def.fields) {
+        for(const BinField &field : def.fields) {
             if (!global_format_identifiers.contains(field.id)) {
                 unknown_format_identifiers.insert(field.id);
             } else {
@@ -498,7 +498,7 @@ struct BinFileReaderState
         int temperature_count = 0;
         double temperature = 0.0;
 
-        foreach(const BinField &field, def.fields) {
+        for(const BinField &field : def.fields) {
             if (!global_format_identifiers.contains(field.id)) {
                 unknown_format_identifiers.insert(field.id);
             } else {
@@ -528,7 +528,7 @@ struct BinFileReaderState
         int i = 0;
         double secs = 0;
 
-        foreach(const BinField &field, def.fields) {
+        for(const BinField &field : def.fields) {
             if (!global_format_identifiers.contains(field.id)) {
                 unknown_format_identifiers.insert(field.id);
             } else {
@@ -555,7 +555,7 @@ struct BinFileReaderState
 
     void decodeDataError(const BinDefinition &def, const std::vector<int> values) {
         int i = 0;
-        foreach(const BinField &field, def.fields) {
+        for(const BinField &field : def.fields) {
             if (!global_format_identifiers.contains(field.id)) {
                 unknown_format_identifiers.insert(field.id);
             } else {
@@ -592,15 +592,12 @@ struct BinFileReaderState
 
     void decodeHistoryData(const BinDefinition &def, const std::vector<int> /*values*/) {
         //int i = 0;
-        foreach(const BinField &field, def.fields) {
+        for(const BinField &field : def.fields) {
             if (!global_format_identifiers.contains(field.id)) {
                 unknown_format_identifiers.insert(field.id);
             } else {
                 //int value = values[i++];
-                switch (field.id) {
-                    default:
-                        unexpected_format_identifiers_for_record_types[def.format_identifier].insert(field.id);
-                }
+                unexpected_format_identifiers_for_record_types[def.format_identifier].insert(field.id);
             }
         }
     }
@@ -670,7 +667,7 @@ struct BinFileReaderState
                 const BinDefinition &def = local_format_identifiers[format_identifier];
                 //printf("- fields type : %d\n", def.format_identifier);
                 std::vector<int> values;
-                foreach(const BinField &field, def.fields) {
+                for(const BinField &field : def.fields) {
                     //printf("- field : %d \n", field.id);
                     int v;
                     switch (field.size) {

--- a/src/FileIO/FitRideFile.cpp
+++ b/src/FileIO/FitRideFile.cpp
@@ -223,7 +223,7 @@ static void loadMetadata()
 
         if (!root.contains("PRODUCTS")) goto badconfig;
         QJsonArray PRODUCTS = root["PRODUCTS"].toArray();
-        foreach(const QJsonValue val, PRODUCTS) {
+        for(const QJsonValue &val : PRODUCTS) {
 
             // convert so we can inspect
             QJsonObject obj = val.toObject();
@@ -240,7 +240,7 @@ static void loadMetadata()
 
         if (!root.contains("MANUFACTURERS")) goto badconfig;
         QJsonArray MANUFACTURERS = root["MANUFACTURERS"].toArray();
-        foreach(const QJsonValue val, MANUFACTURERS) {
+        for(const QJsonValue &val : MANUFACTURERS) {
 
             // convert so we can inspect
             QJsonObject obj = val.toObject();
@@ -256,7 +256,7 @@ static void loadMetadata()
 
         if (!root.contains("FIELDS")) goto badconfig;
         QJsonArray FIELDS = root["FIELDS"].toArray();
-        foreach(const QJsonValue val, FIELDS) {
+        for(const QJsonValue &val : FIELDS) {
 
             // Message:FieldNum lists
             //
@@ -310,7 +310,7 @@ static void loadMetadata()
 
         if (!root.contains("MESSAGES")) goto badconfig;
         QJsonArray MESSAGES = root["MESSAGES"].toArray();
-        foreach(const QJsonValue val, MESSAGES) {
+        for(const QJsonValue &val : MESSAGES) {
 
             // convert so we can inspect
             QJsonObject obj = val.toObject();
@@ -1914,7 +1914,7 @@ struct FitFileParser
         // before being added to the XDATA
         XDataPoint *add= new XDataPoint();
 
-        foreach(const FitField &field, def.fields) {
+        for(const FitField &field : def.fields) {
 
             QString name;
             double value=0;
@@ -2021,7 +2021,7 @@ genericnext:
                       const std::vector<FitValue>& values) {
         int i = 0;
         int manu = -1, prod = -1;
-        foreach(const FitField &field, def.fields) {
+        for(const FitField &field : def.fields) {
             fit_value_t value = values[i++].v;
 
             if( value == NA_VALUE )
@@ -2052,7 +2052,7 @@ genericnext:
                                     const std::vector<FitValue>& values) {
         int i = 0;
 
-        foreach(const FitField &field, def.fields) {
+        for(const FitField &field : def.fields) {
             fit_value_t value = values[i++].v;
 
 
@@ -2123,7 +2123,7 @@ genericnext:
         QString prevSport = rideFile->getTag("Sport", "");
         double pool_length = 0.0;
 
-        foreach(const FitField &field, def.fields) {
+        for(const FitField &field : def.fields) {
             fit_value_t value = values[i++].v;
 
             if( value == NA_VALUE )
@@ -2286,7 +2286,7 @@ genericnext:
 
         QString deviceInfo;
 
-        foreach(const FitField &field, def.fields) {
+        for(const FitField &field : def.fields) {
             FitValue value = values[i++];
 
             //qDebug() << field.num << field.type << value.v;
@@ -2361,7 +2361,7 @@ genericnext:
         const int delta = qbase_time.toSecsSinceEpoch();
         int event = -1, event_type = -1, local_timestamp = -1, timestamp = -1;
 
-        foreach(const FitField &field, def.fields) {
+        for(const FitField &field : def.fields) {
             fit_value_t value = values[i++].v;
 
             if (value == NA_VALUE)
@@ -2438,7 +2438,7 @@ genericnext:
         qint16 data16 = -1;
         qint32 data32 = -1;
         int i = 0;
-        foreach(const FitField &field, def.fields) {
+        for(const FitField &field : def.fields) {
             fit_value_t value = values[i++].v;
 
             if( value == NA_VALUE )
@@ -2606,7 +2606,7 @@ genericnext:
         if (n>0)
             hrv_time = hrvXdata->datapoints[n-1]->secs;
 
-        foreach(const FitField &field, def.fields) {
+        for(const FitField &field : def.fields) {
             FitValue value = values[i++];
             if ( value.type == ListValue && field.num == 0){
                 for (int j=0; j<value.list.size(); j++)
@@ -2655,7 +2655,7 @@ genericnext:
             fprintf(stderr, " FIT decode lap \n");
         }
 
-        foreach(const FitField &field, def.fields) {
+        for(const FitField &field : def.fields) {
             const FitValue& value = values[i++];
 
             if( value.v == NA_VALUE )
@@ -2806,7 +2806,7 @@ genericnext:
 
         fit_value_t lati = NA_VALUE, lngi = NA_VALUE;
         int i = 0;
-        foreach(const FitField &field, def.fields) {
+        for(const FitField &field : def.fields) {
             FitValue _values = values[i];
             fit_value_t value = values[i].v;
             QList<fit_value_t> valueList = values[i++].list;
@@ -3354,7 +3354,7 @@ genericnext:
         double length_duration = 0.0;
 
         int i = 0;
-        foreach(const FitField &field, def.fields) {
+        for(const FitField &field : def.fields) {
             fit_value_t value = values[i++].v;
 
             if( value == NA_VALUE )
@@ -3443,7 +3443,7 @@ genericnext:
         double windHeading = 0.0, windSpeed = 0.0, temp = 0.0, humidity = 0.0;
 
         int i = 0;
-        foreach(const FitField &field, def.fields) {
+        for(const FitField &field : def.fields) {
             fit_value_t value = values[i++].v;
 
             if( value == NA_VALUE )
@@ -3506,7 +3506,7 @@ genericnext:
 
         int a = 0;
         int j = 0;
-        foreach(const FitField &field, def.fields) {
+        for(const FitField &field : def.fields) {
             FitValue value = values[a++];
 
             if( value.type == SingleValue && value.v == NA_VALUE )
@@ -3610,7 +3610,7 @@ genericnext:
                       const std::vector<FitValue>& values) {
         Q_UNUSED(time_offset);
         int i = 0;
-        foreach(const FitField &field, def.fields) {
+        for(const FitField &field : def.fields) {
             fit_value_t value = values[i++].v;
 
             if( value == NA_VALUE )
@@ -3646,7 +3646,7 @@ genericnext:
         QString segment_name;
         bool fail = false;
 
-        foreach(const FitField &field, def.fields) {
+        for(const FitField &field : def.fields) {
             const FitValue& value = values[i++];
 
             if( value.type != StringValue && value.v == NA_VALUE )
@@ -3791,7 +3791,7 @@ genericnext:
                       const std::vector<FitValue>& values) {
         Q_UNUSED(time_offset);
         int i = 0;
-        foreach(const FitField &field, def.fields) {
+        for(const FitField &field : def.fields) {
             fit_value_t value = values[i++].v;
 
             if( value == NA_VALUE )
@@ -3821,7 +3821,7 @@ genericnext:
         // 4	application_version	uint32
 
         int i = 0;
-        foreach(const FitField &field, def.fields) {
+        for(const FitField &field : def.fields) {
             FitValue value = values[i++];
 
             if (FIT_DEBUG && FIT_DEBUG_LEVEL>2)
@@ -3917,7 +3917,7 @@ genericnext:
         fieldDef.native = -1;
         int native_mesg_num = RECORD_MSG_NUM; // just in case it is missing, for backward compatibility
 
-        foreach(const FitField &field, def.fields) {
+        for(const FitField &field : def.fields) {
             FitValue value = values[i++];
 
             switch (field.num) {
@@ -4260,7 +4260,7 @@ genericnext:
             // now we just work through the definition and extract the field values
             // from the file directly
             std::vector<FitValue> values;
-            foreach(const FitField &field, def.fields) {
+            for(const FitField &field : def.fields) {
 
                 // we store the value into a struct that has members
                 // for all the fit base types- so floats are in 'f' and

--- a/src/FileIO/FixDeriveDistance.cpp
+++ b/src/FileIO/FixDeriveDistance.cpp
@@ -242,7 +242,7 @@ FixDeriveDistance::postProcess(RideFile *ride, DataProcessorConfig *config=0, QS
         QString log = ride->getTag("Change History", "");
         log +=  tr("Derive Distance from GPS on ");
         log +=  QDateTime::currentDateTime().toString();
-        if (ride->command->changeLog().count()>0)
+        if (ride->command->changeLog().length()>0)
             log +=  ":\n" + ride->command->changeLog();
         ride->setTag("Change History", log);
     }

--- a/src/FileIO/FixDeriveHeadwind.cpp
+++ b/src/FileIO/FixDeriveHeadwind.cpp
@@ -167,7 +167,7 @@ FixDeriveHeadwind::postProcess(RideFile *ride, DataProcessorConfig *config=0, QS
     QString log = ride->getTag("Change History", "");
     log +=  tr("Derive Headwind from weather on ");
     log +=  QDateTime::currentDateTime().toString();
-    if (ride->command->changeLog().count()>0)
+    if (ride->command->changeLog().length()>0)
         log +=  ":\n" + ride->command->changeLog();
     ride->setTag("Change History", log);
 

--- a/src/FileIO/JouleDevice.cpp
+++ b/src/FileIO/JouleDevice.cpp
@@ -553,12 +553,12 @@ bool
 JoulePacket::write(CommPortPtr dev, QString &err)
 {
     QByteArray bytes = dataArrayForUnit();
-    const char *msg = cEscape(bytes.data(), bytes.count()).toLatin1().constData();
+    const char *msg = cEscape(bytes.data(), bytes.length()).toLatin1().constData();
 
     if (JOULE_DEBUG) printf("writing '%s' to device\n", msg);
 
-    int n = dev->write(bytes.data(), bytes.count() , err); //
-    if (n != bytes.count()) {
+    int n = dev->write(bytes.data(), bytes.length() , err); //
+    if (n != bytes.length()) {
         if (n < 0) {
             if (JOULE_DEBUG) printf("failed to write %s to device: %s\n", msg, err.toLatin1().constData());
             err = QString(tr("failed to write to device: %1")).arg(err);

--- a/src/FileIO/MacroDevice.cpp
+++ b/src/FileIO/MacroDevice.cpp
@@ -352,12 +352,12 @@ MacroPacket::data()
 bool
 MacroPacket::write(CommPortPtr dev, QString &err)
 {
-    const char *msg = cEscape(data(), payload.count()+2).toLatin1().constData();
+    const char *msg = cEscape(data(), payload.size()+2).toLatin1().constData();
 
     if (MACRO_DEBUG) printf("writing '%s' to device\n", msg);
 
-    int n = dev->write(data(), payload.count()+2, err);
-    if (n != payload.count()+2) {
+    int n = dev->write(data(), payload.size()+2, err);
+    if (n != payload.size()+2) {
         if (n < 0) {
             if (MACRO_DEBUG) printf("failed to write %s to device: %s\n", msg, err.toLatin1().constData());
             err = QString(tr("failed to write to device: %1")).arg(err);

--- a/src/FileIO/RideFile.cpp
+++ b/src/FileIO/RideFile.cpp
@@ -3695,7 +3695,7 @@ QList<CIQinfo> CIQinfo::listFromJson(const QString& src)
     if (doc.isArray())
     {
         QJsonArray ciqArray = doc.array();
-        foreach (const QJsonValue& ciqValue, ciqArray)
+        for (const QJsonValue& ciqValue : ciqArray)
         {
             QJsonObject ciqObj = ciqValue.toObject();
             ciqList.append(CIQinfo(ciqObj));
@@ -3716,7 +3716,7 @@ CIQinfo::CIQinfo(const QJsonObject& obj)
     devid = obj[QString(CIQ_ID)].toInt();
 
     QJsonArray jsonfields = obj[QString(FIELDS_KEY)].toArray();
-    foreach (const QJsonValue& field, jsonfields)
+    for (const QJsonValue& field : jsonfields)
     {
         QJsonObject fieldObj = field.toObject();
         CIQfield ciqfield(fieldObj[CIQ_FIELD_MESSAGE].toString(),

--- a/src/FileIO/WkoRideFile.cpp
+++ b/src/FileIO/WkoRideFile.cpp
@@ -346,7 +346,7 @@ WkoParser::parseRawData(WKO_UCHAR *fb)
                         }
                         svalp = sval;
                         temp = sval;
-                        sprintf(GRAPHDATA[i], "%8ld", svalp);
+                        snprintf(GRAPHDATA[i], 32, "%8ld", svalp);
                         break;
                     case '^' : /* Slope */
                         if (get_bit(thelot, bit-1)) { /* is negative */
@@ -375,13 +375,13 @@ WkoParser::parseRawData(WKO_UCHAR *fb)
                     case 'T' : /* Torque */
                         if (imperialflag && WKO_GRAPHS[i]=='S') val = long((double)val * KMTOMI);
                         valp=val;
-                        sprintf(GRAPHDATA[i], "%6ld.%1ld", valp/10, valp%10);
+                        snprintf(GRAPHDATA[i], 32, "%6ld.%1ld", valp/10, valp%10);
                         nm = val; nm /=10;
                         break;
                     case 'S' : /* Speed */
                         if (imperialflag && WKO_GRAPHS[i]=='S') val = long((double)val * KMTOMI);
                         valp=val;
-                        sprintf(GRAPHDATA[i], "%6ld.%1ld", valp/10, valp%10);
+                        snprintf(GRAPHDATA[i], 32, "%6ld.%1ld", valp/10, valp%10);
                         kph = val; kph/= 10;
 
                         // distance is not available so we need to calculate it
@@ -402,7 +402,7 @@ WkoParser::parseRawData(WKO_UCHAR *fb)
                             xf = modf(distance,&xi);
                             f = floor(xf*1000+0.5)/1000.0;
 
-                            sprintf(GRAPHDATA[i], "%g", xi+f);
+                            snprintf(GRAPHDATA[i], 32, "%g", xi+f);
                             km = xi+f;
                         }
                         break;
@@ -425,7 +425,7 @@ WkoParser::parseRawData(WKO_UCHAR *fb)
                         xf = modf(distance,&xi);
                         f = floor(xf*1000+0.5)/1000.0;
 
-                        sprintf(GRAPHDATA[i], "%g", xi+f);
+                        snprintf(GRAPHDATA[i], 32, "%g", xi+f);
                         km = xi+f;
 
 
@@ -452,29 +452,29 @@ WkoParser::parseRawData(WKO_UCHAR *fb)
                             llat=round(lat); llon=round(lon);
                             if (llat == 180 && llon == 180) lat=lon=0;
 
-                            sprintf(slon, "%-3.9g", lon);
-                            sprintf(slat, "%-3.9g", lat);
+                            snprintf(slon, 20, "%-3.9g", lon);
+                            snprintf(slat, 20, "%-3.9g", lat);
 
-                            sprintf(GRAPHDATA[i], "%13s %13s", slat,slon);
+                            snprintf(GRAPHDATA[i], 32, "%13s %13s", slat,slon);
 
                         }
                         break;
                     case 'P' :
                         watts = val;
                         valp=val;
-                        sprintf(GRAPHDATA[i], "%8lu", valp); // just output as numeric
+                        snprintf(GRAPHDATA[i], 32, "%8lu", valp); // just output as numeric
                         break;
 
                     case 'H' :
                         hr = val;
                         valp=val;
-                        sprintf(GRAPHDATA[i], "%8lu", valp); // just output as numeric
+                        snprintf(GRAPHDATA[i], 32, "%8lu", valp); // just output as numeric
                         break;
 
                     case 'C' :
                         cad = val;
 			            valp = val;
-                        sprintf(GRAPHDATA[i], "%8lu", valp); // just output as numeric
+                        snprintf(GRAPHDATA[i], 32, "%8lu", valp); // just output as numeric
                         break;
                     }
                 }

--- a/src/Gui/BatchProcessingDialog.cpp
+++ b/src/Gui/BatchProcessingDialog.cpp
@@ -274,7 +274,7 @@ processed(0), fails(0), numFilesToProcess(0), metadataCompleter(nullptr) {
         QTreeWidgetItem* current = files->invisibleRootItem()->child(i);
 
         connect(static_cast<QCheckBox*>(files->itemWidget(current, 0)),
-            QOverload<int>::of(&QCheckBox::stateChanged),
+            QOverload<Qt::CheckState>::of(&QCheckBox::checkStateChanged),
             [=](int) { this->fileSelected(current); });
     }
 

--- a/src/Gui/DragBar.cpp
+++ b/src/Gui/DragBar.cpp
@@ -27,8 +27,8 @@ DragBar::DragBar(QWidget*parent) : QTabBar(parent)
 void
 DragBar::dragEnterEvent(QDragEnterEvent*event)
 {
-    if (tabAt(event->pos()) != -1 && tabAt(event->pos()) != currentIndex()) {
-        setCurrentIndex(tabAt(event->pos()));
+    if (tabAt(event->position().toPoint()) != -1 && tabAt(event->position().toPoint()) != currentIndex()) {
+        setCurrentIndex(tabAt(event->position().toPoint()));
     }
 }
 
@@ -38,8 +38,8 @@ DragBar::dragLeaveEvent(QDragLeaveEvent*) {}
 void
 DragBar::dragMoveEvent(QDragMoveEvent *event) // we don't get these without accepting dragevent
 {                                             // and that would be a bad idea
-    if (tabAt(event->pos()) != -1 && tabAt(event->pos()) != currentIndex()) {
-        setCurrentIndex(tabAt(event->pos()));
+    if (tabAt(event->position().toPoint()) != -1 && tabAt(event->position().toPoint()) != currentIndex()) {
+        setCurrentIndex(tabAt(event->position().toPoint()));
     }
 }
 

--- a/src/Gui/IntervalTreeView.cpp
+++ b/src/Gui/IntervalTreeView.cpp
@@ -73,7 +73,7 @@ IntervalTreeView::dragEnterEvent(QDragEnterEvent* event)
 void
 IntervalTreeView::dropEvent(QDropEvent* event)
 {
-    QTreeWidgetItem* target = (QTreeWidgetItem *)itemAt(event->pos());
+    QTreeWidgetItem* target = (QTreeWidgetItem *)itemAt(event->position().toPoint());
     QTreeWidgetItem* parent = target->parent();
 
     QList<IntervalItem*> intervals =  context->rideItem()->intervals();

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -522,20 +522,20 @@ MainWindow::MainWindow(const QDir &home)
 
     // ACTIVITY MENU
     QMenu *rideMenu = menuBar()->addMenu(tr("A&ctivity"));
-    rideMenu->addAction(tr("&Download from device..."), this, SLOT(downloadRide()), QKeySequence("Ctrl+D"));
-    rideMenu->addAction(tr("&Import from file..."), this, SLOT (importFile()), QKeySequence("Ctrl+I"));
-    rideMenu->addAction(tr("&Manual entry..."), this, SLOT(manualRide()), QKeySequence("Ctrl+M"));
+    rideMenu->addAction(tr("&Download from device..."), QKeySequence("Ctrl+D"), this, SLOT(downloadRide()));
+    rideMenu->addAction(tr("&Import from file..."), QKeySequence("Ctrl+I"), this, SLOT (importFile()));
+    rideMenu->addAction(tr("&Manual entry..."), QKeySequence("Ctrl+M"), this, SLOT(manualRide()));
     rideMenu->addSeparator ();
-    rideMenu->addAction(tr("&Export..."), this, SLOT(exportRide()), QKeySequence("Ctrl+E"));
-    rideMenu->addAction(tr("&Batch Processing..."), this, SLOT(batchProcessing()), QKeySequence("Ctrl+B"));
+    rideMenu->addAction(tr("&Export..."), QKeySequence("Ctrl+E"), this, SLOT(exportRide()));
+    rideMenu->addAction(tr("&Batch Processing..."), QKeySequence("Ctrl+B"), this, SLOT(batchProcessing()));
 
     rideMenu->addSeparator ();
-    rideMenu->addAction(tr("&Save activity"), this, SLOT(saveRide()), QKeySequence("Ctrl+S"));
+    rideMenu->addAction(tr("&Save activity"), QKeySequence("Ctrl+S"), this, SLOT(saveRide()));
     rideMenu->addAction(tr("D&elete activity..."), this, SLOT(deleteRide()));
     rideMenu->addAction(tr("Split &activity..."), this, SLOT(splitRide()));
     rideMenu->addAction(tr("Combine activities..."), this, SLOT(mergeRide()));
     rideMenu->addSeparator ();
-    rideMenu->addAction(tr("Find intervals..."), this, SLOT(addIntervals()), QKeySequence(""));
+    rideMenu->addAction(tr("Find intervals..."), QKeySequence(""), this, SLOT(addIntervals()));
 
     HelpWhatsThis *helpRideMenu = new HelpWhatsThis(rideMenu);
     rideMenu->setWhatsThis(helpRideMenu->getWhatsThisText(HelpWhatsThis::MenuBar_Activity));
@@ -625,21 +625,21 @@ MainWindow::MainWindow(const QDir &home)
     // VIEW MENU
     QMenu *viewMenu = menuBar()->addMenu(tr("&View"));
 #ifndef Q_OS_MAC
-    viewMenu->addAction(tr("Toggle Full Screen"), this, SLOT(toggleFullScreen()), QKeySequence("F11"));
+    viewMenu->addAction(tr("Toggle Full Screen"), QKeySequence("F11"), this, SLOT(toggleFullScreen()));
 #endif
-    showhideViewbar = viewMenu->addAction(tr("Show View Sidebar"), this, SLOT(showViewbar(bool)), QKeySequence("F2"));
+    showhideViewbar = viewMenu->addAction(tr("Show View Sidebar"), QKeySequence("F2"), this, SLOT(showViewbar(bool)));
     showhideViewbar->setCheckable(true);
     showhideViewbar->setChecked(true);
-    showhideSidebar = viewMenu->addAction(tr("Show Left Sidebar"), this, SLOT(showSidebar(bool)), QKeySequence("F3"));
+    showhideSidebar = viewMenu->addAction(tr("Show Left Sidebar"), QKeySequence("F3"), this, SLOT(showSidebar(bool)));
     showhideSidebar->setCheckable(true);
     showhideSidebar->setChecked(true);
-    showhideLowbar = viewMenu->addAction(tr("Show Compare Pane"), this, SLOT(showLowbar(bool)), QKeySequence("F4"));
+    showhideLowbar = viewMenu->addAction(tr("Show Compare Pane"), QKeySequence("F4"), this, SLOT(showLowbar(bool)));
     showhideLowbar->setCheckable(true);
     showhideLowbar->setChecked(false);
-    showhideToolbar = viewMenu->addAction(tr("Show Toolbar"), this, SLOT(showToolbar(bool)), QKeySequence("F5"));
+    showhideToolbar = viewMenu->addAction(tr("Show Toolbar"), QKeySequence("F5"), this, SLOT(showToolbar(bool)));
     showhideToolbar->setCheckable(true);
     showhideToolbar->setChecked(true);
-    showhideTabbar = viewMenu->addAction(tr("Show Athlete Tabs"), this, SLOT(showTabbar(bool)), QKeySequence("F6"));
+    showhideTabbar = viewMenu->addAction(tr("Show Athlete Tabs"), QKeySequence("F6"), this, SLOT(showTabbar(bool)));
     showhideTabbar->setCheckable(true);
     showhideTabbar->setChecked(true);
 
@@ -2147,7 +2147,7 @@ MainWindow::setOpenTabMenu()
 
     // add create new option
     openTabMenu->addSeparator();
-    openTabMenu->addAction(tr("&New Athlete..."), this, SLOT(newCyclistTab()), QKeySequence("Ctrl+N"));
+    openTabMenu->addAction(tr("&New Athlete..."), QKeySequence("Ctrl+N"), this, SLOT(newCyclistTab()));
 }
 
 void

--- a/src/Gui/Pages.cpp
+++ b/src/Gui/Pages.cpp
@@ -133,7 +133,7 @@ GeneralPage::GeneralPage(Context *context) : context(context)
     garminHWMarkedit->setSuffix(" " + tr("s"));
     garminHWMarkedit->setValue(garminHWMark.toInt());
 
-    connect(garminSmartRecord, &QCheckBox::stateChanged, [=](int state) { garminHWMarkedit->setEnabled(state); });
+    connect(garminSmartRecord, &QCheckBox::checkStateChanged, [=](int state) { garminHWMarkedit->setEnabled(state); });
     garminSmartRecord->setCheckState(! (isGarminSmartRecording.toInt() > 0) ? Qt::Checked : Qt::Unchecked);
     garminSmartRecord->setCheckState(isGarminSmartRecording.toInt() > 0 ? Qt::Checked : Qt::Unchecked);
 
@@ -215,7 +215,7 @@ GeneralPage::GeneralPage(Context *context) : context(context)
     pythonDirectoryLayout->addWidget(pythonBrowseButton);
 
     connect(pythonBrowseButton, SIGNAL(clicked()), this, SLOT(browsePythonDir()));
-    connect(embedPython, &QCheckBox::stateChanged, [=](int state) { pythonDirectorySel->setEnabled(state); });
+    connect(embedPython, &QCheckBox::checkStateChanged, [=](int state) { pythonDirectorySel->setEnabled(state); });
 
     embedPython->setChecked(! appsettings->value(NULL, GC_EMBED_PYTHON, true).toBool());
     embedPython->setChecked(appsettings->value(NULL, GC_EMBED_PYTHON, true).toBool());

--- a/src/Gui/RideNavigator.cpp
+++ b/src/Gui/RideNavigator.cpp
@@ -1111,7 +1111,7 @@ void NavigatorCellDelegate::paint(QPainter *painter, const QStyleOptionViewItem 
     if ((m=rideNavigator->columnMetrics.value(columnName, NULL)) != NULL) {
 
         // get double from model, special case QTime to avoid default .000 msecs
-        if ((QMetaType::Type)index.model()->data(index, Qt::DisplayRole).type() == QMetaType::QTime)
+        if (index.model()->data(index, Qt::DisplayRole).metaType().id() == QMetaType::QTime)
             value = index.model()->data(index, Qt::DisplayRole).toTime().toString("hh:mm:ss");
         else
             value = index.model()->data(index, Qt::DisplayRole).toString();
@@ -1396,7 +1396,7 @@ bool RideNavigatorSortProxyModel::lessThan(const QModelIndex &left,
     QVariant leftData = sourceModel()->data(left);
     QVariant rightData = sourceModel()->data(right);
 
-    if (leftData.type() == QVariant::DateTime) {
+    if (leftData.metaType().id() == QMetaType::QDateTime) {
         return leftData.toDateTime() < rightData.toDateTime();
     }
     QString leftString = leftData.toString();

--- a/src/Train/BicycleSim.cpp
+++ b/src/Train/BicycleSim.cpp
@@ -29,7 +29,7 @@ const PolyFit<double>* GetAltitudeFit(unsigned maxOrder) {
 
 #if 1
     // Data from : Prediction of Critical Powerand W? in Hypoxia : Application to Work - Balance Modelling
-    //             by Nathan E.Townsend1, David S.Nichols, Philip F.Skiba, Sebastien Racinais and Julien D.Périard
+    //             by Nathan E.Townsend1, David S.Nichols, Philip F.Skiba, Sebastien Racinais and Julien D.Periard
     //
     // Data in paper doesn't exceed 4250m. Cubic equation in paper decreases slope after 5000m, which doesn't
     // make sense, so using best fit 3rd order rational instead. Our equation continues at constant slope from

--- a/src/Train/ElevationChartWindow.cpp
+++ b/src/Train/ElevationChartWindow.cpp
@@ -309,8 +309,6 @@ ElevationChartWindow::telemetryUpdate(const RealtimeData &rtData)
     bubbleWidget->setRealtimeData(&m_rtData);
 
     int npoints = 30;
-    int pointsAfter = 25;
-    int pointsBefore = npoints - pointsAfter;
 
     QQueue<QPointF> &plotQ = slopeWidget->getPlotQ();
     plotQ.clear();

--- a/src/Train/FilterEditor.cpp
+++ b/src/Train/FilterEditor.cpp
@@ -210,7 +210,7 @@ FilterEditor::updateCompleterModel
         }
     }
     QStringList completerCmds;
-    for (const auto &origCmd : qAsConst(_origCmds)) {
+    for (const auto &origCmd : std::as_const(_origCmds)) {
         if (! cmds.contains(origCmd, Qt::CaseInsensitive)) {
             completerCmds << origCmd;
         }

--- a/src/Train/ModelFilter.cpp
+++ b/src/Train/ModelFilter.cpp
@@ -86,7 +86,7 @@ bool
 ModelNumberRangeFilter::accept
 (const QVariant &data) const
 {
-    if (! data.canConvert(supportedType())) {
+    if (! data.canConvert(QMetaType(supportedType()))) {
         return false;
     }
     bool ok = false;
@@ -148,7 +148,7 @@ bool
 ModelFloatRangeFilter::accept
 (const QVariant &data) const
 {
-    if (! data.canConvert(supportedType())) {
+    if (! data.canConvert(QMetaType(supportedType()))) {
         return false;
     }
     bool ok = false;
@@ -210,12 +210,12 @@ bool
 ModelStringContainsFilter::accept
 (const QVariant &data) const
 {
-    if (! data.canConvert(supportedType())) {
+    if (! data.canConvert(QMetaType(supportedType()))) {
         return false;
     }
     bool contains = _all;
     QString dataValue = data.toString();
-    for (const auto &item : qAsConst(_values)) {
+    for (const auto &item : std::as_const(_values)) {
         if (_all) {
             contains &= dataValue.contains(item, Qt::CaseInsensitive);
         } else if (dataValue.contains(item, Qt::CaseInsensitive)) {

--- a/src/Train/RatingWidget.cpp
+++ b/src/Train/RatingWidget.cpp
@@ -81,7 +81,7 @@ RatingWidget::mouseMoveEvent
         s.append(QChar(STAR_FILLED));
         QRect starRect = fontMetrics.boundingRect(s);
         int ratingWidth = starRect.width() + leftOffset;
-        if (event->localPos().x() < ratingWidth) {
+        if (event->position().x() < ratingWidth) {
             mouseOverRating = i;
             break;
         }

--- a/src/Train/TrainerDayAPIDialog.cpp
+++ b/src/Train/TrainerDayAPIDialog.cpp
@@ -519,35 +519,35 @@ TrainerDayAPIDialog::setBoxState
     QGroupBox *box = groupBoxes[idx];
     switch (state) {
     case TrainerDayAPIDialogState::importNew:
-        groupBoxes[idx]->setChecked(false);
-        groupBoxes[idx]->setCheckable(allowReimport->isChecked());
-        groupBoxes[idx]->setTitle(workoutTitle + " - " + tr("successfully imported"));
-        groupBoxes[idx]->setProperty("imported", 1);
+        box->setChecked(false);
+        box->setCheckable(allowReimport->isChecked());
+        box->setTitle(workoutTitle + " - " + tr("successfully imported"));
+        box->setProperty("imported", 1);
         break;
     case TrainerDayAPIDialogState::importOld:
-        groupBoxes[idx]->setChecked(false);
-        groupBoxes[idx]->setCheckable(allowReimport->isChecked());
-        groupBoxes[idx]->setTitle(workoutTitle + " - " + tr("already imported"));
-        groupBoxes[idx]->setProperty("imported", 1);
+        box->setChecked(false);
+        box->setCheckable(allowReimport->isChecked());
+        box->setTitle(workoutTitle + " - " + tr("already imported"));
+        box->setProperty("imported", 1);
         break;
     case TrainerDayAPIDialogState::importFailed:
-        groupBoxes[idx]->setChecked(true);
-        groupBoxes[idx]->setCheckable(true);
-        groupBoxes[idx]->setTitle(workoutTitle + " - " + tr("import failed"));
-        groupBoxes[idx]->setProperty("imported", 0);
+        box->setChecked(true);
+        box->setCheckable(true);
+        box->setTitle(workoutTitle + " - " + tr("import failed"));
+        box->setProperty("imported", 0);
         break;
     case TrainerDayAPIDialogState::unimportedFile:
-        groupBoxes[idx]->setChecked(false);
-        groupBoxes[idx]->setCheckable(allowReimport->isChecked());
-        groupBoxes[idx]->setTitle(workoutTitle + " - " + tr("available in filesystem but not imported"));
-        groupBoxes[idx]->setProperty("imported", 0);
+        box->setChecked(false);
+        box->setCheckable(allowReimport->isChecked());
+        box->setTitle(workoutTitle + " - " + tr("available in filesystem but not imported"));
+        box->setProperty("imported", 0);
         break;
     case TrainerDayAPIDialogState::readyForImport:
     default:
-        groupBoxes[idx]->setChecked(true);
-        groupBoxes[idx]->setCheckable(true);
-        groupBoxes[idx]->setTitle(workoutTitle);
-        groupBoxes[idx]->setProperty("imported", 0);
+        box->setChecked(true);
+        box->setCheckable(true);
+        box->setTitle(workoutTitle);
+        box->setProperty("imported", 0);
         break;
     }
 }


### PR DESCRIPTION
Note: This PR has been initially pushed so that I can test the changes compile for other platforms (I only have a Windows platform).

All failing due to Qt versions <6.8.x
- Windows: Using Qt version 5.15.2 in C:/Qt/5.15/msvc2019_64/lib
- Mac: Using Qt version 6.5.3 in /Users/appveyor/Qt/6.5/macos/lib
- Linux: /home/appveyor/Qt/5.15/gcc_64/bin/qmake


The PR aims to remove some of the following warnings:
- Deprecation warnings now GC is using Qt6.8.x, access for points has changed.
- qAsConst should be replaced with std::as_const
- QScopedPointer should be replaced with std::unique_ptr
- addAction constructor has changed, earlier versions are deprecated
- 'QtPrivate::warnIfContainerIsNotShared': Do not use foreach/Q_FOREACH with containers which are not implicitly shared. Prefer using a range-based for loop with these containers: `for (const auto &it : container)`,
- Unused parameters, usually due to platform dependent compilation
- printf formatting type mismatches

There are also other Qt warnings which might be worth looking at in the future:

warning C4996: 'QDateTime::QDateTime': Pass QTimeZone instead
warning C4996: 'QDateTime::setTimeSpec': Use setTimeZone() instead
Charts\OverviewItems.cpp:
warning C4996: 'QChart::setAxisX': was declared deprecated
warning C4996: 'QChart::axisY': was declared deprecated
warning C4996: 'QChart::axisY': was declared deprecated