### PR TITLE
Explicitly applying the palette to the measures-tabs

### DIFF
--- a/src/Charts/PlanningCalendarWindow.cpp
+++ b/src/Charts/PlanningCalendarWindow.cpp
@@ -296,49 +296,51 @@ PlanningCalendarWindow::configChanged
         // change colors to reflect preferences
         setProperty("color", GColor(CPLOTBACKGROUND));
 
-        QColor activeBg = GColor(CPLOTBACKGROUND);
-        QColor activeText = GCColor::invertColor(activeBg);
+        QColor activeBase = GColor(CPLOTBACKGROUND);
+        QColor activeWindow = activeBase;
+        QColor activeText = GCColor::invertColor(activeBase);
         QColor activeHl = GColor(CCALCURRENT);
         QColor activeHlText = GCColor::invertColor(activeHl);
-        QColor alternateBg = GCColor::inactiveColor(activeBg, 0.2);
-        QColor alternateText = GCColor::inactiveColor(activeText, 1.5);
-        QColor buttonBg = activeBg;
+        QColor alternateBg = GCColor::inactiveColor(activeBase, 0.2);
+        QColor inactiveText = GCColor::inactiveColor(activeText, 1.5);
+        QColor activeButtonBg = activeBase;
         QColor disabledButtonBg = alternateBg;
-        if (buttonBg.lightness() < 10) {
-            buttonBg = alternateBg;
-            disabledButtonBg = GCColor::inactiveColor(buttonBg, 0.3);
+        if (activeBase.lightness() < 20) {
+            activeWindow = GCColor::inactiveColor(activeWindow, 0.2);
+            activeButtonBg = alternateBg;
+            disabledButtonBg = GCColor::inactiveColor(activeButtonBg, 0.3);
         }
 
         QPalette palette;
-        palette.setColor(QPalette::Active, QPalette::Window, activeBg);
+        palette.setColor(QPalette::Active, QPalette::Window, activeWindow);
         palette.setColor(QPalette::Active, QPalette::WindowText, activeText);
-        palette.setColor(QPalette::Active, QPalette::Base, activeBg);
+        palette.setColor(QPalette::Active, QPalette::Base, activeBase);
         palette.setColor(QPalette::Active, QPalette::AlternateBase, alternateBg);
         palette.setColor(QPalette::Active, QPalette::Text, activeText);
         palette.setColor(QPalette::Active, QPalette::Highlight, activeHl);
         palette.setColor(QPalette::Active, QPalette::HighlightedText, activeHlText);
-        palette.setColor(QPalette::Active, QPalette::Button, buttonBg);
+        palette.setColor(QPalette::Active, QPalette::Button, activeButtonBg);
         palette.setColor(QPalette::Active, QPalette::ButtonText, activeText);
 
-        palette.setColor(QPalette::Inactive, QPalette::Window, activeBg);
+        palette.setColor(QPalette::Inactive, QPalette::Window, activeWindow);
         palette.setColor(QPalette::Inactive, QPalette::WindowText, activeText);
-        palette.setColor(QPalette::Inactive, QPalette::Base, activeBg);
+        palette.setColor(QPalette::Inactive, QPalette::Base, activeBase);
         palette.setColor(QPalette::Inactive, QPalette::AlternateBase, alternateBg);
         palette.setColor(QPalette::Inactive, QPalette::Text, activeText);
         palette.setColor(QPalette::Inactive, QPalette::Highlight, activeHl);
         palette.setColor(QPalette::Inactive, QPalette::HighlightedText, activeHlText);
-        palette.setColor(QPalette::Inactive, QPalette::Button, buttonBg);
+        palette.setColor(QPalette::Inactive, QPalette::Button, activeButtonBg);
         palette.setColor(QPalette::Inactive, QPalette::ButtonText, activeText);
 
         palette.setColor(QPalette::Disabled, QPalette::Window, alternateBg);
-        palette.setColor(QPalette::Disabled, QPalette::WindowText, alternateText);
+        palette.setColor(QPalette::Disabled, QPalette::WindowText, inactiveText);
         palette.setColor(QPalette::Disabled, QPalette::Base, alternateBg);
         palette.setColor(QPalette::Disabled, QPalette::AlternateBase, alternateBg);
-        palette.setColor(QPalette::Disabled, QPalette::Text, alternateText);
+        palette.setColor(QPalette::Disabled, QPalette::Text, inactiveText);
         palette.setColor(QPalette::Disabled, QPalette::Highlight, activeHl);
         palette.setColor(QPalette::Disabled, QPalette::HighlightedText, activeHlText);
         palette.setColor(QPalette::Disabled, QPalette::Button, disabledButtonBg);
-        palette.setColor(QPalette::Disabled, QPalette::ButtonText, alternateText);
+        palette.setColor(QPalette::Disabled, QPalette::ButtonText, inactiveText);
 
         PaletteApplier::setPaletteRecursively(this, palette, true);
         calendar->applyNavIcons();

--- a/src/Charts/PlanningCalendarWindow.cpp
+++ b/src/Charts/PlanningCalendarWindow.cpp
@@ -309,6 +309,7 @@ PlanningCalendarWindow::configChanged
             activeWindow = GCColor::inactiveColor(activeWindow, 0.2);
             activeButtonBg = alternateBg;
             disabledButtonBg = GCColor::inactiveColor(activeButtonBg, 0.3);
+            inactiveText = GCColor::inactiveColor(activeText, 2.5);
         }
 
         QPalette palette;

