### PR TITLE
Mini Calendar on non-analysis start-up view fix

### DIFF
--- a/src/Gui/Views.cpp
+++ b/src/Gui/Views.cpp
@@ -68,10 +68,10 @@ AnalysisView::~AnalysisView()
 void
 AnalysisView::setRide(RideItem *ride)
 {
-    if (!loaded) return; // not loaded yet, all bets are off till then.
-
     // when ride selected, but not from the sidebar.
     static_cast<AnalysisSidebar*>(sidebar())->setRide(ride); // save settings
+
+    if (!loaded) return; // not loaded yet, all bets are off until the perspectives are loaded.
 
     // if we are the current view and the current perspective is no longer relevant
     // then lets go find one to switch to..


### PR DESCRIPTION
This PR fixes the mini calendar issue raise by @ZajtiM in the calendar discussions:

I noticed one problem with Calendar in Analysis view. It doesn't show month with latest activity. You can see on screenshot. You have to click on activity to show month with selected activity. I tested it with latest Snapshot and it works as it should. This is screenshot of GC (AppImage) from your latest PR.

<img width="314" height="378" alt="image" src="https://github.com/user-attachments/assets/503897a2-0eaa-4a0b-8da7-8e88b62cebc0" />

This also happens when opening a second athlete, it looks like some mini calendar initialization is not happening when Activities is not the starting view.