### PR TITLE
Modify phases and events in calendar

### DIFF
--- a/src/Charts/AgendaWindow.cpp
+++ b/src/Charts/AgendaWindow.cpp
@@ -786,7 +786,7 @@ AgendaWindow::editEventEntry
     SeasonEvent *seasonEvent = nullptr;
     for (Season &s : context->athlete->seasons->seasons) {
         for (SeasonEvent &event : s.events) {
-            // FIXME: Ugly comparison required becuase SeasonEvent::id is not populated
+            // FIXME: Ugly comparison required because SeasonEvent::id is not populated
             if (   event.name == entry.primary
                 && (   (event.priority == 0 && entry.secondary == tr("Uncategorized"))
                     || (event.priority == 1 && entry.secondary == tr("Category A"))

--- a/src/Charts/CalendarWindow.h
+++ b/src/Charts/CalendarWindow.h
@@ -123,6 +123,12 @@ class CalendarWindow : public GcChartWindow
         void updateActivitiesIfInRange(RideItem *rideItem);
         void updateSeason(Season const *season, bool allowKeepMonth = false);
         bool movePlannedActivity(RideItem *rideItem, const QDate &destDay, const QTime &destTime = QTime());
+        void addEvent(const QDate &date);
+        void editEvent(const CalendarEntry &entry);
+        void delEvent(const CalendarEntry &entry);
+        void addPhase(const QDate &date);
+        void editPhase(const CalendarEntry &entry);
+        void delPhase(const CalendarEntry &entry);
 };
 
 #endif

--- a/src/Core/Season.cpp
+++ b/src/Core/Season.cpp
@@ -502,6 +502,17 @@ Season::hasPhaseOrEvent
 }
 
 
+bool
+Season::canHavePhasesOrEvents
+() const
+{
+    return   (   getType() == Season::season
+              || getType() == Season::cycle
+              || getType() == Season::adhoc)
+           && isAbsolute();
+}
+
+
 bool Season::LessThanForStarts(const Season &a, const Season &b)
 {
     return a.getStart().toJulianDay() < b.getStart().toJulianDay();

--- a/src/Core/Season.h
+++ b/src/Core/Season.h
@@ -197,6 +197,7 @@ class Season
 
         bool isAbsolute() const;
         bool hasPhaseOrEvent() const;
+        bool canHavePhasesOrEvents() const;
 
         static bool LessThanForStarts(const Season &a, const Season &b);
 

--- a/src/Core/SeasonDialogs.cpp
+++ b/src/Core/SeasonDialogs.cpp
@@ -19,6 +19,7 @@
 #include "SeasonDialogs.h"
 #include "Seasons.h"
 #include "Athlete.h"
+#include "Colors.h"
 
 #include <QString>
 #include <QFormLayout>
@@ -152,9 +153,9 @@ EditSeasonDialog::EditSeasonDialog
     endValueStack->addWidget(new QLabel(tr("Up to current day and month")));
 
     statusLabel = new QLabel();
-    statusLabel->setWordWrap(true);
+    statusLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
     warningLabel = new QLabel();
-    warningLabel->setWordWrap(true);
+    warningLabel->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
 
     seedEdit = new QDoubleSpinBox();
     seedEdit->setDecimals(0);
@@ -174,7 +175,7 @@ EditSeasonDialog::EditSeasonDialog
     applyButton = buttonBox->addButton(tr("&OK"), QDialogButtonBox::AcceptRole);
     QPushButton *cancelButton = buttonBox->addButton(tr("&Cancel"), QDialogButtonBox::RejectRole);
 
-    QFormLayout *formLayout = new QFormLayout(this);
+    QFormLayout *formLayout = newQFormLayout(this);
     formLayout->addRow(tr("Name"), nameEdit);
     formLayout->addRow(tr("Type"), typeCombo);
     formLayout->addRow(startCombo, startValueStack);
@@ -475,6 +476,9 @@ EditSeasonEventDialog::EditSeasonEventDialog(Context *context, SeasonEvent *even
 {
     setWindowTitle(tr("Edit Event"));
 
+    QLabel *seasonLabel = new QLabel();
+    seasonLabel->setText(season.getName());
+
     nameEdit = new QLineEdit(this);
     nameEdit->setText(event->name);
 
@@ -494,7 +498,8 @@ EditSeasonEventDialog::EditSeasonEventDialog(Context *context, SeasonEvent *even
     applyButton = buttonBox->addButton(tr("&OK"), QDialogButtonBox::AcceptRole);
     QPushButton *cancelButton = buttonBox->addButton(tr("&Cancel"), QDialogButtonBox::RejectRole);
 
-    QFormLayout *formLayout = new QFormLayout(this);
+    QFormLayout *formLayout = newQFormLayout(this);
+    formLayout->addRow(tr("Season"), seasonLabel);
     formLayout->addRow(tr("Name"), nameEdit);
     formLayout->addRow(tr("Date"), dateEdit);
     formLayout->addRow(tr("Priority"), priorityEdit);
@@ -542,6 +547,9 @@ EditPhaseDialog::EditPhaseDialog(Context *context, Phase *phase, Season &season)
 {
     setWindowTitle(tr("Edit Date Range"));
 
+    QLabel *seasonLabel = new QLabel();
+    seasonLabel->setText(season.getName());
+
     nameEdit = new QLineEdit();
     nameEdit->setText(phase->getName());
 
@@ -583,7 +591,8 @@ EditPhaseDialog::EditPhaseDialog(Context *context, Phase *phase, Season &season)
     applyButton = buttonBox->addButton(tr("&OK"), QDialogButtonBox::AcceptRole);
     QPushButton *cancelButton = buttonBox->addButton(tr("&Cancel"), QDialogButtonBox::RejectRole);
 
-    QFormLayout *formLayout = new QFormLayout(this);
+    QFormLayout *formLayout = newQFormLayout(this);
+    formLayout->addRow(tr("Season"), seasonLabel);
     formLayout->addRow(tr("Name"), nameEdit);
     formLayout->addRow(tr("Type"), typeEdit);
     formLayout->addRow(tr("From"), fromEdit);

--- a/src/Gui/Calendar.h
+++ b/src/Gui/Calendar.h
@@ -84,7 +84,7 @@ public:
     QDate selectedDate() const;
     bool isInDateRange(const QDate &date) const;
     void fillEntries(const QHash<QDate, QList<CalendarEntry>> &activityEntries, const QList<CalendarSummary> &summaries, const QHash<QDate, QList<CalendarEntry>> &headlineEntries);
-    void limitDateRange(const DateRange &dr);
+    void limitDateRange(const DateRange &dr, bool canHavePhasesOrEvents = false);
     void setFirstDayOfWeek(Qt::DayOfWeek firstDayOfWeek);
     void setStartHour(int hour);
     void setEndHour(int hour);
@@ -100,6 +100,12 @@ signals:
     void viewActivity(const CalendarEntry &activity);
     void addActivity(bool plan, const QDate &day, const QTime &time);
     void delActivity(const CalendarEntry &activity);
+    void addEvent(const QDate &date);
+    void editEvent(const CalendarEntry &entry);
+    void delEvent(const CalendarEntry &entry);
+    void addPhase(const QDate &date);
+    void editPhase(const CalendarEntry &entry);
+    void delPhase(const CalendarEntry &entry);
 
 protected:
     void changeEvent(QEvent *event) override;
@@ -122,6 +128,7 @@ private:
     Qt::DayOfWeek firstDayOfWeek = Qt::Monday;
     QDate date;
     DateRange dr;
+    bool canHavePhasesOrEvents = false;
     CalendarDayTableType type;
     int defaultStartHour = 8;
     int defaultEndHour = 21;
@@ -133,6 +140,8 @@ private:
     TimeScaleData timeScaleData;
 
     void setDropIndicator(int y, BlockIndicator block);
+    QMenu *makeHeaderMenu(const QModelIndex &index, const QPoint &pos);
+    QMenu *makeActivityMenu(const QModelIndex &index, const QPoint &pos);
 };
 
 
@@ -155,7 +164,7 @@ public:
     QDate firstVisibleDay() const;
     QDate lastVisibleDay() const;
     QDate selectedDate() const;
-    void limitDateRange(const DateRange &dr, bool allowKeepMonth = false);
+    void limitDateRange(const DateRange &dr, bool allowKeepMonth = false, bool canHavePhasesOrEvents = false);
     void setFirstDayOfWeek(Qt::DayOfWeek firstDayOfWeek);
 
 signals:
@@ -180,6 +189,12 @@ signals:
     void repeatSchedule(const QDate &day);
     void insertRestday(const QDate &day);
     void delRestday(const QDate &day);
+    void addEvent(const QDate &date);
+    void editEvent(const CalendarEntry &entry);
+    void delEvent(const CalendarEntry &entry);
+    void addPhase(const QDate &date);
+    void editPhase(const CalendarEntry &entry);
+    void delPhase(const CalendarEntry &entry);
 
 protected:
     void changeEvent(QEvent *event) override;
@@ -205,6 +220,7 @@ private:
     QDate endDate; // last visible date
     QDate currentDate; // currently selected date
     DateRange dr;
+    bool canHavePhasesOrEvents = false;
 
     QTimer dragTimer;
     QPoint pressedPos;
@@ -232,7 +248,7 @@ public:
     void setEndHour(int hour);
     void setSummaryVisible(bool visible);
     void fillEntries(const QHash<QDate, QList<CalendarEntry>> &activityEntries, const QList<CalendarSummary> &summaries, const QHash<QDate, QList<CalendarEntry>> &headlineEntries);
-    void limitDateRange(const DateRange &dr);
+    void limitDateRange(const DateRange &dr, bool canHavePhasesOrEvents = false);
     QDate firstVisibleDay() const;
     QDate lastVisibleDay() const;
     QDate selectedDate() const;
@@ -245,6 +261,12 @@ signals:
     void delActivity(const CalendarEntry &activity);
     void entryMoved(const CalendarEntry &activity, const QDate &srcDay, const QDate &destDay, const QTime &destTime);
     void dayChanged(const QDate &date);
+    void addEvent(const QDate &date);
+    void editEvent(const CalendarEntry &entry);
+    void delEvent(const CalendarEntry &entry);
+    void addPhase(const QDate &date);
+    void editPhase(const CalendarEntry &entry);
+    void delPhase(const CalendarEntry &entry);
 
 private:
     Measures * const athleteMeasures;
@@ -269,7 +291,7 @@ public:
     void setEndHour(int hour);
     void setSummaryVisible(bool visible);
     void fillEntries(const QHash<QDate, QList<CalendarEntry>> &activityEntries, const QList<CalendarSummary> &summaries, const QHash<QDate, QList<CalendarEntry>> &headlineEntries);
-    void limitDateRange(const DateRange &dr);
+    void limitDateRange(const DateRange &dr, bool canHavePhasesOrEvents = false);
     QDate firstVisibleDay() const;
     QDate firstVisibleDay(const QDate &date) const;
     QDate lastVisibleDay() const;
@@ -283,6 +305,12 @@ signals:
     void delActivity(const CalendarEntry &activity);
     void entryMoved(const CalendarEntry &activity, const QDate &srcDay, const QDate &destDay, const QTime &destTime);
     void dayChanged(const QDate &date);
+    void addEvent(const QDate &date);
+    void editEvent(const CalendarEntry &entry);
+    void delEvent(const CalendarEntry &entry);
+    void addPhase(const QDate &date);
+    void editPhase(const CalendarEntry &entry);
+    void delPhase(const CalendarEntry &entry);
 
 private:
     CalendarDayTable *weekTable;
@@ -311,7 +339,7 @@ public:
 
 public slots:
     void setView(CalendarView view);
-    void activateDateRange(const DateRange &dr, bool allowKeepMonth = false);
+    void activateDateRange(const DateRange &dr, bool allowKeepMonth = false, bool canHavePhasesOrEvents = false);
     void setFirstDayOfWeek(Qt::DayOfWeek firstDayOfWeek);
     void setStartHour(int hour);
     void setEndHour(int hour);
@@ -337,6 +365,12 @@ signals:
     void moveActivity(const CalendarEntry &activity, const QDate &srcDay, const QDate &destDay, const QTime &destTime);
     void insertRestday(const QDate &day);
     void delRestday(const QDate &day);
+    void addEvent(const QDate &date);
+    void editEvent(const CalendarEntry &entry);
+    void delEvent(const CalendarEntry &entry);
+    void addPhase(const QDate &date);
+    void editPhase(const CalendarEntry &entry);
+    void delPhase(const CalendarEntry &entry);
 
 private:
     QToolBar *toolbar;

--- a/src/Gui/LTMSidebar.cpp
+++ b/src/Gui/LTMSidebar.cpp
@@ -431,6 +431,11 @@ LTMSidebar::resetSeasons()
     // delete it and its children
     dateRangeTree->clear();
 
+    // clear events - we need to add for currently selected season
+    for (int i = allEvents->childCount(); i > 0; i--) {
+        delete allEvents->takeChild(0);
+    }
+
     // by default choose last 3 months not first one, since the first one is all dates
     // and that means aggregating all data when first starting...
     QString id = appsettings->cvalue(context->athlete->cyclist, GC_LTM_LAST_DATE_RANGE, "{00000000-0000-0000-0000-000000000012}").toString();
@@ -456,6 +461,22 @@ LTMSidebar::resetSeasons()
             }
             addPhase->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsDragEnabled);
             addPhase->setText(0, phase.getName());
+        }
+
+        // Events
+        if (context->currentSeason() != nullptr && context->currentSeason()->id() == season.id()) {
+            // add this seasons events
+            for (int j = 0; j < season.events.count(); j++) {
+                SeasonEvent event = season.events.at(j);
+                QTreeWidgetItem *add = new QTreeWidgetItem(allEvents);
+                add->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsDragEnabled);
+                add->setText(0, event.name);
+                add->setText(1, event.date.toString("MMM d, yyyy"));
+                add->setText(2, SeasonEvent::priorityList().at(event.priority));
+            }
+
+            // make sure they fit
+            eventTree->header()->resizeSections(QHeaderView::ResizeToContents);
         }
     }
 


### PR DESCRIPTION
* Phases and events can be created, edited, deleted in the calendar (all views)
* LTMSidebar reacts to modified events
* Phase and Event dialogs show the associated season
* Menu entries are only active within the current season