### PR TITLE
Update field type definitions to use an enum class

### DIFF
--- a/src/Charts/LTMTool.cpp
+++ b/src/Charts/LTMTool.cpp
@@ -216,7 +216,7 @@ LTMTool::LTMTool(Context *context, LTMSettings *settings) : QWidget(context->mai
 
     // metadata metrics
     foreach (FieldDefinition field, GlobalContext::context()->rideMetadata->getFields()) {
-        if (!sp.isMetric(field.name) && (field.type == 3 || field.type == 4)) {
+        if (!sp.isMetric(field.name) && (field.type == GcFieldType::FIELD_INTEGER || field.type == GcFieldType::FIELD_DOUBLE)) {
             MetricDetail metametric;
             metametric.type = METRIC_META;
             QString underscored = field.name;

--- a/src/Charts/OverviewItems.cpp
+++ b/src/Charts/OverviewItems.cpp
@@ -958,7 +958,7 @@ MetaOverviewItem::configChanged(qint32)
     SpecialFields& sp = SpecialFields::getInstance();
 
     //  Get the field type
-    fieldtype = -1;
+    fieldtype = GcFieldType::NO_FIELD_SET;
     foreach(FieldDefinition p, GlobalContext::context()->rideMetadata->getFields()) {
         if (p.name == symbol) {
             fieldtype = p.type;
@@ -975,7 +975,7 @@ MetaOverviewItem::configChanged(qint32)
     value = rideItem ? rideItem->getText(symbol, "") : "";
 
     // sparkline if are we numeric?
-    if (fieldtype == FIELD_INTEGER || fieldtype == FIELD_DOUBLE) {
+    if (fieldtype == GcFieldType::FIELD_INTEGER || fieldtype == GcFieldType::FIELD_DOUBLE) {
         if (sparkline == NULL) sparkline = new Sparkline(this, name);
     } else {
         if (sparkline) {
@@ -1849,7 +1849,7 @@ MetaOverviewItem::setData(RideItem *item)
 
         // get the metadata value
         value = item->getText(symbol, "0");
-        if (fieldtype == FIELD_DOUBLE) v = value.toDouble();
+        if (fieldtype == GcFieldType::FIELD_DOUBLE) v = value.toDouble();
         else v = value.toInt();
         if (std::isinf(v) || std::isnan(v)) v=0;
         points << QPointF(SPARKDAYS, v);
@@ -1875,7 +1875,7 @@ MetaOverviewItem::setData(RideItem *item)
 
                 double v;
 
-                if (fieldtype == FIELD_DOUBLE)  v = prior->getText(symbol, "").toDouble();
+                if (fieldtype == GcFieldType::FIELD_DOUBLE)  v = prior->getText(symbol, "").toDouble();
                 else v = prior->getText(symbol, "").toInt();
 
                 if (std::isinf(v) || std::isnan(v)) v=0;
@@ -3576,7 +3576,7 @@ TopNOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *,
 void
 MetaOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget *) {
 
-    if (!sparkline && fieldtype >= 0) { // textual metadata field
+    if (!sparkline && fieldtype != GcFieldType::NO_FIELD_SET) { // textual metadata field
 
         // mid is slightly higher to account for space around title, move mid up
         double mid = (ROWHEIGHT*1.5f) + ((geometry().height() - (ROWHEIGHT*2)) / 2.0f);
@@ -3584,7 +3584,7 @@ MetaOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *,
         // we align centre and mid
         QFontMetrics fm(parent->bigfont);
 
-        if (fieldtype == FIELD_TEXTBOX) {
+        if (fieldtype == GcFieldType::FIELD_TEXTBOX) {
             // long texts need to be formatted into a smaller font an word wrapped
             painter->setPen(QColor(150,150,150));
             painter->setFont(parent->smallfont);
@@ -3601,10 +3601,10 @@ MetaOverviewItem::itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *,
             painter->setFont(parent->bigfont);
 
             QString displayValue(value);
-            if ((fieldtype == FIELD_DATE) && (symbol == "Start Date")) {
+            if ((fieldtype == GcFieldType::FIELD_DATE) && (symbol == "Start Date")) {
                 displayValue = (QDate(1900, 1, 1).addDays(value.toInt())).toString("dd/MM/yyyy");
 
-            } else if ((fieldtype == FIELD_TIME) && (symbol == "Start Time")) {
+            } else if ((fieldtype == GcFieldType::FIELD_TIME) && (symbol == "Start Time")) {
                 displayValue = (QTime(0, 0).addSecs(value.toInt())).toString("hh:mm:ss");
             }
 

--- a/src/Charts/OverviewItems.h
+++ b/src/Charts/OverviewItems.h
@@ -383,7 +383,7 @@ class MetaOverviewItem : public ChartSpaceItem
         void configChanged(qint32) override;
 
         QString symbol;
-        int fieldtype;
+        GcFieldType fieldtype;
 
         // for numeric metadata items
         bool up, showrange;

--- a/src/Charts/TreeMapWindow.cpp
+++ b/src/Charts/TreeMapWindow.cpp
@@ -328,9 +328,18 @@ void
 TreeMapWindow::addTextFields(QComboBox *combo)
 {
     combo->addItem(tr("None")); // if "None" is changed to not being first any more, adjust public methods f1,f2,setf1,setf2
-    SpecialFields& sp = SpecialFields::getInstance();;
+    SpecialFields& sp = SpecialFields::getInstance();
     foreach (FieldDefinition x, fieldDefinitions) {
-        if (x.type < 4) combo->addItem(sp.displayName(x.name));
+        switch (x.type) {
+            case GcFieldType::FIELD_TEXT:
+            case GcFieldType::FIELD_TEXTBOX:
+            case GcFieldType::FIELD_SHORTTEXT:
+            case GcFieldType::FIELD_INTEGER:
+                combo->addItem(sp.displayName(x.name));
+                break;
+            default:
+                break;
+        }
     }
 }
 

--- a/src/Cloud/AddCloudWizard.cpp
+++ b/src/Cloud/AddCloudWizard.cpp
@@ -529,7 +529,7 @@ AddSettings::AddSettings(AddCloudWizard *parent) : QWizardPage(parent), wizard(p
     foreach(FieldDefinition field, GlobalContext::context()->rideMetadata->getFields()) {
 
         // only add text fields
-        if (field.type < 3) metaCombo->addItem(field.name, QVariant(field.name));
+        if (field.isTextField()) metaCombo->addItem(field.name, QVariant(field.name));
     }
 
     folderLabel = new QLabel(tr("Folder"));

--- a/src/Core/DataFilter.cpp
+++ b/src/Core/DataFilter.cpp
@@ -3527,7 +3527,7 @@ void DataFilter::configChanged(qint32)
                 field.name = sp.internalName((field.name));
 
                 rt.lookupMap.insert(underscored.replace(" ","_"), field.name);
-                rt.lookupType.insert(underscored.replace(" ","_"), (field.type > 2)); // true if is number
+                rt.lookupType.insert(underscored.replace(" ","_"), (field.isNumericField())); // true if is number
             }
     }
 

--- a/src/Core/GcUpgrade.cpp
+++ b/src/Core/GcUpgrade.cpp
@@ -272,7 +272,7 @@ GcUpgrade::upgrade(const QDir &home)
                 FieldDefinition add;
                 add.tab = pos >= 0 ? fieldDefinitions[pos].tab : tr("Metric");
                 add.diary = false;
-                add.type = 4; // double
+                add.type = GcFieldType::FIELD_DOUBLE;
 
                 // now set pos to non-negative if needed
                 if (pos < 0) pos = 1;
@@ -443,7 +443,7 @@ GcUpgrade::upgrade(const QDir &home)
             FieldDefinition add;
             add.name = "Interval Notes";
             add.tab = "Interval";
-            add.type = FIELD_TEXTBOX;
+            add.type = GcFieldType::FIELD_TEXTBOX;
             add.interval = 1;
             fieldDefinitions << add;
 

--- a/src/Gui/BatchProcessingDialog.cpp
+++ b/src/Gui/BatchProcessingDialog.cpp
@@ -500,29 +500,29 @@ BatchProcessingDialog::updateMetadataTypeField() {
     foreach(FieldDefinition field, GlobalContext::context()->rideMetadata->getFields()) {
         if (metadataFieldToSet->currentText() == field.name) {
             switch (field.type) {
-                case FIELD_INTEGER: {
+                case GcFieldType::FIELD_INTEGER: {
                     metadataEditField->setText(tr("0"));
                     return;
                 }
-                case FIELD_DOUBLE: {
+                case GcFieldType::FIELD_DOUBLE: {
                     metadataEditField->setText(tr("0.00"));
                     return;
                 }
-                case FIELD_DATE: {
+                case GcFieldType::FIELD_DATE: {
                     metadataEditField->setText(tr("dd/mm/yyyy"));
                     return;
                 }
-                case FIELD_TIME: {
+                case GcFieldType::FIELD_TIME: {
                     metadataEditField->setText(tr("hh:mm:ss"));
                     return;
                 }
-                case FIELD_CHECKBOX: {
+                case GcFieldType::FIELD_CHECKBOX: {
                     metadataEditField->setText(tr("1|0"));
                     return;
                 }
-                case FIELD_TEXT:
-                case FIELD_TEXTBOX:
-                case FIELD_SHORTTEXT:
+                case GcFieldType::FIELD_TEXT:
+                case GcFieldType::FIELD_TEXTBOX:
+                case GcFieldType::FIELD_SHORTTEXT:
                 default: {
                     metadataEditField->setText(tr(""));
                     if (metadataCompleter) delete metadataCompleter;
@@ -781,13 +781,13 @@ BatchProcessingDialog::setMetadataForActivities() {
     foreach(FieldDefinition field, GlobalContext::context()->rideMetadata->getFields()) {
         if (metadataFieldName == field.name) {
 
-            if (field.type == FIELD_TIME) {
+            if (field.type == GcFieldType::FIELD_TIME) {
                 metadataValue.simplified().remove(' ');
                 QRegularExpression re("([0-1]?[0-9]|2[0-3]):([0-5]?[0-9]):([0-5]?[0-9])");
                 if (!re.match(metadataValue).hasMatch()) return bpFailureType::timeFormatF;
             }
 
-            if (field.type == FIELD_DATE) {
+            if (field.type == GcFieldType::FIELD_DATE) {
                 metadataValue.simplified().remove(' ');
                 QRegularExpression re("([0]?[1-9]|[1][0-9]|3[0-1])/([0]?[1-9]|[1][0-2])/([0-9]{4})");
                 if (!re.match(metadataValue).hasMatch()) return bpFailureType::dateFormatF;

--- a/src/Gui/LTMSidebar.cpp
+++ b/src/Gui/LTMSidebar.cpp
@@ -745,7 +745,7 @@ LTMSidebar::setAutoFilterMenu()
     SpecialFields& sp = SpecialFields::getInstance();
     foreach(FieldDefinition field, GlobalContext::context()->rideMetadata->getFields()) {
 
-        if (field.tab != "" && (field.type == 0 || field.type == 2)) { // we only do text or shorttext fields
+        if (field.tab != "" && (field.type == GcFieldType::FIELD_TEXT || field.type == GcFieldType::FIELD_SHORTTEXT)) { // we only do text or shorttext fields
 
             QAction *action = new QAction(sp.displayName(field.name), this);
             action->setCheckable(true);

--- a/src/Gui/MetadataDialog.cpp
+++ b/src/Gui/MetadataDialog.cpp
@@ -43,8 +43,8 @@ MetadataDialog::MetadataDialog(Context* context, const QString& fieldName, const
 
     switch (field_.type) {
 
-    case FIELD_TEXT: // text
-    case FIELD_SHORTTEXT: { // shorttext
+    case GcFieldType::FIELD_TEXT: // text
+    case GcFieldType::FIELD_SHORTTEXT: { // shorttext
         metaEdit_ = new QLineEdit(this);
         completer_ = field_.getCompleter(this, context_->athlete->rideCache);
         if (completer_) ((QLineEdit*)metaEdit_)->setCompleter(completer_);
@@ -52,7 +52,7 @@ MetadataDialog::MetadataDialog(Context* context, const QString& fieldName, const
         ((QLineEdit*)metaEdit_)->setText(value);
         } break;
 
-    case FIELD_TEXTBOX: { // textbox
+    case GcFieldType::FIELD_TEXTBOX: { // textbox
         metaEdit_ = new GTextEdit(this);
         // use special style sheet ..
         ((GTextEdit*)metaEdit_)->setObjectName("metadata");
@@ -63,7 +63,7 @@ MetadataDialog::MetadataDialog(Context* context, const QString& fieldName, const
         ((GTextEdit*)metaEdit_)->setText(value);
         } break;
 
-    case FIELD_INTEGER: { // integer
+    case GcFieldType::FIELD_INTEGER: { // integer
         metaEdit_ = new QSpinBox(this);
         ((QSpinBox*)metaEdit_)->setMinimum(-9999999);
         ((QSpinBox*)metaEdit_)->setMaximum(9999999);
@@ -72,7 +72,7 @@ MetadataDialog::MetadataDialog(Context* context, const QString& fieldName, const
         ((QSpinBox*)metaEdit_)->setValue(value.toInt());
         } break;
 
-    case FIELD_DOUBLE: { // double
+    case GcFieldType::FIELD_DOUBLE: { // double
         metaEdit_ = new QDoubleSpinBox(this);
         ((QDoubleSpinBox*)metaEdit_)->setButtonSymbols(QAbstractSpinBox::NoButtons);
         ((QDoubleSpinBox*)metaEdit_)->setMinimum(-9999999.99);
@@ -81,7 +81,7 @@ MetadataDialog::MetadataDialog(Context* context, const QString& fieldName, const
         ((QDoubleSpinBox*)metaEdit_)->setValue(value.toDouble());
         } break;
 
-    case FIELD_DATE: { // date
+    case GcFieldType::FIELD_DATE: { // date
         metaEdit_ = new QDateEdit(this);
         ((QDateEdit*)metaEdit_)->setButtonSymbols(QAbstractSpinBox::NoButtons);
         ((QDateEdit*)metaEdit_)->setDisplayFormat("dd/MM/yyyy");
@@ -96,7 +96,7 @@ MetadataDialog::MetadataDialog(Context* context, const QString& fieldName, const
             ((QDateEdit*)metaEdit_)->setDate(date);
         } } break;
 
-    case FIELD_TIME: { // time
+    case GcFieldType::FIELD_TIME: { // time
         metaEdit_ = new QTimeEdit(this);
         ((QTimeEdit*)metaEdit_)->setButtonSymbols(QAbstractSpinBox::NoButtons);
         ((QTimeEdit*)metaEdit_)->setDisplayFormat("hh:mm:ss");
@@ -110,10 +110,12 @@ MetadataDialog::MetadataDialog(Context* context, const QString& fieldName, const
             ((QTimeEdit*)metaEdit_)->setTime(time);
         } } break;
 
-    case FIELD_CHECKBOX: { // check
+    case GcFieldType::FIELD_CHECKBOX: { // check
         metaEdit_ = new QCheckBox(this);
         ((QCheckBox*)metaEdit_)->setChecked((value == "1") ? true : false);
         } break;
+    default:
+        qDebug() << "Metadata field type not set"; break;
     }
 
     // Metadata
@@ -175,22 +177,24 @@ MetadataDialog::okClicked()
 
     // get the current value into a string
     switch (field_.type) {
-    case FIELD_TEXT:
-    case FIELD_SHORTTEXT: text = ((QLineEdit*)metaEdit_)->text(); break;
-    case FIELD_TEXTBOX: text = ((GTextEdit*)metaEdit_)->document()->toPlainText(); break;
-    case FIELD_INTEGER: text = QString("%1").arg(((QSpinBox*)metaEdit_)->value()); break;
-    case FIELD_DOUBLE: text = QString("%1").arg(((QDoubleSpinBox*)metaEdit_)->value()); break;
-    case FIELD_CHECKBOX: text = ((QCheckBox*)metaEdit_)->isChecked() ? "1" : "0"; break;
-    case FIELD_DATE:
+    case GcFieldType::FIELD_TEXT:
+    case GcFieldType::FIELD_SHORTTEXT: text = ((QLineEdit*)metaEdit_)->text(); break;
+    case GcFieldType::FIELD_TEXTBOX: text = ((GTextEdit*)metaEdit_)->document()->toPlainText(); break;
+    case GcFieldType::FIELD_INTEGER: text = QString("%1").arg(((QSpinBox*)metaEdit_)->value()); break;
+    case GcFieldType::FIELD_DOUBLE: text = QString("%1").arg(((QDoubleSpinBox*)metaEdit_)->value()); break;
+    case GcFieldType::FIELD_CHECKBOX: text = ((QCheckBox*)metaEdit_)->isChecked() ? "1" : "0"; break;
+    case GcFieldType::FIELD_DATE:
         if (((QDateEdit*)metaEdit_)->date().isValid()) {
             text = ((QDateEdit*)metaEdit_)->date().toString("dd/MM/yyyy");
         }
         break;
-    case FIELD_TIME:
+    case GcFieldType::FIELD_TIME:
         if (((QTimeEdit*)metaEdit_)->time().isValid()) {
             text = ((QTimeEdit*)metaEdit_)->time().toString("hh:mm:ss"); break;
         }
         break;
+    default:
+        qDebug() << "Metadata field type not set"; break;
     }
 
     RideItem* rideI = context_->rideItem();

--- a/src/Gui/Pages.cpp
+++ b/src/Gui/Pages.cpp
@@ -2293,7 +2293,9 @@ KeywordsPage::pageSelected()
     QList<FieldDefinition> fromFieldsPage;
     parent->fieldsPage->getDefinitions(fromFieldsPage);
     foreach(FieldDefinition x, fromFieldsPage) {
-        if (x.type < 3) fieldChooser->addItem(sp.displayName(x.name));
+        if (x.isTextField()) {
+            fieldChooser->addItem(sp.displayName(x.name));
+        }
     }
     fieldChooser->setCurrentIndex(fieldChooser->findText(sp.displayName(prev)));
 }
@@ -2457,7 +2459,7 @@ FieldsPage::FieldsPage(QWidget *parent, QList<FieldDefinition>fieldDefinitions) 
         add->setFlags(add->flags() | Qt::ItemIsEditable);
         add->setText(0, specialTabs.displayName(field.tab)); // tab name
         add->setText(1, specials.displayName(field.name)); // field name
-        add->setData(2, Qt::DisplayRole, field.type);
+        add->setData(2, Qt::DisplayRole, static_cast<int>(field.type));
         add->setText(3, field.values.join(",")); // values
         fields->setItemWidget(add, 4, checkBox);
         fields->setItemWidget(add, 5, checkBoxInt);
@@ -2585,9 +2587,9 @@ FieldsPage::getDefinitions(QList<FieldDefinition> &fieldList)
         add.expression = item->text(6);
 
         if (sp.isMetric(add.name))
-            add.type = 4;
+            add.type = GcFieldType::FIELD_DOUBLE;
         else
-            add.type = item->data(2, Qt::DisplayRole).toInt();
+            add.type = static_cast<GcFieldType>(item->data(2, Qt::DisplayRole).toInt());
 
         fieldList.append(add);
     }

--- a/src/Gui/RideNavigator.cpp
+++ b/src/Gui/RideNavigator.cpp
@@ -284,7 +284,7 @@ RideNavigator::resetView()
     // add metadata fields...
     SpecialFields& sp = SpecialFields::getInstance(); // all the special fields are in here...
     foreach(FieldDefinition field, GlobalContext::context()->rideMetadata->getFields()) {
-        if (!sp.isMetric(field.name) && (field.type < 5 || field.type == 7)) {
+        if (!sp.isMetric(field.name) && (field.type != GcFieldType::FIELD_DATE && field.type != GcFieldType::FIELD_TIME)) {
             nameMap.insert(QString("%1").arg(sp.makeTechName(field.name)), sp.displayName(field.name));
             internalNameMap.insert(field.name, sp.displayName(field.name));
         }

--- a/src/Metrics/RideMetadata.h
+++ b/src/Metrics/RideMetadata.h
@@ -32,14 +32,17 @@
 #include <QMessageBox>
 
 // field types
-#define FIELD_TEXT      0
-#define FIELD_TEXTBOX   1
-#define FIELD_SHORTTEXT 2
-#define FIELD_INTEGER   3
-#define FIELD_DOUBLE    4
-#define FIELD_DATE      5
-#define FIELD_TIME      6
-#define FIELD_CHECKBOX  7
+enum class GcFieldType : int {
+    NO_FIELD_SET = -1,
+    FIELD_TEXT = 0,
+    FIELD_TEXTBOX = 1,
+    FIELD_SHORTTEXT = 2,
+    FIELD_INTEGER = 3,
+    FIELD_DOUBLE = 4,
+    FIELD_DATE = 5,
+    FIELD_TIME = 6,
+    FIELD_CHECKBOX = 7
+};
 
 class RideMetadata;
 class RideFileInterval;
@@ -61,19 +64,22 @@ class FieldDefinition
 
         QString tab,
                 name;
-        int type;
+        GcFieldType type;
         bool diary; // show in summary on diary page...
         bool interval; // this is interval specific metadata
 
         QStringList values; // autocomplete 'defaults'
         QString expression; // expression to evaluate, if true field is available
 
+        bool isTextField() const { return type == GcFieldType::FIELD_TEXT || type == GcFieldType::FIELD_TEXTBOX || type == GcFieldType::FIELD_SHORTTEXT; }
+        bool isNumericField() const { return !isTextField() && type != GcFieldType::NO_FIELD_SET; }
+
         static unsigned long fingerprint(QList<FieldDefinition>);
         QCompleter *getCompleter(QObject *parent, RideCache *rideCache);
         QString calendarText(QString value);
 
-        FieldDefinition() : tab(""), name(""), type(0), diary(false), interval(false), values(), expression("") {}
-        FieldDefinition(QString tab, QString name, int type, bool diary, bool interval, QStringList values, QString expression)
+        FieldDefinition() : tab(""), name(""), type(GcFieldType::NO_FIELD_SET), diary(false), interval(false), values(), expression("") {}
+        FieldDefinition(QString tab, QString name, GcFieldType type, bool diary, bool interval, QStringList values, QString expression)
                         : tab(tab), name(name), type(type), diary(diary), interval(interval), values(values), expression(expression) {}
 };
 


### PR DESCRIPTION
This PR does not change GC functionality, it updates the field type definitions to an enum class to provide
strong typing, remove references to specific field values & ranges, and aid the clarity of the code.
		
The following changes in RideMetadata.h are detailed below:

Replace
			
```
				#define FIELD_TEXT      0
				#define FIELD_TEXTBOX   1
				#define FIELD_SHORTTEXT 2
				#define FIELD_INTEGER   3
				#define FIELD_DOUBLE    4
				#define FIELD_DATE      5
				#define FIELD_TIME      6
				#define FIELD_CHECKBOX  7
```
				
with
				
```
				enum class GcFieldType : int {
					NO_FIELD_SET = -1,
					FIELD_TEXT = 0,
					FIELD_TEXTBOX = 1,
					FIELD_SHORTTEXT = 2,
					FIELD_INTEGER = 3,
					FIELD_DOUBLE = 4,
					FIELD_DATE = 5,
					FIELD_TIME = 6,
					FIELD_CHECKBOX = 7
				};
```

Provide helper functions for GC code to remove references to specific field values or ranges:
			
		bool isTextField() const { return type == GcFieldType::FIELD_TEXT || type == GcFieldType::FIELD_TEXTBOX || type == GcFieldType::FIELD_SHORTTEXT; }
		bool isNumericField() const { return !isTextField() && type != GcFieldType::NO_FIELD_SET; }
				
for example:
		`	if (field.tab != "" && field.type < 3 && field.name != "Filename" &&`
becomes:
		`	if (field.tab != "" && field.isTextField() && field.name != "Filename" &&`

		
another example:
		`	rt.lookupType.insert(underscored.replace(" ","_"), (field.type > 2)); // true if is number`
becomes:
                `	rt.lookupType.insert(underscored.replace(" ","_"), (field.isNumericField())); // true if is number`

			
final example:
		`	if (!sp.isMetric(field.name) && (field.type < 5 || field.type == 7)) {`
becomes:
		`	if (!sp.isMetric(field.name) && (field.type != GcFieldType::FIELD_DATE && field.type != GcFieldType::FIELD_TIME)) {`
				
				