### PR TITLE
Add planned workouts / activities

### DIFF
--- a/src/Gui/Colors.cpp
+++ b/src/Gui/Colors.cpp
@@ -1121,7 +1121,7 @@ QIcon colouredIconFromPNG(QString filename, QColor color)
 
 
 QPixmap
-svgAsColouredPixmap
+svgAsColoredPixmap
 (const QString &file, const QSize &size, int margin, const QColor &color)
 {
     QSvgRenderer renderer(file);

--- a/src/Gui/Colors.h
+++ b/src/Gui/Colors.h
@@ -33,8 +33,7 @@
 // A selection of distinct colours, user can adjust also
 extern QIcon colouredIconFromPNG(QString filename, QColor color);
 extern QPixmap colouredPixmapFromPNG(QString filename, QColor color);
-extern QPixmap svgAsColouredPixmap(const QString &file, const QSize &size, int margin, const QColor &color);
-
+extern QPixmap svgAsColoredPixmap(const QString &file, const QSize &size, int margin, const QColor &color);
 
 // dialog scaling
 extern double dpiXFactor, dpiYFactor;

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -525,6 +525,11 @@ MainWindow::MainWindow(const QDir &home)
     rideMenu->addAction(tr("&Download from device..."), this, SLOT(downloadRide()), QKeySequence("Ctrl+D"));
     rideMenu->addAction(tr("&Import from file..."), this, SLOT (importFile()), QKeySequence("Ctrl+I"));
     rideMenu->addAction(tr("&Manual entry..."), this, SLOT(manualRide()), QKeySequence("Ctrl+M"));
+    QAction *actionPlan = new QAction(tr("&Plan activity..."));
+    connect(context, &Context::start, this, [=]() { actionPlan->setEnabled(false); }); // The dialog can change the contexts workout
+    connect(context, &Context::stop, this, [=]() { actionPlan->setEnabled(true); });   // temporarily which might cause unwanted effects
+    connect(actionPlan, &QAction::triggered, this, [=]() { planActivity(); });
+    rideMenu->addAction(actionPlan);
     rideMenu->addSeparator ();
     rideMenu->addAction(tr("&Export..."), this, SLOT(exportRide()), QKeySequence("Ctrl+E"));
     rideMenu->addAction(tr("&Batch Processing..."), this, SLOT(batchProcessing()), QKeySequence("Ctrl+B"));
@@ -1673,6 +1678,14 @@ void
 MainWindow::manualRide()
 {
     ManualActivityWizard wizard(currentAthleteTab->context);
+    wizard.exec();
+}
+
+
+void
+MainWindow::planActivity()
+{
+    ManualActivityWizard wizard(currentAthleteTab->context, true);
     wizard.exec();
 }
 

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -253,6 +253,7 @@ class MainWindow : public QMainWindow
         void saveAllFilesSilent(Context *);
         void downloadRide();
         void manualRide();
+        void planActivity();
         void exportRide();
         void batchProcessing();
         void generateHeatMap();

--- a/src/Gui/ManualActivityWizard.cpp
+++ b/src/Gui/ManualActivityWizard.cpp
@@ -113,9 +113,9 @@ ManualActivityWizard::done
         field2TagString(rideFile, "sport", "Sport");
         field2TagString(rideFile, "subSport", "SubSport");
         field2TagString(rideFile, "workoutCode", "Workout Code");
-        field2TagString(rideFile, "notes", "Notes");
-        field2TagString(rideFile, "objective", "Objective");
         field2TagInt(rideFile, "rpe", "RPE");
+        field2TagString(rideFile, "objective", "Objective");
+        field2TagString(rideFile, "notes", "Notes");
         field2TagString(rideFile, "woFilename", "WorkoutFilename");
         field2TagString(rideFile, "woTitle", "Route");
 
@@ -301,7 +301,7 @@ ManualActivityPageBasics::ManualActivityPageBasics
     }
 
     QLabel *objectiveLabel = new QLabel(tr("Objective"));
-    QTextEdit *objectiveEdit = new QTextEdit();
+    QLineEdit *objectiveEdit = new QLineEdit();
 
     // Set completer for Sport, SubSport and Workout Code fields
     RideMetadata *rideMetadata = GlobalContext::context()->rideMetadata;
@@ -323,8 +323,6 @@ ManualActivityPageBasics::ManualActivityPageBasics
     workoutCodeEdit->setVisible(! plan);
     rpeLabel->setVisible(! plan);
     rpeEdit->setVisible(! plan);
-    notesLabel->setVisible(! plan);
-    notesEdit->setVisible(! plan);
     woTypeLabel->setVisible(plan);
     woTypeEdit->setVisible(plan);
     objectiveLabel->setVisible(plan);
@@ -341,9 +339,9 @@ ManualActivityPageBasics::ManualActivityPageBasics
     registerField("subSport", subSportEdit);
     registerField("workoutCode", workoutCodeEdit);
     registerField("rpe", rpeEdit);
+    registerField("objective", objectiveEdit);
     registerField("notes", notesEdit, "plainText", SIGNAL(textChanged()));
     registerField("woType", woTypeEdit);
-    registerField("objective", objectiveEdit, "plainText", SIGNAL(textChanged()));
 
     QFormLayout *form = newQFormLayout();
     form->addRow(tr("Date") + MANDATORY, dateEdit);
@@ -354,8 +352,8 @@ ManualActivityPageBasics::ManualActivityPageBasics
     form->addRow(subSportLabel, subSportEdit);
     form->addRow(workoutCodeLabel, workoutCodeEdit);
     form->addRow(rpeLabel, rpeEdit);
-    form->addRow(notesLabel, notesEdit);
     form->addRow(objectiveLabel, objectiveEdit);
+    form->addRow(notesLabel, notesEdit);
 
     QWidget *scrollWidget = new QWidget();
     QVBoxLayout *scrollLayout = new QVBoxLayout(scrollWidget);
@@ -1364,8 +1362,6 @@ ManualActivityPageSummary::initializePage
     addRowString(tr("SubSport"), "subSport");
     addRowString(tr("Workout Code"), "workoutCode");
     addRowString(tr("Workout Title"), "woTitle");
-    addRowString(tr("Notes"), "notes");
-    addRowString(tr("Objective"), "objective");
     if (! plan) {
         switch (field("rpe").toInt()) {
         case 0:
@@ -1405,6 +1401,8 @@ ManualActivityPageSummary::initializePage
             break;
         }
     }
+    addRowString(tr("Objective"), "objective");
+    addRowString(tr("Notes"), "notes");
     bool hasActMetricsSection = false;
     QLabel *actMetricsHL = new QLabel(HLO + tr("Activity Metrics") + HLC);
     form->addRow(actMetricsHL);

--- a/src/Gui/ManualActivityWizard.cpp
+++ b/src/Gui/ManualActivityWizard.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2009 Eric Murray (ericm@lne.com)
  * Copyright (c) 2014 Mark Liversedge (liversedge@gmail.com)
+ * Copyright (c) 2025 Joachim Kohlhammer (joachim.kohlhammer@gmx.de)
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -19,23 +20,27 @@
 
 #include "ManualActivityWizard.h"
 
+#include <QtGui>
 #include <QMessageBox>
+#include <QSplitter>
+
+#include <string.h>
+#include <errno.h>
+#include <cmath>
 
 #include "Context.h"
+#include "TrainDB.h"
 #include "Colors.h"
 #include "Athlete.h"
 #include "RideCache.h"
 #include "RideItem.h"
 #include "Settings.h"
 #include "RideMetadata.h"
-#include <string.h>
-#include <errno.h>
-#include <QtGui>
-#include <cmath>
 #include "Units.h"
 #include "HelpWhatsThis.h"
 
 #define MANDATORY " *"
+#define TRADEMARK "<sup>TM</sup>"
 #define ICON_COLOR QColor("#F79130")
 #ifdef Q_OS_MAC
 #define ICON_SIZE 250
@@ -46,16 +51,25 @@
 #define ICON_MARGIN 5
 #define ICON_TYPE QWizard::LogoPixmap
 #endif
+#define HLO "<h4>"
+#define HLC "</h4>"
+
+static QString activityBasename(const QDateTime &dt);
+static QString activityFilename(const QDateTime &dt, bool plan, Context *context);
 
 
 ////////////////////////////////////////////////////////////////////////////////
 // ManualActivityWizard
 
 ManualActivityWizard::ManualActivityWizard
-(Context *context, QWidget *parent)
-: QWizard(parent), context(context)
+(Context *context, bool plan, QWidget *parent)
+: QWizard(parent), context(context), plan(plan)
 {
-    setWindowTitle(tr("Manual Entry"));
+    if (plan) {
+        setWindowTitle(tr("Add a Planned Activity"));
+    } else {
+        setWindowTitle(tr("Create a Completed Activity"));
+    }
     setMinimumSize(800 * dpiXFactor, 650 * dpiYFactor);
     setModal(true);
 
@@ -64,10 +78,12 @@ ManualActivityWizard::ManualActivityWizard
 #else
     setWizardStyle(QWizard::ModernStyle);
 #endif
-    setPixmap(ICON_TYPE, svgAsColouredPixmap(":images/material/summit.svg", QSize(ICON_SIZE * dpiXFactor, ICON_SIZE * dpiYFactor), ICON_MARGIN * dpiXFactor, ICON_COLOR));
+    setPixmap(ICON_TYPE, svgAsColoredPixmap(":images/material/summit.svg", QSize(ICON_SIZE * dpiXFactor, ICON_SIZE * dpiYFactor), ICON_MARGIN * dpiXFactor, ICON_COLOR));
 
-    setPage(PageBasics, new ManualActivityPageBasics(context));
-    setPage(PageSpecifics, new ManualActivityPageSpecifics(context));
+    setPage(PageBasics, new ManualActivityPageBasics(context, plan));
+    setPage(PageWorkout, new ManualActivityPageWorkout(context));
+    setPage(PageMetrics, new ManualActivityPageMetrics(context, plan));
+    setPage(PageSummary, new ManualActivityPageSummary(plan));
 
     setStartId(PageBasics);
 }
