### PR TITLE
The initial analysis view's perspective is incorrect when no items are imported

### DIFF
--- a/src/Gui/AbstractView.cpp
+++ b/src/Gui/AbstractView.cpp
@@ -714,11 +714,9 @@ AbstractView::setPerspectives(QComboBox *perspectiveSelector, bool selectChart)
     if (!loaded || selectChart) {
         loaded = true;
 
-        // generally we just go to the first perspective
-        perspectiveSelected(0);
-
-        // allow views to override the default perspective (if required)
-        setViewSpecificPerspective();
+        // generally we just go to the first perspective, but we allow
+        // the views to override the default perspective (if required)
+        perspectiveSelected(getViewSpecificPerspective());
 
         // due to visibility optimisation we need to force the first tab to be selected in tab mode
         if (perspective_->currentStyle == 0 && perspective_->charts.count()) perspective_->tabSelected(0);

--- a/src/Gui/AbstractView.h
+++ b/src/Gui/AbstractView.h
@@ -188,8 +188,8 @@ class AbstractView : public QWidget
         virtual void notifyViewStateRestored() {}
         virtual void notifyViewPerspectiveAdded(Perspective* page);
         virtual void notifyViewSidebarChanged() {}
-        virtual void setViewSpecificPerspective() {};
-        virtual void notifyViewSplitterMoved() {};
+        virtual int getViewSpecificPerspective() { return 0; }
+        virtual void notifyViewSplitterMoved() {}
 
     private slots:
         void onIdle();

--- a/src/Gui/Views.h
+++ b/src/Gui/Views.h
@@ -51,9 +51,12 @@ class AnalysisView : public AbstractView
 
         void notifyViewStateRestored() override;
         void notifyViewSidebarChanged() override;
-        void setViewSpecificPerspective() override;
+        int getViewSpecificPerspective() override;
         void notifyViewSplitterMoved() override;
 
+    private:
+
+        std::pair<int, Perspective*> findRidesPerspective(RideItem* ride);
 };
 
 class DiarySidebar;


### PR DESCRIPTION
The initial analysis view's perspective is incorrect when no items are imported, this is caused by the following call sequence (this is summary of the main calls relevant to this problem):
Note: mainWindow::resetPerspective is re-entrant in the start-up sequence but protect by its guards
 

```
mainWindow::selectAnalysis
    mainWindow::resetPerspective sets pactive = true
    |     AnalysisView::setPerspectives
    |          on first load it calls AnalysisView::setViewSpecificPerspective()
    |                this then called AnalysisView::setRide()
    |                      this then called mainWindow::switchPerspective
    |                           but as pactive == true, it didn't apply the perspective change      :(
    |  pactive = false
```

the proposed change removes setRide from this initial startup sequence, as AnalysisView::setViewSpecificPerspective only gets called during initial view loading, so using perspectiveSelected with the correct perspective achieves the right result, as the ride has already been set at this point. 

```
mainWindow::selectAnalysis
    mainWindow::resetPerspective sets pactive = true
    |     AbstractView::setPerspectives
    |           on first load it calls AbstractView::perspectiveSelected() with perspective from
    |                  AnalysisView::getViewSpecificPerspective, this sets the ride's perspective correctly,
    |                                                                               and the charts & controls 
    |  pactive = false
```
