### PR TITLE
New calendar chart color issue

### DIFF
--- a/src/Charts/CalendarWindow.cpp
+++ b/src/Charts/CalendarWindow.cpp
@@ -161,6 +161,14 @@ CalendarWindow::CalendarWindow(Context *context)
     });
 }
 
+void
+CalendarWindow::showEvent(QShowEvent*)
+{
+    // When the chart is added to the Perspective's QStackedWidget, the Perspective's style sheets
+    // can conflict with the local calendar palette settings causing the appearance to be lost.
+    // Therefore re-apply the palette upon showEvent to ensure correct calendar appearance.
+    PaletteApplier::setPaletteRecursively(this, palette, true);
+}
 
 int
 CalendarWindow::getDefaultView
@@ -467,7 +475,6 @@ CalendarWindow::configChanged
             inactiveText = GCColor::inactiveColor(activeText, 2.5);
         }
 
-        QPalette palette;
         palette.setColor(QPalette::Active, QPalette::Window, activeWindow);
         palette.setColor(QPalette::Active, QPalette::WindowText, activeText);
         palette.setColor(QPalette::Active, QPalette::Base, activeBase);

--- a/src/Charts/CalendarWindow.h
+++ b/src/Charts/CalendarWindow.h
@@ -93,10 +93,15 @@ class CalendarWindow : public GcChartWindow
         void setSummaryMetrics(const QStringList &summaryMetrics);
         void configChanged(qint32);
 
+    protected:
+
+        void showEvent(QShowEvent*) override;
+
     private:
         Context *context;
         bool first = true;
 
+        QPalette palette;
         QComboBox *defaultViewCombo;
         QComboBox *firstDayOfWeekCombo;
         QSpinBox *startHourSpin;


### PR DESCRIPTION
When manually creating a new calendar chart (with default Modern Dark color scheme, windows 11, qt 6.8.3) the new chart appears with a light background, while existing calendar charts loaded from the perspective's file appear correctly.

This appears to be caused (from google search) by the Perspective's style sheets interacting with the local calendar palette settings when the chart is added to the Perspectives QStackWidget:

[tabbed->addWidget(newone);](https://github.com/GoldenCheetah/GoldenCheetah/blob/9e8ed1717af5ced83cf787e80bfbb93db55cb1b3/src/Gui/Perspective.cpp#L742C13-L742C19)

causing the appearance to be lost. I confirmed this my calling the calendar's configChanged() before and after this line, before the chart has a light background, after the line the chart appearance is correct.

The fix is to reapply the palette settings to the calendar's widgets on the chart's showEvent.

I'm not sure why this is an issue for the calendar chart, as other charts use QPalette settings, but the calendar uses palette options (active, inactive & disabled) not used by any other chart:

        palette.setColor(QPalette::Active, QPalette::Window, activeWindow);
        palette.setColor(QPalette::Inactive, QPalette::Window, activeWindow);
        palette.setColor(QPalette::Disabled, QPalette::Window, alternateBg);