### PR TITLE
Fix for isolate axis hides labels when using bars

### DIFF
--- a/src/Charts/LTMPlot.cpp
+++ b/src/Charts/LTMPlot.cpp
@@ -1088,7 +1088,7 @@ LTMPlot::setData(LTMSettings *set)
             linearGradient.setColorAt(1.0, brushColor);
             linearGradient.setSpread(QGradient::PadSpread);
             current->setBrush(linearGradient);
-            current->setPen(QPen(Qt::NoPen));
+            current->setPen(QPen(metricDetail.penColor));
             current->setCurveAttribute(QwtPlotCurve::Inverted, true);
 
             current->setSymbol(NULL);


### PR DESCRIPTION
Fixes https://github.com/GoldenCheetah/GoldenCheetah/issues/4705

The pen wasn't set for bar charts, and the hack relies upon the pen's color value to set the visibility of the labels.