@@ -79,6 +95,7 @@ ManualActivityWizard::done
 {
     int finalResult = result;
     if (result == QDialog::Accepted) {
+        QString sport = field("sport").toString().trimmed();
         appsettings->setValue(GC_BIKESCOREDAYS, field("estimationDays").toInt());
         int eb = field("estimateBy").toInt();
         appsettings->setValue(GC_BIKESCOREMODE, eb == 0 ? "time" : (eb == 1 ? "dist" : "manual"));
@@ -91,20 +108,14 @@ ManualActivityWizard::done
         rideFile.setDeviceType("Manual");
         rideFile.setFileFormat("GoldenCheetah Json");
 
-        QString sport = field("sport").toString().trimmed();
-        rideFile.setTag("Sport", sport);
-        if (field("subSport").toString().trimmed().size() > 0) {
-            rideFile.setTag("SubSport", field("subSport").toString().trimmed());
-        }
-        if (field("workoutCode").toString().trimmed().size() > 0) {
-            rideFile.setTag("Workout Code", field("workoutCode").toString().trimmed());
-        }
-        if (field("notes").toString().trimmed().size() > 0) {
-            rideFile.setTag("Notes", field("notes").toString().trimmed());
-        }
-        if (field("rpe").toInt() > 0) {
-            rideFile.setTag("RPE", QString::number(field("rpe").toInt()));
-        }
+        field2TagString(rideFile, "sport", "Sport");
+        field2TagString(rideFile, "subSport", "SubSport");
+        field2TagString(rideFile, "workoutCode", "Workout Code");
+        field2TagString(rideFile, "notes", "Notes");
+        field2TagString(rideFile, "objective", "Objective");
+        field2TagInt(rideFile, "rpe", "RPE");
+        field2TagString(rideFile, "woFilename", "WorkoutFilename");
+        field2TagString(rideFile, "woTitle", "Route");
 
         if ((sport == "Run" || sport == "Swim") && field("paceIntervals").toBool()) {
             QList<RideFilePoint*> points = field("laps").value<QList<RideFilePoint*>>();
@@ -117,80 +128,31 @@ ManualActivityWizard::done
                 rideFile.fillInIntervals();
             }
         } else {
-            double distance = field("realDistance").toDouble();
-            if (distance > 0) {
-                QMap<QString,QString> values;
-                values.insert("value", QString("%1").arg(distance));
-                rideFile.metricOverrides.insert("total_distance", values);
-            }
-
-            double seconds = field("realDuration").toDouble();
-            if (seconds > 0) {
-                QMap<QString,QString> values;
-                values.insert("value", QString("%1").arg(seconds));
-                rideFile.metricOverrides.insert("workout_time", values);
-                rideFile.metricOverrides.insert("time_riding", values);
-            }
+            field2MetricDouble(rideFile, "realDistance", "total_distance");
+            field2MetricInt(rideFile, "realDuration", "workout_time");
+            field2MetricInt(rideFile, "realDuration", "time_riding");
         }
-        if (field("averageHr").toInt() > 0) {
-            QMap<QString,QString> values;
-            values.insert("value", QString("%1").arg(field("averageHr").toInt()));
-            rideFile.metricOverrides.insert("average_hr", values);
-        }
-        if (field("averageCadence").toInt() > 0) {
-            QMap<QString,QString> values;
-            values.insert("value", QString("%1").arg(field("averageCadence").toInt()));
-            rideFile.metricOverrides.insert("average_cad", values);
-        }
-        if (field("averagePower").toInt() > 0) {
-            QMap<QString,QString> values;
-            values.insert("value", QString("%1").arg(field("averagePower").toInt()));
-            rideFile.metricOverrides.insert("average_power", values);
-        }
-
-        if (field("work").toInt() > 0) {
-            QMap<QString,QString> values;
-            values.insert("value", QString("%1").arg(field("work").toInt()));
-            rideFile.metricOverrides.insert("total_work", values);
-        }
-        if (field("bikeStress").toInt() > 0 && sport == "Bike") {
-            QMap<QString,QString> values;
-            values.insert("value", QString("%1").arg(field("bikeStress").toInt()));
-            rideFile.metricOverrides.insert("coggan_tss", values);
-        }
-        if (field("bikeScore").toInt() > 0 && sport == "Bike") {
-            QMap<QString,QString> values;
-            values.insert("value", QString("%1").arg(field("bikeScore").toInt()));
-            rideFile.metricOverrides.insert("skiba_bike_score", values);
-        }
-        if (field("swimScore").toInt() > 0 && sport == "Swim") {
-            QMap<QString,QString> values;
-            values.insert("value", QString("%1").arg(field("swimScore").toInt()));
-            rideFile.metricOverrides.insert("swimscore", values);
-        }
-        if (field("triScore").toInt() > 0) {
-            QMap<QString,QString> values;
-            values.insert("value", QString("%1").arg(field("triScore").toInt()));
-            rideFile.metricOverrides.insert("triscore", values);
-        }
+        field2MetricInt(rideFile, "averageHr", "average_hr");
+        field2MetricInt(rideFile, "averageCadence", "average_cad");
+        field2MetricInt(rideFile, "averagePower", "average_power");
+        field2MetricInt(rideFile, "work", "total_work");
+        field2MetricInt(rideFile, "bikeStress", "coggan_tss");
+        field2MetricInt(rideFile, "bikeScore", "skiba_bike_score");
+        field2MetricInt(rideFile, "swimScore", "swimscore");
+        field2MetricInt(rideFile, "triScore", "triscore");
+        field2MetricInt(rideFile, "woElevationGain", "elevation_gain");
+        field2MetricInt(rideFile, "woIsoPower", "coggan_np");
+        field2MetricInt(rideFile, "woXPower", "skiba_xpower");
 
         // process linked defaults
         GlobalContext::context()->rideMetadata->setLinkedDefaults(&rideFile);
 
         // what should the filename be?
-        QChar zero = QLatin1Char('0');
-        QString basename = QString("%1_%2_%3_%4_%5_%6")
-                                  .arg(rideDateTime.date().year(), 4, 10, zero)
-                                  .arg(rideDateTime.date().month(), 2, 10, zero)
-                                  .arg(rideDateTime.date().day(), 2, 10, zero)
-                                  .arg(rideDateTime.time().hour(), 2, 10, zero)
-                                  .arg(rideDateTime.time().minute(), 2, 10, zero)
-                                  .arg(rideDateTime.time().second(), 2, 10, zero);
-        QString filename = context->athlete->home->activities().canonicalPath() + "/" + basename + ".json";
-        QFile out(filename);
+        QString basename = activityBasename(rideDateTime);
+        QFile out(activityFilename(rideDateTime, plan, context));
         if (RideFileFactory::instance().writeRideFile(context, &rideFile, out, "json")) {
             // refresh metric db etc
-            context->athlete->addRide(basename + ".json", true);
+            context->athlete->addRide(basename + ".json", true, true, false, plan);
         } else {
             // rather than dance around renaming existing rides, this time we will let the user
             // work it out -- they may actually want to keep an existing ride, so we shouldn't
@@ -206,15 +168,65 @@ ManualActivityWizard::done
 }
 
 
+void
+ManualActivityWizard::field2MetricDouble
+(RideFile &rideFile, const QString &fieldName, const QString &metricName) const
+{
+    double value = field(fieldName).toDouble();
+    if (value > 0) {
+        QMap<QString,QString> values;
+        values.insert("value", QString::number(value));
+        rideFile.metricOverrides.insert(metricName, values);
+    }
+}
+
+
+void
+ManualActivityWizard::field2MetricInt
+(RideFile &rideFile, const QString &fieldName, const QString &metricName) const
+{
+    int value = field(fieldName).toInt();
+    if (value > 0) {
+        QMap<QString,QString> values;
+        values.insert("value", QString::number(value));
+        rideFile.metricOverrides.insert(metricName, values);
+    }
+}
+
+
+void
+ManualActivityWizard::field2TagString
+(RideFile &rideFile, const QString &fieldName, const QString &tagName) const
+{
+    if (! field(fieldName).toString().trimmed().isEmpty()) {
+        rideFile.setTag(tagName, field(fieldName).toString().trimmed());
+    }
+}
+
+
+void
+ManualActivityWizard::field2TagInt
+(RideFile &rideFile, const QString &fieldName, const QString &tagName) const
+{
+    if (field(fieldName).toInt() > 0) {
+        rideFile.setTag(tagName, QString::number(field(fieldName).toInt()));
+    }
+}
+
+
 ////////////////////////////////////////////////////////////////////////////////
 // ManualActivityPageBasics
 
 ManualActivityPageBasics::ManualActivityPageBasics
-(Context *context, QWidget *parent)
-: QWizardPage(parent), context(context)
+(Context *context, bool plan, QWidget *parent)
+: QWizardPage(parent), context(context), plan(plan)
 {
     setTitle(tr("General Information"));
-    setSubTitle(tr("Some fields will appear only when relevant to the selected sport. Whenever possible, uploading a recording of your activity is preferred over creating it manually."));
+    if (plan) {
+        setSubTitle(tr("Plan your upcoming activity by entering the basic details for this session. On the next pages, you can either manually log your performance metrics or select a workout for train mode."));
+    } else {
+        setSubTitle(tr("Log your activity by entering the basic details of the session. Once finished, you can add your performance metrics on the next page."));
+    }
 
     bool useMetricUnits = GlobalContext::context()->useMetricUnits;
     bool metricSwimPace = appsettings->value(this, GC_SWIMPACE, GlobalContext::context()->useMetricUnits).toBool();
@@ -222,19 +234,32 @@ ManualActivityPageBasics::ManualActivityPageBasics
 
     QDateEdit *dateEdit = new QDateEdit();
     dateEdit->setDisplayFormat(locale.dateFormat(QLocale::ShortFormat));
-    dateEdit->setMaximumDate(QDate::currentDate());
-    dateEdit->setMinimumDate(QDate(2000, 1, 1));
+    if (plan) {
+        dateEdit->setMinimumDate(QDate::currentDate());
+        dateEdit->setMaximumDate(QDate(2099, 31, 12));
+    } else {
+        dateEdit->setMinimumDate(QDate(2000, 1, 1));
+        dateEdit->setMaximumDate(QDate::currentDate());
+    }
     dateEdit->setCalendarPopup(true);
 
     QTimeEdit *timeEdit = new QTimeEdit();
-    dateEdit->setDisplayFormat(locale.timeFormat(QLocale::ShortFormat));
+    timeEdit->setDisplayFormat(locale.timeFormat(QLocale::ShortFormat));
+
+    duplicateActivityLabel = new QLabel(tr("An activity already exists for this date and time. Continuing will overwrite the existing activity."));
+    duplicateActivityLabel->setWordWrap(true);
+    duplicateActivityLabel->setVisible(false);
+    duplicateActivityLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Minimum);
 
     QLineEdit *sportEdit = new QLineEdit();
 
+    QLabel *subSportLabel = new QLabel(tr("Sub Sport"));
     QLineEdit *subSportEdit = new QLineEdit();
 
+    QLabel *workoutCodeLabel = new QLabel(tr("Workout Code"));
     QLineEdit *workoutCodeEdit = new QLineEdit();
 
+    QLabel *rpeLabel = new QLabel(tr("RPE"));
     QComboBox *rpeEdit = new QComboBox();
     rpeEdit->addItem("0 - " + tr("Rest"), QColor(Qt::lightGray));
     rpeEdit->addItem("1 - " + tr("Very, very easy"), QColor(Qt::lightGray));
@@ -247,54 +272,34 @@ ManualActivityPageBasics::ManualActivityPageBasics
     rpeEdit->addItem("8 - " + tr("Very hard+"), QColor(Qt::darkRed));
     rpeEdit->addItem("9 - " + tr("Very hard++"), QColor(Qt::darkRed));
     rpeEdit->addItem("10 - " + tr("Maximum"), QColor(Qt::red));
-
     ColorDelegate *rpeDelegate = new ColorDelegate();
     rpeEdit->setItemDelegate(rpeDelegate);
 
+    QLabel *notesLabel = new QLabel(tr("Notes"));
     QTextEdit *notesEdit = new QTextEdit();
 
-    QSpinBox *averageHrEdit = new QSpinBox();
-    averageHrEdit->setMinimum(0);
-    averageHrEdit->setMaximum(250);
-    averageHrEdit->setSuffix(" " + tr("bpm"));
+    QLabel *woTypeLabel = new QLabel(tr("Type") + MANDATORY);
+    QComboBox *woTypeEdit = new QComboBox();
+    woTypeEdit->addItem(tr("Workout (Train mode)"));
+    woTypeEdit->addItem(tr("Manual Entry"));
+    woTypeEdit->setCurrentIndex(1);
+    if (plan) {
 
-    averagePowerLabel = new QLabel(tr("Average Power"));
+#if QT_VERSION >= 0x060000
+        connect(woTypeEdit, &QComboBox::currentIndexChanged, [=](int index) {
+#else
+        connect(woTypeEdit, QOverload<int>::of(&QComboBox::currentIndexChanged), [=](int index) {
+#endif
+            sportEdit->setEnabled(index != 0);
+            if (index == 0) {
+                sportEdit->setText("Bike");
+                emit sportEdit->editingFinished();
+            }
+        });
+    }
 
-    averagePowerEdit = new QSpinBox();
-    averagePowerEdit->setMinimum(0);
-    averagePowerEdit->setMaximum(2000);
-    averagePowerEdit->setSuffix(" " + tr("W"));
-
-    paceIntervals = new QCheckBox(tr("Pace intervals"));
-
-    lapsEditor = new LapsEditorWidget();
-
-    averageCadenceLabel = new QLabel(tr("Average Cadence"));
-
-    averageCadenceEdit = new QSpinBox();
-    averageCadenceEdit->setMinimum(0);
-    averageCadenceEdit->setMaximum(500);
-    averageCadenceEdit->setSuffix(" " + tr("rpm"));
-
-    distanceLabel = new QLabel(tr("Distance"));
-
-    distanceEdit = new QDoubleSpinBox();
-    distanceEdit->setMinimum(0);
-    distanceEdit->setMaximum(999);
-    distanceEdit->setDecimals(2);
-    distanceEdit->setSuffix(" " + (useMetricUnits ? tr("km") : tr("mi")));
-
-    swimDistanceLabel = new QLabel(tr("Swim Distance"));
-
-    swimDistanceEdit = new QSpinBox();
-    swimDistanceEdit->setMinimum(0);
-    swimDistanceEdit->setMaximum(100000);
-    swimDistanceEdit->setSuffix(" " + (metricSwimPace ? tr("m") : tr("yd")));
-
-    durationLabel = new QLabel(tr("Duration"));
-
-    durationEdit = new QTimeEdit();
-    durationEdit->setDisplayFormat("hh:mm:ss");
+    QLabel *objectiveLabel = new QLabel(tr("Objective"));
+    QTextEdit *objectiveEdit = new QTextEdit();
 
     // Set completer for Sport, SubSport and Workout Code fields
     RideMetadata *rideMetadata = GlobalContext::context()->rideMetadata;
@@ -310,47 +315,49 @@ ManualActivityPageBasics::ManualActivityPageBasics
         }
     }
 
-    connect(sportEdit, &QLineEdit::editingFinished, this, &ManualActivityPageBasics::updateVisibility);
-    connect(sportEdit, &QLineEdit::editingFinished, this, &ManualActivityPageBasics::sportsChanged);
-    connect(paceIntervals, &QCheckBox::toggled, this, &ManualActivityPageBasics::updateVisibility);
+    subSportLabel->setVisible(! plan);
+    subSportEdit->setVisible(! plan);
+    workoutCodeLabel->setVisible(! plan);
+    workoutCodeEdit->setVisible(! plan);
+    rpeLabel->setVisible(! plan);
+    rpeEdit->setVisible(! plan);
+    notesLabel->setVisible(! plan);
+    notesEdit->setVisible(! plan);
+    woTypeLabel->setVisible(plan);
+    woTypeEdit->setVisible(plan);
+    objectiveLabel->setVisible(plan);
+    objectiveEdit->setVisible(plan);
 
-    registerField("activityDate*", dateEdit);
-    registerField("activityTime", timeEdit);
+    connect(dateEdit, &QDateEdit::timeChanged, this, &ManualActivityPageBasics::checkDateTime);
+    connect(timeEdit, &QTimeEdit::timeChanged, this, &ManualActivityPageBasics::checkDateTime);
+    connect(sportEdit, &QLineEdit::editingFinished, this, &ManualActivityPageBasics::sportsChanged);
+    connect(sportEdit, &QLineEdit::textChanged, this, [this]() { emit completeChanged(); });
+
+    registerField("activityDate", dateEdit);
+    registerField("activityTime", timeEdit, "time", SIGNAL(timeChanged(QTime)));
     registerField("sport*", sportEdit);
     registerField("subSport", subSportEdit);
     registerField("workoutCode", workoutCodeEdit);
     registerField("rpe", rpeEdit);
     registerField("notes", notesEdit, "plainText", SIGNAL(textChanged()));
-    registerField("averageHr", averageHrEdit);
-    registerField("averagePower", averagePowerEdit);
-    registerField("paceIntervals", paceIntervals);
-    registerField("laps", lapsEditor, "dataPoints", SIGNAL(editingFinished()));
-    registerField("averageCadence", averageCadenceEdit);
-    registerField("distance", distanceEdit, "value", SIGNAL(valueChanged(double)));
-    registerField("swimDistance", swimDistanceEdit);
-    registerField("duration", durationEdit);
+    registerField("woType", woTypeEdit);
+    registerField("objective", objectiveEdit, "plainText", SIGNAL(textChanged()));
 
     QFormLayout *form = newQFormLayout();
     form->addRow(tr("Date") + MANDATORY, dateEdit);
     form->addRow(tr("Time") + MANDATORY, timeEdit);
+    form->addRow("", duplicateActivityLabel);
+    form->addRow(woTypeLabel, woTypeEdit);
     form->addRow(tr("Sport") + MANDATORY, sportEdit);
-    form->addRow(tr("Sub Sport"), subSportEdit);
-    form->addRow(tr("Workout Code"), workoutCodeEdit);
-    form->addRow(tr("RPE"), rpeEdit);
-    form->addRow(tr("Notes"), notesEdit);
-    form->addRow(tr("Average Heartrate"), averageHrEdit);
-    form->addRow(averagePowerLabel, averagePowerEdit);
-    form->addRow(averageCadenceLabel, averageCadenceEdit);
-    form->addRow("", paceIntervals);
-    form->addRow(distanceLabel, distanceEdit);
-    form->addRow(swimDistanceLabel, swimDistanceEdit);
-    form->addRow(durationLabel, durationEdit);
-    form->addRow(lapsEditor);
+    form->addRow(subSportLabel, subSportEdit);
+    form->addRow(workoutCodeLabel, workoutCodeEdit);
+    form->addRow(rpeLabel, rpeEdit);
+    form->addRow(notesLabel, notesEdit);
+    form->addRow(objectiveLabel, objectiveEdit);
 
     QWidget *scrollWidget = new QWidget();
     QVBoxLayout *scrollLayout = new QVBoxLayout(scrollWidget);
     scrollLayout->addWidget(centerLayoutInWidget(form, false));
-    scrollLayout->addWidget(lapsEditor);
     QScrollArea *scrollArea = new QScrollArea();
     scrollArea->setFrameShape(QFrame::NoFrame);
     scrollArea->setWidget(scrollWidget);
@@ -359,8 +366,6 @@ ManualActivityPageBasics::ManualActivityPageBasics
     QVBoxLayout *all = new QVBoxLayout();
     all->addWidget(scrollArea);
     setLayout(all);
-
-    updateVisibility();
 }
 
 
