### PR TITLE
Optimization of User Chart Hover Performance

### DIFF
--- a/src/Charts/GenericPlot.cpp
+++ b/src/Charts/GenericPlot.cpp
@@ -1280,7 +1280,9 @@ GenericPlot::configureAxis(QString name, bool visible, int align, double min, do
             if (series->type() == QAbstractSeries::SeriesType::SeriesTypeScatter ||
                 series->type() == QAbstractSeries::SeriesType::SeriesTypeBar ||
                 series->type() == QAbstractSeries::SeriesType::SeriesTypeLine) {
-                foreach(QPointF point, static_cast<QXYSeries*>(series)->pointsVector()) {
+                QXYSeries *s = static_cast<QXYSeries*>(series);
+                for(int i=0; i<s->count(); i++) {
+                    QPointF point = s->at(i);
                     if (usey) {
                         if (setmin && point.y() < min) min=point.y();
                         else if (!setmin) { min=point.y(); setmin=true; }
@@ -1309,7 +1311,9 @@ GenericPlot::configureAxis(QString name, bool visible, int align, double min, do
                 if (series->type() == QAbstractSeries::SeriesType::SeriesTypeScatter ||
                     series->type() == QAbstractSeries::SeriesType::SeriesTypeBar ||
                     series->type() == QAbstractSeries::SeriesType::SeriesTypeLine) {
-                    foreach(QPointF point, static_cast<QXYSeries*>(series)->pointsVector()) {
+                    QXYSeries *s = static_cast<QXYSeries*>(series);
+                    for(int i=0; i<s->count(); i++) {
+                        QPointF point = s->at(i);
                         if (usey) {
                             if (setmax && point.y() > max) max=point.y();
                             else if (!setmax) { max=point.y(); setmax=true; }

--- a/src/Charts/GenericSelectTool.cpp
+++ b/src/Charts/GenericSelectTool.cpp
@@ -22,6 +22,7 @@
 #include "AbstractView.h"
 #include "RideFileCommand.h"
 #include "Utils.h"
+#include "SeriesIterator.h"
 
 #include <limits>
 #include <cmath> // for isinf() isnan()
@@ -478,7 +479,7 @@ GenericSelectTool::clicked(QPointF pos)
 }
 
 bool
-GenericSelectTool::released(QPointF pos)
+GenericSelectTool::released(QPointF /* pos */)
 {
     if (mode == RECTANGLE || mode == XRANGE) {
 
@@ -700,23 +701,24 @@ GenericSelectTool::moved(QPointF pos)
 
                 // pointsVector
                 if (series->type() == QAbstractSeries::SeriesTypeLine || series->type() == QAbstractSeries::SeriesTypeArea) {
-
-                    // we take a copy, would love to avoid this.
-                    QVector<QPointF> p = series->type() == QAbstractSeries::SeriesTypeLine ? static_cast<QLineSeries*>(series)->pointsVector() :
-                                                                              static_cast<QAreaSeries*>(series)->upperSeries()->pointsVector();
-
+                    QXYSeries *line = series->type() == QAbstractSeries::SeriesTypeLine ? static_cast<QXYSeries*>(series) :
+                                                                              static_cast<QAreaSeries*>(series)->upperSeries();
                     // value we want
                     QPointF x= QPointF(xvalue,0);
 
-                    // lower_bound to value near x
-                    QVector<QPointF>::const_iterator i = std::lower_bound(p.begin(), p.end(), x, CompareQPointFX());
+                    // use iterator wrapper to avoid copy
+                    SeriesIterator begin(line, 0);
+                    SeriesIterator end(line, line->count());
+                    SeriesIterator it = std::lower_bound(begin, end, x, CompareQPointFX());
 
-                    if (i != p.end()) {
+                    if (it != end) {
+                        QPointF p = *it;
+
                         // collect them away
-                        vals.insert(series, GPointF(i->x(), i->y(), i-p.begin()));
+                        vals.insert(series, GPointF(p.x(), p.y(), it - begin));
 
                         // nearest x?
-                        if (i->x() != 0 && (nearestx == -9999 || (std::fabs(i->x()-xvalue)) < std::fabs((nearestx-xvalue)))) nearestx = i->x();
+                        if (p.x() != 0 && (nearestx == -9999 || (std::fabs(p.x()-xvalue)) < std::fabs((nearestx-xvalue)))) nearestx = p.x();
                     }
                 }
 

--- a/src/Charts/SeriesIterator.h
+++ b/src/Charts/SeriesIterator.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2025 Magnus Gille (mgille@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
+#include <iterator>
+#include <QPointF>
+#include <QXYSeries>
+
+// Minimal iterator to traverse QXYSeries points without copying
+// Required to use std::lower_bound on QXYSeries data in-place
+class SeriesIterator : public std::iterator<std::random_access_iterator_tag, QPointF> {
+public:
+    SeriesIterator(QXYSeries *series, int index) : m_series(series), m_index(index) {}
+
+    QPointF operator*() const { return m_series->at(m_index); }
+    SeriesIterator& operator++() { m_index++; return *this; }
+    SeriesIterator operator++(int) { SeriesIterator tmp = *this; m_index++; return tmp; }
+    SeriesIterator& operator--() { m_index--; return *this; }
+    SeriesIterator operator--(int) { SeriesIterator tmp = *this; m_index--; return tmp; }
+    SeriesIterator& operator+=(int n) { m_index += n; return *this; }
+    SeriesIterator operator+(int n) const { return SeriesIterator(m_series, m_index + n); }
+    SeriesIterator& operator-=(int n) { m_index -= n; return *this; }
+    SeriesIterator operator-(int n) const { return SeriesIterator(m_series, m_index - n); }
+    difference_type operator-(const SeriesIterator& other) const { return m_index - other.m_index; }
+    bool operator==(const SeriesIterator& other) const { return m_index == other.m_index; }
+    bool operator!=(const SeriesIterator& other) const { return m_index != other.m_index; }
+    bool operator<(const SeriesIterator& other) const { return m_index < other.m_index; }
+
+private:
+    QXYSeries *m_series;
+    int m_index;
+};
+

--- a/src/src.pro
+++ b/src/src.pro
@@ -580,9 +580,12 @@ SOURCES += Gui/ChartSpace.cpp Charts/OverviewItems.cpp Charts/Overview.cpp
 # generic chart
 DEFINES += GC_HAVE_GENERIC
 HEADERS += Charts/UserChartWindow.h Charts/UserChartOverviewItem.h Charts/UserChart.h Charts/UserChartData.h \
-           Charts/GenericChart.h Charts/GenericPlot.h Charts/GenericSelectTool.h Charts/GenericLegend.h Charts/GenericAnnotations.h
+           Charts/GenericChart.h Charts/GenericPlot.h Charts/GenericSelectTool.h Charts/GenericLegend.h \
+	   Charts/GenericAnnotations.h Charts/SeriesIterator.h
+
 SOURCES += Charts/UserChartWindow.cpp Charts/UserChartOverviewItem.cpp Charts/UserChart.cpp Charts/UserChartData.cpp \
-           Charts/GenericChart.cpp Charts/GenericPlot.cpp Charts/GenericSelectTool.cpp Charts/GenericLegend.cpp Charts/GenericAnnotations.cpp
+           Charts/GenericChart.cpp Charts/GenericPlot.cpp Charts/GenericSelectTool.cpp Charts/GenericLegend.cpp \
+	   Charts/GenericAnnotations.cpp
 
 ###=====================
 ### LEX AND YACC SOURCES


### PR DESCRIPTION
In GenericSelectTool::moved, inside the XRANGE mode handling:
  Remove pointsVector() call which copies all data.
  Implement a binary search using count() and at()
  methods of QXYSeries (base of QLineSeries).

This changes complexity from O(N) copy + O(log N) search to O(log N) search only.

Fixes ##4442