### PR TITLE
Additional line for entries in calendar day-view

### DIFF
--- a/src/Charts/PlanningCalendarWindow.h
+++ b/src/Charts/PlanningCalendarWindow.h
@@ -43,6 +43,7 @@ class PlanningCalendarWindow : public GcChartWindow
     Q_PROPERTY(QString primaryMainField READ getPrimaryMainField WRITE setPrimaryMainField USER true)
     Q_PROPERTY(QString primaryFallbackField READ getPrimaryFallbackField WRITE setPrimaryFallbackField USER true)
     Q_PROPERTY(QString secondaryMetric READ getSecondaryMetric WRITE setSecondaryMetric USER true)
+    Q_PROPERTY(QString tertiaryField READ getTertiaryField WRITE setTertiaryField USER true)
     Q_PROPERTY(QString summaryMetrics READ getSummaryMetrics WRITE setSummaryMetrics USER true)
 
     public:
@@ -56,6 +57,7 @@ class PlanningCalendarWindow : public GcChartWindow
         QString getPrimaryMainField() const;
         QString getPrimaryFallbackField() const;
         QString getSecondaryMetric() const;
+        QString getTertiaryField() const;
         QString getSummaryMetrics() const;
         QStringList getSummaryMetricsList() const;
 
@@ -65,6 +67,7 @@ class PlanningCalendarWindow : public GcChartWindow
         void setPrimaryMainField(const QString &name);
         void setPrimaryFallbackField(const QString &name);
         void setSecondaryMetric(const QString &name);
+        void setTertiaryField(const QString &name);
         void setSummaryMetrics(const QString &summaryMetrics);
         void setSummaryMetrics(const QStringList &summaryMetrics);
         void configChanged(qint32);
@@ -78,12 +81,14 @@ class PlanningCalendarWindow : public GcChartWindow
         QComboBox *primaryMainCombo;
         QComboBox *primaryFallbackCombo;
         QComboBox *secondaryCombo;
+        QComboBox *tertiaryCombo;
         MultiMetricSelector *multiMetricSelector;
         Calendar *calendar;
 
         void mkControls();
         void updatePrimaryConfigCombos();
         void updateSecondaryConfigCombo();
+        void updateTertiaryConfigCombo();
         QHash<QDate, QList<CalendarEntry>> getActivities(const QDate &firstDay, const QDate &lastDay) const;
         QList<CalendarSummary> getSummaries(const QDate &firstDay, const QDate &lastDay, int timeBucketSize = 7) const;
         QHash<QDate, QList<CalendarEntry>> getPhasesEvents(const Season &season, const QDate &firstDay, const QDate &lastDay) const;

--- a/src/Gui/CalendarData.h
+++ b/src/Gui/CalendarData.h
@@ -39,6 +39,7 @@ struct CalendarEntry {
     QString primary;
     QString secondary;
     QString secondaryMetric;
+    QString tertiary;
     QString iconFile;
     QColor color;
     QString reference;

--- a/src/Gui/CalendarItemDelegates.h
+++ b/src/Gui/CalendarItemDelegates.h
@@ -89,6 +89,7 @@ public:
 private:
     TimeScaleData const * const timeScaleData;
     mutable QHash<QModelIndex, QList<QRect>> entryRects;
+    void drawWrappingText(QPainter &painter, const QRect &rect, const QString &text) const;
 };
 
 

--- a/unittests/Gui/calendarData/testCalendarData.cpp
+++ b/unittests/Gui/calendarData/testCalendarData.cpp
@@ -14,11 +14,11 @@ private slots:
         QSKIP("Skipping test with Qt5");
 #else
         QList<CalendarEntry> entries = {
-            { "", "", "", "", Qt::red, "", QTime(9, 0), 3600 },
-            { "", "", "", "", Qt::red, "", QTime(9, 30), 3600 },
-            { "", "", "", "", Qt::red, "", QTime(10, 30), 1800 },
-            { "", "", "", "", Qt::red, "", QTime(11, 0), 1800 },
-            { "", "", "", "", Qt::red, "", QTime(11, 15), 3600 },
+            { "", "", "", "", "", Qt::red, "", QTime(9, 0), 3600 },
+            { "", "", "", "", "", Qt::red, "", QTime(9, 30), 3600 },
+            { "", "", "", "", "", Qt::red, "", QTime(10, 30), 1800 },
+            { "", "", "", "", "", Qt::red, "", QTime(11, 0), 1800 },
+            { "", "", "", "", "", Qt::red, "", QTime(11, 15), 3600 },
         };
         CalendarEntryLayouter layouter;
         QList<CalendarEntryLayout> layout = layouter.layout(entries);


### PR DESCRIPTION
* Calendar Day-View now supports showing any field as tertiary line (good use: Notes)
* Additional fix: Rewriting metric name (secondary line); now BikeScore^TM is shown instead of BikeScore&8482;