### PR TITLE
Moved the agenda to a dedicated chart

### DIFF
--- a/src/Charts/AgendaWindow.cpp
+++ b/src/Charts/AgendaWindow.cpp
@@ -1,0 +1,819 @@
+/*
+ * Copyright (c) 2025 Joachim Kohlhammer (joachim.kohlhammer@gmx.de)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "AgendaWindow.h"
+
+#include <QComboBox>
+
+#include "MainWindow.h"
+#include "AthleteTab.h"
+#include "Seasons.h"
+#include "Athlete.h"
+#include "RideMetadata.h"
+#include "Colors.h"
+#include "ManualActivityWizard.h"
+#include "RepeatScheduleWizard.h"
+#include "WorkoutFilter.h"
+#include "IconManager.h"
+#include "SeasonDialogs.h"
+
+#define HLO "<h4>"
+#define HLC "</h4>"
+
+
+AgendaWindow::AgendaWindow(Context *context)
+: GcChartWindow(context), context(context)
+{
+    mkControls();
+
+    agendaView = new AgendaView();
+    agendaView->updateDate();
+
+    setAgendaPastDays(7);
+    setAgendaFutureDays(7);
+    setPrimaryMainField("Route");
+    setPrimaryFallbackField("Workout Code");
+    setSecondaryMetric("workout_time");
+    setTertiaryField("Notes");
+    setShowTertiaryFor(0);
+    setActivityMaxTertiaryLines(3);
+    setEventMaxTertiaryLines(3);
+
+    QVBoxLayout *mainLayout = new QVBoxLayout();
+    setChartLayout(mainLayout);
+    mainLayout->addWidget(agendaView);
+
+    connect(context->athlete->seasons, &Seasons::seasonsChanged, this, &AgendaWindow::updateActivities);
+    connect(context, &Context::seasonSelected, this, &AgendaWindow::updateActivities);
+    connect(context, &Context::filterChanged, this, &AgendaWindow::updateActivities);
+    connect(context, &Context::homeFilterChanged, this, &AgendaWindow::updateActivities);
+    connect(context, &Context::rideAdded, this, &AgendaWindow::updateActivitiesIfInRange);
+    connect(context, &Context::rideDeleted, this, &AgendaWindow::updateActivitiesIfInRange);
+    connect(context, &Context::rideChanged, this, &AgendaWindow::updateActivitiesIfInRange);
+    connect(context, &Context::configChanged, this, &AgendaWindow::configChanged);
+    connect(agendaView, &AgendaView::showInTrainMode, this, [this, context](const CalendarEntry &activity) {
+        for (RideItem *rideItem : context->athlete->rideCache->rides()) {
+            if (rideItem != nullptr && rideItem->fileName == activity.reference) {
+                QString filter = buildWorkoutFilter(rideItem);
+                if (! filter.isEmpty()) {
+                    context->mainWindow->fillinWorkoutFilterBox(filter);
+                    context->mainWindow->selectTrain();
+                    context->notifySelectWorkout(0);
+                }
+                break;
+            }
+        }
+    });
+    connect(agendaView, &AgendaView::viewActivity, [this, context](const CalendarEntry &activity) {
+        for (RideItem *rideItem : context->athlete->rideCache->rides()) {
+            if (rideItem != nullptr && rideItem->fileName == activity.reference) {
+                context->notifyRideSelected(rideItem);
+                context->mainWindow->selectAnalysis();
+                break;
+            }
+        }
+    });
+    connect(agendaView, &AgendaView::editPhaseEntry, this, &AgendaWindow::editPhaseEntry);
+    connect(agendaView, &AgendaView::editEventEntry, this, &AgendaWindow::editEventEntry);
+
+    QTimer::singleShot(0, this, [this]() {
+        configChanged(CONFIG_APPEARANCE);
+    });
+}
+
+
+int
+AgendaWindow::getAgendaPastDays
+() const
+{
+    return agendaPastDaysSpin->value();
+}
+
+
+void
+AgendaWindow::setAgendaPastDays
+(int days)
+{
+    agendaPastDaysSpin->setValue(days);
+    if (agendaView != nullptr) {
+        agendaView->setPastDays(days);
+        updateActivities();
+    }
+}
+
+
+int
+AgendaWindow::getAgendaFutureDays
+() const
+{
+    return agendaFutureDaysSpin->value();
+}
+
+
+void
+AgendaWindow::setAgendaFutureDays
+(int days)
+{
+    agendaFutureDaysSpin->setValue(days);
+    if (agendaView != nullptr) {
+        agendaView->setFutureDays(days);
+        updateActivities();
+    }
+}
+
+
+bool
+AgendaWindow::isFiltered
+() const
+{
+    return (context->ishomefiltered || context->isfiltered);
+}
+
+
+QString
+AgendaWindow::getPrimaryMainField
+() const
+{
+    return primaryMainCombo->currentText();
+}
+
+
+void
+AgendaWindow::setPrimaryMainField
+(const QString &name)
+{
+    primaryMainCombo->setCurrentText(name);
+}
+
+
+QString
+AgendaWindow::getPrimaryFallbackField
+() const
+{
+    return primaryFallbackCombo->currentText();
+}
+
+
+void
+AgendaWindow::setPrimaryFallbackField
+(const QString &name)
+{
+    primaryFallbackCombo->setCurrentText(name);
+}
+
+
+void
+AgendaWindow::setSecondaryMetric
+(const QString &name)
+{
+    secondaryCombo->setCurrentIndex(std::max(0, secondaryCombo->findData(name)));
+}
+
+
+QString
+AgendaWindow::getSecondaryMetric
+() const
+{
+    return secondaryCombo->currentData(Qt::UserRole).toString();
+}
+
+
+void
+AgendaWindow::setShowTertiaryFor
+(int showFor)
+{
+    showTertiaryForCombo->setCurrentIndex(showFor);
+}
+
+
+int
+AgendaWindow::getShowTertiaryFor
+() const
+{
+    return showTertiaryForCombo->currentIndex();
+}
+
+
+QString
+AgendaWindow::getTertiaryField
+() const
+{
+    return tertiaryCombo->currentText();
+}
+
+
+void
+AgendaWindow::setTertiaryField
+(const QString &name)
+{
+    tertiaryCombo->setCurrentText(name);
+}
+
+
+int
+AgendaWindow::getActivityMaxTertiaryLines
+() const
+{
+    return activityMaxTertiaryLinesSpin->value();
+}
+
+
+void
+AgendaWindow::setActivityMaxTertiaryLines
+(int maxTertiaryLines)
+{
+    activityMaxTertiaryLinesSpin->setValue(maxTertiaryLines);
+    if (agendaView != nullptr) {
+        agendaView->setActivityMaxTertiaryLines(maxTertiaryLines);
+    }
+}
+
+
+int
+AgendaWindow::getEventMaxTertiaryLines
+() const
+{
+    return eventMaxTertiaryLinesSpin->value();
+}
+
+
+void
+AgendaWindow::setEventMaxTertiaryLines
+(int maxTertiaryLines)
+{
+    eventMaxTertiaryLinesSpin->setValue(maxTertiaryLines);
+    if (agendaView != nullptr) {
+        agendaView->setEventMaxTertiaryLines(maxTertiaryLines);
+    }
+}
+
+
+void
+AgendaWindow::configChanged
+(qint32 what)
+{
+    bool refreshActivities = false;
+    if (   (what & CONFIG_FIELDS)
+        || (what & CONFIG_USERMETRICS)) {
+        updatePrimaryConfigCombos();
+        updateSecondaryConfigCombo();
+        updateTertiaryConfigCombo();
+    }
+    if (what & CONFIG_APPEARANCE) {
+        // change colors to reflect preferences
+        setProperty("color", GColor(CPLOTBACKGROUND));
+
+        QColor activeBase = GColor(CPLOTBACKGROUND);
+        QColor activeWindow = activeBase;
+        QColor activeText = GCColor::invertColor(activeBase);
+        QColor activeHl = GColor(CCALCURRENT);
+        QColor activeHlText = GCColor::invertColor(activeHl);
+        QColor alternateBg = GCColor::inactiveColor(activeBase, 0.2);
+        QColor inactiveText = GCColor::inactiveColor(activeText, 1.5);
+        QColor activeButtonBg = activeBase;
+        QColor disabledButtonBg = alternateBg;
+        if (activeBase.lightness() < 20) {
+            activeWindow = GCColor::inactiveColor(activeWindow, 0.2);
+            activeButtonBg = alternateBg;
+            disabledButtonBg = GCColor::inactiveColor(activeButtonBg, 0.3);
+            inactiveText = GCColor::inactiveColor(activeText, 2.5);
+        }
+
+        palette.setColor(QPalette::Active, QPalette::Window, activeWindow);
+        palette.setColor(QPalette::Active, QPalette::WindowText, activeText);
+        palette.setColor(QPalette::Active, QPalette::Base, activeBase);
+        palette.setColor(QPalette::Active, QPalette::AlternateBase, alternateBg);
+        palette.setColor(QPalette::Active, QPalette::Text, activeText);
+        palette.setColor(QPalette::Active, QPalette::Highlight, activeHl);
+        palette.setColor(QPalette::Active, QPalette::HighlightedText, activeHlText);
+        palette.setColor(QPalette::Active, QPalette::Button, activeButtonBg);
+        palette.setColor(QPalette::Active, QPalette::ButtonText, activeText);
+
+        palette.setColor(QPalette::Inactive, QPalette::Window, activeWindow);
+        palette.setColor(QPalette::Inactive, QPalette::WindowText, activeText);
+        palette.setColor(QPalette::Inactive, QPalette::Base, activeBase);
+        palette.setColor(QPalette::Inactive, QPalette::AlternateBase, alternateBg);
+        palette.setColor(QPalette::Inactive, QPalette::Text, activeText);
+        palette.setColor(QPalette::Inactive, QPalette::Highlight, activeHl);
+        palette.setColor(QPalette::Inactive, QPalette::HighlightedText, activeHlText);
+        palette.setColor(QPalette::Inactive, QPalette::Button, activeButtonBg);
+        palette.setColor(QPalette::Inactive, QPalette::ButtonText, activeText);
+
+        palette.setColor(QPalette::Disabled, QPalette::Window, alternateBg);
+        palette.setColor(QPalette::Disabled, QPalette::WindowText, inactiveText);
+        palette.setColor(QPalette::Disabled, QPalette::Base, alternateBg);
+        palette.setColor(QPalette::Disabled, QPalette::AlternateBase, alternateBg);
+        palette.setColor(QPalette::Disabled, QPalette::Text, inactiveText);
+        palette.setColor(QPalette::Disabled, QPalette::Highlight, activeHl);
+        palette.setColor(QPalette::Disabled, QPalette::HighlightedText, activeHlText);
+        palette.setColor(QPalette::Disabled, QPalette::Button, disabledButtonBg);
+        palette.setColor(QPalette::Disabled, QPalette::ButtonText, inactiveText);
+
+        PaletteApplier::setPaletteRecursively(this, palette, true);
+        refreshActivities = true;
+    }
+
+    if (refreshActivities) {
+        updateActivities();
+    }
+}
+
+
+void
+AgendaWindow::showEvent
+(QShowEvent *event)
+{
+    Q_UNUSED(event)
+
+    PaletteApplier::setPaletteRecursively(this, palette, true);
+}
+
+
+void
+AgendaWindow::mkControls
+()
+{
+    agendaPastDaysSpin = new QSpinBox();
+    agendaPastDaysSpin->setMaximum(31);
+    agendaPastDaysSpin->setSuffix(" " + tr("day(s)"));
+    agendaFutureDaysSpin = new QSpinBox();
+    agendaFutureDaysSpin->setMaximum(31);
+    agendaFutureDaysSpin->setSuffix(" " + tr("day(s)"));
+    primaryMainCombo = new QComboBox();
+    primaryFallbackCombo = new QComboBox();
+    secondaryCombo = new QComboBox();
+    showTertiaryForCombo = new QComboBox();
+    tertiaryCombo = new QComboBox();
+    updatePrimaryConfigCombos();
+    updateSecondaryConfigCombo();
+    showTertiaryForCombo->addItem(tr("all dates"));
+    showTertiaryForCombo->addItem(tr("today"));
+    showTertiaryForCombo->addItem(tr("no dates"));
+    updateTertiaryConfigCombo();
+    primaryMainCombo->setCurrentText("Route");
+    primaryFallbackCombo->setCurrentText("Workout Code");
+    int secondaryIndex = secondaryCombo->findData("workout_time");
+    if (secondaryIndex >= 0) {
+        secondaryCombo->setCurrentIndex(secondaryIndex);
+    }
+    activityMaxTertiaryLinesSpin = new QSpinBox();
+    activityMaxTertiaryLinesSpin->setRange(1, 5);
+    eventMaxTertiaryLinesSpin = new QSpinBox();
+    eventMaxTertiaryLinesSpin->setRange(1, 5);
+
+    QFormLayout *activityForm = newQFormLayout();
+    activityForm->setContentsMargins(0, 10 * dpiYFactor, 0, 10 * dpiYFactor);
+    activityForm->addRow(new QLabel(HLO + tr("Agenda Basics") + HLC));
+    activityForm->addRow(tr("Back to Include"), agendaPastDaysSpin);
+    activityForm->addRow(tr("Ahead to Include"), agendaFutureDaysSpin);
+    activityForm->addItem(new QSpacerItem(0, 20 * dpiYFactor));
+    activityForm->addRow(new QLabel(HLO + tr("Main Line") + HLC));
+    activityForm->addRow(tr("Field"), primaryMainCombo);
+    activityForm->addRow(tr("Fallback Field"), primaryFallbackCombo);
+    activityForm->addItem(new QSpacerItem(0, 20 * dpiYFactor));
+    activityForm->addRow(new QLabel(HLO + tr("Metric Line") + HLC));
+    activityForm->addRow(tr("Metric"), secondaryCombo);
+    activityForm->addItem(new QSpacerItem(0, 20 * dpiYFactor));
+    activityForm->addRow(new QLabel(HLO + tr("Detail Line") + HLC));
+    activityForm->addRow(tr("Show Line for"), showTertiaryForCombo);
+    activityForm->addRow(tr("Field"), tertiaryCombo);
+    activityForm->addRow(tr("Visible Lines"), activityMaxTertiaryLinesSpin);
+
+    QFormLayout *eventForm = newQFormLayout();
+    eventForm->setContentsMargins(0, 10 * dpiYFactor, 0, 10 * dpiYFactor);
+    eventForm->addRow(new QLabel(HLO + tr("Detail Line") + HLC));
+    eventForm->addRow(tr("Visible Lines"), eventMaxTertiaryLinesSpin);
+
+    QTabWidget *controlsTabs = new QTabWidget();
+    controlsTabs->addTab(centerLayoutInWidget(activityForm, false), tr("Activities"));
+    controlsTabs->addTab(centerLayoutInWidget(eventForm, false), tr("Events"));
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    connect(agendaPastDaysSpin, QOverload<int>::of(&QSpinBox::valueChanged), this, &AgendaWindow::setAgendaPastDays);
+    connect(agendaFutureDaysSpin, QOverload<int>::of(&QSpinBox::valueChanged), this, &AgendaWindow::setAgendaFutureDays);
+    connect(primaryMainCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &AgendaWindow::updateActivities);
+    connect(primaryFallbackCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &AgendaWindow::updateActivities);
+    connect(secondaryCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &AgendaWindow::updateActivities);
+    connect(showTertiaryForCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &AgendaWindow::updateActivities);
+    connect(tertiaryCombo, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &AgendaWindow::updateActivities);
+    connect(activityMaxTertiaryLinesSpin, QOverload<int>::of(&QSpinBox::valueChanged), this, &AgendaWindow::setActivityMaxTertiaryLines);
+    connect(eventMaxTertiaryLinesSpin, QOverload<int>::of(&QSpinBox::valueChanged), this, &AgendaWindow::setEventMaxTertiaryLines);
+#else
+    connect(agendaPastDaysSpin, &QSpinBox::valueChanged, this, &AgendaWindow::setAgendaPastDays);
+    connect(agendaFutureDaysSpin, &QSpinBox::valueChanged, this, &AgendaWindow::setAgendaFutureDays);
+    connect(primaryMainCombo, &QComboBox::currentIndexChanged, this, &AgendaWindow::updateActivities);
+    connect(primaryFallbackCombo, &QComboBox::currentIndexChanged, this, &AgendaWindow::updateActivities);
+    connect(secondaryCombo, &QComboBox::currentIndexChanged, this, &AgendaWindow::updateActivities);
+    connect(showTertiaryForCombo, &QComboBox::currentIndexChanged, this, &AgendaWindow::updateActivities);
+    connect(tertiaryCombo, &QComboBox::currentIndexChanged, this, &AgendaWindow::updateActivities);
+    connect(activityMaxTertiaryLinesSpin, &QSpinBox::valueChanged, this, &AgendaWindow::setActivityMaxTertiaryLines);
+    connect(eventMaxTertiaryLinesSpin, &QSpinBox::valueChanged, this, &AgendaWindow::setEventMaxTertiaryLines);
+#endif
+
+    setControls(controlsTabs);
+}
+
+
+void
+AgendaWindow::updatePrimaryConfigCombos
+()
+{
+    QString mainField = getPrimaryMainField();
+    QString fallbackField = getPrimaryFallbackField();
+
+    primaryMainCombo->blockSignals(true);
+    primaryFallbackCombo->blockSignals(true);
+    primaryMainCombo->clear();
+    primaryFallbackCombo->clear();
+    QList<FieldDefinition> fieldsDefs = GlobalContext::context()->rideMetadata->getFields();
+    for (const FieldDefinition &fieldDef : fieldsDefs) {
+        if (fieldDef.isTextField()) {
+            primaryMainCombo->addItem(fieldDef.name);
+            primaryFallbackCombo->addItem(fieldDef.name);
+        }
+    }
+
+    primaryMainCombo->blockSignals(false);
+    primaryFallbackCombo->blockSignals(false);
+    setPrimaryMainField(mainField);
+    setPrimaryFallbackField(fallbackField);
+}
+
+
+void
+AgendaWindow::updateSecondaryConfigCombo
+()
+{
+    QString symbol = getSecondaryMetric();
+
+    secondaryCombo->blockSignals(true);
+    secondaryCombo->clear();
+    const RideMetricFactory &factory = RideMetricFactory::instance();
+    for (const QString &metricSymbol : factory.allMetrics()) {
+        if (metricSymbol.startsWith("compatibility_")) {
+            continue;
+        }
+        secondaryCombo->addItem(Utils::unprotect(factory.rideMetric(metricSymbol)->name()), metricSymbol);
+    }
+
+    secondaryCombo->blockSignals(false);
+    setSecondaryMetric(symbol);
+}
+
+
+void
+AgendaWindow::updateTertiaryConfigCombo
+()
+{
+    QString field = getTertiaryField();
+
+    tertiaryCombo->blockSignals(true);
+    tertiaryCombo->clear();
+    QList<FieldDefinition> fieldsDefs = GlobalContext::context()->rideMetadata->getFields();
+    for (const FieldDefinition &fieldDef : fieldsDefs) {
+        if (fieldDef.isTextField()) {
+            tertiaryCombo->addItem(fieldDef.name);
+        }
+    }
+
+    tertiaryCombo->blockSignals(false);
+    setTertiaryField(field);
+}
+
+
+QHash<QDate, QList<CalendarEntry>>
+AgendaWindow::getActivities
+(const QDate &firstDay, const QDate &today, const QDate &lastDay) const
+{
+    QHash<QDate, QList<CalendarEntry>> activities;
+    const RideMetricFactory &factory = RideMetricFactory::instance();
+    const RideMetric *rideMetric = factory.rideMetric(getSecondaryMetric());
+    QString rideMetricName;
+    QString rideMetricUnit;
+    if (rideMetric != nullptr) {
+        rideMetricName = rideMetric->name();
+        if (   ! rideMetric->isTime()
+            && ! rideMetric->isDate()) {
+            rideMetricUnit = rideMetric->units(GlobalContext::context()->useMetricUnits);
+        }
+    }
+
+    int showTertiaryFor = getShowTertiaryFor();
+    for (RideItem *rideItem : context->athlete->rideCache->rides()) {
+        if (   rideItem == nullptr
+            || rideItem->dateTime.date() < firstDay
+            || rideItem->dateTime.date() > lastDay) {
+            continue;
+        }
+        if (   (context->isfiltered && ! context->filters.contains(rideItem->fileName))
+            || (context->ishomefiltered && ! context->homeFilters.contains(rideItem->fileName))) {
+            continue;
+        }
+
+        QString sport = rideItem->sport;
+        CalendarEntry activity;
+
+        QString primaryMain = rideItem->getText(getPrimaryMainField(), "").trimmed();
+        if (! primaryMain.isEmpty()) {
+            activity.primary = primaryMain;
+        } else {
+            QString primaryFallback = rideItem->getText(getPrimaryFallbackField(), "").trimmed();
+            if (! primaryFallback.isEmpty()) {
+                activity.primary = primaryFallback;
+            } else if (! sport.isEmpty()) {
+                activity.primary = tr("Unnamed %1").arg(sport);
+            } else {
+                activity.primary = tr("<unknown>");
+            }
+        }
+        if (rideMetric != nullptr && rideMetric->isRelevantForRide(rideItem)) {
+            activity.secondary = rideItem->getStringForSymbol(getSecondaryMetric(), GlobalContext::context()->useMetricUnits);
+            if (! rideMetricUnit.isEmpty()) {
+                activity.secondary += " " + rideMetricUnit;
+            }
+            activity.secondaryMetric = rideMetricName;
+        } else {
+            activity.secondary = "";
+            activity.secondaryMetric = "";
+        }
+        if (showTertiaryFor == 0 || (showTertiaryFor == 1 && rideItem->dateTime.date() == today)) {
+            activity.tertiary = rideItem->getText(getTertiaryField(), "").trimmed();
+            activity.tertiary = Utils::unprotect(activity.tertiary);
+        }
+        activity.primary = Utils::unprotect(activity.primary);
+        activity.secondary = Utils::unprotect(activity.secondary);
+        activity.secondaryMetric = Utils::unprotect(activity.secondaryMetric);
+
+        activity.iconFile = IconManager::instance().getFilepath(rideItem);
+        if (rideItem->color.alpha() < 255 || rideItem->planned) {
+            activity.color = GColor(CCALPLANNED);
+        } else {
+            activity.color = rideItem->color;
+        }
+        activity.reference = rideItem->fileName;
+        activity.start = rideItem->dateTime.time();
+        activity.durationSecs = rideItem->getForSymbol("workout_time", GlobalContext::context()->useMetricUnits);
+        activity.type = rideItem->planned ? ENTRY_TYPE_PLANNED_ACTIVITY : ENTRY_TYPE_ACTIVITY;
+        activity.isRelocatable = rideItem->planned;
+        activity.hasTrainMode = rideItem->planned && sport == "Bike" && ! buildWorkoutFilter(rideItem).isEmpty();
+        activities[rideItem->dateTime.date()] << activity;
+    }
+    for (auto dayIt = activities.begin(); dayIt != activities.end(); ++dayIt) {
+        std::sort(dayIt.value().begin(), dayIt.value().end(), [](const CalendarEntry &a, const CalendarEntry &b) {
+            if (a.start == b.start) {
+                return a.primary < b.primary;
+            } else {
+                return a.start < b.start;
+            }
+        });
+    }
+    return activities;
+}
+
+
+std::pair<QList<CalendarEntry>, QList<CalendarEntry>>
+AgendaWindow::getPhases
+(const Season &season, const QDate &firstDay) const
+{
+    QList<CalendarEntry> ongoingPhases;
+    QList<CalendarEntry> futurePhases;
+    for (const Phase &phase : season.phases) {
+        if (phase.getAbsoluteStart().isValid() && phase.getAbsoluteEnd().isValid()) {
+            QString phaseType;
+            switch (phase.getType()) {
+            case Phase::camp:
+                phaseType = Phase::types[5];
+                break;
+            default:
+                phaseType = Phase::types[static_cast<int>(phase.getType()) - static_cast<int>(Phase::phase)];
+            }
+            CalendarEntry entry;
+            entry.primary = phase.getName();
+            entry.iconFile = ":images/breeze/network-mobile-100.svg";
+            entry.color = GColor(CCALPHASE);
+            entry.reference = phase.id().toString();
+            entry.start = QTime(0, 0, 1);
+            entry.type = ENTRY_TYPE_PHASE;
+            entry.isRelocatable = false;
+            entry.spanStart = phase.getAbsoluteStart();
+            entry.spanEnd = phase.getAbsoluteEnd();
+            int duration = entry.spanStart.daysTo(entry.spanEnd);
+            ShowDaysAsUnit unit = showDaysAs(duration);
+            if (unit == ShowDaysAsUnit::Days) {
+                if (duration > 1) {
+                    entry.secondary = tr("%1 • %2 days").arg(phaseType).arg(duration);
+                } else {
+                    entry.secondary = tr("%1 • %2 day").arg(phaseType).arg(duration);
+                }
+            } else if (unit == ShowDaysAsUnit::Weeks) {
+                duration = daysToWeeks(duration);
+                if (duration > 1) {
+                    entry.secondary = tr("%1 • %2 weeks").arg(phaseType).arg(duration);
+                } else {
+                    entry.secondary = tr("%1 • %2 week").arg(phaseType).arg(duration);
+                }
+            } else {
+                duration = daysToMonths(duration);
+                if (duration > 1) {
+                    entry.secondary = tr("%1 • %2 months").arg(phaseType).arg(duration);
+                } else {
+                    entry.secondary = tr("%1 • %2 month").arg(phaseType).arg(duration);
+                }
+            }
+            if (phase.getAbsoluteStart() <= firstDay && phase.getAbsoluteEnd() >= firstDay) {
+                ongoingPhases << entry;
+            } else if (phase.getAbsoluteStart() >= firstDay) {
+                futurePhases << entry;
+            }
+        }
+    }
+    std::sort(ongoingPhases.begin(), ongoingPhases.end(), [](const CalendarEntry &a, const CalendarEntry &b) {
+        return a.spanEnd < b.spanEnd;
+    });
+    std::sort(futurePhases.begin(), futurePhases.end(), [](const CalendarEntry &a, const CalendarEntry &b) {
+        return a.spanStart < b.spanStart;
+    });
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    return std::pair<QList<CalendarEntry>, QList<CalendarEntry>>(ongoingPhases, futurePhases);
+#else
+    return std::pair(ongoingPhases, futurePhases);
+#endif
+}
+
+
+QHash<QDate, QList<CalendarEntry>>
+AgendaWindow::getEvents
+(const QDate &firstDay) const
+{
+    QHash<QDate, QList<CalendarEntry>> events;
+    QList<Season> tmpSeasons = context->athlete->seasons->seasons;
+    std::sort(tmpSeasons.begin(), tmpSeasons.end(), Season::LessThanForStarts);
+    for (const Season &s : tmpSeasons) {
+        for (const SeasonEvent &event : s.events) {
+            if (   (   (   firstDay.isValid()
+                        && event.date >= firstDay)
+                    || ! firstDay.isValid())) {
+                CalendarEntry entry;
+                entry.primary = event.name;
+                if (event.priority == 0) {
+                    entry.iconFile = ":images/breeze/task-process-4.svg";
+                    entry.secondary = tr("Uncategorized");
+                } else if (event.priority == 1) {
+                    entry.iconFile = ":images/breeze/task-process-4.svg";
+                    entry.secondary = tr("Category A");
+                } else if (event.priority == 2) {
+                    entry.iconFile = ":images/breeze/task-process-3.svg";
+                    entry.secondary = tr("Category B");
+                } else if (event.priority == 3) {
+                    entry.iconFile = ":images/breeze/task-process-2.svg";
+                    entry.secondary = tr("Category C");
+                } else if (event.priority == 4) {
+                    entry.iconFile = ":images/breeze/task-process-1.svg";
+                    entry.secondary = tr("Category D");
+                } else {
+                    entry.iconFile = ":images/breeze/task-process-0.svg";
+                    entry.secondary = tr("Category E");
+                }
+                entry.tertiary = event.description.trimmed();
+                entry.color = GColor(CCALEVENT);
+                entry.reference = event.id;
+                entry.start = QTime(0, 0, 0);
+                entry.durationSecs = 0;
+                entry.type = ENTRY_TYPE_EVENT;
+                entry.spanStart = event.date;
+                entry.spanEnd = event.date;
+                entry.isRelocatable = false;
+                events[event.date] << entry;
+            }
+        }
+    }
+
+    return events;
+}
+
+
+void
+AgendaWindow::updateActivities
+()
+{
+    QHash<QDate, QList<CalendarEntry>> activities = getActivities(agendaView->firstVisibleDay(), agendaView->selectedDate(), agendaView->lastVisibleDay());
+    std::pair<QList<CalendarEntry>, QList<CalendarEntry>> phases;
+    QHash<QDate, QList<CalendarEntry>> events;
+    QString seasonName;
+
+    tertiaryCombo->setEnabled(getShowTertiaryFor() != 2);
+    activityMaxTertiaryLinesSpin->setEnabled(getShowTertiaryFor() != 2);
+
+    Season const *season = context->currentSeason();
+    if (season) {
+        phases = getPhases(*season, agendaView->selectedDate());
+        events = getEvents(agendaView->selectedDate());
+        seasonName = season->getName();
+    }
+
+    agendaView->fillEntries(activities, phases, events, seasonName, isFiltered());
+}
+
+
+void
+AgendaWindow::updateActivitiesIfInRange
+(RideItem *rideItem)
+{
+    if (   rideItem->dateTime.date() >= agendaView->firstVisibleDay()
+        && rideItem->dateTime.date() <= agendaView->lastVisibleDay()) {
+        updateActivities();
+    }
+}
+
+
+void
+AgendaWindow::editPhaseEntry
+(const CalendarEntry &entry)
+{
+    if (entry.type != ENTRY_TYPE_PHASE) {
+        return;
+    }
+    Season const *currentSeason = context->currentSeason();
+    if (currentSeason == nullptr) {
+        return;
+    }
+    Season *phaseSeason = nullptr;
+    for (Season &s : context->athlete->seasons->seasons) {
+        if (s.id() == currentSeason->id()) {
+            phaseSeason = &s;
+            break;
+        }
+    }
+    if (phaseSeason == nullptr) {
+        return;
+    }
+    for (Phase &editPhase : phaseSeason->phases) {
+        if (entry.reference == editPhase.id().toString()) {
+            EditPhaseDialog dialog(context, &editPhase, *phaseSeason);
+            if (dialog.exec()) {
+                context->athlete->seasons->writeSeasons();
+                updateActivities();
+            }
+            break;
+        }
+    }
+}
+
+
+void
+AgendaWindow::editEventEntry
+(const CalendarEntry &entry)
+{
+    if (entry.type != ENTRY_TYPE_EVENT) {
+        return;
+    }
+    Season *season = nullptr;
+    SeasonEvent *seasonEvent = nullptr;
+    for (Season &s : context->athlete->seasons->seasons) {
+        for (SeasonEvent &event : s.events) {
+            // FIXME: Ugly comparison required becuase SeasonEvent::id is not populated
+            if (   event.name == entry.primary
+                && (   (event.priority == 0 && entry.secondary == tr("Uncategorized"))
+                    || (event.priority == 1 && entry.secondary == tr("Category A"))
+                    || (event.priority == 2 && entry.secondary == tr("Category B"))
+                    || (event.priority == 3 && entry.secondary == tr("Category C"))
+                    || (event.priority == 4 && entry.secondary == tr("Category D"))
+                    || (   (event.priority < 0 || event.priority > 4)
+                        && entry.secondary == tr("Category E")))
+                && event.description.trimmed() == entry.tertiary
+                && event.id == entry.reference
+                && event.date == entry.spanStart
+                && event.date == entry.spanEnd) {
+                season = &s;
+                seasonEvent = &event;
+                break;
+            }
+        }
+        if (seasonEvent != nullptr) {
+            break;
+        }
+    }
+    if (seasonEvent == nullptr) {
+        return;
+    }
+    EditSeasonEventDialog dialog(context, seasonEvent, *season);
+    if (dialog.exec()) {
+        context->athlete->seasons->writeSeasons();
+        updateActivities();
+    }
+}

--- a/src/Charts/AgendaWindow.h
+++ b/src/Charts/AgendaWindow.h
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2025 Joachim Kohlhammer (joachim.kohlhammer@gmx.de)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef _GC_AgendaWindow_h
+#define _GC_AgendaWindow_h
+
+#include "GoldenCheetah.h"
+
+#include <QtGui>
+#include <QCheckBox>
+#include <QHash>
+#include <QList>
+#include <QDate>
+
+#include "MetricSelect.h"
+#include "Context.h"
+#include "Season.h"
+#include "Agenda.h"
+#include "CalendarData.h"
+
+
+class AgendaWindow : public GcChartWindow
+{
+    Q_OBJECT
+
+    Q_PROPERTY(int agendaPastDays READ getAgendaPastDays WRITE setAgendaPastDays USER true)
+    Q_PROPERTY(int agendaFutureDays READ getAgendaFutureDays WRITE setAgendaFutureDays USER true)
+    Q_PROPERTY(QString primaryMainField READ getPrimaryMainField WRITE setPrimaryMainField USER true)
+    Q_PROPERTY(QString primaryFallbackField READ getPrimaryFallbackField WRITE setPrimaryFallbackField USER true)
+    Q_PROPERTY(QString secondaryMetric READ getSecondaryMetric WRITE setSecondaryMetric USER true)
+    Q_PROPERTY(int showTertiaryFor READ getShowTertiaryFor WRITE setShowTertiaryFor USER true)
+    Q_PROPERTY(QString tertiaryField READ getTertiaryField WRITE setTertiaryField USER true)
+    Q_PROPERTY(int activityMaxTertiaryLines READ getActivityMaxTertiaryLines WRITE setActivityMaxTertiaryLines USER true)
+    Q_PROPERTY(int eventMaxTertiaryLines READ getEventMaxTertiaryLines WRITE setEventMaxTertiaryLines USER true)
+
+    public:
+        AgendaWindow(Context *context);
+
+        int getAgendaPastDays() const;
+        int getAgendaFutureDays() const;
+
+        bool isFiltered() const;
+
+        QString getPrimaryMainField() const;
+        QString getPrimaryFallbackField() const;
+        QString getSecondaryMetric() const;
+        int getShowTertiaryFor() const;
+        QString getTertiaryField() const;
+        int getActivityMaxTertiaryLines() const;
+        int getEventMaxTertiaryLines() const;
+
+    public slots:
+        void setAgendaPastDays(int days);
+        void setAgendaFutureDays(int days);
+        void setPrimaryMainField(const QString &name);
+        void setPrimaryFallbackField(const QString &name);
+        void setSecondaryMetric(const QString &name);
+        void setShowTertiaryFor(int showFor);
+        void setTertiaryField(const QString &name);
+        void setActivityMaxTertiaryLines(int maxTertiaryLines);
+        void setEventMaxTertiaryLines(int maxTertiaryLines);
+        void configChanged(qint32);
+
+    protected:
+        void showEvent(QShowEvent *event) override;
+
+    private:
+        Context *context;
+        QPalette palette;
+
+        QSpinBox *agendaPastDaysSpin;
+        QSpinBox *agendaFutureDaysSpin;
+        QComboBox *primaryMainCombo;
+        QComboBox *primaryFallbackCombo;
+        QComboBox *secondaryCombo;
+        QComboBox *showTertiaryForCombo;
+        QComboBox *tertiaryCombo;
+        QSpinBox *activityMaxTertiaryLinesSpin;
+        QSpinBox *eventMaxTertiaryLinesSpin;
+        AgendaView *agendaView = nullptr;
+
+        void mkControls();
+        void updatePrimaryConfigCombos();
+        void updateSecondaryConfigCombo();
+        void updateTertiaryConfigCombo();
+        QHash<QDate, QList<CalendarEntry>> getActivities(const QDate &firstDay, const QDate &today, const QDate &lastDay) const;
+        std::pair<QList<CalendarEntry>, QList<CalendarEntry>> getPhases(const Season &season, const QDate &firstDay) const;
+        QHash<QDate, QList<CalendarEntry>> getEvents(const QDate &firstDay) const;
+
+    private slots:
+        void updateActivities();
+        void updateActivitiesIfInRange(RideItem *rideItem);
+        void editPhaseEntry(const CalendarEntry &entry);
+        void editEventEntry(const CalendarEntry &entry);
+};
+
+#endif

--- a/src/Charts/CalendarWindow.h
+++ b/src/Charts/CalendarWindow.h
@@ -42,8 +42,6 @@ class CalendarWindow : public GcChartWindow
     Q_PROPERTY(int firstDayOfWeek READ getFirstDayOfWeek WRITE setFirstDayOfWeek USER true)
     Q_PROPERTY(int startHour READ getStartHour WRITE setStartHour USER true)
     Q_PROPERTY(int endHour READ getEndHour WRITE setEndHour USER true)
-    Q_PROPERTY(int agendaPastDays READ getAgendaPastDays WRITE setAgendaPastDays USER true)
-    Q_PROPERTY(int agendaFutureDays READ getAgendaFutureDays WRITE setAgendaFutureDays USER true)
     Q_PROPERTY(bool summaryVisibleDay READ isSummaryVisibleDay WRITE setSummaryVisibleDay USER true)
     Q_PROPERTY(bool summaryVisibleWeek READ isSummaryVisibleWeek WRITE setSummaryVisibleWeek USER true)
     Q_PROPERTY(bool summaryVisibleMonth READ isSummaryVisibleMonth WRITE setSummaryVisibleMonth USER true)
@@ -60,8 +58,6 @@ class CalendarWindow : public GcChartWindow
         int getFirstDayOfWeek() const;
         int getStartHour() const;
         int getEndHour() const;
-        int getAgendaPastDays() const;
-        int getAgendaFutureDays() const;
         bool isSummaryVisibleDay() const;
         bool isSummaryVisibleWeek() const;
         bool isSummaryVisibleMonth() const;
@@ -80,8 +76,6 @@ class CalendarWindow : public GcChartWindow
         void setFirstDayOfWeek(int fdw);
         void setStartHour(int hour);
         void setEndHour(int hour);
-        void setAgendaPastDays(int days);
-        void setAgendaFutureDays(int days);
         void setSummaryVisibleDay(bool visible);
         void setSummaryVisibleWeek(bool visible);
         void setSummaryVisibleMonth(bool svm);
@@ -106,8 +100,6 @@ class CalendarWindow : public GcChartWindow
         QComboBox *firstDayOfWeekCombo;
         QSpinBox *startHourSpin;
         QSpinBox *endHourSpin;
-        QSpinBox *agendaPastDaysSpin;
-        QSpinBox *agendaFutureDaysSpin;
         QCheckBox *summaryDayCheck;
         QCheckBox *summaryWeekCheck;
         QCheckBox *summaryMonthCheck;

--- a/src/Core/SeasonDialogs.cpp
+++ b/src/Core/SeasonDialogs.cpp
@@ -554,12 +554,12 @@ EditPhaseDialog::EditPhaseDialog(Context *context, Phase *phase, Season &season)
     typeEdit->setCurrentIndex(typeEdit->findData(phase->getType()));
 
     fromEdit = new QDateEdit();
-    fromEdit->setDateRange(season.getStart(), season.getEnd());
+    fromEdit->setDateRange(season.getStart(), phase->getEnd().isValid() ? phase->getEnd().addDays(-1) : season.getEnd());
     fromEdit->setDate(phase->getStart());
     fromEdit->setCalendarPopup(true);
 
     toEdit = new QDateEdit();
-    toEdit->setDateRange(season.getStart(), season.getEnd());
+    toEdit->setDateRange(phase->getEnd().isValid() ? phase->getStart().addDays(1) : season.getStart(), season.getEnd());
     toEdit->setDate(phase->getEnd());
     toEdit->setCalendarPopup(true);
 
@@ -596,6 +596,8 @@ EditPhaseDialog::EditPhaseDialog(Context *context, Phase *phase, Season &season)
     connect(applyButton, SIGNAL(clicked()), this, SLOT(applyClicked()));
     connect(cancelButton, SIGNAL(clicked()), this, SLOT(cancelClicked()));
     connect(nameEdit, SIGNAL(textChanged(const QString &)), this, SLOT(nameChanged()));
+    connect(fromEdit, &QDateEdit::dateChanged, this, [this](const QDate &date) { toEdit->setMinimumDate(date.addDays(1)); });
+    connect(toEdit, &QDateEdit::dateChanged, this, [this](const QDate &date) { fromEdit->setMaximumDate(date.addDays(-1)); });
 
     // initialize button state
     nameChanged();

--- a/src/Core/TimeUtils.cpp
+++ b/src/Core/TimeUtils.cpp
@@ -94,6 +94,27 @@ QString time_to_string_minutes(double secs)
     return result;
 }
 
+int daysToWeeks(int days)
+{
+    return std::round(std::abs(days) / 7.0);
+}
+
+int daysToMonths(int days)
+{
+    return std::round(std::abs(days) / 30.44);
+}
+
+ShowDaysAsUnit showDaysAs(int days)
+{
+    int d = std::abs(days);
+    if (d <= 13) {
+        return ShowDaysAsUnit::Days;
+    } else if (d <= 59) {
+        return ShowDaysAsUnit::Weeks;
+    }
+    return ShowDaysAsUnit::Months;
+}
+
 double str_to_interval(QString s)
 {
     QRegExp rx("(\\d+\\s*h)?\\s*(\\d{1,2}\\s*m)?\\s*(\\d{1,2})(\\.\\d+)?\\s*s");

--- a/src/Core/TimeUtils.h
+++ b/src/Core/TimeUtils.h
@@ -34,6 +34,15 @@ double str_to_interval(QString s);     // convert 1h 2m 3s -> 3123.0 , e.g.
 QString time_to_string(double secs, bool forceMinutes=false);   // output like 1:02:03
 QString time_to_string_for_sorting(double secs);   // output always xx:yy:zz
 QString time_to_string_minutes(double secs); // output always hh:mm - seconds are cut-off
+extern int daysToWeeks(int days);
+extern int daysToMonths(int days);
+enum class ShowDaysAsUnit {
+    Days,
+    Weeks,
+    Months
+};
+extern ShowDaysAsUnit showDaysAs(int days);
+
 
 /* takes a string containing an ISO 8601 timestamp and converts it to local time
 */

