### PR TITLE
Metric override icon incorrectly displayed in Trends Overview

### DIFF
--- a/src/Charts/OverviewItems.cpp
+++ b/src/Charts/OverviewItems.cpp
@@ -850,8 +850,10 @@ MetricOverviewItem::configChanged(qint32) {
     RideMetricFactory& factory = RideMetricFactory::instance();
     metric = factory.rideMetric(symbol);
 
-    // Only display the override option for metrics that exist.
-    setShowEdit(metric != nullptr);
+    // Only display the override option for metrics that exist, and those related to specific activities.
+    // It doesn't make sense to overide metrics related to multiple activities, date ranges and/or filters.
+    setShowEdit((metric != nullptr) && (parent->scope == OverviewScope::ANALYSIS));
+
     units = (metric) ? metric->units(GlobalContext::context()->useMetricUnits) : "";
 
     // Update the value and override status


### PR DESCRIPTION
The Metric tile's override icon is incorrectly displayed in Trends Overview, clicking the pencil icon on a Trends Metric Tile doesn't display the metric override menu (correctly I think), so in this case the pencil edit icon should be hidden. It doesn't make sense to override metrics whose displayed value is based upon date ranges and/or activity filters.