### PR TITLE
Calendar: Agenda View

### DIFF
--- a/src/Charts/PlanningCalendarWindow.h
+++ b/src/Charts/PlanningCalendarWindow.h
@@ -42,6 +42,8 @@ class PlanningCalendarWindow : public GcChartWindow
     Q_PROPERTY(int firstDayOfWeek READ getFirstDayOfWeek WRITE setFirstDayOfWeek USER true)
     Q_PROPERTY(int startHour READ getStartHour WRITE setStartHour USER true)
     Q_PROPERTY(int endHour READ getEndHour WRITE setEndHour USER true)
+    Q_PROPERTY(int agendaPastDays READ getAgendaPastDays WRITE setAgendaPastDays USER true)
+    Q_PROPERTY(int agendaFutureDays READ getAgendaFutureDays WRITE setAgendaFutureDays USER true)
     Q_PROPERTY(bool summaryVisibleDay READ isSummaryVisibleDay WRITE setSummaryVisibleDay USER true)
     Q_PROPERTY(bool summaryVisibleWeek READ isSummaryVisibleWeek WRITE setSummaryVisibleWeek USER true)
     Q_PROPERTY(bool summaryVisibleMonth READ isSummaryVisibleMonth WRITE setSummaryVisibleMonth USER true)
@@ -58,6 +60,8 @@ class PlanningCalendarWindow : public GcChartWindow
         int getFirstDayOfWeek() const;
         int getStartHour() const;
         int getEndHour() const;
+        int getAgendaPastDays() const;
+        int getAgendaFutureDays() const;
         bool isSummaryVisibleDay() const;
         bool isSummaryVisibleWeek() const;
         bool isSummaryVisibleMonth() const;
@@ -76,6 +80,8 @@ class PlanningCalendarWindow : public GcChartWindow
         void setFirstDayOfWeek(int fdw);
         void setStartHour(int hour);
         void setEndHour(int hour);
+        void setAgendaPastDays(int days);
+        void setAgendaFutureDays(int days);
         void setSummaryVisibleDay(bool visible);
         void setSummaryVisibleWeek(bool visible);
         void setSummaryVisibleMonth(bool svm);
@@ -95,6 +101,8 @@ class PlanningCalendarWindow : public GcChartWindow
         QComboBox *firstDayOfWeekCombo;
         QSpinBox *startHourSpin;
         QSpinBox *endHourSpin;
+        QSpinBox *agendaPastDaysSpin;
+        QSpinBox *agendaFutureDaysSpin;
         QCheckBox *summaryDayCheck;
         QCheckBox *summaryWeekCheck;
         QCheckBox *summaryMonthCheck;

--- a/src/Gui/AthletePages.h
+++ b/src/Gui/AthletePages.h
@@ -52,6 +52,7 @@
 #include "RemoteControl.h"
 #include "Measures.h"
 #include "StyledItemDelegates.h"
+#include "Qt5Compatibility.h"
 
 class MeasuresPage : public QWidget
 {
@@ -243,31 +244,6 @@ class SchemePage : public QWidget
         QTreeWidget *scheme;
         SpinBoxEditDelegate zoneFromDelegate;
 };
-
-
-// Compatibility helper for Qt5
-// exposes methods that turned public in Qt6 from protected in Qt5
-#if QT_VERSION < 0x060000
-class TreeWidget6 : public QTreeWidget
-{
-    Q_OBJECT
-
-    public:
-        TreeWidget6(QWidget *parent = nullptr): QTreeWidget(parent) {
-        }
-
-        QModelIndex indexFromItem(const QTreeWidgetItem *item, int column = 0) const {
-            return QTreeWidget::indexFromItem(item, column);
-        }
-
-        QTreeWidgetItem* itemFromIndex(const QModelIndex &index) const {
-            return QTreeWidget::itemFromIndex(index);
-        }
-
-};
-#else
-typedef QTreeWidget TreeWidget6;
-#endif
 
 
 class CPPage : public QWidget

