### PR TITLE
Explicitly converting a QUrl to a QFile

### DIFF
--- a/src/Gui/Pages.cpp
+++ b/src/Gui/Pages.cpp
@@ -2752,8 +2752,7 @@ IconsPage::eventFilterIconList
             const QList<QUrl> urls = dropEvent->mimeData()->urls();
             int added = 0;
             for (const QUrl &url : urls) {
-                QString path = url.toLocalFile();
-                if (IconManager::instance().addIconFile(path)) {
+                if (IconManager::instance().addIconFile(QFile(url.toLocalFile()))) {
                     ++added;
                 }
             }


### PR DESCRIPTION
Should fix #4699 (tested with Qt 6.8.2 and 5.15.15)