### PR TITLE
Improve support for CORE sensor

### DIFF
--- a/src/Gui/Colors.cpp
+++ b/src/Gui/Colors.cpp
@@ -233,6 +233,9 @@ void GCColor::setupColors()
         { tr("Gui"), tr("Overview Tile Background Vibrant"), "CCARDBACKGROUND3", QColor(52,52,52) },
         { tr("Gui"), tr("Map Route Line"), "MAPROUTELINE", Qt::red },
         { tr("Data"), tr("Stress Ramp Rate"), "COLORRR", Qt::green },
+        { tr("Data"), tr("Skin Temp"), "CSKINTEMP", Qt::cyan },
+        { tr("Data"), tr("Heat Strain"), "CHEATSTRAIN", Qt::green },
+        { tr("Data"), tr("Heat Load"), "CHEATLOAD", Qt::red },
         { "", "", "", QColor(0,0,0) },
     };
 
@@ -357,6 +360,9 @@ void GCColor::setupColors()
     LightDefaultColorList[107].color = QColor(238,248,255); // 107:Tile Vibrant
     LightDefaultColorList[108].color = QColor(255, 0, 0); // 105:MapRouteLine
     LightDefaultColorList[109].color = QColor(0,102,0); // 109:Stress Ramp Rate
+    LightDefaultColorList[110].color = Qt::cyan; //CSKINTEMP
+    LightDefaultColorList[111].color = Qt::green; //CHEATSTRAIN
+    LightDefaultColorList[112].color = Qt::red; //CHEATLOAD
 }
 
 // returns a luminance for a color from 0 (dark) to 255 (very light) 127 is a half way house gray
@@ -365,7 +371,7 @@ double GCColor::luminance(QColor color)
     QColor cRGB = color.convertTo(QColor::Rgb);
 
     // based upon http://en.wikipedia.org/wiki/Luminance_(relative)
-    return (0.2126f * double(cRGB.red()))  + 
+    return (0.2126f * double(cRGB.red()))  +
            (0.7152f * double(cRGB.green())) +
            (0.0722f * double(cRGB.blue()));
 }
@@ -550,7 +556,7 @@ GCColor::css(bool ridesummary)
                                .arg(200 * dpiXFactor)
                                .arg(100 * dpiXFactor);
 }
-QPalette 
+QPalette
 GCColor::palette()
 {
     // make it to order, to reflect current config
@@ -621,7 +627,7 @@ GCColor::linearGradient(int size, bool, bool)
     returning.setColorAt(1.0, color);
 
 
-    return returning; 
+    return returning;
 }
 
 void
@@ -1054,7 +1060,7 @@ QColor GCColor::getThemeColor(const ColorTheme& theme, int colorIdx)
 }
 
 void
-GCColor::applyTheme(int index) 
+GCColor::applyTheme(int index)
 {
     // now get the theme selected
     ColorTheme theme = GCColor::themes().themes[index];
@@ -1089,7 +1095,7 @@ ColorLabel::paintEvent(QPaintEvent *)
     QRectF allF(0,0,width(),height());
     QRect all(0,0,width(),height());
 
-    const double x = width() / 5; 
+    const double x = width() / 5;
     const double y = height();
 
     // now do all the color blocks

--- a/src/Gui/Colors.h
+++ b/src/Gui/Colors.h
@@ -193,7 +193,7 @@ class ColorEngine : public QObject
 #define GColor(x) GCColor::getColor(x)
 
 // Define how many cconfigurable metric colors are available
-#define CNUMOFCFGCOLORS       110
+#define CNUMOFCFGCOLORS       113
 
 #define CPLOTBACKGROUND       0
 #define CRIDEPLOTBACKGROUND   1
@@ -305,4 +305,7 @@ class ColorEngine : public QObject
 #define CCARDBACKGROUND3      107
 #define MAPROUTELINE          108
 #define COLORRR               109
+#define CSKINTEMP             110
+#define CHEATSTRAIN           111
+#define CHEATLOAD             112
 #endif

--- a/src/Train/DialWindow.cpp
+++ b/src/Train/DialWindow.cpp
@@ -114,10 +114,10 @@ DialWindow::DialWindow(Context *context) :
 
 
     //do this on init, but not in resetValues as we want to preserve the heat load across sessions, resetting if local midnight passes while not running
-    this->heatLoadMSec = 0;
-    this->heatLoad = 0;
-    this->heatLoadLocalDate = QDateTime::currentDateTime();
-    this->isRunning = false;
+    heatLoadMSec = 0;
+    heatLoad = 0;
+    heatLoadLocalDate = QDateTime::currentDateTime();
+    isRunning = false;
 }
 
 void
