### PR TITLE
Natural sort order for workouts in train mode

### DIFF
--- a/src/Train/MultiFilterProxyModel.cpp
+++ b/src/Train/MultiFilterProxyModel.cpp
@@ -26,6 +26,8 @@ MultiFilterProxyModel::MultiFilterProxyModel
 (QObject *parent)
 : QSortFilterProxyModel(parent), _filters()
 {
+    _collator.setCaseSensitivity(Qt::CaseInsensitive);
+    _collator.setNumericMode(true);
 }
 
 
@@ -81,4 +83,14 @@ MultiFilterProxyModel::filterAcceptsRow
         }
     }
     return true;
+}
+
+
+bool
+MultiFilterProxyModel::lessThan
+(const QModelIndex &left, const QModelIndex &right) const
+{
+    QString leftText = left.data().toString();
+    QString rightText = right.data().toString();
+    return _collator.compare(leftText, rightText) < 0;
 }

--- a/src/Train/MultiFilterProxyModel.h
+++ b/src/Train/MultiFilterProxyModel.h
@@ -21,6 +21,7 @@
 
 
 #include <QSortFilterProxyModel>
+#include <QCollator>
 #include <QList>
 
 #include "ModelFilter.h"
@@ -40,9 +41,11 @@ public:
 
 protected:
     virtual bool filterAcceptsRow(int sourceRow, const QModelIndex &sourceParent) const override;
+    virtual bool lessThan(const QModelIndex &left, const QModelIndex &right) const override;
 
 private:
     QList<ModelFilter*> _filters;
+    QCollator _collator;
 };
 
 #endif // MultiFilterProxyModel_H


### PR DESCRIPTION
* Switched from lexicographical to natural sort order in the workouttree
* Example before:
  * week 1 day 1
  * week 1 day 3
  * week 10 day 2
  * week 2 day 2
* Example after:
  * week 1 day 1
  * week 1 day 3
  * week 2 day 2
  * week 10 day 2