@@ -369,7 +374,14 @@ ManualActivityPageBasics::initializePage
 ()
 {
     setField("activityDate", QDate::currentDate());
-    setField("activityTime", QDateTime::currentDateTime().addSecs(-4 * 3600)); // 4 hours ago by default
+    if (plan) {
+        setField("activityTime", QTime(16, 0, 0)); // Planned: 16:00 by default
+    } else {
+        setField("activityTime", QTime::currentTime().addSecs(-4 * 3600)); // Completed: 4 hours ago by default
+    }
+    if (plan) {
+        setField("woType", 0);
+    }
 }
 
 
@@ -377,78 +389,25 @@ int
 ManualActivityPageBasics::nextId
 () const
 {
-    return ManualActivityWizard::PageSpecifics;
+    return (plan && field("woType").toInt() == 0) ? ManualActivityWizard::PageWorkout : ManualActivityWizard::PageMetrics;
+}
+
+
+bool
+ManualActivityPageBasics::isComplete
+() const
+{
+    return field("sport").toString().trimmed().size() > 0;
 }
 
 
 void
-ManualActivityPageBasics::updateVisibility
+ManualActivityPageBasics::checkDateTime
 ()
 {
-    bool useMetricUnits = GlobalContext::context()->useMetricUnits;
-    bool showAveragePower = true;
-    bool showAverageCadence = true;
-    bool showDistance = true;
-    bool showSwimDistance = false;
-    bool showDuration = true;
-    bool showLapsEditor = false;
-    bool showPaceIntervals = false;
-    QString sport = field("sport").toString().trimmed();
-
-    if (sport == "") {
-        // Hide all conditional fields
-        showAveragePower = false;
-        showAverageCadence = false;
-        showDistance = false;
-        showSwimDistance = false;
-        showDuration = false;
-        showLapsEditor = false;
-        showPaceIntervals = false;
-    } else if (sport == "Bike") {
-        // Stick to defaults
-    } else if (sport == "Run") {
-        useMetricUnits = appsettings->value(this, GC_PACE, GlobalContext::context()->useMetricUnits).toBool();
-        showPaceIntervals = true;
-        showLapsEditor = paceIntervals->isChecked();
-        showDistance = ! showLapsEditor;
-        showDuration = ! showLapsEditor;
-        lapsEditor->setSwim(false);
-    } else if (sport == "Swim") {
-        showAveragePower = false;
-        showDistance = false;
-        showPaceIntervals = true;
-        showLapsEditor = paceIntervals->isChecked();
-        showSwimDistance = ! showLapsEditor;
-        showDuration = ! showLapsEditor;
-        lapsEditor->setSwim(true);
-    } else if (sport == "Row") {
-        // Stick to defaults
-    } else if (sport == "Ski") {
-        showAveragePower = false;
-        showAverageCadence = false;
-    } else if (sport == "Gym") {
-        showAveragePower = false;
-        showAverageCadence = false;
-        showDistance = false;
-        showSwimDistance = false;
-    } else {
-        // Stick to defaults
-    }
-
-    paceIntervals->setVisible(showPaceIntervals);
-    lapsEditor->setVisible(showLapsEditor);
-
-    averageCadenceLabel->setVisible(showAverageCadence);
-    averageCadenceEdit->setVisible(showAverageCadence);
-    averagePowerLabel->setVisible(showAveragePower);
-    averagePowerEdit->setVisible(showAveragePower);
-    distanceLabel->setVisible(showDistance);
-    distanceEdit->setVisible(showDistance);
-    distanceEdit->setSuffix(" " + (useMetricUnits ? tr("km") : tr("mi")));
-    swimDistanceLabel->setVisible(showSwimDistance);
-    swimDistanceEdit->setVisible(showSwimDistance);
-    durationLabel->setVisible(showDuration);
-    durationEdit->setVisible(showDuration);
+    QDateTime dt(field("activityDate").toDate(), field("activityTime").toTime());
+    QFile file(activityFilename(dt, plan, context));
+    duplicateActivityLabel->setVisible(file.exists());
 }
 
 
