### PR TITLE
Fix warnings about override and fields initialization order

### DIFF
--- a/src/Charts/Overview.cpp
+++ b/src/Charts/Overview.cpp
@@ -570,7 +570,7 @@ badconfig:
 //
 // Config dialog that pops up when you click on the config button
 //
-OverviewConfigDialog::OverviewConfigDialog(ChartSpaceItem*item, QPoint pos) : QDialog(NULL), item(item), pos(pos)
+OverviewConfigDialog::OverviewConfigDialog(ChartSpaceItem*item, QPoint pos) : QDialog(NULL), pos(pos), item(item)
 {
     if (item->type == OverviewItemType::USERCHART) setWindowTitle(tr("Chart Settings"));
     else setWindowTitle(tr("Tile Settings"));

--- a/src/Train/VideoWindow.cpp
+++ b/src/Train/VideoWindow.cpp
@@ -41,7 +41,7 @@ public:
 };
 
 VideoWindow::VideoWindow(Context *context)  :
-    GcChartWindow(context), context(context), m_MediaChanged(false), layoutSelector(NULL), container(nullptr)
+    GcChartWindow(context), context(context), m_MediaChanged(false), container(nullptr), layoutSelector(NULL)
 {
     HelpWhatsThis *helpContents = new HelpWhatsThis(this);
     this->setWhatsThis(helpContents->getWhatsThisText(HelpWhatsThis::ChartTrain_VideoPlayer));

--- a/src/Train/VideoWindow.h
+++ b/src/Train/VideoWindow.h
@@ -273,7 +273,7 @@ class VideoWindow : public GcChartWindow
         void showEvent(QShowEvent *event) override;
         void hideEvent(QHideEvent *event) override;
 
-        void resizeEvent(QResizeEvent *);
+        void resizeEvent(QResizeEvent *) override;
 
         // media data
 


### PR DESCRIPTION
### What
- Fixes compiler warnings related to the order of member initialization in constructor initializer lists. The order of initialization is now aligned with the order those fields are declared in their corresponding header files, preventing warnings about fields being initialized out of order.
- A member function was explicitly marked with override to clarify that it overrides a base class method, which resolves another common compiler warning.
 
No logic or functional behavior of the application was changed; only warning cleanups were performed.