@@ -131,14 +131,14 @@ void
 DialWindow::start()
 {
     resetValues();
-    this->isRunning = true;
+    isRunning = true;
 }
 
 void
 DialWindow::stop()
 {
     resetValues();
-    this->isRunning = false;
+    isRunning = false;
 }
 
 void
@@ -578,35 +578,35 @@ DialWindow::telemetryUpdate(const RealtimeData &rtData)
             QDateTime currentTime = QDateTime::currentDateTimeUtc();
             qint64 msecEpoc = currentTime.toMSecsSinceEpoch();
 
-            //qDebug()<<"reset check time isRunning" << this->isRunning << "at" << QDateTime::currentDateTime() << "heatLoadLocalDate" << this->heatLoadLocalDate << "DOY" << this->heatLoadLocalDate.date().dayOfYear();
-            if(!this->isRunning && this->heatLoadLocalDate.date().dayOfYear() != QDateTime::currentDateTime().date().dayOfYear())
+            //qDebug()<<"reset check time isRunning" << isRunning << "at" << QDateTime::currentDateTime() << "heatLoadLocalDate" << heatLoadLocalDate << "DOY" << heatLoadLocalDate.date().dayOfYear();
+            if(!isRunning && heatLoadLocalDate.date().dayOfYear() != QDateTime::currentDateTime().date().dayOfYear())
             {
-                qDebug()<<"resetting heat load at " << QDateTime::currentDateTime() << "heatLoadLocalDate" << this->heatLoadLocalDate;
-                this->heatLoadMSec = 0;
-                this->heatLoad = 0;
-                this->heatLoadLocalDate = QDateTime::currentDateTime();
+                qDebug()<<"resetting heat load at " << QDateTime::currentDateTime() << "heatLoadLocalDate" << heatLoadLocalDate;
+                heatLoadMSec = 0;
+                heatLoad = 0;
+                heatLoadLocalDate = QDateTime::currentDateTime();
             }
 
-            if(this->heatLoadMSec != 0 && heatStrain > HEATLOAD_OFFSET) //don't try to calculate a negative effective heat strain
+            if(heatLoadMSec != 0 && heatStrain > HEATLOAD_OFFSET) //don't try to calculate a negative effective heat strain
             {
                 //(HSI-AOC_Off)^AOC_EXP*TIME/AOC_Mult
 
-                qint64 deltaMSec = msecEpoc - this->heatLoadMSec;
+                qint64 deltaMSec = msecEpoc - heatLoadMSec;
                 double deltamin = deltaMSec / (1000.0 * 60.0); //msec to minutes
 
                 double newLoad = pow(heatStrain-HEATLOAD_OFFSET, HEATLOAD_EXP) * deltamin / HEATLOAD_MULT;
 
                 if(newLoad > 0)
-                    this->heatLoad += newLoad;
+                    heatLoad += newLoad;
 
-                //qDebug()<<"newLoad is "<< newLoad << "a" << a << "b" << b << "heatStrain" << heatStrain << "c" << c << "deltamin" << deltamin << "heatLoad" << this->heatLoad;
+                //qDebug()<<"newLoad is "<< newLoad << "a" << a << "b" << b << "heatStrain" << heatStrain << "c" << c << "deltamin" << deltamin << "heatLoad" << heatLoad;
 
-                if(this->heatLoad >= 10.0)
-                    this->heatLoad = 10.0;
+                if(heatLoad >= 10.0)
+                    heatLoad = 10.0;
             }
-            this->heatLoadMSec = msecEpoc;
+            heatLoadMSec = msecEpoc;
 
