### PR TITLE
Check for the latest version of GC

### DIFF
--- a/src/Core/GcUpgrade.h
+++ b/src/Core/GcUpgrade.h
@@ -131,6 +131,7 @@
 #define VERSION31_BUILD VERSION31_UPG
 
 // the next two will with each build/release
+// note: the GC version check functionality in mainWindow is dependent upon format of VERSION_STRING
 #define VERSION_LATEST 5006
 #define VERSION_STRING "V3.7.1"
 //#define GC_VERSION VERSION_STRING // To force version string on non-tagged ci builds

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -27,6 +27,7 @@
 #include <QtGui>
 #include <QMainWindow>
 #include <QStackedWidget>
+#include <QNetworkReply>
 #include "RideItem.h"
 #include "TimeUtils.h"
 #include "DragBar.h"
@@ -121,6 +122,8 @@ class MainWindow : public QMainWindow
         virtual void closeEvent(QCloseEvent*);
         virtual void dragEnterEvent(QDragEnterEvent *);
         virtual void dropEvent(QDropEvent *);
+
+        void gcVersionCheck();
 
         // working with splash screens
         SplashScreen *splash;
@@ -293,6 +296,10 @@ class MainWindow : public QMainWindow
 
         void configChanged(qint32);
 
+    protected slots:
+
+        void gcVersionResponse(QNetworkReply*);
+
     private:
 
         // when loading athlete
@@ -350,6 +357,9 @@ class MainWindow : public QMainWindow
 
         QAction *shareAction;
         QAction *checkAction;
+
+        // Latest version checking
+        QNetworkAccessManager networkAccessMngr;
 
         // Miscellany
         QSignalMapper *toolMapper = nullptr;


### PR DESCRIPTION
The following PR checks the user's installed GC application is the latest version every 31 days, and reminds them to upgrade if they are using an old version. The new checking functionality downloads the GCUpgrade.h file from the GoldenCheetah Github project, and compares the versions with those within the users application. This means there is no additional overhead for the build release process.

An example of the dialog is below:

<img width="519" height="282" alt="image" src="https://github.com/user-attachments/assets/9aa816df-22f7-46ff-81d7-d6b370a35b2d" />


**Questions:**

- If you prefer accessing the version information from the goldencheetah.org website, let me know and I'll update the PR? I searched the internet for the supported file request rate on Github, and got the following response: "A free GitHub account is subject to a rate limit of 60 requests per hour per IP address when accessing public raw files without an authentication token. This limit applies to direct access via raw.githubusercontent.com." so the PRs Github use will not cause any issues with each active GC instance making a single request every 31 days.
- I think this now replaces the CloudDBVersionClient classes informUserAboutLatestVersions() functionality (I have commented out the function call), or is that to check the DB version?
- Is every 31 days ok?
- The check only retries every 31 days, if the connection fails when attempting to get GCUpgrade.h it will retry in 31 days, is this ok?

**To test**
set the date test in gcVersionCheck() to true, and set the following in GCUpgrade.h to old versions:
#define VERSION_LATEST 5001
#define VERSION_STRING "V3.6"