@@ -473,40 +432,391 @@ ManualActivityPageBasics::sportsChanged
     } else if (! sport.isEmpty()) {
         path = ":images/material/torch.svg";
     }
-    wizard()->setPixmap(ICON_TYPE, svgAsColouredPixmap(path, QSize(ICON_SIZE * dpiXFactor, ICON_SIZE * dpiYFactor), ICON_MARGIN * dpiXFactor, ICON_COLOR));
+    wizard()->setPixmap(ICON_TYPE, svgAsColoredPixmap(path, QSize(ICON_SIZE * dpiXFactor, ICON_SIZE * dpiYFactor), ICON_MARGIN * dpiXFactor, ICON_COLOR));
 }
 
 
 ////////////////////////////////////////////////////////////////////////////////
-// ManualActivityPageSpecifics
+// ManualActivityPageWorkout
 
-ManualActivityPageSpecifics::ManualActivityPageSpecifics
+ManualActivityPageWorkout::ManualActivityPageWorkout
 (Context *context, QWidget *parent)
 : QWizardPage(parent), context(context)
 {
-    setTitle(tr("Stress Information"));
-    setSubTitle(tr("Stress values can be estimated or entered manually. Estimates are based on recent activities of the same sport, or your full history if none are found."));
-    setFinalPage(true);
+    setTitle(tr("Workout for Train Mode"));
+    setSubTitle(tr("Browse and filter workouts based on your goals and preferences. Choose the one that best suits your needs to guide your upcoming session."));
 
-    estimateBy = new QComboBox();
-    estimateBy->addItem(tr("Duration"));
-    estimateBy->addItem(tr("Distance"));
-    estimateBy->addItem(tr("Manually"));
-    QString bsMode = appsettings->value(this, GC_BIKESCOREMODE).toString();
-    if (bsMode == "time") {
-        estimateBy->setCurrentIndex(0);
-    } else if (bsMode == "dist") {
-        estimateBy->setCurrentIndex(1);
-    } else {
-        estimateBy->setCurrentIndex(2);
+    workoutFilterBox = new WorkoutFilterBox();
+
+    workoutModel = trainDB->getWorkoutModel();
+
+    sortModel = new MultiFilterProxyModel(this);
+    sortModel->setSourceModel(workoutModel);
+    workoutModel->setParent(this);
+    sortModel->setDynamicSortFilter(true);
+    sortModel->setSortCaseSensitivity(Qt::CaseInsensitive);
+    sortModel->sort(TdbWorkoutModelIdx::sortdummy, Qt::AscendingOrder); //sort by sortdummy-field
+
+    workoutTree = new QTreeView();
+    workoutTree->setModel(sortModel);
+
+    // hide unwanted columns and header
+    for (int i = 0; i < workoutTree->header()->count(); i++) {
+        workoutTree->setColumnHidden(i, true);
+    }
+    workoutTree->setColumnHidden(TdbWorkoutModelIdx::displayname, false); // show displayname
+    workoutTree->header()->hide();
+    workoutTree->setFrameStyle(QFrame::NoFrame);
+    workoutTree->setAlternatingRowColors(false);
+    workoutTree->setEditTriggers(QAbstractItemView::NoEditTriggers); // read-only
+    workoutTree->expandAll();
+    workoutTree->header()->setCascadingSectionResizes(true); // easier to resize this way
+    workoutTree->setContextMenuPolicy(Qt::CustomContextMenu);
+    workoutTree->header()->setStretchLastSection(true);
+    workoutTree->header()->setMinimumSectionSize(0);
+    workoutTree->header()->setFocusPolicy(Qt::NoFocus);
+    workoutTree->setFrameStyle(QFrame::NoFrame);
+    workoutTree->setRootIsDecorated(false);
+#ifdef Q_OS_MAC
+    workoutTree->header()->setSortIndicatorShown(false); // blue looks nasty
+    workoutTree->setAttribute(Qt::WA_MacShowFocusRect, 0);
+#endif
+#ifdef Q_OS_WIN
+    xde = QStyleFactory::create(OS_STYLE);
+    workoutTree->verticalScrollBar()->setStyle(xde);
+#endif
+
+    backupWorkout = context->workout; // ergFilePlot->setData is not sufficient for showing a workout, ErgFilePlot also
+                                      // relies on context->workout therefore keeping a backup of the original workout in
+                                      // the context so it can be reset on destruction of this page (yes, this is ugly)
+    context->workout = nullptr;
+    ergFilePlot = new ErgFilePlot(context);
+    ergFilePlot->setShowColorZones(2);
+    ergFilePlot->setShowTooltip(1);
+
+    QWidget *ergFileWrapperWidget = new QWidget();
+    QHBoxLayout *ergFileWrapperLayout = new QHBoxLayout(ergFileWrapperWidget);
+    ergFileWrapperLayout->addWidget(ergFilePlot);
+
+    int zonerange = context->athlete->zones("Bike")->whichRange(QDateTime::currentDateTime().date());
+    QList<QColor> zoneColors;
+    if (zonerange != -1) {
+        int numZones = context->athlete->zones("Bike")->numZones(zonerange);
+        for (int j = 0; j < numZones; ++j) {
+            zoneColors << zoneColor(j, numZones);
+        }
+    }
+    infoWidget = new InfoWidget(zoneColors, context->athlete->zones("Bike")->getZoneDescriptions(zonerange), false, false);
+
+    QWidget *detailsWrapperWidget = new QWidget();
+    QHBoxLayout *detailsWrapperLayout = new QHBoxLayout(detailsWrapperWidget);
+    detailsWrapperLayout->addWidget(infoWidget);
+
+    QWidget *detailsScrollWidget = new QWidget();
+    QVBoxLayout *detailsScrollLayout = new QVBoxLayout(detailsScrollWidget);
+    detailsScrollLayout->addWidget(infoWidget);
+    detailsScrollLayout->addStretch(100);
+    QScrollArea *detailsScrollArea = new QScrollArea();
+    detailsScrollArea->setFrameShape(QFrame::NoFrame);
+    detailsScrollArea->setWidget(detailsScrollWidget);
+    detailsScrollArea->setWidgetResizable(true);
+
+    QTabWidget *ergTabs = new QTabWidget();
+    ergTabs->addTab(detailsScrollArea, tr("Metrics"));
+    ergTabs->addTab(ergFileWrapperWidget, tr("Chart"));
+
+    QLabel *noWorkoutLabel = new QLabel(tr("Select a workout to view its details and continue to the next page."));
+    noWorkoutLabel->setWordWrap(true);
+    noWorkoutLabel->setAlignment(Qt::AlignCenter);
+
+    QLabel *noDataLabel = new QLabel(tr("No details are available for this workout."));
+    noDataLabel->setWordWrap(true);
+    noDataLabel->setAlignment(Qt::AlignCenter);
+
+    contentStack = new QStackedWidget();
+    contentStack->addWidget(noWorkoutLabel);
+    contentStack->addWidget(ergTabs);
+    contentStack->addWidget(noDataLabel);
+    contentStack->setCurrentIndex(0);
+
+    QLineEdit *woFilename = new QLineEdit();
+    QLineEdit *woTitle = new QLineEdit();
+    QLineEdit *woFileType = new QLineEdit();
+    QSpinBox *woElevationGain = new QSpinBox();
+    woElevationGain->setMaximum(10000);
+    QSpinBox *woIsoPower = new QSpinBox();
+    woIsoPower->setMaximum(10000);
+    QSpinBox *woXPower = new QSpinBox();
+    woXPower->setMaximum(10000);
+
+    registerField("woFilename*", woFilename);
+    registerField("woTitle*", woTitle);
+    registerField("woFileType*", woFileType);
+    registerField("woElevationGain", woElevationGain);
+    registerField("woIsoPower", woIsoPower);
+    registerField("woXPower", woXPower);
+
+    connect(workoutFilterBox, &WorkoutFilterBox::workoutFiltersChanged, [=](QList<ModelFilter*> &f) {
+        sortModel->setFilters(f);
+    });
+    connect(workoutFilterBox, &WorkoutFilterBox::workoutFiltersRemoved, [=]() {
+        sortModel->removeFilters();
+    });
+    connect(workoutTree->selectionModel(), &QItemSelectionModel::selectionChanged, this, &ManualActivityPageWorkout::selectionChanged);
+
+    QSplitter *splitter = new QSplitter(Qt::Horizontal);
+    splitter->addWidget(workoutTree);
+    splitter->addWidget(contentStack);
+    splitter->setHandleWidth(10 * dpiXFactor);
+    splitter->setStyleSheet(R"(QSplitter::handle { background: transparent; margin: 0px; })");
+    splitter->setStretchFactor(0, 2);
+    splitter->setStretchFactor(1, 3);
+    splitter->setChildrenCollapsible(false);
+    splitter->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::MinimumExpanding);
+
+    QVBoxLayout *hiddenLayout = new QVBoxLayout();
+    hiddenLayout->addWidget(woFilename);
+    hiddenLayout->addWidget(woTitle);
+    hiddenLayout->addWidget(woFileType);
+    hiddenLayout->addWidget(woElevationGain);
+    hiddenLayout->addWidget(woIsoPower);
+    hiddenLayout->addWidget(woXPower);
+    for (int i = 0; i < hiddenLayout->count(); ++i) {
+        QLayoutItem *item = hiddenLayout->itemAt(i);
+        if (item) {
+            QWidget* widget = item->widget();
+            if (widget) {
+                widget->setVisible(false);
+            }
+        }
     }
 
-    estimationDayEdit = new QSpinBox();
-    estimationDayEdit->setSingleStep(1);
-    estimationDayEdit->setMinimum(1);
-    estimationDayEdit->setMaximum(999);
-    estimationDayEdit->setValue(appsettings->value(this, GC_BIKESCOREDAYS, "30").toInt());
+    QVBoxLayout *all = new QVBoxLayout();
+    all->addWidget(workoutFilterBox);
+    all->addSpacing(10 * dpiYFactor);
+    all->addWidget(splitter);
+    all->addLayout(hiddenLayout);
 
+    setLayout(all);
+
+    workoutFilterBox->installEventFilter(this);
+}
+
+
+ManualActivityPageWorkout::~ManualActivityPageWorkout
+()
+{
+    context->workout = backupWorkout;
+    if (workoutModel != nullptr) {
+        delete workoutModel;
+    }
+    if (ergFile != nullptr) {
+        delete ergFile;
+    }
+}
+
+
+void
+ManualActivityPageWorkout::initializePage
+()
+{
+}
+
+
+int
+ManualActivityPageWorkout::nextId
+() const
+{
+    return ManualActivityWizard::PageMetrics;
+}
+
+
+void
+ManualActivityPageWorkout::resetFields
+()
+{
+    setField("woFilename", QString());
+    setField("woTitle", QString());
+    setField("woFileType", QString());
+    setField("woElevationGain", 0);
+    setField("woIsoPower", 0);
+    setField("woXPower", 0);
+    setField("bikeStress", 0);
+    setField("bikeScore", 0);
+    setField("averagePower", 0);
+    setField("realDuration", 0);
+    setField("duration", QTime());
+    setField("realDistance", 0);
+    setField("distance", 0);
+}
+
+
+void
+ManualActivityPageWorkout::selectionChanged
+()
+{
+    QModelIndex current = workoutTree->currentIndex();
+    if (! current.isValid()) {
+        setField("woFilename", QString());
+        contentStack->setCurrentIndex(0);
+        if (ergFile != nullptr) {
+            delete ergFile;
+            ergFile = nullptr;
+        }
+        return;
+    }
+    resetFields();
+    QModelIndex target = sortModel->mapToSource(current);
+    QString filename = workoutModel->data(workoutModel->index(target.row(), TdbWorkoutModelIdx::filepath), Qt::DisplayRole).toString();
+    QString title = workoutModel->data(workoutModel->index(target.row(), TdbWorkoutModelIdx::displayname), Qt::DisplayRole).toString();
+    QString type = workoutModel->data(workoutModel->index(target.row(), TdbWorkoutModelIdx::type), Qt::DisplayRole).toString();
+    int avgPower = workoutModel->data(workoutModel->index(target.row(), TdbWorkoutModelIdx::avgPower), Qt::DisplayRole).toInt();
+    int bikeStress = workoutModel->data(workoutModel->index(target.row(), TdbWorkoutModelIdx::bikestress), Qt::DisplayRole).toInt();
+    int bikeScore = workoutModel->data(workoutModel->index(target.row(), TdbWorkoutModelIdx::bs), Qt::DisplayRole).toInt();
+    int elevationGain = workoutModel->data(workoutModel->index(target.row(), TdbWorkoutModelIdx::elevation), Qt::DisplayRole).toInt();
+    int isoPower = workoutModel->data(workoutModel->index(target.row(), TdbWorkoutModelIdx::isoPower), Qt::DisplayRole).toInt();
+    int xPower = workoutModel->data(workoutModel->index(target.row(), TdbWorkoutModelIdx::xp), Qt::DisplayRole).toInt();
+    setField("woFilename", filename);
+    setField("woTitle", title);
+    setField("woFileType", type);
+    setField("woElevationGain", elevationGain);
+    setField("woIsoPower", isoPower);
+    setField("woXPower", xPower);
+    setField("bikeStress", bikeStress);
+    setField("bikeScore", bikeScore);
+    if (type == "erg") {
+        int durationSecs = workoutModel->data(workoutModel->index(target.row(), TdbWorkoutModelIdx::duration), Qt::DisplayRole).toInt() / 1000;
+        setField("averagePower", avgPower);
+        setField("realDuration", durationSecs);
+        setField("duration", QTime(0, 0, 0).addSecs(durationSecs));
+    } else if (type == "slp") {
+        bool useMetricUnits = GlobalContext::context()->useMetricUnits;
+        double distanceKM = workoutModel->data(workoutModel->index(target.row(), TdbWorkoutModelIdx::distance), Qt::DisplayRole).toDouble() / 1000;
+        setField("realDistance", distanceKM);
+        setField("distance", distanceKM * (useMetricUnits ? 1.0 : MILES_PER_KM));
+    }
+
+    if (ergFile != nullptr) {
+        delete ergFile;
+        ergFile = nullptr;
+    }
+
+    if (type != "code") {
+        ergFile = new ErgFile(filename, ErgFileFormat::unknown, context);
+        if (! ergFile->isValid()) {
+            delete ergFile;
+            ergFile = nullptr;
+        }
+    }
+    contentStack->setCurrentIndex(ergFile != nullptr ? 1 : 2);
+    context->workout = ergFile;
+    ergFilePlot->setData(ergFile);
+    ergFilePlot->replot();
+    infoWidget->ergFileSelected(ergFile);
+}
+
+
+bool
+ManualActivityPageWorkout::eventFilter
+(QObject *watched, QEvent *event)
+{
+    if (watched == workoutFilterBox && event->type() == QEvent::KeyPress) {
+        QKeyEvent *keyEvent = static_cast<QKeyEvent *>(event);
+        if (keyEvent->key() == Qt::Key_Return || keyEvent->key() == Qt::Key_Enter) {
+            emit workoutFilterBox->returnPressed();
+            keyEvent->accept();
+            return true;
+        }
+    }
+    return QWizardPage::eventFilter(watched, event);
+}
+
+
+void
+ManualActivityPageWorkout::cleanupPage
+()
+{
+    workoutTree->setCurrentIndex(QModelIndex());
+    QWizardPage::cleanupPage();
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// ManualActivityPageMetrics
+
+ManualActivityPageMetrics::ManualActivityPageMetrics
+(Context *context, bool plan, QWidget *parent)
+: QWizardPage(parent), context(context), plan(plan)
+{
+    setTitle(tr("Activity Metrics"));
+
+    bool useMetricUnits = GlobalContext::context()->useMetricUnits;
+    bool metricSwimPace = appsettings->value(this, GC_SWIMPACE, GlobalContext::context()->useMetricUnits).toBool();
+
+    QSpinBox *averageHrEdit = new QSpinBox();
+    averageHrEdit->setMinimum(0);
+    averageHrEdit->setMaximum(250);
+    averageHrEdit->setSuffix(" " + tr("bpm"));
+
+    averagePowerLabel = new QLabel(tr("Average Power"));
+    averagePowerEdit = new QSpinBox();
+    averagePowerEdit->setMinimum(0);
+    averagePowerEdit->setMaximum(2000);
+    averagePowerEdit->setSuffix(" " + tr("W"));
+
+    paceIntervals = new QCheckBox(tr("Pace intervals"));
+
+    lapsEditor = new LapsEditorWidget();
+    lapsEditor->setSizePolicy(QSizePolicy::Minimum, QSizePolicy::Minimum);
+    lapsEditor->setMinimumSize(50 * dpiXFactor, 200 * dpiYFactor);
+
+    averageCadenceLabel = new QLabel(tr("Average Cadence"));
+    averageCadenceEdit = new QSpinBox();
+    averageCadenceEdit->setMinimum(0);
+    averageCadenceEdit->setMaximum(500);
+    averageCadenceEdit->setSuffix(" " + tr("rpm"));
+
+    distanceLabel = new QLabel(tr("Distance"));
+    distanceEdit = new QDoubleSpinBox();
+    distanceEdit->setMinimum(0);
+    distanceEdit->setMaximum(999);
+    distanceEdit->setDecimals(2);
+    distanceEdit->setSuffix(" " + (useMetricUnits ? tr("km") : tr("mi")));
+
+    swimDistanceLabel = new QLabel(tr("Swim Distance"));
+    swimDistanceEdit = new QSpinBox();
+    swimDistanceEdit->setMinimum(0);
+    swimDistanceEdit->setMaximum(100000);
+    swimDistanceEdit->setSuffix(" " + (metricSwimPace ? tr("m") : tr("yd")));
+
+    durationLabel = new QLabel(tr("Duration"));
+    durationEdit = new QTimeEdit();
+    durationEdit->setDisplayFormat("hh:mm:ss");
+
+    stressHL = new QLabel(HLO + tr("Stress & Workload") + HLC);
+
+    estimateByLabel = new QLabel(tr("Estimate by"));
+    estimateByEdit = new QComboBox();
+    estimateByEdit->addItem(tr("Duration"));
+    estimateByEdit->addItem(tr("Distance"));
+    estimateByEdit->addItem(tr("Manually"));
+    QString bsMode = appsettings->value(this, GC_BIKESCOREMODE).toString();
+    if (bsMode == "time") {
+        estimateByEdit->setCurrentIndex(0);
+    } else if (bsMode == "dist") {
+        estimateByEdit->setCurrentIndex(1);
+    } else {
+        estimateByEdit->setCurrentIndex(2);
+    }
+
+    estimationDaysLabel = new QLabel(tr("Estimate Stress Days"));
+    estimationDaysEdit = new QSpinBox();
+    estimationDaysEdit->setSingleStep(1);
+    estimationDaysEdit->setMinimum(1);
+    estimationDaysEdit->setMaximum(999);
+    estimationDaysEdit->setValue(appsettings->value(this, GC_BIKESCOREDAYS, "30").toInt());
+
+    workLabel = new QLabel(tr("Work"));
     workEdit = new QSpinBox();
     workEdit->setSuffix(" " + tr("kJ"));
     workEdit->setSingleStep(1);
@@ -514,28 +824,24 @@ ManualActivityPageSpecifics::ManualActivityPageSpecifics
     workEdit->setMaximum(9999);
 
     bikeStressLabel = new QLabel(tr("BikeStress"));
-
     bikeStressEdit = new QSpinBox();
     bikeStressEdit->setSingleStep(1);
     bikeStressEdit->setMinimum(0);
     bikeStressEdit->setMaximum(999);
 
-    bikeScoreLabel = new QLabel(tr("BikeScore") + "<sup>TM</sup>");
-
+    bikeScoreLabel = new QLabel(tr("BikeScore") + TRADEMARK);
     bikeScoreEdit = new QSpinBox();
     bikeScoreEdit->setSingleStep(1);
     bikeScoreEdit->setMinimum(0);
     bikeScoreEdit->setMaximum(999);
 
-    swimScoreLabel = new QLabel(tr("SwimScore") + "<sup>TM</sup>");
-
+    swimScoreLabel = new QLabel(tr("SwimScore") + TRADEMARK);
     swimScoreEdit = new QSpinBox();
     swimScoreEdit->setSingleStep(1);
     swimScoreEdit->setMinimum(0);
     swimScoreEdit->setMaximum(999);
 
-    triScoreLabel = new QLabel(tr("TriScore") + "<sup>TM</sup");
-
+    triScoreLabel = new QLabel(tr("TriScore") + TRADEMARK);
     triScoreEdit = new QSpinBox();
     triScoreEdit->setSingleStep(1);
     triScoreEdit->setMinimum(0);
@@ -548,21 +854,35 @@ ManualActivityPageSpecifics::ManualActivityPageSpecifics
 
     QDoubleSpinBox *realDistance = new QDoubleSpinBox();
     realDistance->setMinimum(0);
+    realDistance->setDecimals(15);
     realDistance->setMaximum(10000);
     realDistance->setVisible(false);
 
+    connect(durationEdit, &QTimeEdit::editingFinished, this, &ManualActivityPageMetrics::updateEstimates);
+    connect(distanceEdit, &QDoubleSpinBox::editingFinished, this, &ManualActivityPageMetrics::updateEstimates);
+    connect(swimDistanceEdit, &QDoubleSpinBox::editingFinished, this, &ManualActivityPageMetrics::updateEstimates);
+    connect(paceIntervals, &QCheckBox::toggled, this, &ManualActivityPageMetrics::updateVisibility);
+    connect(lapsEditor, &LapsEditorWidget::editingFinished, this, &ManualActivityPageMetrics::updateEstimates);
 #if QT_VERSION >= 0x060000
-    connect(estimateBy, &QComboBox::currentIndexChanged, this, &ManualActivityPageSpecifics::updateVisibility);
-    connect(estimateBy, &QComboBox::currentIndexChanged, this, &ManualActivityPageSpecifics::updateEstimates);
-    connect(estimationDayEdit, &QSpinBox::valueChanged, this, &ManualActivityPageSpecifics::updateEstimates);
+    connect(estimateByEdit, &QComboBox::currentIndexChanged, this, &ManualActivityPageMetrics::updateVisibility);
+    connect(estimateByEdit, &QComboBox::currentIndexChanged, this, &ManualActivityPageMetrics::updateEstimates);
+    connect(estimationDaysEdit, &QSpinBox::valueChanged, this, &ManualActivityPageMetrics::updateEstimates);
 #else
-    connect(estimateBy, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ManualActivityPageSpecifics::updateVisibility);
-    connect(estimateBy, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ManualActivityPageSpecifics::updateEstimates);
-    connect(estimationDayEdit, QOverload<int>::of(&QSpinBox::valueChanged), this, &ManualActivityPageSpecifics::updateEstimates);
+    connect(estimateByEdit, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ManualActivityPageMetrics::updateVisibility);
+    connect(estimateByEdit, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &ManualActivityPageMetrics::updateEstimates);
+    connect(estimationDaysEdit, QOverload<int>::of(&QSpinBox::valueChanged), this, &ManualActivityPageMetrics::updateEstimates);
 #endif
 
-    registerField("estimateBy", estimateBy);
-    registerField("estimationDays", estimationDayEdit);
+    registerField("averageHr", averageHrEdit);
+    registerField("averagePower", averagePowerEdit);
+    registerField("paceIntervals", paceIntervals);
+    registerField("laps", lapsEditor, "dataPoints", SIGNAL(editingFinished()));
+    registerField("averageCadence", averageCadenceEdit);
+    registerField("distance", distanceEdit, "value", SIGNAL(valueChanged(double)));
+    registerField("swimDistance", swimDistanceEdit);
+    registerField("duration", durationEdit, "time", SIGNAL(timeChanged(QTime)));
+    registerField("estimateBy", estimateByEdit);
+    registerField("estimationDays", estimationDaysEdit);
     registerField("work", workEdit);
     registerField("bikeStress", bikeStressEdit);
     registerField("bikeScore", bikeScoreEdit);
@@ -571,79 +891,202 @@ ManualActivityPageSpecifics::ManualActivityPageSpecifics
     registerField("realDuration", realDuration, "value", SIGNAL(valueChanged(double)));
     registerField("realDistance", realDistance, "value", SIGNAL(valueChanged(double)));
 
-    QFormLayout *form = newQFormLayout();
-    form->addRow(tr("Estimate by"), estimateBy);
-    form->addRow(tr("Estimate Stress Days"), estimationDayEdit);
-    form->addRow(tr("Work"), workEdit);
-    form->addRow(bikeStressLabel, bikeStressEdit);
-    form->addRow(bikeScoreLabel, bikeScoreEdit);
-    form->addRow(swimScoreLabel, swimScoreEdit);
-    form->addRow(triScoreLabel, triScoreEdit);
-    form->addRow(realDuration);
-    form->addRow(realDistance);
+    QFormLayout *form1 = newQFormLayout();
+    form1->addRow(new QLabel(HLO + tr("Core Training Metrics") + HLC));
+    form1->addRow(tr("Average Heartrate"), averageHrEdit);
+    form1->addRow(averagePowerLabel, averagePowerEdit);
+    form1->addRow(averageCadenceLabel, averageCadenceEdit);
+    form1->addRow("", paceIntervals);
+    form1->addRow(distanceLabel, distanceEdit);
+    form1->addRow(swimDistanceLabel, swimDistanceEdit);
+    form1->addRow(durationLabel, durationEdit);
 
-    setLayout(centerLayout(form));
+    QFormLayout *form2 = newQFormLayout();
+    form2->addRow(stressHL);
+    form2->addRow(estimateByLabel, estimateByEdit);
+    form2->addRow(estimationDaysLabel, estimationDaysEdit);
+    form2->addRow(workLabel, workEdit);
+    form2->addRow(bikeStressLabel, bikeStressEdit);
+    form2->addRow(bikeScoreLabel, bikeScoreEdit);
+    form2->addRow(swimScoreLabel, swimScoreEdit);
+    form2->addRow(triScoreLabel, triScoreEdit);
+    form2->addRow(realDuration);
+    form2->addRow(realDistance);
+
+    QWidget *scrollWidget = new QWidget();
+    QVBoxLayout *scrollLayout = new QVBoxLayout(scrollWidget);
+    scrollLayout->addWidget(centerLayoutInWidget(form1, false));
+    scrollLayout->addWidget(lapsEditor);
+    scrollLayout->addWidget(centerLayoutInWidget(form2, false));
+    scrollLayout->addStretch(100);
+    QScrollArea *scrollArea = new QScrollArea();
+    scrollArea->setFrameShape(QFrame::NoFrame);
+    scrollArea->setWidget(scrollWidget);
+    scrollArea->setWidgetResizable(true);
+
+    QVBoxLayout *all = new QVBoxLayout();
+    all->addWidget(scrollArea);
+    setLayout(all);
 }
 
 
 void
-ManualActivityPageSpecifics::cleanupPage
+ManualActivityPageMetrics::cleanupPage
 ()
 {
-    // Overriden to prevent "estimate by" and "Estimate Stress days" from being reset when going back
+    // Prevent estimateBy and estimationDays from being reset when going back
+    QVariant estBy = field("estimateBy");
+    QVariant estDays = field("estimationDays");
+    QWizardPage::cleanupPage();
+    setField("estimateBy", estBy);
+    setField("estimationDays", estDays);
 }
 
 
 void
-ManualActivityPageSpecifics::initializePage
+ManualActivityPageMetrics::initializePage
 ()
 {
+    if (plan) {
+        if (field("woType").toInt() == 0) {
+            setSubTitle(tr("Add more details for your upcoming activity by entering the expected values to track your planned performance."));
+        } else {
+            setSubTitle(tr("Plan the key details for your upcoming activity based on the selected sport. Enter the expected values to track your performance goals."));
+        }
+    } else {
+        setSubTitle(tr("Record the key details of your activity based on the selected sport. Enter the relevant data to track your performance."));
+    }
     updateVisibility();
     updateEstimates();
 }
 
 
 int
-ManualActivityPageSpecifics::nextId
+ManualActivityPageMetrics::nextId
 () const
 {
-    return ManualActivityWizard::Finalize;
+    return ManualActivityWizard::PageSummary;
 }
 
 
 void
-ManualActivityPageSpecifics::updateVisibility
+ManualActivityPageMetrics::updateVisibility
 ()
 {
-    bool manual = estimateBy->currentIndex() == 2;
-
+    bool workoutPlan = plan && field("woType").toInt() == 0;
+    QString sport = field("sport").toString().trimmed();
+    bool useMetricUnits = GlobalContext::context()->useMetricUnits;
+    bool showAveragePower = true;
+    bool showAverageCadence = true;
+    bool showDistance = true;
+    bool showSwimDistance = false;
+    bool showDuration = true;
+    bool showLapsEditor = false;
+    bool showPaceIntervals = false;
+    bool manual = estimateByEdit->currentIndex() == 2;
+    bool showEstimate = true;
+    bool showWork = true;
     bool showBikeStress = false;
     bool showBikeScore = false;
     bool showSwimScore = false;
     bool showTriScore = true;
-    QString sport = field("sport").toString().trimmed();
-    if (sport == "Bike") {
+
+    if (workoutPlan) {
+        QString woFileType = field("woFileType").toString().trimmed();
+        if (woFileType == "erg") {
+            showAveragePower = false;
+            showDistance = false;
+            showDuration = false;
+            showEstimate = false;
+        } else if (woFileType == "slp") {
+            showDistance = false;
+            showBikeStress = true;
+            showBikeScore = true;
+        } else {
+            showBikeStress = true;
+            showBikeScore = true;
+        }
+        showWork = false;
+        showTriScore = false;
+    } else if (sport == "") {
+        // Hide all conditional fields
+        showAveragePower = false;
+        showAverageCadence = false;
+        showDistance = false;
+        showSwimDistance = false;
+        showDuration = false;
+        showLapsEditor = false;
+        showPaceIntervals = false;
+        showBikeStress = false;
+        showBikeScore = false;
+        showSwimScore = false;
+        showTriScore = false;
+    } else if (sport == "Bike") {
         showBikeStress = true;
         showBikeScore = true;
     } else if (sport == "Run") {
-        // Use defaults
+        useMetricUnits = appsettings->value(this, GC_PACE, GlobalContext::context()->useMetricUnits).toBool();
+        showPaceIntervals = true;
+        showLapsEditor = paceIntervals->isChecked();
+        showDistance = ! showLapsEditor;
+        showDuration = ! showLapsEditor;
+        lapsEditor->setSwim(false);
     } else if (sport == "Swim") {
+        showAveragePower = false;
+        showDistance = false;
+        showPaceIntervals = true;
+        showLapsEditor = paceIntervals->isChecked();
+        showSwimDistance = ! showLapsEditor;
+        showDuration = ! showLapsEditor;
+        lapsEditor->setSwim(true);
         showSwimScore = true;
     } else if (sport == "Row") {
-        // Use defaults
+        // Stick to defaults
     } else if (sport == "Ski") {
-        // Use defaults
+        showAveragePower = false;
+        showAverageCadence = false;
     } else if (sport == "Gym") {
-        // Use defaults
+        showAveragePower = false;
+        showAverageCadence = false;
+        showDistance = false;
+        showSwimDistance = false;
+    } else {
+        // Stick to defaults
     }
 
+    paceIntervals->setVisible(showPaceIntervals);
+    lapsEditor->setVisible(showLapsEditor);
+    averageCadenceLabel->setVisible(showAverageCadence);
+    averageCadenceEdit->setVisible(showAverageCadence);
+    averagePowerLabel->setVisible(showAveragePower);
+    averagePowerEdit->setVisible(showAveragePower);
+    distanceLabel->setVisible(showDistance);
+    distanceEdit->setVisible(showDistance);
+    distanceEdit->setSuffix(" " + (useMetricUnits ? tr("km") : tr("mi")));
+    swimDistanceLabel->setVisible(showSwimDistance);
+    swimDistanceEdit->setVisible(showSwimDistance);
+    durationLabel->setVisible(showDuration);
+    durationEdit->setVisible(showDuration);
+
+    estimationDaysEdit->setEnabled(! manual);
     workEdit->setEnabled(manual);
     bikeStressEdit->setEnabled(manual);
     bikeScoreEdit->setEnabled(manual);
     swimScoreEdit->setEnabled(manual);
     triScoreEdit->setEnabled(manual);
 
-    estimationDayEdit->setEnabled(! manual);
+    stressHL->setVisible(   showEstimate
+                         || showWork
+                         || showBikeStress
+                         || showBikeScore
+                         || showSwimScore
+                         || showTriScore);
+    estimateByLabel->setVisible(showEstimate);
+    estimateByEdit->setVisible(showEstimate);
+    estimationDaysLabel->setVisible(showEstimate);
+    estimationDaysEdit->setVisible(showEstimate);
+    workLabel->setVisible(showWork);
+    workEdit->setVisible(showWork);
     bikeStressLabel->setVisible(showBikeStress);
     bikeStressEdit->setVisible(showBikeStress);
     bikeScoreLabel->setVisible(showBikeScore);
@@ -656,15 +1099,15 @@ ManualActivityPageSpecifics::updateVisibility
 
 
 void
-ManualActivityPageSpecifics::updateEstimates
+ManualActivityPageMetrics::updateEstimates
 ()
 {
-    std::pair<double, double> durationDistance = getDurationDistance();
-    double actDuration = durationDistance.first;
-    double actDistance = durationDistance.second;
-    setField("realDuration", actDuration);
-    setField("realDistance", actDistance);
-
+    QString sport = field("sport").toString().trimmed();
+    if (   plan
+        && field("woType").toInt() == 0
+        && field("woFileType").toString().trimmed() == "erg") { // no estimation if planning a ergmode workout
+        return;
+    }
     int estimateBy = field("estimateBy").toInt();
     if (estimateBy == 2) { // manual
         return;
@@ -680,8 +1123,6 @@ ManualActivityPageSpecifics::updateEstimates
     double distanceSwimScore = 0.0;
     double timeTriScore = 0.0;
     double distanceTriScore = 0.0;
-
-    QString sport = field("sport").toString().trimmed();
 
     double metricFactor = 1.0;
     if (   (sport == "Run" && ! appsettings->value(this, GC_PACE, GlobalContext::context()->useMetricUnits).toBool())
@@ -780,6 +1221,11 @@ ManualActivityPageSpecifics::updateEstimates
         }
     }
 
+    std::pair<double, double> durationDistance = getDurationDistance();
+    double actDuration = durationDistance.first;
+    double actDistance = durationDistance.second;
+    setField("realDuration", actDuration);
+    setField("realDistance", actDistance);
     if (estimateBy == 0) { // by time
         setField("work", actDuration * timeWork / 3600.0);
         setField("bikeStress", actDuration * timeBikeStress / 3600.0);
@@ -797,7 +1243,7 @@ ManualActivityPageSpecifics::updateEstimates
 
 
 std::pair<double, double>
-ManualActivityPageSpecifics::getDurationDistance
+ManualActivityPageMetrics::getDurationDistance
 () const
 {
     double durationSeconds = 0;
@@ -834,4 +1280,242 @@ ManualActivityPageSpecifics::getDurationDistance
         }
     }
     return std::make_pair(durationSeconds, distanceKm);
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// ManualActivityPageMetrics
+
+ManualActivityPageSummary::ManualActivityPageSummary
+(bool plan, QWidget *parent)
+: QWizardPage(parent), plan(plan)
+{
+    setTitle(tr("Summary"));
+    if (plan) {
+        setSubTitle(tr("Summary of your upcoming activity. Review the plan to ensure everything is set for your session."));
+    } else {
+        setSubTitle(tr("Summary of your activity. Review the data to ensure it accurately reflects the session."));
+    }
+    setFinalPage(true);
+
+    form = newQFormLayout();
+
+    QWidget *scrollWidget = new QWidget();
+    QVBoxLayout *scrollLayout = new QVBoxLayout(scrollWidget);
+    scrollLayout->addWidget(centerLayoutInWidget(form, false));
+    QScrollArea *scrollArea = new QScrollArea();
+    scrollArea->setFrameShape(QFrame::NoFrame);
+    scrollArea->setWidget(scrollWidget);
+    scrollArea->setWidgetResizable(true);
+
+    QVBoxLayout *all = new QVBoxLayout();
+    all->addWidget(scrollArea);
+    setLayout(all);
+}
+
+
+void
+ManualActivityPageSummary::cleanupPage
+()
+{
+    while (form->count() > 0) {
+        QLayoutItem *item = form->takeAt(0);
+        if (! item) {
+            continue;
+        }
+        QWidget *widget = item->widget();
+        if (widget) {
+            form->removeWidget(widget);
+            delete widget;
+        }
+        delete item;
+    }
+}
+
+
+void
+ManualActivityPageSummary::initializePage
+()
+{
+    QString sport = field("sport").toString().trimmed();
+    bool useMetricUnits = true;
+    double metricFactorKM = 1.0;
+    double metricFactorM = 1.0;
+    if (   (sport == "Run" && ! appsettings->value(this, GC_PACE, GlobalContext::context()->useMetricUnits).toBool())
+        || (sport == "Swim" && ! appsettings->value(this, GC_SWIMPACE, GlobalContext::context()->useMetricUnits).toBool())
+        || (sport != "Run" && sport != "Swim" && ! GlobalContext::context()->useMetricUnits)) {
+        metricFactorKM = MILES_PER_KM;
+        metricFactorM = 1.0 / METERS_PER_YARD;
+        useMetricUnits = false;
+    }
+
+    QLocale locale;
+    QDateTime when = QDateTime(field("activityDate").toDate(), field("activityTime").toTime());
+
+    form->addRow(new QLabel(HLO + tr("General Information") + HLC));
+    if (plan) {
+        addRow(tr("Scheduled for"), locale.toString(when, QLocale::ShortFormat));
+    } else {
+        addRow(tr("Date"), locale.toString(when, QLocale::ShortFormat));
+    }
+    addRowString(tr("Sport"), "sport");
+    addRowString(tr("SubSport"), "subSport");
+    addRowString(tr("Workout Code"), "workoutCode");
+    addRowString(tr("Workout Title"), "woTitle");
+    addRowString(tr("Notes"), "notes");
+    addRowString(tr("Objective"), "objective");
+    if (! plan) {
+        switch (field("rpe").toInt()) {
+        case 0:
+            addRow(tr("RPE"), "0 - " + tr("Rest"));
+            break;
+        case 1:
+            addRow(tr("RPE"), "1 - " + tr("Very, very easy"));
+            break;
+        case 2:
+            addRow(tr("RPE"), "2 - " + tr("Easy"));
+            break;
+        case 3:
+            addRow(tr("RPE"), "3 - " + tr("Moderate"));
+            break;
+        case 4:
+            addRow(tr("RPE"), "4 - " + tr("Somewhat hard"));
+            break;
+        case 5:
+            addRow(tr("RPE"), "5 - " + tr("Hard"));
+            break;
+        case 6:
+            addRow(tr("RPE"), "6 - " + tr("Hard+"));
+            break;
+        case 7:
+            addRow(tr("RPE"), "7 - " + tr("Very hard"));
+            break;
+        case 8:
+            addRow(tr("RPE"), "8 - " + tr("Very hard+"));
+            break;
+        case 9:
+            addRow(tr("RPE"), "9 - " + tr("Very hard++"));
+            break;
+        case 10:
+            addRow(tr("RPE"), "10 - " + tr("Maximum"));
+            break;
+        default:
+            break;
+        }
+    }
+    bool hasActMetricsSection = false;
+    QLabel *actMetricsHL = new QLabel(HLO + tr("Activity Metrics") + HLC);
+    form->addRow(actMetricsHL);
+    if (sport == "Swim") {
+        hasActMetricsSection |= addRowDouble(tr("Distance"), "realDistance", useMetricUnits ? tr("m") : tr("yd"), metricFactorM * 1000.0);
+    } else {
+        hasActMetricsSection |= addRowDouble(tr("Distance"), "realDistance", useMetricUnits ? tr("km") : tr("mi"), metricFactorKM);
+    }
+    int duration = field("realDuration").toInt();
+    if (duration > 0) {
+        QTime durationTime = QTime(0, 0, 0).addSecs(duration);
+        hasActMetricsSection |= addRow(tr("Duration"), durationTime.toString("h:mm:ss"));
+    }
+    hasActMetricsSection |= addRowInt(tr("Average Heartrate"), "averageHr", tr("bpm"));
+    hasActMetricsSection |= addRowInt(tr("Average Cadence"), "averageCadence", tr("rpm"));
+    hasActMetricsSection |= addRowInt(tr("Average Power"), "averagePower", tr("W"));
+    hasActMetricsSection |= addRowInt(tr("Elevation Gain"), "woElevationGain", useMetricUnits ? tr("m") : tr("yd"), metricFactorM);
+    hasActMetricsSection |= addRowInt(tr("IsoPower"), "woIsoPower", tr("W"));
+    hasActMetricsSection |= addRowInt(tr("xPower"), "woXPower", tr("W"));
+    hasActMetricsSection |= addRowInt(tr("Work"), "work", tr("W"));
+    hasActMetricsSection |= addRowInt(tr("BikeStress"), "bikeStress");
+    hasActMetricsSection |= addRowInt(tr("BikeScore") + TRADEMARK, "bikeScore");
+    hasActMetricsSection |= addRowInt(tr("SwimScore") + TRADEMARK, "swimScore");
+    hasActMetricsSection |= addRowInt(tr("TriScore") + TRADEMARK, "triScore");
+    actMetricsHL->setVisible(hasActMetricsSection);
+}
+
+
+int
+ManualActivityPageSummary::nextId
+() const
+{
+    return ManualActivityWizard::Finalize;
+}
+
+
+bool
+ManualActivityPageSummary::addRowString
+(const QString &label, const QString &fieldName)
+{
+    return addRow(label, field(fieldName).toString().trimmed());
+}
+
+
+bool
+ManualActivityPageSummary::addRowInt
+(const QString &label, const QString &fieldName, const QString &unit, double metricFactor)
+{
+    double value = field(fieldName).toInt() * metricFactor;
+    if (value > 0) {
+        QString valueStr = QString::number(value);
+        if (! unit.isEmpty()) {
+            valueStr += " " + unit;
+        }
+        return addRow(label, valueStr);
+    }
+    return false;
+}
+
+
+bool
+ManualActivityPageSummary::addRowDouble
+(const QString &label, const QString &fieldName, const QString &unit, double metricFactor)
+{
+    double value = field(fieldName).toDouble() * metricFactor;
+    if (value > 0) {
+        QString valueStr = QString::number(value);
+        if (! unit.isEmpty()) {
+            valueStr += " " + unit;
+        }
+        return addRow(label, valueStr);
+    }
+    return false;
+}
+
+
+bool
+ManualActivityPageSummary::addRow
+(const QString &label, const QString &value)
+{
+    if (! value.isEmpty()) {
+        QLabel *valueWidget = new QLabel(value);
+        valueWidget->setWordWrap(true);
+        valueWidget->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Minimum);
+        valueWidget->adjustSize();
+        form->addRow(label, valueWidget);
+        return true;
+    }
+    return false;
+}
+
+
+////////////////////////////////////////////////////////////////////////////////
+// Helpers & Utilities
+
+static QString
+activityBasename
+(const QDateTime &dt)
+{
+    return dt.toString("yyyy_MM_dd_HH_mm_ss");
+}
+
+
+static QString
+activityFilename
+(const QDateTime &dt, bool plan, Context *context)
+{
+    QString basename = activityBasename(dt);
+    QString filename;
+    if (plan) {
+        filename = context->athlete->home->planned().canonicalPath() + "/" + basename + ".json";
+    } else {
+        filename = context->athlete->home->activities().canonicalPath() + "/" + basename + ".json";
+    }
+    return filename;
 }

--- a/src/Gui/ManualActivityWizard.cpp
+++ b/src/Gui/ManualActivityWizard.cpp
@@ -23,6 +23,8 @@
 #include <QtGui>
 #include <QMessageBox>
 #include <QSplitter>
+#include <QStyleFactory>
+#include <QScrollBar>
 
 #include <string.h>
 #include <errno.h>
@@ -482,7 +484,7 @@ ManualActivityPageWorkout::ManualActivityPageWorkout
     workoutTree->setAttribute(Qt::WA_MacShowFocusRect, 0);
 #endif
 #ifdef Q_OS_WIN
-    xde = QStyleFactory::create(OS_STYLE);
+    QStyle *xde = QStyleFactory::create(OS_STYLE);
     workoutTree->verticalScrollBar()->setStyle(xde);
 #endif
 

--- a/src/Train/InfoWidget.h
+++ b/src/Train/InfoWidget.h
@@ -40,7 +40,7 @@ class InfoWidget : public QFrame
     Q_OBJECT
 
     public:
-        InfoWidget(QList<QColor> powerZoneColors, QList<QString> powerZoneNames, QWidget *parent = nullptr);
+        InfoWidget(QList<QColor> powerZoneColors, QList<QString> powerZoneNames, bool showRating = true, bool showTags = true, QWidget *parent = nullptr);
         ~InfoWidget();
 
         void setContent(const ErgFileBase &ergFileBase, int rating, qlonglong lastRun);
@@ -59,13 +59,13 @@ class InfoWidget : public QFrame
         virtual void changeEvent(QEvent *event);
 
     private:
-        RatingWidget *ratingWidget;
+        RatingWidget *ratingWidget = nullptr;
         PowerInfoWidget *powerInfoWidget;
         QLabel *slpLabel;
         PowerZonesWidget *powerZonesWidget;
         QLabel *descriptionLabel;
         QLabel *lastRunLabel;
-        TagBar *tagBar;
+        TagBar *tagBar = nullptr;
         QString filepath;
         WorkoutTagWrapper workoutTagWrapper;
 

--- a/src/Train/WorkoutFilterBox.h
+++ b/src/Train/WorkoutFilterBox.h
@@ -39,6 +39,10 @@ public slots:
     void clear();
     void setText(const QString &text);
 
+signals:
+    void workoutFiltersChanged(QList<ModelFilter*> &f); // only emitted if no context given
+    void workoutFiltersRemoved(); // only emitted if no context given
+
 private slots:
     void processInput();
     void configChanged(qint32 topic);


### PR DESCRIPTION
* Extended the ManualActivityWizard by a flow to add planned activities
* Changed the grouping of fields on the pages to allow code reuse between completed and planned activities
* Added a summary page to Manual ActivityWizard (both planned and completed activities)
* Added an additional menu entry "Plan Activity..." to Activity menu
* Allowing WorkoutFilterBox to be used as widget in any dialog without modifying the context
* Added option to InfoWidget to use it without parts that can modify the TrainDB (rating and tags)
* See https://groups.google.com/g/golden-cheetah-users/c/Yz8g2J1Ue6w/m/U5OXTBv3BQAJ