-            valueLabel->setText(QString("%1").arg(this->heatLoad, 0, 'f', 3)); //HACK, three DP for extra details
+            valueLabel->setText(QString("%1").arg(heatLoad, 0, 'f', 3)); //HACK, three DP for extra details
         }
         break;
 

--- a/src/Train/DialWindow.cpp
+++ b/src/Train/DialWindow.cpp
@@ -23,6 +23,12 @@
 #include "RideFile.h"
 #include "HelpWhatsThis.h"
 
+
+#define HEATLOAD_OFFSET 0.9596
+#define  HEATLOAD_MULT 35.92
+#define  HEATLOAD_EXP 1.324
+
+
 DialWindow::DialWindow(Context *context) :
     GcChartWindow(context), context(context), average(1), isNewLap(false)
 {
@@ -105,6 +111,13 @@ DialWindow::DialWindow(Context *context) :
 
     // set to zero
     resetValues();
+
+
+    //do this on init, but not in resetValues as we want to preserve the heat load across sessions, resetting if local midnight passes while not running
+    this->heatLoadMSec = 0;
+    this->heatLoad = 0;
+    this->heatLoadLocalDate = QDateTime::currentDateTime();
+    this->isRunning = false;
 }
 
 void
@@ -118,12 +131,14 @@ void
 DialWindow::start()
 {
     resetValues();
+    this->isRunning = true;
 }
 
 void
 DialWindow::stop()
 {
     resetValues();
+    this->isRunning = false;
 }
 
 void
@@ -548,6 +563,52 @@ DialWindow::telemetryUpdate(const RealtimeData &rtData)
     case RealtimeData::CoreTemp:
         valueLabel->setText(QString("%1").arg(displayValue, 0, 'f', 2));
         break;
+    //Skin temp, heat strain, and heat load are from CORE sensor
+    case RealtimeData::SkinTemp:
+        valueLabel->setText(QString("%1").arg(displayValue, 0, 'f', 2));
+        break;
+
+    case RealtimeData::HeatStrain:
+        valueLabel->setText(QString("%1").arg(displayValue, 0, 'f', 1));
+        break;
+
+    case RealtimeData::HeatLoad:
+        {
+            double heatStrain = rtData.getHeatStrain();
+            QDateTime currentTime = QDateTime::currentDateTimeUtc();
+            qint64 msecEpoc = currentTime.toMSecsSinceEpoch();
+
+            //qDebug()<<"reset check time isRunning" << this->isRunning << "at" << QDateTime::currentDateTime() << "heatLoadLocalDate" << this->heatLoadLocalDate << "DOY" << this->heatLoadLocalDate.date().dayOfYear();
+            if(!this->isRunning && this->heatLoadLocalDate.date().dayOfYear() != QDateTime::currentDateTime().date().dayOfYear())
+            {
+                qDebug()<<"resetting heat load at " << QDateTime::currentDateTime() << "heatLoadLocalDate" << this->heatLoadLocalDate;
+                this->heatLoadMSec = 0;
+                this->heatLoad = 0;
+                this->heatLoadLocalDate = QDateTime::currentDateTime();
+            }
+
+            if(this->heatLoadMSec != 0 && heatStrain > HEATLOAD_OFFSET) //don't try to calculate a negative effective heat strain
+            {
+                //(HSI-AOC_Off)^AOC_EXP*TIME/AOC_Mult
+
+                qint64 deltaMSec = msecEpoc - this->heatLoadMSec;
+                double deltamin = deltaMSec / (1000.0 * 60.0); //msec to minutes
+
+                double newLoad = pow(heatStrain-HEATLOAD_OFFSET, HEATLOAD_EXP) * deltamin / HEATLOAD_MULT;
+
+                if(newLoad > 0)
+                    this->heatLoad += newLoad;
+
+                //qDebug()<<"newLoad is "<< newLoad << "a" << a << "b" << b << "heatStrain" << heatStrain << "c" << c << "deltamin" << deltamin << "heatLoad" << this->heatLoad;
+
+                if(this->heatLoad >= 10.0)
+                    this->heatLoad = 10.0;
+            }
+            this->heatLoadMSec = msecEpoc;
+
+            valueLabel->setText(QString("%1").arg(this->heatLoad, 0, 'f', 3)); //HACK, three DP for extra details
+        }
+        break;
 
     default:
         valueLabel->setText(QString("%1").arg(round(displayValue)));
