### PR TITLE
Calendar: Additionally respecting homefilters

### DIFF
--- a/src/Charts/PlanningCalendarWindow.cpp
+++ b/src/Charts/PlanningCalendarWindow.cpp
@@ -708,7 +708,8 @@ PlanningCalendarWindow::getActivities
             || rideItem == nullptr) {
             continue;
         }
-        if (context->isfiltered && ! context->filters.contains(rideItem->fileName)) {
+        if (   (context->isfiltered && ! context->filters.contains(rideItem->fileName))
+            || (context->ishomefiltered && ! context->homeFilters.contains(rideItem->fileName))) {
             continue;
         }
 


### PR DESCRIPTION
When collecting the activities for the planning calendar, only the filter was used. Now the homefilter is considered as well.

See https://groups.google.com/g/golden-cheetah-developers/c/viSV80ze3r8/m/lbkJnG1jCAAJ