### PR TITLE
Fix ride navigator asterisk column problem for additional athletes

### DIFF
--- a/src/Gui/RideNavigator.cpp
+++ b/src/Gui/RideNavigator.cpp
@@ -330,7 +330,8 @@ RideNavigator::resetView()
     tableView->setColumnHidden(0, true);
     tableView->setColumnWidth(0,0);
 
-    // set the column widths
+    // set the column widths, column zero is the
+    // group by column, so we always set that to zero width.
     int columnnumber=0;
     foreach(QString size, _widths.split("|", Qt::SkipEmptyParts)) {
 
@@ -490,10 +491,11 @@ RideNavigator::eventFilter(QObject *object, QEvent *e)
         case QEvent::LayoutRequest:
         {
             active=true;
-            // set the column widths
+            // set the column widths, column zero is the
+            // group by column, so we always set that to zero width.
             int columnnumber=0;
             foreach(QString size, _widths.split("|", Qt::SkipEmptyParts)) {
-                tableView->setColumnWidth(columnnumber, size.toInt());
+                tableView->setColumnWidth(columnnumber, columnnumber ? size.toInt() : 0);
                 columnnumber++;
             }
             active=false;
@@ -606,7 +608,8 @@ RideNavigator::calcColumnsChanged(bool resized, int logicalIndex, int oldSize, i
     // correct width and store result
     setColumnWidth(geometry().width(), resized, logicalIndex, oldSize, newSize); // calculate width...
 
-    // get column widths
+    // get column widths, column zero is the
+    // group by column, so we always set that to zero width.
     QString widths("0|");
     for (int i=1; i<tableView->header()->count(); i++) {
         int index = tableView->header()->logicalIndex(i);


### PR DESCRIPTION
The problem of the hidden asterisk column (used for groupby) appearing when additional athletes were created was due in part to there no being an ActiveWindow event being generated for the additional athletes, so this has been changed to LayoutRequest event, also the hidden asterisk column was not always set to zero width.

Test steps:

1. Open GC
2. Switch to athletes view
3. Either create or open an additional athlete
4. Switch to activities view
5. Asterisk displayed without this fix.

Switching between Athletes using the tabbar, opening and closing athletes all now work, without the hidden groupby column being displayed.