@@ -593,7 +654,7 @@ void DialWindow::seriesChanged()
     case RealtimeData::FeO2:
         foreground = GColor(CFEO2);
         break;
-            
+
     case RealtimeData::Distance:
     case RealtimeData::RouteDistance:
     case RealtimeData::DistanceRemaining:
@@ -626,10 +687,10 @@ void DialWindow::seriesChanged()
         foreground = GColor(CTIDALVOLUME);
         break;
 
-    case RealtimeData::Slope:  
+    case RealtimeData::Slope:
         foreground = GColor(CSLOPE);
         break;
-            
+
     case RealtimeData::Load:
         foreground = GColor(CLOAD);
         break;
@@ -655,7 +716,6 @@ void DialWindow::seriesChanged()
     case RealtimeData::VirtualSpeed:
     case RealtimeData::AvgSpeed:
     case RealtimeData::AvgSpeedLap:
-    case RealtimeData::CoreTemp:
             foreground = GColor(CSPEED);
             break;
 
@@ -718,6 +778,19 @@ void DialWindow::seriesChanged()
 
     case RealtimeData::Altitude:
            foreground = GColor(CALTITUDE);
+           break;
+
+    case RealtimeData::CoreTemp:
+           foreground = GColor(CCORETEMP);
+           break;
+    case RealtimeData::SkinTemp:
+           foreground = GColor(CSKINTEMP);
+           break;
+    case RealtimeData::HeatStrain:
+           foreground = GColor(CHEATSTRAIN);
+           break;
+    case RealtimeData::HeatLoad:
+           foreground = GColor(CHEATLOAD);
            break;
     }
 

--- a/src/Train/DialWindow.h
+++ b/src/Train/DialWindow.h
@@ -129,6 +129,13 @@ class DialWindow : public GcChartWindow
         // used by XPower algorithm
         double rsum, ewma;
 