--- a/src/Gui/Agenda.cpp
+++ b/src/Gui/Agenda.cpp
@@ -1,0 +1,1048 @@
+/*
+ * Copyright (c) 2025 Joachim Kohlhammer (joachim.kohlhammer@gmx.de)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include "Agenda.h"
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+#include <QAbstractItemDelegate>
+#endif
+#include <QHeaderView>
+#include <QGridLayout>
+#include <QToolTip>
+
+#include "Colors.h"
+#include "Settings.h"
+#include "Context.h"
+
+
+//////////////////////////////////////////////////////////////////////////////
+// AgendaTree
+
+AgendaTree::AgendaTree
+(QWidget *parent)
+: QTreeWidget(parent)
+{
+    setColumnCount(2);
+    setUniformRowHeights(false);
+    setItemsExpandable(false);
+    setRootIsDecorated(false);
+    setIndentation(0);
+
+    multiDelegate = new AgendaMultiDelegate(this);
+    AgendaMultiDelegate::Attributes multiAttributes = multiDelegate->getAttributes();
+    multiAttributes.paddingDL = QMargins(20 * dpiXFactor, 9 * dpiYFactor, 4 * dpiXFactor, 9 * dpiYFactor);
+    multiAttributes.paddingHL = QMargins(20 * dpiXFactor, 20 * dpiYFactor, 20 * dpiXFactor, 14 * dpiYFactor);
+    multiDelegate->setAttributes(multiAttributes);
+    setItemDelegateForColumn(0, multiDelegate);
+
+    entryDelegate = new AgendaEntryDelegate(this);
+    AgendaEntryDelegate::Attributes entryAttributes = entryDelegate->getAttributes();
+    entryAttributes.padding = QMargins(0 * dpiXFactor, 9 * dpiYFactor, 20 * dpiXFactor, 9 * dpiYFactor);
+    entryDelegate->setAttributes(entryAttributes);
+    setItemDelegateForColumn(1, entryDelegate);
+
+    setFocusPolicy(Qt::NoFocus);
+    setFrameShape(QFrame::NoFrame);
+    header()->setVisible(false);
+    header()->setSectionResizeMode(0, QHeaderView::ResizeToContents);
+    header()->setSectionResizeMode(1, QHeaderView::Stretch);
+    setMouseTracking(true);
+    viewport()->setMouseTracking(true);
+}
+
+
+void
+AgendaTree::updateDate
+()
+{
+    currentDate = QDate::currentDate();
+    emit dayChanged(currentDate);
+}
+
+
+QDate
+AgendaTree::selectedDate
+() const
+{
+    return currentDate;
+}
+
+
+bool
+AgendaTree::isRowHovered
+(const QModelIndex &index) const
+{
+    return    (   hoveredIndex.isValid()
+               && hoveredIndex.model() == index.model()
+               && hoveredIndex == index.siblingAtColumn(0))
+           || (   contextMenuIndex.isValid()
+               && contextMenuIndex.model() == index.model()
+               && contextMenuIndex == index.siblingAtColumn(0));
+}
+
+
+void
+AgendaTree::setMaxTertiaryLines
+(int maxTertiaryLines)
+{
+    AgendaEntryDelegate::Attributes attributes = entryDelegate->getAttributes();
+    attributes.maxTertiaryLines = maxTertiaryLines;
+    entryDelegate->setAttributes(attributes);
+    doItemsLayout();
+}
+
+
+void
+AgendaTree::changeEvent
+(QEvent *event)
+{
+    if (event->type() == QEvent::PaletteChange) {
+        clearHover();
+        QTimer::singleShot(0, this, [this]() {
+            QPalette treePal = palette();
+            treePal.setColor(QPalette::Base, treePal.color(QPalette::Base));
+            setPalette(treePal);
+            viewport()->setPalette(treePal);
+            setAutoFillBackground(false);
+        });
+    }
+    QWidget::changeEvent(event);
+}
+
+
+bool
+AgendaTree::viewportEvent
+(QEvent *event)
+{
+    if (event->type() == QEvent::ToolTip) {
+        QHelpEvent *helpEvent = static_cast<QHelpEvent*>(event);
+        QModelIndex hoverIndex = indexAt(helpEvent->pos());
+
+        if (! hoverIndex.isValid()) {
+            return QTreeWidget::viewportEvent(event);
+        }
+
+        QModelIndex col1 = hoverIndex.siblingAtColumn(1);
+        if (! col1.isValid()) {
+            return QTreeWidget::viewportEvent(event);
+        }
+
+        QString toolTipText;
+        if (entryDelegate->hasToolTip(col1, &toolTipText)) {
+            QToolTip::showText(helpEvent->globalPos(), toolTipText, this);
+            return true;
+        }
+        QToolTip::hideText();
+        event->ignore();
+        return true;
+    }
+    return QTreeWidget::viewportEvent(event);
+}
+
+
+void
+AgendaTree::mouseMoveEvent
+(QMouseEvent *event)
+{
+    if (! contextMenuIndex.isValid()) {
+        updateHoveredIndex(event->pos());
+    }
+    QTreeWidget::mouseMoveEvent(event);
+}
+
+
+void
+AgendaTree::wheelEvent
+(QWheelEvent *event)
+{
+    if (! contextMenuIndex.isValid()) {
+        updateHoveredIndex(event->position().toPoint());
+    }
+    QTreeWidget::wheelEvent(event);
+}
+
+
+void
+AgendaTree::leaveEvent
+(QEvent *event)
+{
+    if (! contextMenuIndex.isValid()) {
+        clearHover();
+    }
+    QTreeWidget::leaveEvent(event);
+}
+
+
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+void
+AgendaTree::enterEvent
+(QEvent *event)
+{
+    if (! contextMenuIndex.isValid()) {
+        mapFromGlobal(QCursor::pos());
+    }
+#else
+void
+AgendaTree::enterEvent
+(QEnterEvent *event)
+{
+    if (! contextMenuIndex.isValid()) {
+        updateHoveredIndex(event->position().toPoint());
+    }
+#endif
+    QTreeWidget::enterEvent(event);
+}
+
+
+void
+AgendaTree::updateHoveredIndex
+(const QPoint &pos)
+{
+    QModelIndex index = indexAt(pos);
+
+    if (index.isValid()) {
+        index = index.siblingAtColumn(0);
+    }
+
+    if (index != hoveredIndex) {
+        QToolTip::hideText();
+        QPersistentModelIndex oldIndex = hoveredIndex;
+        hoveredIndex = QPersistentModelIndex(index);
+
+        if (oldIndex.isValid()) {
+
+            QRect oldRect = visualRect(oldIndex);
+            oldRect.setLeft(0);
+            oldRect.setRight(viewport()->width());
+            viewport()->update(oldRect);
+        }
+
+        if (hoveredIndex.isValid()) {
+            QRect newRect = visualRect(hoveredIndex);
+            newRect.setLeft(0);
+            newRect.setRight(viewport()->width());
+            viewport()->update(newRect);
+        }
+    }
+}
+
+
+void
+AgendaTree::clearHover
+()
+{
+    if (hoveredIndex.isValid()) {
+        QRect oldRect = visualRect(hoveredIndex);
+        oldRect.setLeft(0);
+        oldRect.setRight(viewport()->width());
+        viewport()->update(oldRect);
+        QToolTip::hideText();
+
+        hoveredIndex = QPersistentModelIndex();
+    }
+}
+
+
+void
+AgendaTree::contextMenuEvent
+(QContextMenuEvent *event)
+{
+    QModelIndex index = indexAt(event->pos());
+    if (! index.isValid()) {
+        return;
+    }
+
+    index = index.siblingAtColumn(0);
+    QMenu *contextMenu = createContextMenu(index);
+    if (contextMenu == nullptr) {
+        return;
+    }
+
+    contextMenuIndex = QPersistentModelIndex(index);
+    hoveredIndex = contextMenuIndex;
+
+    QRect rowRect = visualRect(index);
+    rowRect.setLeft(0);
+    rowRect.setRight(viewport()->width());
+    viewport()->update(rowRect);
+
+    contextMenu->exec(event->globalPos());
+
+    delete contextMenu;
+
+    QPersistentModelIndex oldContextIndex = contextMenuIndex;
+    contextMenuIndex = QPersistentModelIndex();
+
+    QPoint currentPos = viewport()->mapFromGlobal(QCursor::pos());
+    if (viewport()->rect().contains(currentPos)) {
+        updateHoveredIndex(currentPos);
+    } else {
+        if (oldContextIndex.isValid()) {
+            QRect oldRowRect = visualRect(oldContextIndex);
+            oldRowRect.setLeft(0);
+            oldRowRect.setRight(viewport()->width());
+            viewport()->update(oldRowRect);
+        }
+        hoveredIndex = QPersistentModelIndex();
+    }
+}
+
+
+void
+AgendaTree::drawRow
+(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
+{
+    bool isTopLevel = ! index.parent().isValid();
+    int type = index.siblingAtColumn(0).data(AgendaMultiDelegate::TypeRole).toInt();
+    bool hover = isRowHovered(index);
+    QStyleOptionViewItem opt = option;
+    if (! isTopLevel && type == 0 && hover) {
+        painter->save();
+        QColor bgColor = option.palette.color(QPalette::Active, QPalette::Highlight);
+        bgColor.setAlphaF(0.2);
+        QRect hoverRect(option.rect);
+        hoverRect.setX(hoverRect.x() + 4 * dpiXFactor);
+        painter->fillRect(hoverRect, bgColor);
+        bgColor.setAlphaF(0.6);
+        QRect markerRect(option.rect);
+        markerRect.setWidth(4 * dpiXFactor);
+        painter->fillRect(markerRect, bgColor);
+        painter->restore();
+        opt.state |= QStyle::State_MouseOver;
+    } else {
+        opt.state &= ~QStyle::State_MouseOver;
+    }
+    QTreeWidget::drawRow(painter, opt, index);
+}
+
+
+QMenu*
+AgendaTree::createContextMenu
+(const QModelIndex &index)
+{
+    Q_UNUSED(index)
+
+    return nullptr;
+}
+
+
+void
+AgendaTree::fillFonts
+(Fonts &fonts) const
+{
+    fonts.defaultFont = font();
+    fonts.relativeFont = font();
+    fonts.relativeFont.setWeight(QFont::ExtraLight);
+    fonts.hoverFont = font();
+    fonts.hoverFont.setWeight(QFont::DemiBold);
+    fonts.headlineDefaultFont = font();
+    fonts.headlineTodayFont = font();
+    fonts.headlineEmptyFont = font();
+    fonts.headlineSmallEmptyFont = font();
+    if (fonts.headlineDefaultFont.pointSizeF() > 0) {
+        fonts.headlineDefaultFont.setPointSizeF(fonts.headlineDefaultFont.pointSizeF() * 1.3);
+        fonts.headlineTodayFont.setPointSizeF(fonts.headlineTodayFont.pointSizeF() * 1.35);
+        fonts.headlineEmptyFont.setPointSizeF(fonts.headlineEmptyFont.pointSizeF() * 1.3);
+        fonts.headlineSmallEmptyFont.setPointSizeF(fonts.headlineSmallEmptyFont.pointSizeF() * 1.1);
+    } else {
+        fonts.headlineDefaultFont.setPixelSize(fonts.headlineDefaultFont.pixelSize() * 1.3);
+        fonts.headlineTodayFont.setPixelSize(fonts.headlineTodayFont.pixelSize() * 1.35);
+        fonts.headlineEmptyFont.setPixelSize(fonts.headlineEmptyFont.pixelSize() * 1.3);
+        fonts.headlineSmallEmptyFont.setPixelSize(fonts.headlineSmallEmptyFont.pixelSize() * 1.1);
+    }
+    fonts.headlineTodayFont.setWeight(QFont::DemiBold);
+    fonts.headlineDefaultFont.setWeight(QFont::DemiBold);
+    fonts.headlineEmptyFont.setWeight(QFont::DemiBold);
+    fonts.headlineEmptyFont.setItalic(true);
+    fonts.headlineSmallEmptyFont.setWeight(QFont::DemiBold);
+    fonts.headlineSmallEmptyFont.setItalic(true);
+}
+
+
+//////////////////////////////////////////////////////////////////////////////
+// ActivityTree
+
+ActivityTree::ActivityTree
+(QWidget *parent)
+: AgendaTree(parent)
+{
+    AgendaEntryDelegate::Attributes attributes = entryDelegate->getAttributes();
+    attributes.secondaryWeight = attributes.primaryWeight;
+    entryDelegate->setAttributes(attributes);
+
+    connect(this, &QTreeWidget::itemDoubleClicked, this, [this](QTreeWidgetItem *item, int column) {
+        Q_UNUSED(column)
+
+        QVariant data = item->data(1, AgendaEntryDelegate::EntryRole);
+        if (! data.isNull()) {
+            CalendarEntry entry = data.value<CalendarEntry>();
+            if (entry.type == ENTRY_TYPE_PLANNED_ACTIVITY) {
+                emit viewActivity(entry);
+            }
+        }
+    });
+}
+
+
+void
+ActivityTree::setPastDays
+(int days)
+{
+    pastDays = days;
+    emit dayChanged(selectedDate());
+}
+
+
+void
+ActivityTree::setFutureDays
+(int days)
+{
+    futureDays = days;
+    emit dayChanged(selectedDate());
+}
+
+
+void
+ActivityTree::fillEntries
+(const QHash<QDate, QList<CalendarEntry>> &activities)
+{
+    QDate today = selectedDate();
+    QDate pastFirst = today.addDays(-pastDays);
+    QDate futureLast = today.addDays(futureDays);
+    if (! pastFirst.isValid() || ! futureLast.isValid()) {
+        return;
+    }
+    bool todayHasPlanned = false;
+    QList<QDate> missedDays;
+    QList<QDate> upcomingDays;
+    QHash<QDate, QList<CalendarEntry>> missedEntries;
+    QList<CalendarEntry> todayEntries;
+    QHash<QDate, QList<CalendarEntry>> upcomingEntries;
+    for (QDate date = pastFirst; date <= futureLast; date = date.addDays(1)) {
+        QList<CalendarEntry> dateEntries;
+        dateEntries = activities.value(date);
+        for (const CalendarEntry &entry : dateEntries) {
+            if (entry.type == ENTRY_TYPE_PLANNED_ACTIVITY) {
+                if (date < today) {
+                    if (! missedDays.contains(date)) {
+                        missedDays << date;
+                    }
+                    missedEntries[date].append(entry);
+                } else if (date > today) {
+                    if (! upcomingDays.contains(date)) {
+                        upcomingDays << date;
+                    }
+                    upcomingEntries[date].append(entry);
+                } else {
+                    todayHasPlanned = true;
+                    todayEntries.append(entry);
+                }
+            }
+        }
+    }
+    std::sort(missedDays.begin(), missedDays.end());
+    std::sort(upcomingDays.begin(), upcomingDays.end());
+
+    clearHover();
+    clear();
+    QString label;
+
+    Fonts fonts;
+    fillFonts(fonts);
+
+    if (pastDays > 0) {
+        QTreeWidgetItem *pastItem = new QTreeWidgetItem();
+        addTopLevelItem(pastItem);
+        QFont hlFont(fonts.headlineDefaultFont);
+        if (missedDays.count() > 0) {
+            label = tr("Missed Planned Activities");
+            for (const QDate &date : missedDays) {
+                addEntries(today, date, missedEntries[date], pastItem, fonts);
+            }
+        } else {
+            hlFont = fonts.headlineSmallEmptyFont;
+            label = tr("No missed planned activities");
+        }
+        if (pastDays > 1) {
+            label += " " + tr("(Past %1 days)").arg(pastDays);
+        } else {
+            label += " " + tr("(Yesterday)");
+        }
+        pastItem->setData(0, Qt::DisplayRole, label);
+        pastItem->setData(0, Qt::FontRole, hlFont);
+        pastItem->setData(0, AgendaMultiDelegate::TypeRole, 1);
+        pastItem->setFirstColumnSpanned(true);
+    }
+
+    QTreeWidgetItem *todayItem = new QTreeWidgetItem();
+    addTopLevelItem(todayItem);
+    QFont hlFont(fonts.headlineTodayFont);
+    if (todayHasPlanned) {
+        label = tr("Today’s Planned Activities");
+        addEntries(today, today, todayEntries, todayItem, fonts);
+    } else {
+        hlFont = fonts.headlineEmptyFont;
+        label = tr("No planned activities for today");
+    }
+    todayItem->setData(0, Qt::DisplayRole, label);
+    todayItem->setData(0, Qt::FontRole, hlFont);
+    todayItem->setData(0, AgendaMultiDelegate::TypeRole, 1);
+    todayItem->setFirstColumnSpanned(true);
+
+    if (futureDays > 0) {
+        QTreeWidgetItem *futureItem = new QTreeWidgetItem();
+        addTopLevelItem(futureItem);
+        QFont hlFont(fonts.headlineDefaultFont);
+        if (upcomingDays.count() > 0) {
+            label = tr("Upcoming Planned Activities");
+            for (const QDate &date : upcomingDays) {
+                addEntries(today, date, upcomingEntries[date], futureItem, fonts);
+            }
+        } else {
+            hlFont = fonts.headlineSmallEmptyFont;
+            label = tr("No upcoming planned activities");
+        }
+        if (futureDays > 1) {
+            label += " " + tr("(Next %1 days)").arg(futureDays);
+        } else {
+            label += " " + tr("(Tomorrow)");
+        }
+        futureItem->setData(0, Qt::DisplayRole, label);
+        futureItem->setData(0, Qt::FontRole, hlFont);
+        futureItem->setData(0, AgendaMultiDelegate::TypeRole, 1);
+        futureItem->setFirstColumnSpanned(true);
+    }
+
+    expandAll();
+}
+
+
+QDate
+ActivityTree::firstVisibleDay
+() const
+{
+    return selectedDate().addDays(-pastDays);
+}
+
+
+QDate
+ActivityTree::lastVisibleDay
+() const
+{
+    return selectedDate().addDays(futureDays);
+}
+
+
+QMenu*
+ActivityTree::createContextMenu
+(const QModelIndex &index)
+{
+    QTreeWidgetItem *item = itemFromIndex(index);
+    if (! item) {
+        return nullptr;
+    }
+    QVariant entryData = item->data(1, AgendaEntryDelegate::EntryRole);
+    if (entryData.isNull()) {
+        return nullptr;
+    }
+    CalendarEntry entry = entryData.value<CalendarEntry>();
+    if (entry.type != ENTRY_TYPE_PLANNED_ACTIVITY) {
+        return nullptr;
+    }
+    QMenu *contextMenu = new QMenu(this);
+    if (entry.hasTrainMode) {
+        contextMenu->addAction(tr("Show in train mode..."), this, [this, entry]() {
+            emit showInTrainMode(entry);
+        });
+    }
+    contextMenu->addAction(tr("View planned activity..."), this, [this, entry]() {
+        emit viewActivity(entry);
+    });
+    return contextMenu;
+}
+
+
+void
+ActivityTree::addEntries
+(const QDate &today, const QDate &date, const QList<CalendarEntry> &activities, QTreeWidgetItem *parent, const Fonts &fonts)
+{
+    int activityIdx = 0;
+    for (const CalendarEntry &activity : activities) {
+        QTreeWidgetItem *entryItem = new QTreeWidgetItem();
+        QString diffStr;
+        int diff = date.daysTo(today);
+        if (diff > 1) {
+            diffStr = tr("%1 days ago").arg(diff);
+        } else if (diff == 1) {
+            diffStr = tr("yesterday");
+        } else if (diff == 0) {
+            diffStr = tr("today");
+        } else if (diff == -1) {
+            diffStr = tr("tomorrow");
+        } else {
+            diffStr = tr("in %1 days").arg(std::abs(diff));
+        }
+        if (activityIdx == 0) {
+            entryItem->setData(0, Qt::DisplayRole, date.toString(tr("ddd, d.M.")));
+            entryItem->setData(0, Qt::FontRole, fonts.defaultFont);
+            entryItem->setData(0, AgendaMultiDelegate::SecondaryDisplayRole, diffStr);
+            entryItem->setData(0, AgendaMultiDelegate::SecondaryFontRole, fonts.relativeFont);
+        }
+        entryItem->setData(0, AgendaMultiDelegate::HoverTextRole, date.toString(tr("ddd, d.M.")));
+        entryItem->setData(0, AgendaMultiDelegate::HoverFontRole, fonts.hoverFont);
+        entryItem->setData(0, AgendaMultiDelegate::SecondaryHoverTextRole, diffStr);
+        entryItem->setData(0, AgendaMultiDelegate::SecondaryHoverFontRole, fonts.hoverFont);
+        entryItem->setData(1, AgendaEntryDelegate::EntryRole, QVariant::fromValue(activity));
+        entryItem->setData(1, AgendaEntryDelegate::EntryDateRole, date);
+        parent->addChild(entryItem);
+        ++activityIdx;
+    }
+}
+
+
+//////////////////////////////////////////////////////////////////////////////
+// PhaseTree
+
+void
+PhaseTree::fillEntries
+(const std::pair<QList<CalendarEntry>, QList<CalendarEntry>> &phases)
+{
+    QDate today = selectedDate();
+    if (! today.isValid()) {
+        return;
+    }
+    clear();
+
+    Fonts fonts;
+    fillFonts(fonts);
+
+    QTreeWidgetItem *ongoingItem = new QTreeWidgetItem();
+    addTopLevelItem(ongoingItem);
+    QFont hlFont(fonts.headlineDefaultFont);
+    QString label;
+    if (phases.first.count() > 0) {
+        label = tr("Ongoing Phases");
+        addEntries(today, phases.first, ongoingItem, fonts);
+    } else {
+        hlFont = fonts.headlineSmallEmptyFont;
+        label = tr("No ongoing phases");
+    }
+    ongoingItem->setData(0, Qt::DisplayRole, label);
+    ongoingItem->setData(0, Qt::FontRole, hlFont);
+    ongoingItem->setData(0, AgendaMultiDelegate::TypeRole, 1);
+    ongoingItem->setFirstColumnSpanned(true);
+
+    QTreeWidgetItem *upcomingItem = new QTreeWidgetItem();
+    addTopLevelItem(upcomingItem);
+    hlFont = fonts.headlineDefaultFont;
+    if (phases.second.count() > 0) {
+        label = tr("Upcoming Phases");
+        addEntries(today, phases.second, upcomingItem, fonts);
+    } else {
+        hlFont = fonts.headlineSmallEmptyFont;
+        label = tr("No upcoming phases");
+    }
+    upcomingItem->setData(0, Qt::DisplayRole, label);
+    upcomingItem->setData(0, Qt::FontRole, hlFont);
+    upcomingItem->setData(0, AgendaMultiDelegate::TypeRole, 1);
+    upcomingItem->setFirstColumnSpanned(true);
+
+    expandAll();
+}
+
+
+QMenu*
+PhaseTree::createContextMenu
+(const QModelIndex &index)
+{
+    QTreeWidgetItem *item = itemFromIndex(index);
+    if (! item) {
+        return nullptr;
+    }
+    QVariant entryData = item->data(1, AgendaEntryDelegate::EntryRole);
+    if (entryData.isNull()) {
+        return nullptr;
+    }
+    CalendarEntry entry = entryData.value<CalendarEntry>();
+    if (entry.type != ENTRY_TYPE_PHASE) {
+        return nullptr;
+    }
+    QMenu *contextMenu = new QMenu(this);
+    contextMenu->addAction(tr("Edit phase..."), this, [this, entry]() {
+        emit editPhaseEntry(entry);
+    });
+    return contextMenu;
+}
+
+
+void
+PhaseTree::addEntries
+(const QDate &today, const QList<CalendarEntry> &phases, QTreeWidgetItem *parent, const Fonts &fonts)
+{
+    for (const CalendarEntry &phase : phases) {
+        QTreeWidgetItem *entryItem = new QTreeWidgetItem();
+        QString diffStr;
+        int diffStart = today.daysTo(phase.spanStart);
+        int diffEnd = today.daysTo(phase.spanEnd);
+        if (diffStart >= 0) {
+            if (diffStart == 0) {
+                diffStr = tr("begins today");
+            } else if (diffStart == 1) {
+                diffStr = tr("begins tomorrow");
+            } else {
+                ShowDaysAsUnit unit = showDaysAs(diffStart);
+                if (unit == ShowDaysAsUnit::Days) {
+                    diffStr = tr("begins in %1 days").arg(diffStart);
+                } else if (unit == ShowDaysAsUnit::Weeks) {
+                    int weeks = daysToWeeks(diffStart);
+                    if (weeks > 1) {
+                        diffStr = tr("begins in %1 weeks").arg(weeks);
+                    } else {
+                        diffStr = tr("begins in %1 week").arg(weeks);
+                    }
+                } else {
+                    int months = daysToMonths(diffStart);
+                    if (months > 1) {
+                        diffStr = tr("begins in %1 months").arg(months);
+                    } else {
+                        diffStr = tr("begins in %1 month").arg(months);
+                    }
+                }
+            }
+        } else {
+            if (diffEnd == 0) {
+                diffStr = tr("ends today");
+            } else if (diffEnd == 1) {
+                diffStr = tr("ends tomorrow");
+            } else {
+                ShowDaysAsUnit unit = showDaysAs(diffEnd);
+                if (unit == ShowDaysAsUnit::Days) {
+                    diffStr = tr("ends in %1 days").arg(diffEnd);
+                } else if (unit == ShowDaysAsUnit::Weeks) {
+                    int weeks = daysToWeeks(diffEnd);
+                    if (weeks > 1) {
+                        diffStr = tr("ends in %1 weeks").arg(weeks);
+                    } else {
+                        diffStr = tr("ends in %1 week").arg(weeks);
+                    }
+                } else {
+                    int months = daysToMonths(diffEnd);
+                    if (months > 1) {
+                        diffStr = tr("ends in %1 months").arg(months);
+                    } else {
+                        diffStr = tr("ends in %1 month").arg(months);
+                    }
+                }
+            }
+        }
+        QString dateRangeStr = QString("%1 - %2")
+                                      .arg(phase.spanStart.toString(tr("ddd, d.M.")))
+                                      .arg(phase.spanEnd.toString(tr("ddd, d.M.")));
+        entryItem->setData(0, Qt::DisplayRole, dateRangeStr);
+        entryItem->setData(0, Qt::FontRole, fonts.defaultFont);
+        entryItem->setData(0, AgendaMultiDelegate::SecondaryDisplayRole, diffStr);
+        entryItem->setData(0, AgendaMultiDelegate::SecondaryFontRole, fonts.relativeFont);
+        entryItem->setData(0, AgendaMultiDelegate::HoverTextRole, dateRangeStr);
+        entryItem->setData(0, AgendaMultiDelegate::HoverFontRole, fonts.hoverFont);
+        entryItem->setData(0, AgendaMultiDelegate::SecondaryHoverTextRole, diffStr);
+        entryItem->setData(0, AgendaMultiDelegate::SecondaryHoverFontRole, fonts.hoverFont);
+        entryItem->setData(1, AgendaEntryDelegate::EntryRole, QVariant::fromValue(phase));
+        entryItem->setData(1, AgendaEntryDelegate::EntryDateRole, phase.spanEnd);
+        parent->addChild(entryItem);
+    }
+}
+
+
+//////////////////////////////////////////////////////////////////////////////
+// EventTree
+
+void
+EventTree::fillEntries
+(const QHash<QDate, QList<CalendarEntry>> &events)
+{
+    QDate today = selectedDate();
+    if (! today.isValid()) {
+        return;
+    }
+    clear();
+
+    Fonts fonts;
+    fillFonts(fonts);
+
+    QTreeWidgetItem *eventItem = new QTreeWidgetItem();
+    addTopLevelItem(eventItem);
+    QFont hlFont(fonts.headlineDefaultFont);
+    QString label;
+    if (events.count() > 0) {
+        label = tr("Upcoming Events");
+        QList<QDate> dates = events.keys();
+        std::sort(dates.begin(), dates.end());
+        for (const QDate &date : dates) {
+            addEntries(today, events[date], eventItem, fonts);
+        }
+    } else {
+        hlFont = fonts.headlineSmallEmptyFont;
+        label = tr("No upcoming events");
+    }
+    eventItem->setData(0, Qt::DisplayRole, label);
+    eventItem->setData(0, Qt::FontRole, hlFont);
+    eventItem->setData(0, AgendaMultiDelegate::TypeRole, 1);
+    eventItem->setFirstColumnSpanned(true);
+
+    expandAll();
+}
+
+
+QMenu*
+EventTree::createContextMenu
+(const QModelIndex &index)
+{
+    QTreeWidgetItem *item = itemFromIndex(index);
+    if (! item) {
+        return nullptr;
+    }
+    QVariant entryData = item->data(1, AgendaEntryDelegate::EntryRole);
+    if (entryData.isNull()) {
+        return nullptr;
+    }
+    CalendarEntry entry = entryData.value<CalendarEntry>();
+    if (entry.type != ENTRY_TYPE_EVENT) {
+        return nullptr;
+    }
+    QMenu *contextMenu = new QMenu(this);
+    contextMenu->addAction(tr("Edit event..."), this, [this, entry]() {
+        emit editEventEntry(entry);
+    });
+    return contextMenu;
+}
+
+
+void
+EventTree::addEntries
+(const QDate &today, const QList<CalendarEntry> &events, QTreeWidgetItem *parent, const Fonts &fonts)
+{
+    bool firstEntry = true;
+    for (const CalendarEntry &event : events) {
+        QTreeWidgetItem *entryItem = new QTreeWidgetItem();
+        int diffStart = today.daysTo(event.spanStart);
+        QString diffStr;
+        if (diffStart == 0) {
+            diffStr = tr("today");
+        } else if (diffStart == 1) {
+            diffStr = tr("tomorrow");
+        } else {
+            ShowDaysAsUnit unit = showDaysAs(diffStart);
+            if (unit == ShowDaysAsUnit::Days) {
+                diffStr = tr("in %1 days").arg(diffStart);
+            } else if (unit == ShowDaysAsUnit::Weeks) {
+                if (diffStart > 1) {
+                    diffStr = tr("in %1 weeks").arg(daysToWeeks(diffStart));
+                } else {
+                    diffStr = tr("in %1 week").arg(daysToWeeks(diffStart));
+                }
+            } else {
+                if (diffStart > 1) {
+                    diffStr = tr("in %1 months").arg(daysToMonths(diffStart));
+                } else {
+                    diffStr = tr("in %1 month").arg(daysToMonths(diffStart));
+                }
+            }
+        }
+        if (firstEntry) {
+            entryItem->setData(0, Qt::DisplayRole, event.spanStart.toString(tr("ddd, d.M.")));
+            entryItem->setData(0, Qt::FontRole, fonts.defaultFont);
+            entryItem->setData(0, AgendaMultiDelegate::SecondaryDisplayRole, diffStr);
+            entryItem->setData(0, AgendaMultiDelegate::SecondaryFontRole, fonts.relativeFont);
+        }
+        entryItem->setData(0, AgendaMultiDelegate::HoverTextRole, event.spanStart.toString(tr("ddd, d.M.")));
+        entryItem->setData(0, AgendaMultiDelegate::HoverFontRole, fonts.hoverFont);
+        entryItem->setData(0, AgendaMultiDelegate::SecondaryHoverTextRole, diffStr);
+        entryItem->setData(0, AgendaMultiDelegate::SecondaryHoverFontRole, fonts.hoverFont);
+        entryItem->setData(1, AgendaEntryDelegate::EntryRole, QVariant::fromValue(event));
+        entryItem->setData(1, AgendaEntryDelegate::EntryDateRole, event.spanStart);
+        parent->addChild(entryItem);
+        firstEntry = false;
+    }
+}
+
+
+//////////////////////////////////////////////////////////////////////////////
+// AgendaView
+
+AgendaView::AgendaView
+(QWidget *parent)
+: QWidget(parent)
+{
+    QFont baseFont;
+
+    QLabel *headline = new QLabel(tr("Your Training Agenda"));
+    headline->setAlignment(Qt::AlignCenter);
+    QFont hlFont = headline->font();
+    hlFont.setPointSizeF(baseFont.pointSizeF() * 1.4);
+    hlFont.setWeight(QFont::DemiBold);
+    headline->setFont(hlFont);
+
+    filterLabel = new QLabel("<i>" + tr("Filters applied") + "</i>");
+    filterLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
+    QSizePolicy sp = filterLabel->sizePolicy();
+    sp.setRetainSizeWhenHidden(true);
+    filterLabel->setSizePolicy(sp);
+
+    seasonLabel = new QLabel();
+    seasonLabel->setAlignment(Qt::AlignCenter);
+    QFont seasonFont = headline->font();
+    seasonFont.setPointSize(baseFont.pointSizeF() * 1.1);
+    seasonFont.setWeight(QFont::Normal);
+    seasonLabel->setFont(seasonFont);
+
+    activityTree = new ActivityTree();
+    connect(activityTree, &ActivityTree::dayChanged, [this](const QDate &date) { emit dayChanged(date); });
+    connect(activityTree, &ActivityTree::showInTrainMode, [this](const CalendarEntry &activity) { emit showInTrainMode(activity); });
+    connect(activityTree, &ActivityTree::viewActivity, [this](const CalendarEntry &activity) { emit viewActivity(activity); });
+
+    phaseTree = new PhaseTree();
+    connect(phaseTree, &PhaseTree::dayChanged, [this](const QDate &date) { emit dayChanged(date); });
+    connect(phaseTree, &PhaseTree::editPhaseEntry, [this](const CalendarEntry &phase) { emit editPhaseEntry(phase); });
+
+    eventTree = new EventTree();
+    connect(eventTree, &EventTree::dayChanged, [this](const QDate &date) { emit dayChanged(date); });
+    connect(eventTree, &EventTree::editEventEntry, [this](const CalendarEntry &event) { emit editEventEntry(event); });
+
+    QGridLayout* headLayout = new QGridLayout();
+    headLayout->setColumnStretch(0, 1);
+    headLayout->setColumnStretch(2, 1);
+    headLayout->addWidget(headline, 0, 1, Qt::AlignCenter);
+    headLayout->addWidget(filterLabel, 0, 2, Qt::AlignRight | Qt::AlignVCenter);
+
+    QVBoxLayout *rightLayout = new QVBoxLayout();
+    rightLayout->addWidget(phaseTree);
+    rightLayout->addSpacing(16 * dpiXFactor);
+    rightLayout->addWidget(eventTree);
+
+    QHBoxLayout *contentLayout = new QHBoxLayout();
+    contentLayout->addSpacing(16 * dpiXFactor);
+    contentLayout->addWidget(activityTree, 1);
+    contentLayout->addSpacing(16 * dpiXFactor);
+    contentLayout->addLayout(rightLayout, 1);
+    contentLayout->addSpacing(16 * dpiXFactor);
+
+    QVBoxLayout *layout = new QVBoxLayout(this);
+    layout->addLayout(headLayout);
+    layout->addWidget(seasonLabel);
+    layout->addSpacing(16 * dpiYFactor);
+    layout->addLayout(contentLayout);
+    layout->addSpacing(16 * dpiYFactor);
+}
+
+
+void
+AgendaView::updateDate
+()
+{
+    activityTree->updateDate();
+    phaseTree->updateDate();
+    eventTree->updateDate();
+}
+
+
+void
+AgendaView::setPastDays
+(int days)
+{
+    activityTree->setPastDays(days);
+}
+
+
+void
+AgendaView::setFutureDays
+(int days)
+{
+    activityTree->setFutureDays(days);
+}
+
+
+void
+AgendaView::fillEntries
+(const QHash<QDate, QList<CalendarEntry>> &activities, std::pair<QList<CalendarEntry>, QList<CalendarEntry>> &phases , const QHash<QDate, QList<CalendarEntry>> &events, const QString &seasonName, bool isFiltered)
+{
+    if (! seasonName.isNull()) {
+        seasonLabel->setText(tr("Season: %1").arg(seasonName));
+    } else {
+        seasonLabel->setText(tr("No season selected"));
+    }
+    activityTree->fillEntries(activities);
+    phaseTree->fillEntries(phases);
+    eventTree->fillEntries(events);
+    filterLabel->setVisible(isFiltered);
+}
+
+
+QDate
+AgendaView::firstVisibleDay
+() const
+{
+    return activityTree->firstVisibleDay();
+}
+
+
+QDate
+AgendaView::lastVisibleDay
+() const
+{
+    return activityTree->lastVisibleDay();
+}
+
+
+QDate
+AgendaView::selectedDate
+() const
+{
+    return activityTree->selectedDate();
+}
+
+
+void
+AgendaView::setActivityMaxTertiaryLines
+(int maxTertiaryLines)
+{
+    activityTree->setMaxTertiaryLines(maxTertiaryLines);
+}
+
+
+void
+AgendaView::setEventMaxTertiaryLines
+(int maxTertiaryLines)
+{
+    eventTree->setMaxTertiaryLines(maxTertiaryLines);
+}
+
+
+void
+AgendaView::changeEvent
+(QEvent *event)
+{
+    if (event->type() == QEvent::PaletteChange) {
+        QTimer::singleShot(0, this, [this]() {
+            QPalette parentPal = palette();
+            parentPal.setColor(QPalette::Window, parentPal.color(QPalette::AlternateBase));
+            setAutoFillBackground(true);
+            setPalette(parentPal);
+        });
+    }
+    QWidget::changeEvent(event);
+}

--- a/src/Gui/Agenda.h
+++ b/src/Gui/Agenda.h
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2025 Joachim Kohlhammer (joachim.kohlhammer@gmx.de)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#ifndef AGENDA_H
+#define AGENDA_H
+
+#include <QtGui>
+#include <QLabel>
+#include <QTreeWidget>
+
+#include "CalendarItemDelegates.h"
+#include "CalendarData.h"
+#include "Measures.h"
+
+
+class AgendaTree : public QTreeWidget {
+    Q_OBJECT
+
+public:
+    explicit AgendaTree(QWidget *parent = nullptr);
+
+    void updateDate();
+    QDate selectedDate() const;
+
+    bool isRowHovered(const QModelIndex &index) const;
+
+public slots:
+    void setMaxTertiaryLines(int maxTertiaryLines);
+
+signals:
+    void dayChanged(const QDate &date);
+
+protected:
+    void mouseMoveEvent(QMouseEvent *event) override;
+    void wheelEvent(QWheelEvent *event) override;
+    void leaveEvent(QEvent *event) override;
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    void enterEvent(QEvent *event) override;
+#else
+    void enterEvent(QEnterEvent *event) override;
+#endif
+    void contextMenuEvent(QContextMenuEvent *event) override;
+    void changeEvent(QEvent *event) override;
+    bool viewportEvent(QEvent *event) override;
+    void drawRow(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
+
+    virtual QMenu *createContextMenu(const QModelIndex &index);
+
+    void clearHover();
+
+protected:
+    struct Fonts {
+        QFont defaultFont;
+        QFont relativeFont;
+        QFont hoverFont;
+        QFont headlineDefaultFont;
+        QFont headlineTodayFont;
+        QFont headlineEmptyFont;
+        QFont headlineSmallEmptyFont;
+    };
+
+    void fillFonts(Fonts &fonts) const;
+
+    AgendaMultiDelegate *multiDelegate;
+    AgendaEntryDelegate *entryDelegate;
+
+private:
+    QDate currentDate;
+    QPersistentModelIndex hoveredIndex;
+    QPersistentModelIndex contextMenuIndex;
+
+    void updateHoveredIndex(const QPoint &pos);
+};
+
+
+class ActivityTree : public AgendaTree {
+    Q_OBJECT
+
+public:
+    explicit ActivityTree(QWidget *parent = nullptr);
+
+    void setPastDays(int days);
+    void setFutureDays(int days);
+    void fillEntries(const QHash<QDate, QList<CalendarEntry>> &activities);
+    QDate firstVisibleDay() const;
+    QDate lastVisibleDay() const;
+
+signals:
+    void showInTrainMode(const CalendarEntry &activity);
+    void viewActivity(const CalendarEntry &activity);
+
+protected:
+    QMenu *createContextMenu(const QModelIndex &index) override;
+
+private:
+    int pastDays = 7;
+    int futureDays = 7;
+
+    void addEntries(const QDate &today, const QDate &date, const QList<CalendarEntry> &activities, QTreeWidgetItem *parent, const Fonts &fonts);
+};
+
+
+class PhaseTree : public AgendaTree {
+    Q_OBJECT
+
+public:
+    void fillEntries(const std::pair<QList<CalendarEntry>, QList<CalendarEntry>> &phases);
+
+signals:
+    void editPhaseEntry(const CalendarEntry &entry);
+
+protected:
+    QMenu *createContextMenu(const QModelIndex &index) override;
+
+private:
+    void addEntries(const QDate &today, const QList<CalendarEntry> &phases, QTreeWidgetItem *parent, const Fonts &fonts);
+};
+
+
+class EventTree : public AgendaTree {
+    Q_OBJECT
+
+public:
+    void fillEntries(const QHash<QDate, QList<CalendarEntry>> &events);
+
+signals:
+    void editEventEntry(const CalendarEntry &entry);
+
+protected:
+    virtual QMenu *createContextMenu(const QModelIndex &index);
+
+private:
+    void addEntries(const QDate &today, const QList<CalendarEntry> &phases, QTreeWidgetItem *parent, const Fonts &fonts);
+};
+
+
+class AgendaView : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit AgendaView(QWidget *parent = nullptr);
+
+    void updateDate();
+    void setDateRange(const DateRange &dateRange);
+    void setPastDays(int days);
+    void setFutureDays(int days);
+    void fillEntries(const QHash<QDate, QList<CalendarEntry>> &activities, std::pair<QList<CalendarEntry>, QList<CalendarEntry>> &phases, const QHash<QDate, QList<CalendarEntry>> &events, const QString &seasonName, bool isFiltered);
+
+    QDate firstVisibleDay() const;
+    QDate lastVisibleDay() const;
+    QDate selectedDate() const;
+
+public slots:
+    void setActivityMaxTertiaryLines(int maxTertiaryLines);
+    void setEventMaxTertiaryLines(int maxTertiaryLines);
+
+signals:
+    void showInTrainMode(const CalendarEntry &activity);
+    void viewActivity(const CalendarEntry &activity);
+    void editPhaseEntry(const CalendarEntry &entry);
+    void editEventEntry(const CalendarEntry &entry);
+    void dayChanged(const QDate &date);
+
+protected:
+    void changeEvent(QEvent *event) override;
+
+private:
+    QLabel *filterLabel;
+    QLabel *seasonLabel;
+    ActivityTree *activityTree;
+    PhaseTree *phaseTree;
+    EventTree *eventTree;
+};
+
+#endif

--- a/src/Gui/Calendar.h
+++ b/src/Gui/Calendar.h
@@ -36,7 +36,6 @@
 #include "CalendarData.h"
 #include "TimeUtils.h"
 #include "Measures.h"
-#include "Qt5Compatibility.h"
 
 
 class CalendarOverview : public QCalendarWidget {
@@ -218,7 +217,6 @@ enum class CalendarView {
     Day = 0,
     Week = 1,
     Month = 2,
-    Agenda = 3
 };
 
 
@@ -291,65 +289,6 @@ private:
 };
 
 
-struct CalendarAgendaStyles {
-    QFont defaultFont;
-    QFont relativeFont;
-    QFont hoverFont;
-    QFont headlineDefaultFont;
-    QFont headlineTodayFont;
-    QFont headlineEmptyFont;
-    QFont headlineSmallEmptyFont;
-
-    int sectionSpacerHeight;
-    int sectionEntrySpacerHeight;
-    int entrySpacerHeight;
-    int daySpacerHeight;
-};
-
-class CalendarAgendaView : public QWidget {
-    Q_OBJECT
-
-public:
-    explicit CalendarAgendaView(QWidget *parent = nullptr);
-
-    void updateDate();
-    void setDateRange(const DateRange &dateRange);
-    void setPastDays(int days);
-    void setFutureDays(int days);
-    void fillEntries(const QHash<QDate, QList<CalendarEntry>> &activityEntries, const QList<CalendarSummary> &summaries, const QHash<QDate, QList<CalendarEntry>> &headlineEntries);
-    QDate firstVisibleDay() const;
-    QDate lastVisibleDay() const;
-    QDate selectedDate() const;
-
-signals:
-    void showInTrainMode(const CalendarEntry &activity);
-    void showInMonthView(const QDate &date);
-    void viewActivity(const CalendarEntry &activity);
-    void dayChanged(const QDate &date);
-
-protected:
-    bool eventFilter(QObject *watched, QEvent *event) override;
-    void changeEvent(QEvent *event) override;
-
-private:
-    QDate currentDate;
-    DateRange dateRange;
-    int pastDays = 7;
-    int futureDays = 7;
-    TreeWidget6 *agendaTree;
-    QTreeWidgetItem *lastHoveredItem = nullptr;
-    int lastHoveredColumn = -1;
-    void clearHover();
-    void addEntries(const QDate &today, const QDate &date, const QList<CalendarEntry> &entries, QTreeWidgetItem *parent, const CalendarAgendaStyles &cas);
-    void addSpacer(QTreeWidgetItem *parent, int height);
-    void addSeparator(QTreeWidgetItem *parent, int top, int bottom);
-    void fillStyles(CalendarAgendaStyles &cas) const;
-
-private slots:
-    void showContextMenu(const QPoint &pos);
-};
-
-
 class Calendar : public QWidget {
     Q_OBJECT
 
@@ -376,8 +315,6 @@ public slots:
     void setFirstDayOfWeek(Qt::DayOfWeek firstDayOfWeek);
     void setStartHour(int hour);
     void setEndHour(int hour);
-    void setAgendaPastDays(int days);
-    void setAgendaFutureDays(int days);
     void setSummaryDayVisible(bool visible);
     void setSummaryWeekVisible(bool visible);
     void setSummaryMonthVisible(bool visible);
@@ -410,7 +347,6 @@ private:
     QAction *dayAction;
     QAction *weekAction;
     QAction *monthAction;
-    QAction *agendaAction;
     QToolButton *dateNavigator;
     QAction *dateNavigatorAction;
     QMenu *dateMenu;
@@ -423,10 +359,8 @@ private:
     CalendarDayView *dayView;
     CalendarWeekView *weekView;
     CalendarMonthTable *monthView;
-    CalendarAgendaView *agendaView;
     DateRange dateRange;
     Qt::DayOfWeek firstDayOfWeek = Qt::Monday;
-    QDate lastNonAgendaDate;
 
     void setNavButtonState();
     void updateHeader();

--- a/src/Gui/CalendarItemDelegates.cpp
+++ b/src/Gui/CalendarItemDelegates.cpp
@@ -26,9 +26,11 @@
 #include <QPixmap>
 #include <QSvgRenderer>
 #include <QPainterPath>
+#include <QHeaderView>
 
 #include "CalendarData.h"
 #include "Colors.h"
+#include "Agenda.h"
 
 static bool toolTipHeadlineEntry(const QPoint &pos, QAbstractItemView *view, const CalendarDay &day, int idx);
 static bool toolTipDayEntry(const QPoint &pos, QAbstractItemView *view, const CalendarDay &day, int idx);
@@ -56,7 +58,7 @@ void
 HitTester::resize
 (const QModelIndex &index, qsizetype size)
 {
-#if QT_VERSION < 0x060000
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
     rects[index].clear();
     for (int i = 0; i < size; ++i) {
         rects[index] << QRect();
@@ -342,7 +344,8 @@ CalendarDetailedDayDelegate::CalendarDetailedDayDelegate
 
 
 void
-CalendarDetailedDayDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
+CalendarDetailedDayDelegate::paint
+(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     painter->save();
     painter->setRenderHint(QPainter::Antialiasing, true);
@@ -1054,25 +1057,28 @@ AgendaMultiDelegate::AgendaMultiDelegate
 {
 }
 
+
 void
 AgendaMultiDelegate::paint
 (QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
     QStyleOptionViewItem opt = option;
     initStyleOption(&opt, index);
+    int type = index.data(TypeRole).toInt();
+    bool hover = (type == 0) && opt.state & QStyle::State_MouseOver;
     opt.state &= ~QStyle::State_Selected;
     opt.state &= ~QStyle::State_HasFocus;
     opt.state &= ~QStyle::State_MouseOver;
 
-    int type = index.data(TypeRole).toInt();
-    if (type == 0) {
+    if (type == 0) { // Dual Line Text
         opt.displayAlignment = Qt::AlignLeft | Qt::AlignTop;
 
-        const bool hovered = index.data(HoverFlagRole).toBool();
-        const QString hoverText = index.data(HoverTextRole).toString();
-        const QFont hoverFont = index.data(HoverFontRole).value<QFont>();
+        const QString secondaryText = index.data(SecondaryDisplayRole).toString();
+        const QString secondaryHoverText = index.data(SecondaryHoverTextRole).toString();
 
-        if (hovered) {
+        if (hover) {
+            const QString hoverText = index.data(HoverTextRole).toString();
+            const QFont hoverFont = index.data(HoverFontRole).value<QFont>();
             if (! hoverText.isEmpty()) {
                 opt.text = hoverText;
             }
@@ -1081,24 +1087,51 @@ AgendaMultiDelegate::paint
             }
         }
 
+        QFontMetrics upperFM(opt.font);
+        QRect upperRect(opt.rect.x() + attributes.paddingDL.left(),
+                        opt.rect.y() + attributes.paddingDL.top(),
+                        std::max(0, opt.rect.width() - attributes.paddingDL.left() - attributes.paddingDL.right()),
+                        std::min(opt.rect.height(), upperFM.height()));
+
+        const QWidget *widget = opt.widget;
+        QStyle *style = widget ? widget->style() : QApplication::style();
+        opt.rect = upperRect;
+        style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, widget);
+
+        if (   (   ! hover
+                && ! secondaryText.isEmpty())
+            || (   hover
+                && ! secondaryHoverText.isEmpty())) {
+            opt.text = secondaryText;
+            if (! hover) {
+                const QFont secondaryFont = index.data(SecondaryFontRole).value<QFont>();
+                if (secondaryFont != QFont()) {
+                    opt.font = secondaryFont;
+                }
+            } else {
+                const QFont secondaryHoverFont = index.data(SecondaryHoverFontRole).value<QFont>();
+                if (secondaryHoverFont != QFont()) {
+                    opt.font = secondaryHoverFont;
+                }
+                if (! secondaryHoverText.isEmpty()) {
+                    opt.text = secondaryHoverText;
+                }
+            }
+            QFontMetrics lowerFM(opt.font);
+            opt.rect.translate(0, opt.rect.height());
+            opt.rect.setHeight(lowerFM.height());
+            style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, widget);
+        }
+    } else if (type == 1) { // Headline
+        opt.displayAlignment = Qt::AlignLeft | Qt::AlignTop;
+        opt.rect = QRect(opt.rect.x() + attributes.paddingHL.left(),
+                         opt.rect.y() + attributes.paddingHL.top(),
+                         std::max(0, opt.rect.width() - attributes.paddingHL.left() - attributes.paddingHL.right()),
+                         std::min(opt.rect.height(), opt.fontMetrics.height()));
+
         const QWidget *widget = opt.widget;
         QStyle *style = widget ? widget->style() : QApplication::style();
         style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, widget);
-    } else if (type == 1) {
-        const QWidget *widget = opt.widget;
-        QStyle *style = widget ? widget->style() : QApplication::style();
-        style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, widget);
-    } else if (type == 2) {
-        const int horPadding = 4 * dpiXFactor;
-        const QWidget *widget = option.widget;
-        QStyle *style = widget ? widget->style() : QApplication::style();
-        style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, widget);
-        int topMargin = index.data(MarginTopRole).toInt();
-        QStyleOption sepOpt;
-        sepOpt.rect = QRect(opt.rect.x() + horPadding + 1, opt.rect.y() + topMargin + 1, opt.rect.width() - 2 * horPadding - 2, 1);
-        sepOpt.palette = opt.palette;
-        sepOpt.state = QStyle::State_Enabled;
-        style->drawPrimitive(QStyle::PE_IndicatorToolBarSeparator, &sepOpt, painter, widget);
     }
 }
 
@@ -1111,7 +1144,7 @@ AgendaMultiDelegate::sizeHint
     initStyleOption(&opt, index);
 
     int type = index.data(TypeRole).toInt();
-    if (type == 0) {
+    if (type == 0) { // Dual Line Text
         QString text = index.data(Qt::DisplayRole).toString();
         QFont normalFont = index.data(Qt::FontRole).value<QFont>();
         if (! normalFont.family().isEmpty()) {
@@ -1121,55 +1154,118 @@ AgendaMultiDelegate::sizeHint
         QFontMetrics normalFM(opt.font);
         QSize normalSize = normalFM.size(Qt::TextSingleLine, text);
 
-        QString hoverText = index.data(HoverTextRole).toString();
+        const QString hoverText = index.data(HoverTextRole).toString();
         QFont hoverFont = index.data(HoverFontRole).value<QFont>();
 
         QSize hoverSize = QSize(0, 0);
-        if (! hoverText.isEmpty() || hoverFont != QFont()) {
-            QFontMetrics hoverFM(hoverFont != QFont() ? hoverFont : opt.font);
+        if (! hoverText.isEmpty()) {
+            if (hoverFont == QFont()) {
+                hoverFont = opt.font;
+            }
+            QFontMetrics hoverFM(hoverFont);
             hoverSize = hoverFM.size(Qt::TextSingleLine, hoverText.isEmpty() ? text : hoverText);
         }
-
         QSize maxSize(std::max(normalSize.width(), hoverSize.width()), std::max(normalSize.height(), hoverSize.height()));
-        maxSize += QSize(8, 4);
+
+        QSize secondarySize(0, 0);
+        const QString secondaryText = index.data(SecondaryDisplayRole).toString();
+        if (! secondaryText.isEmpty()) {
+            QFont secondaryFont = index.data(SecondaryFontRole).value<QFont>();
+            if (secondaryFont == QFont()) {
+                secondaryFont = normalFont;
+            }
+            QFontMetrics secondaryFM(secondaryFont);
+            secondarySize = secondaryFM.size(Qt::TextSingleLine, secondaryText);
+        }
+        const QString secondaryHoverText = index.data(SecondaryHoverTextRole).toString();
+        if (! secondaryHoverText.isEmpty()) {
+            QFont secondaryHoverFont = index.data(SecondaryHoverFontRole).value<QFont>();
+            if (secondaryHoverFont == QFont()) {
+                secondaryHoverFont = hoverFont;
+            }
+            QFontMetrics secondaryHoverFM(secondaryHoverFont);
+            QSize secondaryHoverSize = secondaryHoverFM.size(Qt::TextSingleLine, secondaryText);
+            secondarySize.setWidth(std::max(secondarySize.width(), secondaryHoverSize.width()));
+            secondarySize.setHeight(std::max(secondarySize.height(), secondaryHoverSize.height()));
+        }
+        maxSize.setWidth(std::max(maxSize.width(), secondarySize.width()));
+        maxSize.setHeight(maxSize.height() + secondarySize.height());
+
+        maxSize += QSize(8 + attributes.paddingDL.left() + attributes.paddingDL.right(), 4 + attributes.paddingDL.top() + attributes.paddingDL.bottom());
 
         return maxSize;
-    } else if (type == 1) {
-        return QSize(opt.rect.width(), index.data(MarginTopRole).toInt());
-    } else if (type == 2) {
-        int topMargin = index.data(MarginTopRole).toInt();
-        int bottomMargin = index.data(MarginBottomRole).toInt();
+    } else if (type == 1) { // Headline
         const QWidget *widget = opt.widget;
         QStyle *style = widget ? widget->style() : QApplication::style();
-        int sepHeight = style->pixelMetric(QStyle::PM_DefaultFrameWidth, nullptr, widget);
-        return QSize(option.rect.width(), sepHeight + topMargin + bottomMargin);
+        int height = style->sizeFromContents(QStyle::CT_ItemViewItem, &opt, QSize(), opt.widget).height();
+        return QSize(option.rect.width(), height + attributes.paddingHL.top() + attributes.paddingHL.bottom());
     }
     return QStyledItemDelegate::sizeHint(option, index);
 }
 
 
-//////////////////////////////////////////////////////////////////////////////
-// CalendarSingleActivityDelegate
-
-CalendarSingleActivityDelegate::CalendarSingleActivityDelegate
-(QObject *parent)
+AgendaMultiDelegate::Attributes
+AgendaMultiDelegate::getAttributes
+() const
 {
-    Q_UNUSED(parent)
+    return attributes;
 }
 
 
 void
-CalendarSingleActivityDelegate::paint
+AgendaMultiDelegate::setAttributes
+(const Attributes &attributes)
+{
+    this->attributes = attributes;
+}
+
+
+void
+AgendaMultiDelegate::initStyleOption
+(QStyleOptionViewItem *option, const QModelIndex &index) const
+{
+    QStyledItemDelegate::initStyleOption(option, index);
+
+    if (AgendaTree *tree = qobject_cast<AgendaTree*>(parent())) {
+        if (tree->isRowHovered(index)) {
+            option->state |= QStyle::State_MouseOver;
+        } else {
+            option->state &= ~QStyle::State_MouseOver;
+        }
+    }
+}
+
+
+//////////////////////////////////////////////////////////////////////////////
+// AgendaEntryDelegate
+
+AgendaEntryDelegate::AgendaEntryDelegate
+(QTreeWidget *parent)
+: QStyledItemDelegate(parent), treeWidget(parent)
+{
+    connect(parent, &QTreeWidget::itemChanged, this, &AgendaEntryDelegate::updateColumnWidth, Qt::QueuedConnection);
+    connect(parent->header(), &QHeaderView::sectionResized, this, &AgendaEntryDelegate::onSectionResized);
+    QTimer::singleShot(0, this, &AgendaEntryDelegate::updateColumnWidth);
+}
+
+
+
+void
+AgendaEntryDelegate::paint
 (QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
+    if (column < 0) {
+        column = index.column();
+    }
     CalendarEntry entry = index.data(EntryRole).value<CalendarEntry>();
-    bool hover = index.data(HoverFlagRole).toBool();
 
     painter->save();
     painter->setRenderHint(QPainter::Antialiasing);
 
     QStyleOptionViewItem opt = option;
     initStyleOption(&opt, index);
+    bool hover = opt.state & QStyle::State_MouseOver;
+
     opt.state &= ~QStyle::State_Selected;
     opt.state &= ~QStyle::State_HasFocus;
     opt.state &= ~QStyle::State_MouseOver;
@@ -1179,67 +1275,116 @@ CalendarSingleActivityDelegate::paint
     QStyle *style = widget ? widget->style() : QApplication::style();
     style->drawControl(QStyle::CE_ItemViewItem, &opt, painter, widget);
 
-    QFontMetrics entryFM(painter->font());
-    const int horPadding = 4 * dpiXFactor;
-    const int lineSpacing = 2 * dpiYFactor;
-    const int lineHeight = entryFM.height();
+    QFont line1Font = painter->font();
+
+    QFont::Weight primaryWeight = attributes.primaryWeight;
+    QFont::Weight secondaryWeight = attributes.secondaryWeight;
+    QFont::Weight secondaryMetricWeight = attributes.secondaryMetricWeight;
+    if (hover) {
+        primaryWeight = attributes.primaryHoverWeight;
+        secondaryWeight = attributes.secondaryHoverWeight;
+        secondaryMetricWeight = attributes.secondaryMetricHoverWeight;
+    }
+    if (primaryWeight == 0) {
+#if QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+        primaryWeight = static_cast<QFont::Weight>(line1Font.weight());
+#else
+        primaryWeight = line1Font.weight();
+#endif
+    }
+    if (secondaryWeight == 0) {
+        secondaryWeight = primaryWeight;
+    }
+    if (secondaryMetricWeight == 0) {
+        secondaryMetricWeight = secondaryWeight;
+    }
+
+    line1Font.setWeight(primaryWeight);
+    QFontMetrics line1FM(line1Font);
+    const int lineSpacing = attributes.lineSpacing * dpiYFactor;
+    const int lineHeight = line1FM.height();
     const int radius = 4 * dpiXFactor;
-    const int iconSpacing = 4 * dpiXFactor;
+    const int iconInnerSpacing = 4 * dpiXFactor;
+    const int iconTextSpacing = attributes.iconTextSpacing * dpiXFactor;
     const int iconWidth = 2 * lineHeight + lineSpacing;
     const QSize pixmapSize(iconWidth, iconWidth);
     QColor textColor = opt.palette.color(QPalette::Active, QPalette::Text);
     QColor iconColor = entry.color;
 
+    const int textX = opt.rect.x() + iconWidth + iconTextSpacing + attributes.padding.left();
+    const int textWidth = opt.rect.width() - iconWidth - iconTextSpacing - attributes.padding.left() - attributes.padding.right();
+
     if (hover) {
-        painter->save();
-        QRect hoverRect;
-        if (entry.type == ENTRY_TYPE_PLANNED_ACTIVITY) {
-            hoverRect = QRect(opt.rect.x() + horPadding + 1, opt.rect.y() + 1, opt.rect.width() - 2 * horPadding - 2, iconWidth - 2);
-        } else {
-            hoverRect = QRect(opt.rect.x() + horPadding + 1, opt.rect.y() + 1, opt.rect.width() - 2 * horPadding - 2, lineHeight - 2);
-        }
         QColor bgColor = opt.palette.color(QPalette::Active, QPalette::Highlight);
         bgColor.setAlphaF(0.2);
         QColor bgBorder = bgColor;
         bgBorder.setAlphaF(0.6);
         iconColor = GCColor::invertColor(GCColor::blendedColor(bgColor, opt.palette.color(QPalette::Active, QPalette::AlternateBase)));
         textColor = iconColor;
-
-        painter->setPen(bgBorder);
-        painter->setBrush(bgColor);
-        painter->drawRoundedRect(hoverRect, radius, radius);
-        painter->restore();
     }
 
-    if (entry.type == ENTRY_TYPE_PLANNED_ACTIVITY) {
-        QPixmap pixmap = svgAsColoredPixmap(entry.iconFile, pixmapSize, iconSpacing, iconColor);
-        painter->drawPixmap(opt.rect.x() + horPadding, opt.rect.y(), pixmap);
-    } else {
-        QPixmap pixmap = svgOnBackground(entry.iconFile, QSize(lineHeight, lineHeight), iconSpacing, entry.color, radius);
-        painter->drawPixmap(opt.rect.x() + horPadding + lineHeight / 2, opt.rect.y(), pixmap);
-    }
+    QPixmap pixmap = svgAsColoredPixmap(entry.iconFile, pixmapSize, iconInnerSpacing, iconColor);
+    painter->drawPixmap(opt.rect.x() + attributes.padding.left(), opt.rect.y() + attributes.padding.top(), pixmap);
 
     painter->setPen(textColor);
-    QRect textRect(opt.rect.x() + iconWidth + iconSpacing + horPadding, opt.rect.y(), opt.rect.width() - iconWidth - iconSpacing - 2 * horPadding, lineHeight);
+    QRect textRect(textX, opt.rect.y() + attributes.padding.top(), textWidth, lineHeight);
 
-    const QFontMetrics fm(painter->font());
     QString primary(entry.primary);
-    QRect boundingRect = fm.boundingRect(primary);
+    QRect boundingRect = line1FM.boundingRect(primary);
     if (boundingRect.width() > textRect.width()) {
-        primary = fm.elidedText(primary, Qt::ElideRight, textRect.width());
+        primary = line1FM.elidedText(primary, Qt::ElideRight, textRect.width());
     }
 
+    painter->save();
+    painter->setFont(line1Font);
     painter->drawText(textRect, Qt::AlignLeft | Qt::AlignTop | Qt::TextDontClip, primary);
+    painter->restore();
     if (! entry.secondary.isEmpty()) {
+        painter->save();
+        QFont metricValueFont = painter->font();
+        metricValueFont.setWeight(secondaryWeight);
+        QFontMetrics metricValueFM(metricValueFont);
+        painter->setFont(metricValueFont);
         textRect.translate(0, lineHeight + lineSpacing);
-        QString secondary = entry.secondary;
+        QRect secRect = metricValueFM.boundingRect(entry.secondary);
+        secRect.setRect(textRect.x(), textRect.y(), secRect.width(), secRect.height());
+        painter->drawText(secRect, Qt::AlignLeft | Qt::AlignTop | Qt::TextDontClip, entry.secondary);
+        painter->restore();
         if (! entry.secondaryMetric.isEmpty()) {
-            secondary += " (" + entry.secondaryMetric + ")";
+            painter->save();
+            QFont metricLabelFont = painter->font();
+            metricLabelFont.setWeight(secondaryMetricWeight);
+            QFontMetrics metricLabelFM(metricLabelFont);
+            painter->setFont(metricLabelFont);
+            int remainingWidth = opt.rect.x() + opt.rect.width() - secRect.right() - attributes.padding.left() - attributes.padding.right();
+
+            QString txt = " " + entry.secondaryMetric;
+            QRect secMetricRect = metricLabelFM.boundingRect(txt);
+            if (secMetricRect.width() > remainingWidth) {
+                txt = metricLabelFM.elidedText(txt, Qt::ElideRight, remainingWidth);
+            }
+            secMetricRect.setRect(secRect.x() + secRect.width() + 2 * dpiXFactor,
+                                  secRect.y(),
+                                  remainingWidth,
+                                  secMetricRect.height());
+            painter->drawText(secMetricRect, Qt::AlignLeft | Qt::AlignTop, txt);
+            painter->restore();
         }
-        if (fm.boundingRect(secondary).width() > textRect.width()) {
-            secondary = fm.elidedText(secondary, Qt::ElideRight, textRect.width());
+        if (! entry.tertiary.isEmpty()) {
+            painter->save();
+            painter->setPen(GCColor::inactiveColor(painter->pen().color(), attributes.tertiaryDimLevel));
+            int y = opt.rect.y() + attributes.padding.top() + pixmapSize.height() + 2 * lineSpacing;
+            QStringList tertiaryLines;
+            int numLines;
+            int tertiaryHeight;
+            layoutTertiaryText(entry.tertiary, opt.font, textWidth, numLines, tertiaryHeight, &tertiaryLines, true);
+            QRect tertiaryRect(textX, y, textWidth, lineHeight);
+            for (const QString &tertiaryLine : tertiaryLines) {
+                painter->drawText(tertiaryRect, Qt::AlignLeft | Qt::AlignTop, tertiaryLine);
+                tertiaryRect.translate(0, lineHeight);
+            }
+            painter->restore();
         }
-        painter->drawText(textRect, Qt::AlignLeft | Qt::AlignTop | Qt::TextDontClip, secondary);
     }
 
     painter->restore();
@@ -1247,22 +1392,286 @@ CalendarSingleActivityDelegate::paint
 
 
 QSize
-CalendarSingleActivityDelegate::sizeHint
+AgendaEntryDelegate::sizeHint
 (const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
+    if (column < 0) {
+        column = index.column();
+    }
+    QStyleOptionViewItem opt(option);
+    initStyleOption(&opt, index);
+
+    int width = columnWidth;
+    if (width <= 0) {
+        const QTreeWidget *tw = qobject_cast<const QTreeWidget*>(option.widget);
+        if (tw) {
+            width = tw->columnWidth(column);
+            if (width <= 0) {
+                width = tw->viewport()->width() / 2;
+            }
+        } else {
+            width = 200;
+        }
+    }
+
     QVariant data = index.data(EntryRole);
     if (! data.isNull()) {
-        QFontMetrics entryFM(option.font);
-        const int lineSpacing = 2 * dpiYFactor;
-        const int lineHeight = entryFM.height();
+        const int lineSpacing = attributes.lineSpacing * dpiYFactor;
+        const int lineHeight = option.fontMetrics.height();
         CalendarEntry entry = data.value<CalendarEntry>();
-        if (entry.type == ENTRY_TYPE_PLANNED_ACTIVITY) {
-            return QSize(100, 2 * lineHeight + lineSpacing);
-        } else {
-            return QSize(100, lineHeight);
+        int tertiaryHeight = 0;
+        if (! entry.tertiary.isEmpty()) {
+            const int iconWidth = 2 * lineHeight + lineSpacing;
+            int tertiaryWidth = width - iconWidth - attributes.iconTextSpacing * dpiXFactor - attributes.padding.left() - attributes.padding.right();
+            int numLines;
+            int tertiary;
+            layoutTertiaryText(entry.tertiary, option.font, tertiaryWidth, numLines, tertiaryHeight, nullptr, true);
+            tertiaryHeight += 2 * lineSpacing;
         }
-    } else {
-        return QSize(0, 0);
+        return QSize(width, 2 * lineHeight + lineSpacing + attributes.padding.top() + attributes.padding.bottom() + tertiaryHeight);
+    }
+    return QSize(width, attributes.padding.top() + attributes.padding.bottom());
+}
+
+
+AgendaEntryDelegate::Attributes
+AgendaEntryDelegate::getAttributes
+() const
+{
+    return attributes;
+}
+
+
+void
+AgendaEntryDelegate::setAttributes
+(const Attributes &attributes)
+{
+    this->attributes = attributes;
+}
+
+
+bool
+AgendaEntryDelegate::hasToolTip
+(const QModelIndex &index, QString *toolTipText) const
+{
+    if (! index.isValid()) {
+        return false;
+    }
+    CalendarEntry entry = index.data(EntryRole).value<CalendarEntry>();
+    QString text(entry.tertiary.trimmed());
+    if (text.isEmpty()) {
+        return false;
+    }
+    QStyleOptionViewItem opt;
+    initStyleOption(&opt, index);
+    const int lineSpacing = attributes.lineSpacing * dpiYFactor;
+    const int lineHeight = opt.fontMetrics.height();
+    const int iconTextSpacing = attributes.iconTextSpacing * dpiXFactor;
+    const int iconWidth = 2 * lineHeight + lineSpacing;
+    int availableWidth = columnWidth - iconWidth - iconTextSpacing - attributes.padding.left() - attributes.padding.right();
+    int numLines;
+    int height;
+    layoutTertiaryText(entry.tertiary, opt.font, availableWidth, numLines, height, nullptr, false);
+    bool show = numLines > attributes.maxTertiaryLines;
+    if (show) {
+        QStringList ttlines = entry.tertiary.split('\n');
+        *toolTipText = QString("<h4>%1</h4>").arg(entry.primary.trimmed());
+        for (const QString &line : ttlines) {
+            *toolTipText += QString("<div style='max-width: %1px; white-space: normal;'>%2</div>")
+                                   .arg(600 * dpiXFactor)
+                                   .arg(line);
+        }
+    }
+
+    return show;
+}
+
+
+void
+AgendaEntryDelegate::initStyleOption
+(QStyleOptionViewItem *option, const QModelIndex &index) const
+{
+    QStyledItemDelegate::initStyleOption(option, index);
+
+    if (AgendaTree *tree = qobject_cast<AgendaTree*>(parent())) {
+        if (tree->isRowHovered(index)) {
+            option->state |= QStyle::State_MouseOver;
+        } else {
+            option->state &= ~QStyle::State_MouseOver;
+        }
+    }
+}
+
+
+AgendaEntryDelegate::LayoutResult
+AgendaEntryDelegate::processLayoutText(const QString &text, const QFont &font, int availableWidth, bool limitHeight, bool needLines) const
+{
+    LayoutResult result;
+    if (text.isEmpty() || availableWidth <= 0) {
+        return result;
+    }
+
+    if (needLines) {
+        result.lines.reserve(limitHeight ? attributes.maxTertiaryLines : 20);
+    }
+
+    QStringList paragraphs = text.split('\n');
+
+    int calcHeight = 0;
+    int calcLines = 0;
+    QFontMetrics fm(font);
+    const int lineHeight = fm.height();
+
+    for (int p = 0; p < paragraphs.size(); ++p) {
+        const QString &paragraph = paragraphs[p];
+
+        if (paragraph.isEmpty()) {
+            ++calcLines;
+            if (needLines) {
+                result.lines.append(QString());
+            }
+            if (! limitHeight || calcLines <= attributes.maxTertiaryLines) {
+                calcHeight += lineHeight;
+            }
+            if (limitHeight && calcLines >= attributes.maxTertiaryLines) {
+                result.numLines = calcLines;
+                result.height = calcHeight;
+                return result;
+            }
+            continue;
+        }
+
+        QTextLayout layout(paragraph, font);
+        layout.setCacheEnabled(true);
+        layout.beginLayout();
+
+        while (true) {
+            QTextLine line = layout.createLine();
+            if (! line.isValid()) {
+                break;
+            }
+            line.setLineWidth(availableWidth);
+            ++calcLines;
+
+            bool isLastDisplayLine = limitHeight && calcLines >= attributes.maxTertiaryLines;
+            if (isLastDisplayLine && needLines) {
+                bool hasMoreLinesInParagraph = (line.textStart() + line.textLength() < paragraph.length());
+                bool hasMoreParagraphs = (p < paragraphs.size() - 1);
+                bool hasMoreText = hasMoreLinesInParagraph || hasMoreParagraphs;
+                if (hasMoreText) {
+                    const QString ellipsis = "…";
+                    const int ellipsisWidth = fm.horizontalAdvance(ellipsis);
+                    QString lineText = paragraph.mid(line.textStart(), line.textLength());
+
+                    int fullWidth = fm.horizontalAdvance(lineText);
+                    if (fullWidth + ellipsisWidth <= availableWidth) {
+                        result.lines.append(lineText + ellipsis);
+                    } else {
+                        int left = 0;
+                        int right = lineText.length();
+                        while (left < right) {
+                            int mid = (left + right + 1) / 2;
+                            QString testText = lineText.left(mid);
+                            if (fm.horizontalAdvance(testText + ellipsis) <= availableWidth) {
+                                left = mid;
+                            } else {
+                                right = mid - 1;
+                            }
+                        }
+                        QString truncatedText = lineText.left(left).trimmed();
+
+                        int wordBoundary = -1;
+                        for (int i = truncatedText.length() - 1; i >= 0; --i) {
+                            if (truncatedText[i].isSpace()) {
+                                wordBoundary = i;
+                                break;
+                            }
+                        }
+
+                        if (wordBoundary > 0 && wordBoundary >= truncatedText.length() * 0.8) {
+                            QString wordBrokenText = truncatedText.left(wordBoundary).trimmed();
+                            if (fm.horizontalAdvance(wordBrokenText + ellipsis) <= availableWidth) {
+                                truncatedText = wordBrokenText;
+                            }
+                        }
+                        result.lines.append(truncatedText + ellipsis);
+                    }
+                    calcHeight += line.height();
+                    layout.endLayout();
+                    result.numLines = calcLines;
+                    result.height = calcHeight;
+                    return result;
+                } else {
+                    result.lines.append(paragraph.mid(line.textStart(), line.textLength()));
+                    calcHeight += line.height();
+                    layout.endLayout();
+                    result.numLines = calcLines;
+                    result.height = calcHeight;
+                    return result;
+                }
+            }
+
+            if (needLines) {
+                result.lines.append(paragraph.mid(line.textStart(), line.textLength()));
+            }
+
+            if (! limitHeight || calcLines <= attributes.maxTertiaryLines) {
+                calcHeight += line.height();
+            }
+
+            if (isLastDisplayLine) {
+                layout.endLayout();
+                result.numLines = calcLines;
+                result.height = calcHeight;
+                return result;
+            }
+        }
+        layout.endLayout();
+    }
+    result.numLines = calcLines;
+    result.height = calcHeight;
+
+    return result;
+}
+
+
+void
+AgendaEntryDelegate::layoutTertiaryText
+(const QString &text, const QFont &font, int availableWidth, int &numLines, int &height, QStringList *lines, bool limitHeight) const
+{
+    LayoutResult result = processLayoutText(text, font, availableWidth, limitHeight, lines != nullptr);
+    numLines = result.numLines;
+    height = result.height;
+    if (lines) {
+        *lines = result.lines;
+    }
+}
+
+
+void
+AgendaEntryDelegate::updateColumnWidth
+()
+{
+    if (column >= 0) {
+        int newWidth = treeWidget->columnWidth(column);
+        if (newWidth > 50 && newWidth != columnWidth) {
+            columnWidth = newWidth;
+            treeWidget->setItemDelegateForColumn(column, nullptr);
+            treeWidget->setItemDelegateForColumn(column, this);
+        }
+    }
+}
+
+
+void
+AgendaEntryDelegate::onSectionResized
+(int logicalIndex, int oldSize, int newSize)
+{
+    Q_UNUSED(oldSize)
+    Q_UNUSED(newSize)
+
+    if (column >= 0 && column <= logicalIndex) {
+        QTimer::singleShot(100, this, &AgendaEntryDelegate::updateColumnWidth);
     }
 }
 

--- a/src/Gui/GcWindowRegistry.cpp
+++ b/src/Gui/GcWindowRegistry.cpp
@@ -44,6 +44,7 @@
 #include "WebPageWindow.h"
 #include "LiveMapWebPageWindow.h"
 #include "CalendarWindow.h"
+#include "AgendaWindow.h"
 #ifdef GC_WANT_R
 #include "RChart.h"
 #endif
@@ -109,6 +110,7 @@ GcWindowRegistry::initialize()
     { VIEW_TRAIN, tr("Elevation Chart"),GcWindowTypes::ElevationChart },
     { VIEW_ANALYSIS|VIEW_TRENDS|VIEW_TRAIN, tr("Web page"),GcWindowTypes::WebPageWindow },
     { VIEW_TRENDS, tr("Calendar"),GcWindowTypes::Calendar },
+    { VIEW_TRENDS, tr("Agenda"),GcWindowTypes::Agenda },
     { 0, "", GcWindowTypes::None }};
   // initialize the global registry
   GcWindows = GcWindowsInit;
@@ -250,6 +252,7 @@ GcWindowRegistry::newGcWindow(GcWinID id, Context *context)
     case GcWindowTypes::UserTrends: returning = new UserChartWindow(context, true); break;
     case GcWindowTypes::Diary:
     case GcWindowTypes::Calendar: returning = new CalendarWindow(context); break;
+    case GcWindowTypes::Agenda: returning = new AgendaWindow(context); break;
     default: return NULL; break;
     }
     if (returning) returning->setProperty("type", QVariant::fromValue<GcWinID>(id));

--- a/src/Gui/GcWindowRegistry.h
+++ b/src/Gui/GcWindowRegistry.h
@@ -78,7 +78,8 @@ enum gcwinid {
         OverviewAnalysisBlank=49,
         OverviewTrendsBlank=50,
         ElevationChart=51,
-        Calendar=52
+        Calendar=52,
+        Agenda=53
 };
 };
 typedef enum GcWindowTypes::gcwinid GcWinID;

--- a/src/Gui/Qt5Compatibility.h
+++ b/src/Gui/Qt5Compatibility.h
@@ -40,7 +40,6 @@ class TreeWidget6 : public QTreeWidget
         QTreeWidgetItem* itemFromIndex(const QModelIndex &index) const {
             return QTreeWidget::itemFromIndex(index);
         }
-
 };
 #else
 typedef QTreeWidget TreeWidget6;

--- a/src/src.pro
+++ b/src/src.pro
@@ -606,7 +606,7 @@ HEADERS += Charts/Aerolab.h Charts/AerolabWindow.h Charts/AllPlot.h Charts/AllPl
            Charts/MetadataWindow.h Charts/MUPlot.h Charts/MUPool.h Charts/MUWidget.h Charts/PfPvPlot.h Charts/PfPvWindow.h \
            Charts/PowerHist.h Charts/ReferenceLineDialog.h Charts/RideEditor.h Charts/RideMapWindow.h \
            Charts/ScatterPlot.h Charts/ScatterWindow.h Charts/SmallPlot.h Charts/TreeMapPlot.h \
-           Charts/TreeMapWindow.h Charts/ZoneScaleDraw.h Charts/CalendarWindow.h
+           Charts/TreeMapWindow.h Charts/ZoneScaleDraw.h Charts/CalendarWindow.h Charts/AgendaWindow.h
 
 # cloud services
 HEADERS += Cloud/CalendarDownload.h Cloud/CloudService.h \
@@ -651,7 +651,7 @@ HEADERS += Gui/AboutDialog.h Gui/AddIntervalDialog.h Gui/AnalysisSidebar.h Gui/C
            Gui/AddTileWizard.h Gui/NavigationModel.h Gui/AthleteView.h Gui/AthleteConfigDialog.h Gui/AthletePages.h Gui/Perspective.h \
            Gui/PerspectiveDialog.h Gui/SplashScreen.h Gui/StyledItemDelegates.h Gui/MetadataDialog.h Gui/ActionButtonBox.h \
            Gui/MetricOverrideDialog.h Gui/RepeatScheduleWizard.h \
-           Gui/Calendar.h Gui/CalendarData.h Gui/CalendarItemDelegates.h \
+           Gui/Calendar.h Gui/Agenda.h Gui/CalendarData.h Gui/CalendarItemDelegates.h \
            Gui/IconManager.h Gui/Qt5Compatibility.h
 
 # metrics and models
@@ -716,7 +716,7 @@ SOURCES += Charts/Aerolab.cpp Charts/AerolabWindow.cpp Charts/AllPlot.cpp Charts
            Charts/MetadataWindow.cpp Charts/MUPlot.cpp Charts/MUWidget.cpp Charts/PfPvPlot.cpp Charts/PfPvWindow.cpp \
            Charts/PowerHist.cpp Charts/ReferenceLineDialog.cpp Charts/RideEditor.cpp Charts/RideMapWindow.cpp \
            Charts/ScatterPlot.cpp Charts/ScatterWindow.cpp Charts/SmallPlot.cpp Charts/TreeMapPlot.cpp \
-           Charts/TreeMapWindow.cpp Charts/CalendarWindow.cpp
+           Charts/TreeMapWindow.cpp Charts/CalendarWindow.cpp Charts/AgendaWindow.cpp
 
 ## Cloud Services / Web resources
 SOURCES += Cloud/CalendarDownload.cpp Cloud/CloudService.cpp \
@@ -764,7 +764,7 @@ SOURCES += Gui/AboutDialog.cpp Gui/AddIntervalDialog.cpp Gui/AnalysisSidebar.cpp
            Gui/AddTileWizard.cpp Gui/NavigationModel.cpp Gui/AthleteView.cpp Gui/AthleteConfigDialog.cpp Gui/AthletePages.cpp Gui/Perspective.cpp \
            Gui/PerspectiveDialog.cpp Gui/SplashScreen.cpp Gui/StyledItemDelegates.cpp Gui/MetadataDialog.cpp Gui/ActionButtonBox.cpp \
            Gui/MetricOverrideDialog.cpp Gui/RepeatScheduleWizard.cpp \
-           Gui/Calendar.cpp Gui/CalendarData.cpp Gui/CalendarItemDelegates.cpp \
+           Gui/Calendar.cpp Gui/Agenda.cpp Gui/CalendarData.cpp Gui/CalendarItemDelegates.cpp \
            Gui/IconManager.cpp
 
 ## Models and Metrics


### PR DESCRIPTION
* New chart: Agenda
* Removed the agenda from the calendar chart
* Reworked the agenda
  * Separate panes for activities, phases, events
  * Phases and events can be edited from this chart
  * Showing descriptions of activities and events (optional)
* TimeUtils: New functions to convert days to weeks or months for user friendly UIs
* EditPhaseDialog: Enforcing from-date < to-date
* Hack: Since ids of events are not filled, matching them by comparing all available fields when selecting the instance to edit