### PR TITLE
Fix memory leak

### DIFF
--- a/src/FileIO/JouleDevice.cpp
+++ b/src/FileIO/JouleDevice.cpp
@@ -55,17 +55,18 @@ JouleDevices::newDevice( CommPortPtr dev )
 }
 
 static QString
-cEscape(char *buf, int len)
-{
-    char *result = new char[4 * len + 1];
-    char *tmp = result;
+cEscape(const char* buf, int len) {
+
+    QString result;
+    result.reserve(4 * len + 1);
+
     for (int i = 0; i < len; ++i) {
         if (buf[i] == '"')
-            tmp += sprintf(tmp, "\\\"");
+            result += "\\\"";
         else if (isprint(buf[i]))
-            *(tmp++) = buf[i];
+            result += buf[i];
         else
-            tmp += sprintf(tmp, "\\x%02x", 0xff & (unsigned) buf[i]);
+            result += QString::asprintf("\\x%02x", 0xff & (unsigned)buf[i]);
     }
     return result;
 }

--- a/src/FileIO/MacroDevice.cpp
+++ b/src/FileIO/MacroDevice.cpp
@@ -57,17 +57,18 @@ MacroDevices::newDevice( CommPortPtr dev )
 }
 
 static QString
-cEscape(char *buf, int len)
-{
-    char *result = new char[4 * len + 1];
-    char *tmp = result;
+cEscape(const char* buf, int len) {
+
+    QString result;
+    result.reserve(4 * len + 1);
+
     for (int i = 0; i < len; ++i) {
         if (buf[i] == '"')
-            tmp += sprintf(tmp, "\\\"");
+            result += "\\\"";
         else if (isprint(buf[i]))
-            *(tmp++) = buf[i];
+            result += buf[i];
         else
-            tmp += sprintf(tmp, "\\x%02x", 0xff & (unsigned) buf[i]);
+            result += QString::asprintf("\\x%02x", 0xff & (unsigned)buf[i]);
     }
     return result;
 }

--- a/src/FileIO/MoxyDevice.cpp
+++ b/src/FileIO/MoxyDevice.cpp
@@ -455,17 +455,18 @@ hasNewline(const char *buf, int len)
 }
 
 static QString
-cEscape(const char *buf, int len)
-{
-    char *result = new char[4 * len + 1];
-    char *tmp = result;
+cEscape(const char* buf, int len) {
+
+    QString result;
+    result.reserve(4 * len + 1);
+
     for (int i = 0; i < len; ++i) {
         if (buf[i] == '"')
-            tmp += sprintf(tmp, "\\\"");
+            result += "\\\"";
         else if (isprint(buf[i]))
-            *(tmp++) = buf[i];
+            result += buf[i];
         else
-            tmp += sprintf(tmp, "\\x%02x", 0xff & (unsigned) buf[i]);
+            result += QString::asprintf("\\x%02x", 0xff & (unsigned)buf[i]);
     }
     return result;
 }

--- a/src/FileIO/PowerTapDevice.cpp
+++ b/src/FileIO/PowerTapDevice.cpp
@@ -60,17 +60,18 @@ hasNewline(const char *buf, int len)
 }
 
 static QString
-cEscape(const char *buf, int len)
-{
-    char *result = new char[4 * len + 1];
-    char *tmp = result;
+cEscape(const char* buf, int len) {
+
+    QString result;
+    result.reserve(4 * len + 1);
+
     for (int i = 0; i < len; ++i) {
         if (buf[i] == '"')
-            tmp += sprintf(tmp, "\\\"");
+            result += "\\\"";
         else if (isprint(buf[i]))
-            *(tmp++) = buf[i];
+            result += buf[i];
         else
-            tmp += sprintf(tmp, "\\x%02x", 0xff & (unsigned) buf[i]);
+            result += QString::asprintf("\\x%02x", 0xff & (unsigned)buf[i]);
     }
     return result;
 }

--- a/src/FileIO/SyncRideFile.cpp
+++ b/src/FileIO/SyncRideFile.cpp
@@ -90,18 +90,19 @@ struct SyncFileReaderState
     }
 
 
-    QString
-    cEscape(char *buf, int len)
-    {
-        char *result = new char[4 * len + 1];
-        char *tmp = result;
+    static QString
+    cEscape(const char* buf, int len) {
+
+        QString result;
+        result.reserve(4 * len + 1);
+
         for (int i = 0; i < len; ++i) {
             if (buf[i] == '"')
-                tmp += sprintf(tmp, "\\\"");
+                result += "\\\"";
             else if (isprint(buf[i]))
-                *(tmp++) = buf[i];
+                result += buf[i];
             else
-                tmp += sprintf(tmp, "\\x%02x", 0xff & (unsigned) buf[i]);
+                result += QString::asprintf("\\x%02x", 0xff & (unsigned)buf[i]);
         }
         return result;
     }


### PR DESCRIPTION
Whilst looking through the code I noticed in FileIO/JouleDevice.cpp (and some others) that the _result_ char array is not deleted on exit, the returned QString copies _result_ on return and the _result_ memory is leaked. I have changed the function to use QString concatenation, with reserve to improve performance, removing the memory leak.

```
static QString
cEscape(char *buf, int len)
{
    char *result = new char[4 * len + 1];
    char *tmp = result;
    for (int i = 0; i < len; ++i) {
        if (buf[i] == '"')
            tmp += sprintf(tmp, "\\\"");
        else if (isprint(buf[i]))
            *(tmp++) = buf[i];
        else
            tmp += sprintf(tmp, "\\x%02x", 0xff & (unsigned) buf[i]);
    }
    return result;
}
```

I have tested the new function's o/p against the original version, they are the same:

**Original function output:**
\x00\x01\x02\x03\x04\x05\x06\x07\x08        \x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~\x7f\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9d\x9e\x9f\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff

**New function output:**
\x00\x01\x02\x03\x04\x05\x06\x07\x08        \x0a\x0b\x0c\x0d\x0e\x0f\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !\"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]^_`abcdefghijklmnopqrstuvwxyz{|}~\x7f\x80\x81\x82\x83\x84\x85\x86\x87\x88\x89\x8a\x8b\x8c\x8d\x8e\x8f\x90\x91\x92\x93\x94\x95\x96\x97\x98\x99\x9a\x9b\x9c\x9d\x9e\x9f\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf\xd0\xd1\xd2\xd3\xd4\xd5\xd6\xd7\xd8\xd9\xda\xdb\xdc\xdd\xde\xdf\xe0\xe1\xe2\xe3\xe4\xe5\xe6\xe7\xe8\xe9\xea\xeb\xec\xed\xee\xef\xf0\xf1\xf2\xf3\xf4\xf5\xf6\xf7\xf8\xf9\xfa\xfb\xfc\xfd\xfe\xff
