### PR TITLE
Add the .qtc_clangd folder to git ignored list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,9 @@ doc/doxygen/html
 # qt creator builds
 build-src*
 
+# It contains cache and index files for Clangd, the language server that Qt Creator uses to provide advanced C++ code editing features
+.qtc_clangd/
+
 qwt/src/debug/
 qwt/src/release/
 src/Makefile.Debug


### PR DESCRIPTION
### What is the `.qtc_clangd` folder?
This folder is created and managed by the **Qt Creator** IDE. It contains cache and index files for **Clangd**, the language server that Qt Creator uses to provide advanced C++ code editing features, such as:
  * Code completion
  * Real-time error checking (diagnostics)
  * Syntax highlighting
  * Go-to-definition functionality

Essentially, it's a folder of temporary, auto-generated data that helps the IDE understand the code quickly without having to re-parse it constantly.

### Why it should be ignored?
Because its contents are:
  * **User-Specific:** The files contain local paths and information specific to your machine and your Qt Creator setup.
  * **Auto-Generated:** The folder and its contents are generated automatically by the IDE. If another developer clones the project, their Qt Creator will generate its own version.
  * **Unnecessary for the Build:** The code will compile and run perfectly without this folder. It only serves the IDE's code intelligence features.