+        //heat load estimate (don't reset in resetValues, but preserve between sessions, and reset when local date changes)
+        //note: each athelete has it's own set of DialWindows if more than one athlete is loaded at the same time
+        double heatLoad;
+        qint64 heatLoadMSec;
+        QDateTime heatLoadLocalDate;
+        bool isRunning = false;
+
         void resetValues() {
 
             rolling.fill(0.00);

--- a/src/Train/NullController.cpp
+++ b/src/Train/NullController.cpp
@@ -24,15 +24,28 @@
 #include "RealtimeData.h"
 #include "PhysicsUtility.h"
 
+#define CORE_START 37.5
+#define CORE_UPPER_LIMIT 40.0
+#define CORE_LOWER_LIMIT 35.0
+
+#define SKIN_START 35.0
+#define SKIN_UPPER_LIMIT 40.0
+#define SKIN_LOWER_LIMIT 30.0
+
+#define HSI_START 2.0
+#define HSI_UPPER_LIMIT 5.0
+#define HSI_LOWER_LIMIT 0
+
+
 NullController::NullController(TrainSidebar *parent,
                                DeviceConfiguration *dc)
   : RealtimeController(parent, dc), parent(parent), load(100),
     bicycle(NULL)
 {
-  //set values before start as heat 
-  this->core = 37.5;
-  this->skin = 37.0;
-  this->heatStrain = 2.0;  
+  //set values before start as heat
+  core = 37.5;
+  skin = 37.0;
+  heatStrain = 2.0;
 }
 
 int NullController::start() {
@@ -79,24 +92,24 @@ void NullController::getRealtimeData(RealtimeData &rtData) {
     rtData.setHr(145 + ((rand()%3)-2));
     rtData.setHb(35 + ((rand()%30)), 11 + (double(rand()%100) * 0.01f));
 
-    rtData.setCoreTemp(this->core, this->skin, this->heatStrain);
+    rtData.setCoreTemp(core, skin, heatStrain);
 
     //randomize robot temp for testing
-    this->core += ((rand()%4) - 2) /10.0;
-    if(this->core < 37)
-      this->core = 37.5;
-    if(this->core > 40)
-      this->core = 39.5;
-    this->skin += ((rand()%4) - 2) /10.0;
-    if(this->skin < 37)
-      this->skin = 37.5;
-    if(this->skin > 40)
-      this->skin = 39.5;
-    this->heatStrain += ((rand()%2) - 1) /10.0;
-    if(this->heatStrain < 1)
-      this->heatStrain = 1.5;
-    if(this->heatStrain > 5)
-      this->heatStrain = 4.5;
+    core += ((rand()%5) - 2) /10.0;
+    if(core < CORE_LOWER_LIMIT)
+      core = CORE_START;
+    if(core > CORE_UPPER_LIMIT)
+      core = CORE_START;
+    skin += ((rand()%5) - 2) /10.0;
+    if(skin < SKIN_LOWER_LIMIT)
+      skin = SKIN_START;
+    if(skin > SKIN_UPPER_LIMIT)
+      skin = SKIN_START;
+    heatStrain += ((rand()%3) - 1) /10.0;
+    if(heatStrain < HSI_LOWER_LIMIT)
+      heatStrain = HSI_START;
+    if(heatStrain > HSI_UPPER_LIMIT)
+      heatStrain = HSI_START;
 
     processRealtimeData(rtData); // for testing virtual power etc
 

--- a/src/Train/NullController.cpp
+++ b/src/Train/NullController.cpp
@@ -29,6 +29,10 @@ NullController::NullController(TrainSidebar *parent,
   : RealtimeController(parent, dc), parent(parent), load(100),
     bicycle(NULL)
 {
+  //set values before start as heat 
+  this->core = 37.5;
+  this->skin = 37.0;
+  this->heatStrain = 2.0;  
 }
 
 int NullController::start() {
@@ -74,6 +78,26 @@ void NullController::getRealtimeData(RealtimeData &rtData) {
     rtData.setCadence(85 + ((rand()%10)-5));
     rtData.setHr(145 + ((rand()%3)-2));
     rtData.setHb(35 + ((rand()%30)), 11 + (double(rand()%100) * 0.01f));
+
+    rtData.setCoreTemp(this->core, this->skin, this->heatStrain);
+
+    //randomize robot temp for testing
+    this->core += ((rand()%4) - 2) /10.0;
+    if(this->core < 37)
+      this->core = 37.5;
+    if(this->core > 40)
+      this->core = 39.5;
+    this->skin += ((rand()%4) - 2) /10.0;
+    if(this->skin < 37)
+      this->skin = 37.5;
+    if(this->skin > 40)
+      this->skin = 39.5;
+    this->heatStrain += ((rand()%2) - 1) /10.0;
+    if(this->heatStrain < 1)
+      this->heatStrain = 1.5;
+    if(this->heatStrain > 5)
+      this->heatStrain = 4.5;
+
     processRealtimeData(rtData); // for testing virtual power etc
 
     // generate an R-R data signal based upon 60bpm +/- 2bpm

--- a/src/Train/NullController.h
+++ b/src/Train/NullController.h
@@ -71,7 +71,8 @@ class NullController : public RealtimeController
 
         double load;
         int beats,count; // send an R-R signal every 4th call
-
+        double core, skin, heatStrain;
+        
         Bicycle bicycle;
 };
 

--- a/src/Train/RealtimeData.cpp
+++ b/src/Train/RealtimeData.cpp
@@ -175,9 +175,9 @@ void RealtimeData::setRPS(double x)
 
 //Skin temp passed but not used elsewhere
 void RealtimeData::setCoreTemp(double core, double skin, double heatStrain) {
-  this->coreTemp = core;
-  this->skinTemp = skin;
-  this->heatStrain = heatStrain;
+    this->coreTemp = core;
+    this->skinTemp = skin;
+    this->heatStrain = heatStrain;
 }
 
 const char *
@@ -536,6 +536,10 @@ double RealtimeData::value(DataSeries series) const
 
     case CoreTemp: return coreTemp;
         break;
+    case SkinTemp: return skinTemp;
+        break;
+    case HeatStrain: return heatStrain;
+        break;
 
     case None:
     default:
@@ -611,6 +615,9 @@ const QList<RealtimeData::DataSeries> &RealtimeData::listDataSeries()
         seriesList << DistanceRemaining;
         seriesList << Temp;
         seriesList << CoreTemp;
+        seriesList << SkinTemp;
+        seriesList << HeatStrain;
+        seriesList << HeatLoad;
     }
     return seriesList;
 }
@@ -803,7 +810,13 @@ QString RealtimeData::seriesName(DataSeries series)
     case Temp: return tr("Temperature");
         break;
 
-    case CoreTemp: return tr("CoreTemp");
+    case CoreTemp: return tr("Core Temp");
+        break;
+    case SkinTemp: return tr("Skin Temp");
+        break;
+    case HeatStrain: return tr("Heat Strain");
+        break;
+    case HeatLoad: return tr("Estimated Heat Load");
         break;
     }
 }

--- a/src/Train/RealtimeData.h
+++ b/src/Train/RealtimeData.h
@@ -56,7 +56,7 @@ public:
                       RightPowerPhasePeakBegin, RightPowerPhasePeakEnd,
                       Position, RightPCO, LeftPCO,
                       Temp,
-                      CoreTemp, SkinTemp, HeatStrain
+                      CoreTemp, SkinTemp, HeatStrain, HeatLoad
                     };
 
     typedef enum dataseries DataSeries;

