### PR TITLE
Fix warnings: unused variable and diff types for print function

### DIFF
--- a/src/ANT/ANTMessage.cpp
+++ b/src/ANT/ANTMessage.cpp
@@ -577,8 +577,8 @@ ANTMessage::ANTMessage(ANT *parent, const unsigned char *message) {
 
                 case POWER_MANUFACTURER_ID:
                 {
-                    uint16_t manuf_id = (message[8] + (static_cast<uint16_t>(message[9])<<8));
-                    uint16_t product_id = (message[10] + (static_cast<uint16_t>(message[11])<<8));
+                    // uint16_t manuf_id = (message[8] + (static_cast<uint16_t>(message[9])<<8));
+                    // uint16_t product_id = (message[10] + (static_cast<uint16_t>(message[11])<<8));
                     // qDebug()<<channel<<"Received power sensor info: Manufacturer id:" << manuf_id << ", Product id:" << product_id;
                     break;
                 }

--- a/src/Charts/GenericSelectTool.cpp
+++ b/src/Charts/GenericSelectTool.cpp
@@ -504,7 +504,7 @@ GenericSelectTool::released(QPointF pos)
             if (yseries) {
 
                 // convert value to series value
-                QPointF v = host->qchart->mapToValue(pos,yseries);
+                // QPointF v = host->qchart->mapToValue(pos,yseries);
 
                 // add to chart
                 // not implemented yet, need to decide how they persist, will do in 3.7

--- a/src/Charts/OverviewItems.cpp
+++ b/src/Charts/OverviewItems.cpp
@@ -4838,13 +4838,11 @@ BubbleViz::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
     } else {
 
         // when transition is -1 we are rescaling the axes first
-        int index=0;
         foreach(BPointF point, oldpoints) {
 
             if (point.x < minx || point.x > maxx ||
                 point.y < miny || point.y > maxy ||
                 !std::isfinite(point.z) || std::isnan(point.z)) {
-                index++;
                 continue;
             }
 
@@ -4863,8 +4861,6 @@ BubbleViz::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
 
             double radius = sqrt(size/3.1415927f);
             painter->drawEllipse(center, radius, radius);
-
-            index++;
         }
 
     }
@@ -5176,7 +5172,6 @@ Routeline::setData(RideItem *item)
     int div = item->ride()->dataPoints().count() / ROUTEPOINTS;
     int count=0;
     height = geom.width() * aspectratio;
-    int lines=0;
     foreach(RideFilePoint *p, item->ride()->dataPoints()){
 
         // ignore zero values and out of bounds
@@ -5201,7 +5196,6 @@ Routeline::setData(RideItem *item)
             path.lineTo((geom.width() / (xdiff / (p->lon - minlon))),
                         (height-(height / (ydiff / (mercator_projection(p->lat) - minlat)))));
             count=div;
-            lines++;
 
         }
     }

--- a/src/Charts/PfPvPlot.cpp
+++ b/src/Charts/PfPvPlot.cpp
@@ -798,7 +798,6 @@ PfPvPlot::showIntervals(RideItem *_rideItem)
        if (frameIntervals()==false && num_intervals) mainCurvesSetVisible(false);
        QVector<std::set<std::pair<double, double> > > dataSetInterval(num_intervals);
 
-       long tot_cad = 0;
        long tot_cad_points = 0;
 
         foreach(const RideFilePoint *p1, ride->dataPoints()) {
@@ -829,7 +828,6 @@ PfPvPlot::showIntervals(RideItem *_rideItem)
                         }
                     }
                 }
-                tot_cad += p1->cad;
                 tot_cad_points++;
             }
         }
@@ -1333,7 +1331,6 @@ PfPvPlot::showCompareIntervals()
     recalcCompare();
 
     QVector<std::set<std::pair<double, double> > > dataSetInterval(num_intervals);
-    long tot_cad = 0;
     long tot_cad_points = 0;
 
     // prepare aggregates
@@ -1360,7 +1357,6 @@ PfPvPlot::showCompareIntervals()
 #else
                         dataSetInterval[high].insert(std::MAKEPAIR<double, double>(aepf, cpv));
 #endif
-                    tot_cad += p1->cad;
                     tot_cad_points++;
                 }
             }

