### PR TITLE
Running speed read from Footpod ANT+ device

### DIFF
--- a/src/ANT/ANTChannel.cpp
+++ b/src/ANT/ANTChannel.cpp
@@ -1207,7 +1207,7 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                     if (fpCount==4) {
 
                         // default or get config
-                        double STRIDELENGTH=115; // 1.15m seems to be a common L2 pace stride length (?)
+                        double STRIDELENGTH= 0.0;
                         if (parent->devConf) STRIDELENGTH=parent->devConf->stridelength;
 
                         // convert to meters
@@ -1221,8 +1221,11 @@ void ANTChannel::broadcastEvent(unsigned char *ant_message)
                         parent->setCadence(fpStrides * (60/(fpMS/1000.00f)));
 
                         // running speed is strides x 2 (for left and right) multiplied
-                        // by the user defined stride length, which is typicall ~78cm
-                        parent->setSpeed((fpStrides*2*STRIDELENGTH) / (fpMS/1000.00f) * 3.6f);
+                        // by the user defined stride length
+                        if (STRIDELENGTH > 0.0)
+                            parent->setSpeed((fpStrides*2*STRIDELENGTH) / (fpMS/1000.00f) * 3.6f);
+                        else
+                            parent->setSpeed(antMessage.fpodSpeed * 3.6f);
 
                         // reset counters
                         fpCount=0;

--- a/src/ANT/ANTMessage.cpp
+++ b/src/ANT/ANTMessage.cpp
@@ -815,7 +815,7 @@ ANTMessage::ANTMessage(ANT *parent, const unsigned char *message) {
                         // SDM main format - strides loop at 255 should be x2
                         fpodInstant=false;
                         fpodStrides = message[10];
-                        fpodSpeed = 0;
+                        fpodSpeed = double(message[8]&0x0f) + (double(message[9]/256.00f));
                         fpodCadence = 0;
                     }
                     break;

--- a/src/Train/DeviceConfiguration.cpp
+++ b/src/Train/DeviceConfiguration.cpp
@@ -36,7 +36,7 @@ DeviceConfiguration::DeviceConfiguration()
     type=0;
     wheelSize=2100;
     postProcess=0;
-    stridelength=80;
+    stridelength=0;
     controller = NULL;
     virtualPowerDefinitionString = "";
 }
@@ -109,7 +109,6 @@ DeviceConfigurations::readConfig()
             configStr = QString("%1%2").arg(GC_DEV_STRIDE).arg(i+1);
             configVal = appsettings->value(NULL, configStr);
             Entry.stridelength = configVal.toInt();
-            if (Entry.stridelength == 0) Entry.stridelength = 78; // default to 78cm
 
             configStr = QString("%1%2").arg(GC_DEV_PROF).arg(i+1);
             configVal = appsettings->value(NULL, configStr);


### PR DESCRIPTION
It is read if the footpod does not send cadence or stride length is not configured.
For such, stridelength is not initially set to 115 cm, but to 0, so if it is not read from the device, it means the device is not able to use it.
Also, if cadence is not captured by the device, also the speed cannot be computed.
In any of those situations, speed can be read from the device