--- a/src/Train/WorkoutWidget.cpp
+++ b/src/Train/WorkoutWidget.cpp
@@ -179,11 +179,12 @@ WorkoutWidget::start()
     vo2Avg.clear();
     ventilation.clear();
     ventilationAvg.clear();
-    ctemp.clear(); 
-    stemp.clear(); 
-    hsi.clear(); 
+    ctemp.clear();
+    stemp.clear();
+    hsi.clear();
     // and resampling data
     count = wbalSum = wattsSum = hrSum = speedSum = cadenceSum = vo2Sum = ventilationSum = 0;
+    ctempSum = stempSum = hsiSum = 0;
 
     // set initial
     cadenceMax = 200;
@@ -275,7 +276,7 @@ WorkoutWidget::telemetryUpdate(RealtimeData rt)
         if(st_headroom > stempMax) stempMax = st_headroom;
         double hi_headroom = hi * 1.05;
         if(hi_headroom > hsiMax) hsiMax = hi_headroom;
-        
+
         // Do we need to increase plot x-axis max? (add 15 min at a time)
         if (cadence.size() > maxVX_) setMaxVX(maxVX_ + 900);
 
@@ -2595,7 +2596,7 @@ WorkoutWidget::transform(double seconds, double watts, WwSeriesType s)
         }
         break;
     //scale the hight of the line for core temp , which has base subtracted
-    case CORETEMP: 
+    case CORETEMP:
         yratio = double(c.height()) / double(ctempMax);
         break;
     case SKINTEMP:

--- a/src/Train/WorkoutWidget.h
+++ b/src/Train/WorkoutWidget.h
@@ -137,6 +137,9 @@ class WorkoutWidget : public QWidget
         QList<int> vo2; // 1s samples [ml/min]
         QList<int> ventilation; // 1s samples [l/min]
         QList<double> hrAvg, pwrAvg, cadenceAvg, vo2Avg, ventilationAvg, speedAvg; // averages
+		QList<double> ctemp;
+		QList<double> stemp;
+		QList<double> hsi;
 
         // interaction state;
         // none - initial state
@@ -146,7 +149,7 @@ class WorkoutWidget : public QWidget
         // create - clicked to create
         enum { none, create, drag, dragblock, rect } state;
 
-        enum wwseriestype { CADENCE, HEARTRATE, POWER, SPEED, WBAL, VO2, VENTILATION };
+        enum wwseriestype { CADENCE, HEARTRATE, POWER, SPEED, WBAL, VO2, VENTILATION, CORETEMP, SKINTEMP, HSI };
         typedef enum wwseriestype WwSeriesType;
 
         // adding items and points