--- a/src/Gui/CalendarItemDelegates.h
+++ b/src/Gui/CalendarItemDelegates.h
@@ -94,6 +94,12 @@ private:
 
 class CalendarDetailedDayDelegate : public QStyledItemDelegate {
 public:
+    enum Roles {
+        DayRole = Qt::UserRole + 1, // [CalendarDay] Calendar day
+        PressedEntryRole,           // [int] Index of the currently pressed CalendarDay (see DayRole >> entries)
+        LayoutRole                  // [QList<CalendarEntryLayout>] Layout of the activities in one column
+    };
+
     explicit CalendarDetailedDayDelegate(TimeScaleData const * const timeScaleData, QObject *parent = nullptr);
 
     void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
@@ -109,6 +115,10 @@ private:
 
 class CalendarHeadlineDelegate : public QStyledItemDelegate {
 public:
+    enum Roles {
+        DayRole = Qt::UserRole + 1 // [CalendarDay] Calendar day
+    };
+
     explicit CalendarHeadlineDelegate(QObject *parent = nullptr);
 
     void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
@@ -124,6 +134,11 @@ private:
 
 class CalendarTimeScaleDelegate : public QStyledItemDelegate {
 public:
+    enum Roles {
+        CurrentYRole = Qt::UserRole, // [int] Current Y value of the mousepointer
+        BlockRole                    // [int / BlockIndicator] How the timescale should be marked as blocked
+    };
+
     explicit CalendarTimeScaleDelegate(TimeScaleData *timeScaleData, QObject *parent = nullptr);
 
     void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
@@ -138,6 +153,11 @@ private:
 
 class CalendarCompactDayDelegate : public QStyledItemDelegate {
 public:
+    enum Roles {
+        DayRole = Qt::UserRole + 1, // [CalendarDay] Calendar day
+        PressedEntryRole            // [int] Index of the currently pressed CalendarDay (see DayRole >> entries)
+    };
+
     explicit CalendarCompactDayDelegate(QObject *parent = nullptr);
 
     void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
@@ -151,6 +171,10 @@ public:
 
 class CalendarSummaryDelegate : public QStyledItemDelegate {
 public:
+    enum Roles {
+        SummaryRole = Qt::UserRole  // [CalendarSummary] Summary data
+    };
+
     explicit CalendarSummaryDelegate(int horMargin = 4, QObject *parent = nullptr);
 
     void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
@@ -162,6 +186,43 @@ private:
     const int horMargin;
     const int vertMargin = 4;
     const int lineSpacing = 2;
+};
+
+
+class AgendaMultiDelegate : public QStyledItemDelegate {
+public:
+    enum Roles {
+        // Qt::DisplayRole // [QString] The default text to display
+        // Qt::FontRole    // [QFont] The default font to use for text
+        HoverFlagRole = Qt::UserRole, // [bool] Hover flag. True if the item is hovered. If not set or invalid, treated as false
+        HoverTextRole,                // [QString] Hover text to display when the hover flag is true. If empty, the normal DisplayRole text is used
+        HoverFontRole,                // [QFont] Hover font to use when the hover flag is true. If default-constructed, the normal font is used
+        TypeRole,                     // [int] 0: Text
+                                      //       1: Spacer (Qt::UserRole + 4: Height)
+                                      //       2: Separator
+        MarginTopRole,                // [int] Margin above (Type Spacer + Separator only)
+        MarginBottomRole              // [int] Margin below (Type Separator only)
+    };
+
+    explicit AgendaMultiDelegate(QObject *parent = nullptr);
+
+    void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+};
+
+
+class CalendarSingleActivityDelegate : public QStyledItemDelegate {
+public:
+    enum Roles {
+        EntryRole = Qt::UserRole, // [CalendarEntry] Entry to be displayed
+        HoverFlagRole,            // [bool] Hover flag. True if the item is hovered. If not set or invalid, treated as false
+        EntryDateRole             // [bool] Date of the CalendarEntry
+    };
+
+    explicit CalendarSingleActivityDelegate(QObject *parent = nullptr);
+
+    void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+    QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 };
 
 #endif

--- a/src/Gui/Colors.cpp
+++ b/src/Gui/Colors.cpp
@@ -1282,6 +1282,21 @@ newQFormLayout
 
 
 extern QLayout*
+centerWidgetInLayout
+(QWidget *widget, bool margins)
+{
+    QHBoxLayout *centerLayout = new QHBoxLayout();
+    if (! margins) {
+        centerLayout->setContentsMargins(0, 0, 0, 0);
+    }
+    centerLayout->addStretch(1);
+    centerLayout->addWidget(widget, 3);
+    centerLayout->addStretch(1);
+    return centerLayout;
+}
+
+
+extern QLayout*
 centerLayout
 (QLayout *layout, bool margins)
 {

--- a/src/Gui/Colors.h
+++ b/src/Gui/Colors.h
@@ -43,6 +43,7 @@ extern QFont baseFont;
 // layout and widget styling
 extern void basicTreeWidgetStyle(QTreeWidget *tree, bool editable = true);
 extern QFormLayout *newQFormLayout(QWidget *parent = nullptr);
+extern QLayout *centerWidgetInLayout(QWidget *widget, bool margins = true);
 extern QLayout *centerLayout(QLayout *layout, bool margins = true);
 extern QWidget *centerLayoutInWidget(QLayout *layout, bool margins = true);
 

--- a/src/Gui/Qt5Compatibility.h
+++ b/src/Gui/Qt5Compatibility.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2025 Joachim Kohlhammer (joachim.kohlhammer@gmx.de)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef QT5COMPATIBILITY__H
+#define QT5COMPATIBILITY__H
+
+#include <QTreeWidget>
+
+
+// Compatibility helper for Qt5
+// exposes methods that turned public in Qt6 from protected in Qt5
+#if QT_VERSION < 0x060000
+class TreeWidget6 : public QTreeWidget
+{
+    Q_OBJECT
+
+    public:
+        TreeWidget6(QWidget *parent = nullptr): QTreeWidget(parent) {
+        }
+
+        QModelIndex indexFromItem(const QTreeWidgetItem *item, int column = 0) const {
+            return QTreeWidget::indexFromItem(item, column);
+        }
+
+        QTreeWidgetItem* itemFromIndex(const QModelIndex &index) const {
+            return QTreeWidget::itemFromIndex(index);
+        }
+
+};
+#else
+typedef QTreeWidget TreeWidget6;
+#endif
+
+
+#endif

--- a/src/src.pro
+++ b/src/src.pro
@@ -652,7 +652,7 @@ HEADERS += Gui/AboutDialog.h Gui/AddIntervalDialog.h Gui/AnalysisSidebar.h Gui/C
            Gui/PerspectiveDialog.h Gui/SplashScreen.h Gui/StyledItemDelegates.h Gui/MetadataDialog.h Gui/ActionButtonBox.h \
            Gui/MetricOverrideDialog.h Gui/RepeatScheduleWizard.h \
            Gui/Calendar.h Gui/CalendarData.h Gui/CalendarItemDelegates.h \
-           Gui/IconManager.h
+           Gui/IconManager.h Gui/Qt5Compatibility.h
 
 # metrics and models
 HEADERS += Metrics/Banister.h Metrics/CPSolver.h Metrics/Estimator.h Metrics/ExtendedCriticalPower.h Metrics/HrZones.h Metrics/PaceZones.h \


### PR DESCRIPTION
* Read-only view to show
  * missed planned activities (configurable number of days to look back)
  * todays planned activities, phases and events
  * upcoming planned activities, phases and events (configurable number of days to look ahead)
* Color of planned activities is now user configurable (coming from global color theme)
* Added a hint to show whether a filter is active (all calendar views)
* Configuration: Reorganized in tabs
* Refactoring: Created enums for all user roles used in the calendar (all views, all delegates) to improve readability; removed data that was only written but never read