--- a/src/Charts/PlanningCalendarWindow.cpp
+++ b/src/Charts/PlanningCalendarWindow.cpp
@@ -300,22 +300,16 @@ PlanningCalendarWindow::configChanged
         QColor activeText = GCColor::invertColor(activeBg);
         QColor activeHl = GColor(CCALCURRENT);
         QColor activeHlText = GCColor::invertColor(activeHl);
-
-        QColor alternateBg = GCColor::inactiveColor(activeBg, 0.3);
+        QColor alternateBg = GCColor::inactiveColor(activeBg, 0.2);
         QColor alternateText = GCColor::inactiveColor(activeText, 1.5);
+        QColor buttonBg = activeBg;
+        QColor disabledButtonBg = alternateBg;
+        if (buttonBg.lightness() < 10) {
+            buttonBg = alternateBg;
+            disabledButtonBg = GCColor::inactiveColor(buttonBg, 0.3);
+        }
 
         QPalette palette;
-
-        palette.setColor(QPalette::Normal, QPalette::Window, activeBg);
-        palette.setColor(QPalette::Normal, QPalette::WindowText, activeText);
-        palette.setColor(QPalette::Normal, QPalette::Base, activeBg);
-        palette.setColor(QPalette::Normal, QPalette::AlternateBase, alternateBg);
-        palette.setColor(QPalette::Normal, QPalette::Text, activeText);
-        palette.setColor(QPalette::Normal, QPalette::Highlight, activeHl);
-        palette.setColor(QPalette::Normal, QPalette::HighlightedText, activeHlText);
-        palette.setColor(QPalette::Normal, QPalette::Button, activeBg);
-        palette.setColor(QPalette::Normal, QPalette::ButtonText, activeText);
-
         palette.setColor(QPalette::Active, QPalette::Window, activeBg);
         palette.setColor(QPalette::Active, QPalette::WindowText, activeText);
         palette.setColor(QPalette::Active, QPalette::Base, activeBg);
@@ -323,18 +317,8 @@ PlanningCalendarWindow::configChanged
         palette.setColor(QPalette::Active, QPalette::Text, activeText);
         palette.setColor(QPalette::Active, QPalette::Highlight, activeHl);
         palette.setColor(QPalette::Active, QPalette::HighlightedText, activeHlText);
-        palette.setColor(QPalette::Active, QPalette::Button, activeBg);
+        palette.setColor(QPalette::Active, QPalette::Button, buttonBg);
         palette.setColor(QPalette::Active, QPalette::ButtonText, activeText);
-
-        palette.setColor(QPalette::Disabled, QPalette::Window, alternateBg);
-        palette.setColor(QPalette::Disabled, QPalette::WindowText, alternateText);
-        palette.setColor(QPalette::Disabled, QPalette::Base, alternateBg);
-        palette.setColor(QPalette::Disabled, QPalette::AlternateBase, alternateBg);
-        palette.setColor(QPalette::Disabled, QPalette::Text, alternateText);
-        palette.setColor(QPalette::Disabled, QPalette::Highlight, activeHl);
-        palette.setColor(QPalette::Disabled, QPalette::HighlightedText, activeHlText);
-        palette.setColor(QPalette::Disabled, QPalette::Button, alternateBg);
-        palette.setColor(QPalette::Disabled, QPalette::ButtonText, alternateText);
 
         palette.setColor(QPalette::Inactive, QPalette::Window, activeBg);
         palette.setColor(QPalette::Inactive, QPalette::WindowText, activeText);
