### PR TITLE
Trends activity click thru doesn't set the correct perspective for the activity in Analysis View

### DIFF
--- a/src/Gui/AthleteTab.cpp
+++ b/src/Gui/AthleteTab.cpp
@@ -187,6 +187,8 @@ AthleteTab::selectView(int index)
 void
 AthleteTab::rideSelected(RideItem*)
 {
+    emit rideItemSelected(context->ride);
+
     // if we selected a ride we should be on the analysis
     // view-- this is new with the overview and click thru
     // coming in other charts but when navigation model is
@@ -205,8 +207,6 @@ AthleteTab::rideSelected(RideItem*)
             selectView(1);
         }
     }
-
-    emit rideItemSelected(context->ride);
 
     // update the ride property on all widgets
     // to let them know they need to replot new

--- a/src/Gui/NavigationModel.h
+++ b/src/Gui/NavigationModel.h
@@ -57,10 +57,8 @@ public:
     NavigationModel(AthleteTab *tab);
     ~NavigationModel();
 
-    // keep a track of the rides we've looked
-    // at recently-- might want to quick link
-    // to these in the future ...
-    QVector<RideItem*> recent;
+    // list of rides we've looked at recently
+    const QVector<RideItem*>& recentRides() const { return recent; }
 
 public slots:
 
@@ -70,7 +68,6 @@ public slots:
 
     void back();
     void forward();
-    void action(bool redo, NavigationEvent); // redo/undo the event
 
 private:
 
@@ -91,4 +88,15 @@ private:
     void addToStack(NavigationEvent&); // truncates stack if needed
     int stackpointer;
     QVector<NavigationEvent> stack;
+
+    // action the stack changes
+    void action(bool redo, NavigationEvent); // redo/undo the event
+
+    // keep a track of the rides we've looked
+    // at recently-- might want to quick link
+    // to these in the future ...
+    QVector<RideItem*> recent;
+
+    // when all else fails...
+    void debugStack(const QString& caller);
 };


### PR DESCRIPTION
The trends view activity click thru doesn't set the correct perspective for the activity in Analysis View, this is because the view hasn't been updated before the ride is set in Analysis view and its guard in setRide() rejects it, as:
context->mainWindow->athleteTab()->currentView() == 1 is not true, the current view is still trends.
