### PR TITLE
Trainmode: ZWO-Files Cooldown

### DIFF
--- a/src/Train/ZwoParser.cpp
+++ b/src/Train/ZwoParser.cpp
@@ -73,6 +73,10 @@ ZwoParser::startElement(const QString &, const QString &, const QString &qName, 
         int from = int(100.0 * PowerLow);
         int to = int(100.0 * PowerHigh);
 
+        if (qName == "Cooldown" && from < to) {
+            std::swap(from, to);
+        }
+
         // some kind of old kludge, should be flat, but isn't always
         if (qName == "SteadyState") {
             int ap = (from+to) / 2;


### PR DESCRIPTION
For many ZWO-Workouts (e.g. 10-12wk FTP Builder) using the cooldown-tag, power increased over time.
This PR ensures decreasing power if the cooldown indicates a gradient.