### PR TITLE
Add the override classifier for some overridden functions

### DIFF
--- a/src/Charts/GoldenCheetah.h
+++ b/src/Charts/GoldenCheetah.h
@@ -220,7 +220,7 @@ public:
     bool operator< (GcWindow right) const { return geometry().x() < right.geometry().x(); }
 
     // we paint a heading if there is space in the top margin
-    void paintEvent (QPaintEvent * event);
+    void paintEvent (QPaintEvent * event) override;
 
     // mouse actions -- resizing and dragging tiles
     //bool eventFilter(QObject *object, QEvent *e);

--- a/src/Charts/OverviewItems.h
+++ b/src/Charts/OverviewItems.h
@@ -252,14 +252,14 @@ class MetricOverviewItem : public ChartSpaceItem
         MetricOverviewItem(ChartSpace *parent, QString name, QString symbol);
         ~MetricOverviewItem();
 
-        void itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget *);
-        void itemGeometryChanged();
-        void setData(RideItem *item);
-        void setDateRange(DateRange);
+        void itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget *) override;
+        void itemGeometryChanged() override;
+        void setData(RideItem *item) override;
+        void setDateRange(DateRange) override;
 
         virtual void displayTileEditMenu(const QPoint& pos) override;
 
-        QWidget *config() { return configwidget; }
+        QWidget *config() override { return configwidget; }
 
         // create and config
         static ChartSpaceItem *create(ChartSpace *parent) { return new MetricOverviewItem(parent, "PowerIndex", "power_index"); }

--- a/src/Gui/AbstractView.h
+++ b/src/Gui/AbstractView.h
@@ -230,7 +230,7 @@ public:
 protected:
     double fh() { QFontMetrics fm(baseFont); return fm.height(); }
     double spacer() { return (2 * dpiYFactor); }
-    QSplitterHandle *createHandle() {
+    QSplitterHandle *createHandle() override {
         if (this->tabView)
         {
             if (this->tabView->viewType() == VIEW_TRAIN)

--- a/src/Gui/Perspective.h
+++ b/src/Gui/Perspective.h
@@ -112,12 +112,12 @@ class Perspective : public GcWindow
         void tabSelected(int id, bool forride);
         void tabMoved(int from, int to);
         void tabMenu(int index, int x);
-        virtual void dragEnterEvent(QDragEnterEvent *);
-        virtual void dropEvent(QDropEvent *);
-        void resizeEvent(QResizeEvent *);
+        virtual void dragEnterEvent(QDragEnterEvent *) override;
+        virtual void dropEvent(QDropEvent *) override;
+        void resizeEvent(QResizeEvent *) override;
         void resize();
-        void showEvent(QShowEvent *);
-        bool eventFilter(QObject *object, QEvent *e);
+        void showEvent(QShowEvent *) override;
+        bool eventFilter(QObject *object, QEvent *e) override;
 
         // My widget signals and events
         void styleChanged(int, bool force=false);


### PR DESCRIPTION
To fix the `inconsistent-missing-override` compilation warning:
> "'xxx' overrides a member function but is not marked 'override'".