@@ -310,6 +313,9 @@ class WorkoutWidget : public QWidget
         bool shouldPlotVo2();
         bool shouldPlotVentilation();
         bool shouldPlotSpeed();
+        bool shouldPlotCoreTemp();
+        bool shouldPlotSkinTemp();
+        bool shouldPlotHSI();
 
         int hrPlotAvgLength();
         int pwrPlotAvgLength();
@@ -416,6 +422,9 @@ class WorkoutWidget : public QWidget
         double speedMax;
         int vo2Max;
         int ventilationMax;
+		double ctempMax;
+		double stempMax;
+		double hsiMax;
 
         // resampling when recording
         double wbalSum;
@@ -425,6 +434,9 @@ class WorkoutWidget : public QWidget
         double hrSum;
         double vo2Sum;
         double ventilationSum;
+        double ctempSum; 
+        double stempSum;
+        double hsiSum; 
         int count;
 };
 

--- a/src/Train/WorkoutWidgetItems.cpp
+++ b/src/Train/WorkoutWidgetItems.cpp
@@ -370,6 +370,19 @@ WWTelemetry::paint(QPainter *painter)
     // only when recording
     if (!workoutWidget()->recording()) return;
 
+    if (workoutWidget()->shouldPlotSkinTemp())
+    {
+        paintSampleList(painter, GColor(CSKINTEMP), workoutWidget()->stemp, WorkoutWidget::SKINTEMP);
+    }
+    if (workoutWidget()->shouldPlotCoreTemp())
+    {
+        paintSampleList(painter, GColor(CCORETEMP), workoutWidget()->ctemp, WorkoutWidget::CORETEMP);
+    }
+    if (workoutWidget()->shouldPlotHSI())
+    {
+        paintSampleList(painter, GColor(CHEATSTRAIN), workoutWidget()->hsi, WorkoutWidget::HSI);
+    }
+
     // Draw POWER
     if (workoutWidget()->shouldPlotPwr())
     {

--- a/src/Train/WorkoutWindow.cpp
+++ b/src/Train/WorkoutWindow.cpp
@@ -52,6 +52,9 @@ WorkoutWindow::WorkoutWindow(Context *context) :
     plotVo2CB = new QCheckBox();
     plotVentilationCB = new QCheckBox();
     plotSpeedCB = new QCheckBox();
+    plotCoreTempCB = new QCheckBox();
+    plotSkinTempCB = new QCheckBox();
+    plotHSICB = new QCheckBox();
 
     plotHrSB = new QSpinBox(); plotHrSB->setMinimum(1);
     plotPwrSB = new QSpinBox(); plotPwrSB->setMinimum(1);
@@ -111,8 +114,15 @@ WorkoutWindow::WorkoutWindow(Context *context) :
 
     gridLayout->addWidget(new QLabel(tr("Show WBal")),row,0);
     gridLayout->addWidget(plotWbalCB,row++,1);
-    gridLayout->addItem(new QSpacerItem(1,1,QSizePolicy::Preferred,QSizePolicy::Expanding),row,0);
 
+    gridLayout->addWidget(new QLabel(tr("Show Core Temp")),row,0);
+    gridLayout->addWidget(plotCoreTempCB,row++,1);
+    gridLayout->addWidget(new QLabel(tr("Show Skin Temp")),row,0);
+    gridLayout->addWidget(plotSkinTempCB,row++,1);
+    gridLayout->addWidget(new QLabel(tr("Show Heat Strain Index")),row,0);
+    gridLayout->addWidget(plotHSICB,row++,1);
+
+    gridLayout->addItem(new QSpacerItem(1,1,QSizePolicy::Preferred,QSizePolicy::Expanding),row,0);
 
     setControls(settingsWidget);
     ergFile = NULL;
@@ -702,6 +712,18 @@ void WorkoutWindow::setShouldPlotVentilation(bool value)
 void WorkoutWindow::setShouldPlotSpeed(bool value)
 {
     plotSpeedCB->setChecked(value);
+}
+void WorkoutWindow::setShouldPlotCoreTemp(bool value)
+{
+    plotCoreTempCB->setChecked(value);
+}
+void WorkoutWindow::setShouldPlotSkinTemp(bool value)
+{
+    plotSkinTempCB->setChecked(value);
+}
+void WorkoutWindow::setShouldPlotHSI(bool value)
+{
+    plotHSICB->setChecked(value);
 }
 
 int WorkoutWindow::hrPlotAvgLength()

--- a/src/Train/WorkoutWindow.h
+++ b/src/Train/WorkoutWindow.h
@@ -70,6 +70,10 @@ class WorkoutWindow : public GcChartWindow
     Q_PROPERTY(bool plotVentilation READ shouldPlotVentilation WRITE setShouldPlotVentilation USER true)
     Q_PROPERTY(bool plotSpeed READ shouldPlotSpeed WRITE setShouldPlotSpeed USER true)
 
+    Q_PROPERTY(bool plotCoreTemp READ shouldPlotCoreTemp WRITE setShouldPlotCoreTemp USER true)
+    Q_PROPERTY(bool plotSkinTemp READ shouldPlotSkinTemp WRITE setShouldPlotSkinTemp USER true)
+    Q_PROPERTY(bool plotHSI READ shouldPlotHSI WRITE setShouldPlotHSI USER true)
+    
     Q_PROPERTY(int hrPlotAvgLength READ hrPlotAvgLength WRITE setPlotHrAvgLength USER true)
     Q_PROPERTY(int pwrPlotAvgLength READ pwrPlotAvgLength WRITE setPlotPwrAvgLength USER true)
     Q_PROPERTY(int cadencePlotAvgLength READ cadencePlotAvgLength WRITE setPlotCadenceAvgLength USER true)
@@ -158,6 +162,10 @@ class WorkoutWindow : public GcChartWindow
         void setShouldPlotVentilation(bool);
         void setShouldPlotSpeed(bool);
 
+        void setShouldPlotCoreTemp(bool);
+        void setShouldPlotSkinTemp(bool);
+        void setShouldPlotHSI(bool);
+
         void setPlotHrAvgLength(int);
         void setPlotPwrAvgLength(int);
         void setPlotCadenceAvgLength(int);
@@ -173,7 +181,9 @@ class WorkoutWindow : public GcChartWindow
         bool shouldPlotVo2() { return plotVo2CB->checkState() != Qt::Unchecked;}
         bool shouldPlotVentilation() { return plotVentilationCB->checkState() != Qt::Unchecked;}
         bool shouldPlotSpeed() { return plotSpeedCB->checkState() != Qt::Unchecked;}
-
+        bool shouldPlotCoreTemp() { return plotCoreTempCB->checkState() != Qt::Unchecked;}
+        bool shouldPlotSkinTemp() { return plotSkinTempCB->checkState() != Qt::Unchecked;}
+        bool shouldPlotHSI() { return plotHSICB->checkState() != Qt::Unchecked;}
         int hrPlotAvgLength();
         int pwrPlotAvgLength();
         int cadencePlotAvgLength();
@@ -192,6 +202,7 @@ class WorkoutWindow : public GcChartWindow
         WorkoutWidget *workout; // will become editor.
         QScrollBar *scroll;     // for controlling the position
         QCheckBox *plotHrCB, *plotPwrCB, *plotCadenceCB, *plotWbalCB, *plotVo2CB, *plotVentilationCB, *plotSpeedCB;
+        QCheckBox *plotCoreTempCB, *plotSkinTempCB, *plotHSICB;
         QSpinBox *plotHrSB, *plotPwrSB, *plotCadenceSB, *plotVo2SB, *plotVentilationSB, *plotSpeedSB;
 
         WWPowerScale *powerscale;


### PR DESCRIPTION
This is to resolve the issue "Improve support for CORE sensor #4665"

- Add dial window (telemetry chart) for skin temp, heat strain index, and estimated heat load
- Calculate an estimate of heat load. This is different from the propitiatory CORE calculation, but seems good enough to give a useful indication. Heat load resets at midnight local time. (An option to input a starting value for heat load would be a follow on update.)
- Add option to plot skin temperature and heat strain index
- Modify robot to give random values for core temp, skin temp, and HSI for testing.
- 