### PR TITLE
If a footpod device is present, simulated speed will not be used

### DIFF
--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -1891,6 +1891,8 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
 
             double distanceTick = 0;
 
+            // If any of the active devices is a footpod, simulated speed will not be used, as it is a treadmill
+            bool deviceIsFootpod = false;
             // fetch the right data from each device...
             foreach(int dev, activeDevices) {
 
@@ -1961,12 +1963,15 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
                     rtData.setTrainerConfigRequired(local.getTrainerConfigRequired());
                     rtData.setTrainerBrakeFault(local.getTrainerBrakeFault());
                 }
+                if (Devices[dev].type == DEV_ANTLOCAL && Devices[dev].deviceProfile.contains("o")) {
+                    deviceIsFootpod = true;
+                }
             }
 
             // If simulated speed is *not* checked then you get speed reported by
             // trainer which in ergo mode will be dictated by your gear and cadence,
             // and in slope mode is whatever the trainer happens to implement.
-            if (useSimulatedSpeed) {
+            if (useSimulatedSpeed && !deviceIsFootpod) {
                 BicycleSimState newState(rtData);
                 SpeedDistance ret = bicycle.SampleSpeed(newState);
 


### PR DESCRIPTION
In case there is a footpod device, it does not make sense to simulate speed by GC, as that simulated speed is computed usign bycicle dynamics; if a footpod is in use, it means the activity is running on a treadmill