--- a/src/Cloud/CyclingAnalytics.cpp
+++ b/src/Cloud/CyclingAnalytics.cpp
@@ -402,7 +402,6 @@ CyclingAnalytics::readFileCompleted()
             add.secs = index;
 
             // move through tracks if they're waiting for this point
-            bool updated=false;
             for(int t=0; t<data.count(); t++) {
 
                // hr, distance et al

--- a/src/Cloud/CyclingAnalytics.cpp
+++ b/src/Cloud/CyclingAnalytics.cpp
@@ -246,7 +246,7 @@ CyclingAnalytics::readdir(QString path, QStringList &errors, QDateTime, QDateTim
 
 
     // all good ?
-    printd("returning count(%d), errors(%s)\n", returning.count(), errors.join(",").toStdString().c_str());
+    printd("returning count(%lld), errors(%s)\n", returning.count(), errors.join(",").toStdString().c_str());
     return returning;
 }
 

--- a/src/Cloud/OpenData.cpp
+++ b/src/Cloud/OpenData.cpp
@@ -278,7 +278,7 @@ OpenData::run()
     postingdata = zip.readAll();
     zip.close();
 
-    printd("Compressed to %s, size %d\n", zipFile.fileName().toStdString().c_str(), postingdata.size());
+    printd("Compressed to %s, size %lld\n", zipFile.fileName().toStdString().c_str(), postingdata.size());
 
     // ----------------------------------------------------------------
     // STEP FOUR: Sending data to server

--- a/src/Cloud/SixCycle.cpp
+++ b/src/Cloud/SixCycle.cpp
@@ -258,7 +258,7 @@ SixCycle::readdir(QString path, QStringList &errors, QDateTime from, QDateTime t
         // results ?
         QJsonArray results = document.array();
 
-        printd("items found: %d\n", results.size());
+        printd("items found: %lld\n", results.size());
 
         // lets look at that then
         for(int i=0; i<results.size(); i++) {

--- a/src/Cloud/SportTracks.cpp
+++ b/src/Cloud/SportTracks.cpp
@@ -246,7 +246,7 @@ SportTracks::readdir(QString path, QStringList &errors, QDateTime, QDateTime)
     }
 
     // all good ?
-    printd("returning count(%d), errors(%s)\n", returning.count(), errors.join(",").toStdString().c_str());
+    printd("returning count(%lld), errors(%s)\n", returning.count(), errors.join(",").toStdString().c_str());
     return returning;
 }
 

--- a/src/Cloud/Strava.cpp
+++ b/src/Cloud/Strava.cpp
@@ -770,8 +770,6 @@ Strava:: fixSmartRecording(RideFile* ret)
 
     // OK, so there are probably some gaps, lets post process them
     RideFilePoint *last = NULL;
-    int dropouts = 0;
-    double dropouttime = 0.0;
 
     for (int position = 0; position < ret->dataPoints().count(); position++) {
         RideFilePoint *point = ret->dataPoints()[position];
@@ -785,11 +783,6 @@ Strava:: fixSmartRecording(RideFile* ret)
 
             // moved for less than GarminHWM seconds ... interpolate
             if (!stationary && gap >= 1 && gap <= GarminHWM.toInt()) {
-
-                // what's needed?
-                dropouts++;
-                dropouttime += gap;
-
                 int count = gap/ret->recIntSecs();
                 double hrdelta = (point->hr - last->hr) / (double) count;
                 double pwrdelta = (point->watts - last->watts) / (double) count;

--- a/src/Cloud/Xert.cpp
+++ b/src/Cloud/Xert.cpp
@@ -258,7 +258,7 @@ Xert::readdir(QString path, QStringList &errors, QDateTime from, QDateTime to)
     }
 
     // all good ?
-    printd("returning count(%d), errors(%s)\n", returning.count(), errors.join(",").toStdString().c_str());
+    printd("returning count(%lld), errors(%s)\n", returning.count(), errors.join(",").toStdString().c_str());
     return returning;
 }
 


### PR DESCRIPTION
### What
- Removed or commented the local variables that never used.
- Reused `%lld` to print long long integer.

### Why
To fix the compilation warnings like:
- `variable '***' set but not used`
- `unused variable '***'`
- `format specifies type 'int' but the argument has type 'qsizetype'`