@@ -343,13 +327,21 @@ PlanningCalendarWindow::configChanged
         palette.setColor(QPalette::Inactive, QPalette::Text, activeText);
         palette.setColor(QPalette::Inactive, QPalette::Highlight, activeHl);
         palette.setColor(QPalette::Inactive, QPalette::HighlightedText, activeHlText);
-        palette.setColor(QPalette::Inactive, QPalette::Button, activeBg);
+        palette.setColor(QPalette::Inactive, QPalette::Button, buttonBg);
         palette.setColor(QPalette::Inactive, QPalette::ButtonText, activeText);
 
+        palette.setColor(QPalette::Disabled, QPalette::Window, alternateBg);
+        palette.setColor(QPalette::Disabled, QPalette::WindowText, alternateText);
+        palette.setColor(QPalette::Disabled, QPalette::Base, alternateBg);
+        palette.setColor(QPalette::Disabled, QPalette::AlternateBase, alternateBg);
+        palette.setColor(QPalette::Disabled, QPalette::Text, alternateText);
+        palette.setColor(QPalette::Disabled, QPalette::Highlight, activeHl);
+        palette.setColor(QPalette::Disabled, QPalette::HighlightedText, activeHlText);
+        palette.setColor(QPalette::Disabled, QPalette::Button, disabledButtonBg);
+        palette.setColor(QPalette::Disabled, QPalette::ButtonText, alternateText);
+
         PaletteApplier::setPaletteRecursively(this, palette, true);
-
         calendar->applyNavIcons();
-
         refreshActivities = true;
     }
 

--- a/src/Gui/Calendar.cpp
+++ b/src/Gui/Calendar.cpp
@@ -1217,6 +1217,7 @@ CalendarDayView::CalendarDayView
 : QWidget(parent), athleteMeasures(athleteMeasures)
 {
     dayDateSelector = new CalendarOverview();
+    dayDateSelector->setFixedHeight(std::max(static_cast<int>(280 * dpiYFactor), dayDateSelector->sizeHint().height()));
 
     dayPhaseLabel = new QLabel(tr("No Phase"));
     dayPhaseLabel->setWordWrap(true);

--- a/src/Gui/Calendar.cpp
+++ b/src/Gui/Calendar.cpp
@@ -1427,6 +1427,7 @@ CalendarDayView::updateMeasures
     if (measureTabs->count() > currentIndex) {
         measureTabs->setCurrentIndex(currentIndex);
     }
+    PaletteApplier::setPaletteRecursively(measureTabs, this->palette(), true);
 }
 
 

--- a/src/Gui/Calendar.cpp
+++ b/src/Gui/Calendar.cpp
@@ -21,6 +21,7 @@
 #include <QHeaderView>
 #include <QHBoxLayout>
 #include <QTextEdit>
+#include <QScrollArea>
 #include <QEvent>
 #include <QMouseEvent>
 #include <QMenu>
@@ -1229,12 +1230,13 @@ CalendarDayView::CalendarDayView
     leftPaneLayout->addWidget(dayPhaseLabel);
     leftPaneLayout->addWidget(dayEventLabel);
     leftPaneLayout->addWidget(measureTabs, 1);
+    dayLeftPane->setFixedWidth(dayDateSelector->sizeHint().width() + leftPaneLayout->contentsMargins().left() + leftPaneLayout->contentsMargins().right());
 
     dayTable = new CalendarDayTable(dateInMonth);
 
     QHBoxLayout *dayLayout = new QHBoxLayout(this);
