### PR TITLE
New configuration-options for Calendar

### DIFF
--- a/src/Charts/PlanningCalendarWindow.h
+++ b/src/Charts/PlanningCalendarWindow.h
@@ -38,7 +38,12 @@ class PlanningCalendarWindow : public GcChartWindow
 {
     Q_OBJECT
 
+    Q_PROPERTY(int defaultView READ getDefaultView WRITE setDefaultView USER true)
     Q_PROPERTY(int firstDayOfWeek READ getFirstDayOfWeek WRITE setFirstDayOfWeek USER true)
+    Q_PROPERTY(int startHour READ getStartHour WRITE setStartHour USER true)
+    Q_PROPERTY(int endHour READ getEndHour WRITE setEndHour USER true)
+    Q_PROPERTY(bool summaryVisibleDay READ isSummaryVisibleDay WRITE setSummaryVisibleDay USER true)
+    Q_PROPERTY(bool summaryVisibleWeek READ isSummaryVisibleWeek WRITE setSummaryVisibleWeek USER true)
     Q_PROPERTY(bool summaryVisibleMonth READ isSummaryVisibleMonth WRITE setSummaryVisibleMonth USER true)
     Q_PROPERTY(QString primaryMainField READ getPrimaryMainField WRITE setPrimaryMainField USER true)
     Q_PROPERTY(QString primaryFallbackField READ getPrimaryFallbackField WRITE setPrimaryFallbackField USER true)
@@ -49,7 +54,12 @@ class PlanningCalendarWindow : public GcChartWindow
     public:
         PlanningCalendarWindow(Context *context);
 
+        int getDefaultView() const;
         int getFirstDayOfWeek() const;
+        int getStartHour() const;
+        int getEndHour() const;
+        bool isSummaryVisibleDay() const;
+        bool isSummaryVisibleWeek() const;
         bool isSummaryVisibleMonth() const;
 
         bool isFiltered() const;
@@ -62,7 +72,12 @@ class PlanningCalendarWindow : public GcChartWindow
         QStringList getSummaryMetricsList() const;
 
     public slots:
+        void setDefaultView(int view);
         void setFirstDayOfWeek(int fdw);
+        void setStartHour(int hour);
+        void setEndHour(int hour);
+        void setSummaryVisibleDay(bool visible);
+        void setSummaryVisibleWeek(bool visible);
         void setSummaryVisibleMonth(bool svm);
         void setPrimaryMainField(const QString &name);
         void setPrimaryFallbackField(const QString &name);
@@ -76,14 +91,19 @@ class PlanningCalendarWindow : public GcChartWindow
         Context *context;
         bool first = true;
 
+        QComboBox *defaultViewCombo;
         QComboBox *firstDayOfWeekCombo;
+        QSpinBox *startHourSpin;
+        QSpinBox *endHourSpin;
+        QCheckBox *summaryDayCheck;
+        QCheckBox *summaryWeekCheck;
         QCheckBox *summaryMonthCheck;
         QComboBox *primaryMainCombo;
         QComboBox *primaryFallbackCombo;
         QComboBox *secondaryCombo;
         QComboBox *tertiaryCombo;
         MultiMetricSelector *multiMetricSelector;
-        Calendar *calendar;
+        Calendar *calendar = nullptr;
 
         void mkControls();
         void updatePrimaryConfigCombos();

--- a/src/Gui/Calendar.cpp
+++ b/src/Gui/Calendar.cpp
@@ -317,10 +317,8 @@ void
 CalendarDayTable::fillEntries
 (const QHash<QDate, QList<CalendarEntry>> &activityEntries, const QList<CalendarSummary> &summaries, const QHash<QDate, QList<CalendarEntry>> &headlineEntries)
 {
-    Q_UNUSED(headlineEntries)
-
-    int startHour = 8;
-    int endHour = 21;
+    int startHour = defaultStartHour;
+    int endHour = defaultEndHour;
     int numDays = type == CalendarDayTableType::Day ? 1 : 7;
     for (int i = 0; i < numDays; ++i) {
         QTableWidgetItem *headlineItem = this->item(0, i + 1);
@@ -396,6 +394,22 @@ CalendarDayTable::setFirstDayOfWeek
     if (type == CalendarDayTableType::Week) {
         setDay(selectedDate());
     }
+}
+
+
+void
+CalendarDayTable::setStartHour
+(int hour)
+{
+    defaultStartHour = hour;
+}
+
+
+void
+CalendarDayTable::setEndHour
+(int hour)
+{
+    defaultEndHour = hour;
 }
 
 
@@ -1424,6 +1438,30 @@ CalendarDayView::setFirstDayOfWeek
 
 
 void
+CalendarDayView::setStartHour
+(int hour)
+{
+    dayTable->setStartHour(hour);
+}
+
+
+void
+CalendarDayView::setEndHour
+(int hour)
+{
+    dayTable->setEndHour(hour);
+}
+
+
+void
+CalendarDayView::setSummaryVisible
+(bool visible)
+{
+    dayTable->setRowHidden(2, ! visible);
+}
+
+
+void
 CalendarDayView::fillEntries
 (const QHash<QDate, QList<CalendarEntry>> &activityEntries, const QList<CalendarSummary> &summaries, const QHash<QDate, QList<CalendarEntry>> &headlineEntries)
 {
@@ -1680,6 +1718,30 @@ CalendarWeekView::setFirstDayOfWeek
 (Qt::DayOfWeek firstDayOfWeek)
 {
     weekTable->setFirstDayOfWeek(firstDayOfWeek);
+}
+
+
+void
+CalendarWeekView::setStartHour
+(int hour)
+{
+    weekTable->setStartHour(hour);
+}
+
+
+void
+CalendarWeekView::setEndHour
+(int hour)
+{
+    weekTable->setEndHour(hour);
+}
+
+
+void
+CalendarWeekView::setSummaryVisible
+(bool visible)
+{
+    weekTable->setRowHidden(2, ! visible);
 }
 
 
@@ -2074,6 +2136,40 @@ Calendar::setFirstDayOfWeek
     } else if (currentView() == CalendarView::Month) {
         setDate(fitToMonth(currentDate, false), true);
     }
+}
+
+
+void
+Calendar::setStartHour
+(int hour)
+{
+    weekView->setStartHour(hour);
+    dayView->setStartHour(hour);
+}
+
+
+void
+Calendar::setEndHour
+(int hour)
+{
+    weekView->setEndHour(hour);
+    dayView->setEndHour(hour);
+}
+
+
+void
+Calendar::setSummaryDayVisible
+(bool visible)
+{
+    dayView->setSummaryVisible(visible);
+}
+
+
+void
+Calendar::setSummaryWeekVisible
+(bool visible)
+{
+    weekView->setSummaryVisible(visible);
 }
 
 

--- a/src/Gui/Calendar.h
+++ b/src/Gui/Calendar.h
@@ -86,6 +86,8 @@ public:
     void fillEntries(const QHash<QDate, QList<CalendarEntry>> &activityEntries, const QList<CalendarSummary> &summaries, const QHash<QDate, QList<CalendarEntry>> &headlineEntries);
     void limitDateRange(const DateRange &dr);
     void setFirstDayOfWeek(Qt::DayOfWeek firstDayOfWeek);
+    void setStartHour(int hour);
+    void setEndHour(int hour);
 
 signals:
     void dayClicked(const CalendarDay &day, const QTime &time);
@@ -121,6 +123,8 @@ private:
     QDate date;
     DateRange dr;
     CalendarDayTableType type;
+    int defaultStartHour = 8;
+    int defaultEndHour = 21;
 
     QTimer dragTimer;
     QPoint pressedPos;
@@ -220,6 +224,9 @@ public:
 
     bool setDay(const QDate &date);
     void setFirstDayOfWeek(Qt::DayOfWeek firstDayOfWeek);
+    void setStartHour(int hour);
+    void setEndHour(int hour);
+    void setSummaryVisible(bool visible);
     void fillEntries(const QHash<QDate, QList<CalendarEntry>> &activityEntries, const QList<CalendarSummary> &summaries, const QHash<QDate, QList<CalendarEntry>> &headlineEntries);
     void limitDateRange(const DateRange &dr);
     QDate firstVisibleDay() const;
@@ -254,6 +261,9 @@ public:
 
     bool setDay(const QDate &date);
     void setFirstDayOfWeek(Qt::DayOfWeek firstDayOfWeek);
+    void setStartHour(int hour);
+    void setEndHour(int hour);
+    void setSummaryVisible(bool visible);
     void fillEntries(const QHash<QDate, QList<CalendarEntry>> &activityEntries, const QList<CalendarSummary> &summaries, const QHash<QDate, QList<CalendarEntry>> &headlineEntries);
     void limitDateRange(const DateRange &dr);
     QDate firstVisibleDay() const;
@@ -299,6 +309,10 @@ public slots:
     void setView(CalendarView view);
     void activateDateRange(const DateRange &dr, bool allowKeepMonth = false);
     void setFirstDayOfWeek(Qt::DayOfWeek firstDayOfWeek);
+    void setStartHour(int hour);
+    void setEndHour(int hour);
+    void setSummaryDayVisible(bool visible);
+    void setSummaryWeekVisible(bool visible);
     void setSummaryMonthVisible(bool visible);
     void applyNavIcons();
     void updateMeasures();


### PR DESCRIPTION
* Start- and end-hour for day and week view
* Summaries can be hidden for day and week view (month view was already available)
* The default view for first start can be selected