-    dayLayout->addWidget(dayLeftPane, 1);
-    dayLayout->addWidget(dayTable, 3);
+    dayLayout->addWidget(dayLeftPane);
+    dayLayout->addWidget(dayTable);
 
     connect(dayDateSelector, &QCalendarWidget::selectionChanged, [=]() {
         if (dayTable->selectedDate() != dayDateSelector->selectedDate()) {
@@ -1375,21 +1377,30 @@ CalendarDayView::updateMeasures
                     form->addRow(measuresGroup->getFieldNames()[i], new QLabel(measureText));
                 }
             }
-            QTextEdit *commentField = new QTextEdit();
-            commentField->setAcceptRichText(false);
-            commentField->setReadOnly(true);
-            commentField->setText(measure.comment);
-            form->addRow(tr("Comment"), commentField);
+            if (! measure.comment.isEmpty()) {
+                QTextEdit *commentField = new QTextEdit();
+                commentField->setAcceptRichText(false);
+                commentField->setReadOnly(true);
+                commentField->setText(measure.comment);
+                commentField->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+                form->addRow(commentField);
+            }
             QLocale locale;
             QString validText = locale.toString(measure.when, QLocale::ShortFormat);
             int validDays = measure.when.date().daysTo(date);
             if (validDays > 1) {
-                validText.append(tr(" (%1 days earlier)").arg(validDays));
+                validText.append(tr("\n(%1 days earlier)").arg(validDays));
             } else if (validDays > 0) {
-                validText.append(tr(" (%1 day earlier)").arg(validDays));
+                validText.append(tr("\n(%1 day earlier)").arg(validDays));
             }
             form->addRow(tr("Valid since"), new QLabel(validText));
-            measureLayout->addLayout(form);
+            QWidget *scrollWidget = new QWidget();
+            scrollWidget->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+            scrollWidget->setLayout(form);
+            QScrollArea *scrollArea = new QScrollArea();
+            scrollArea->setWidget(scrollWidget);
+            scrollArea->setWidgetResizable(true);
+            measureLayout->addWidget(scrollArea);
             if (validDays == 0) {
                 buttonType = 1;
             }
@@ -1545,6 +1556,7 @@ Calendar::Calendar
     dayAction = toolbar->addAction(tr("Day"));
     dayAction->setCheckable(true);
     dayAction->setActionGroup(viewGroup);
+
     connect(dayAction, &QAction::triggered, [=]() { setView(CalendarView::Day); });
 
     monthAction = toolbar->addAction(tr("Month"));

--- a/src/Gui/Calendar.cpp
+++ b/src/Gui/Calendar.cpp
@@ -202,7 +202,7 @@ CalendarDayTable::setDay
     item->setData(Qt::UserRole, date);
     CalendarDay day;
     day.date = date;
-    day.isDimmed = false;
+    day.isDimmed = DayDimLevel::None;
     item->setData(Qt::UserRole + 1, QVariant::fromValue(day));
     setItem(0, 1, item);
     setSelectionMode(QAbstractItemView::NoSelection);
@@ -699,7 +699,12 @@ CalendarMonthTable::setMonth
         int col = (date.dayOfWeek() - firstDayOfWeek + 7) % 7;
         QTableWidgetItem *item = new QTableWidgetItem();
         item->setData(Qt::UserRole, date);
-        bool isDimmed = ! dr.pass(date);
+        DayDimLevel isDimmed = DayDimLevel::None;
+        if (! dr.pass(date)) {
+            isDimmed = DayDimLevel::Full;
+        } else if (date.month() != dateInMonth.month()) {
+            isDimmed = DayDimLevel::Partial;
+        }
         CalendarDay day;
         day.date = date;
         day.isDimmed = isDimmed;

--- a/src/Gui/CalendarData.h
+++ b/src/Gui/CalendarData.h
@@ -57,9 +57,15 @@ struct CalendarEntryLayout {
     int columnCount;
 };
 
+enum class DayDimLevel {
+    None,
+    Full,
+    Partial
+};
+
 struct CalendarDay {
     QDate date;
-    bool isDimmed;
+    DayDimLevel isDimmed;
     QList<CalendarEntry> entries = QList<CalendarEntry>();
     QList<CalendarEntry> headlineEntries = QList<CalendarEntry>();
 };

--- a/src/Gui/CalendarItemDelegates.cpp
+++ b/src/Gui/CalendarItemDelegates.cpp
@@ -566,9 +566,14 @@ CalendarTimeScaleDelegate::paint
 
 QSize
 CalendarTimeScaleDelegate::sizeHint
-(const QStyleOptionViewItem& option, const QModelIndex& index) const
+(const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
-    return QStyledItemDelegate::sizeHint(option, index);
+    Q_UNUSED(index)
+
+    QFont font = option.font;
+    font.setPointSizeF(font.pointSizeF() * 0.9);
+    QFontMetrics fm(font);
+    return QSize(fm.horizontalAdvance("00:00") + 10 * dpiXFactor, option.rect.height());
 }
 
 
@@ -920,7 +925,7 @@ CalendarSummaryDelegate::paint
 (QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     bool hasToolTip = false;
-    const QColor bgColor = GCColor::inactiveColor(option.palette.color(QPalette::Active, QPalette::Base));
+    const QColor bgColor = option.palette.color(QPalette::Active, QPalette::AlternateBase);
     const QColor fgColor = option.palette.color(QPalette::Active, QPalette::Text);
     const CalendarSummary summary = index.data(Qt::UserRole).value<CalendarSummary>();
     QFont valueFont(painter->font());

--- a/src/Gui/CalendarItemDelegates.cpp
+++ b/src/Gui/CalendarItemDelegates.cpp
@@ -629,8 +629,8 @@ CalendarDayDelegate::paint
     }
 
     if (pressedEntryIdx < 0 && opt.state & QStyle::State_Selected) {
-        bgColor = opt.palette.color(calendarDay.isDimmed ? QPalette::Disabled : QPalette::Active, QPalette::Highlight);
-    } else if (calendarDay.isDimmed) {
+        bgColor = opt.palette.color(calendarDay.isDimmed == DayDimLevel::Full ? QPalette::Disabled : QPalette::Active, QPalette::Highlight);
+    } else if (calendarDay.isDimmed == DayDimLevel::Full) {
         bgColor = opt.palette.color(QPalette::Disabled, QPalette::Base);
     } else {
         bgColor = opt.palette.base().color();
@@ -663,16 +663,16 @@ CalendarDayDelegate::paint
         dayRect.setX(opt.rect.x() + 1);
         dayRect.setWidth(dayRect.width() - 1);
         painter->save();
-        painter->setPen(opt.palette.color(calendarDay.isDimmed ? QPalette::Disabled : QPalette::Active, QPalette::Base)),
-        painter->setBrush(opt.palette.color(calendarDay.isDimmed ? QPalette::Disabled : QPalette::Active, QPalette::Highlight)),
+        painter->setPen(opt.palette.color(calendarDay.isDimmed == DayDimLevel::Full ? QPalette::Disabled : QPalette::Active, QPalette::Base)),
+        painter->setBrush(opt.palette.color(calendarDay.isDimmed == DayDimLevel::Full ? QPalette::Disabled : QPalette::Active, QPalette::Highlight)),
         painter->drawRoundedRect(dayRect, 2 * radius, 2 * radius);
         painter->restore();
-        dayColor = opt.palette.color(calendarDay.isDimmed ? QPalette::Disabled : QPalette::Active, QPalette::HighlightedText);
+        dayColor = opt.palette.color((calendarDay.isDimmed == DayDimLevel::Full || calendarDay.isDimmed == DayDimLevel::Partial) ? QPalette::Disabled : QPalette::Active, QPalette::HighlightedText);
         alignFlags = Qt::AlignHCenter | Qt::AlignTop;
     } else if (pressedEntryIdx < 0 && opt.state & QStyle::State_Selected) {
-        dayColor = opt.palette.color(calendarDay.isDimmed ? QPalette::Disabled : QPalette::Active, QPalette::HighlightedText);
+        dayColor = opt.palette.color((calendarDay.isDimmed == DayDimLevel::Full || calendarDay.isDimmed == DayDimLevel::Partial) ? QPalette::Disabled : QPalette::Active, QPalette::HighlightedText);
     } else {
-        dayColor = opt.palette.color(calendarDay.isDimmed ? QPalette::Disabled : QPalette::Active, QPalette::Text);
+        dayColor = opt.palette.color((calendarDay.isDimmed == DayDimLevel::Full || calendarDay.isDimmed == DayDimLevel::Partial) ? QPalette::Disabled : QPalette::Active, QPalette::Text);
     }
 
     painter->setFont(dayFont);


### PR DESCRIPTION
See https://groups.google.com/g/golden-cheetah-users/c/Yz8g2J1Ue6w/m/ne9DEEQCAQAJ

As the measures tabs are recreated when selecting a day and palette inheritatance doesn't work as expected, it is now applied explicitly

Additional changes in this PR:

- Improved palette for dark themes
- Day view: Reserving more space for the CalendarOverview (preventing too much overlap of the activity / phase triangles and the day number)
- Day view: Made the measures content scrollable to better support lower resolutions
- Month view: Dimming day numbers for non-current month