### PR TITLE
Planning workout: Adding description to Notes

### DIFF
--- a/src/Gui/ManualActivityWizard.cpp
+++ b/src/Gui/ManualActivityWizard.cpp
@@ -117,9 +117,21 @@ ManualActivityWizard::done
         field2TagString(rideFile, "workoutCode", "Workout Code");
         field2TagInt(rideFile, "rpe", "RPE");
         field2TagString(rideFile, "objective", "Objective");
-        field2TagString(rideFile, "notes", "Notes");
         field2TagString(rideFile, "woFilename", "WorkoutFilename");
         field2TagString(rideFile, "woTitle", "Route");
+
+        // Special case notes: Combine notes and workout description (if available)
+        QString notesCombined = field("notes").toString().trimmed();
+        QString description = field("woDescription").toString().trimmed();
+        if (! description.isEmpty()) {
+            if (! notesCombined.isEmpty()) {
+                notesCombined += "\n";
+            }
+            notesCombined += description;
+        }
+        if (! notesCombined.isEmpty()) {
+        }
+        rideFile.setTag("Notes", notesCombined);
 
         if ((sport == "Run" || sport == "Swim") && field("paceIntervals").toBool()) {
             QList<RideFilePoint*> points = field("laps").value<QList<RideFilePoint*>>();
@@ -534,6 +546,7 @@ ManualActivityPageWorkout::ManualActivityPageWorkout
     QLineEdit *woFilename = new QLineEdit();
     QLineEdit *woTitle = new QLineEdit();
     QLineEdit *woFileType = new QLineEdit();
+    QTextEdit *woDescription = new QTextEdit();
     QSpinBox *woElevationGain = new QSpinBox();
     woElevationGain->setMaximum(10000);
     QSpinBox *woIsoPower = new QSpinBox();
@@ -544,6 +557,7 @@ ManualActivityPageWorkout::ManualActivityPageWorkout
     registerField("woFilename*", woFilename);
     registerField("woTitle*", woTitle);
     registerField("woFileType*", woFileType);
+    registerField("woDescription", woDescription, "plainText", SIGNAL(textChanged()));
     registerField("woElevationGain", woElevationGain);
     registerField("woIsoPower", woIsoPower);
     registerField("woXPower", woXPower);
@@ -570,6 +584,7 @@ ManualActivityPageWorkout::ManualActivityPageWorkout
     hiddenLayout->addWidget(woFilename);
     hiddenLayout->addWidget(woTitle);
     hiddenLayout->addWidget(woFileType);
+    hiddenLayout->addWidget(woDescription);
     hiddenLayout->addWidget(woElevationGain);
     hiddenLayout->addWidget(woIsoPower);
     hiddenLayout->addWidget(woXPower);
@@ -630,6 +645,7 @@ ManualActivityPageWorkout::resetFields
     setField("woFilename", QString());
     setField("woTitle", QString());
     setField("woFileType", QString());
+    setField("woDescription", QString());
     setField("woElevationGain", 0);
     setField("woIsoPower", 0);
     setField("woXPower", 0);
@@ -662,6 +678,7 @@ ManualActivityPageWorkout::selectionChanged
     QString filename = workoutModel->data(workoutModel->index(target.row(), TdbWorkoutModelIdx::filepath), Qt::DisplayRole).toString();
     QString title = workoutModel->data(workoutModel->index(target.row(), TdbWorkoutModelIdx::displayname), Qt::DisplayRole).toString();
     QString type = workoutModel->data(workoutModel->index(target.row(), TdbWorkoutModelIdx::type), Qt::DisplayRole).toString();
+    QString description = workoutModel->data(workoutModel->index(target.row(), TdbWorkoutModelIdx::description), Qt::DisplayRole).toString();
     int avgPower = workoutModel->data(workoutModel->index(target.row(), TdbWorkoutModelIdx::avgPower), Qt::DisplayRole).toInt();
     int bikeStress = workoutModel->data(workoutModel->index(target.row(), TdbWorkoutModelIdx::bikestress), Qt::DisplayRole).toInt();
     int bikeScore = workoutModel->data(workoutModel->index(target.row(), TdbWorkoutModelIdx::bs), Qt::DisplayRole).toInt();
@@ -671,6 +688,7 @@ ManualActivityPageWorkout::selectionChanged
     setField("woFilename", filename);
     setField("woTitle", title);
     setField("woFileType", type);
+    setField("woDescription", description);
     setField("woElevationGain", elevationGain);
     setField("woIsoPower", isoPower);
     setField("woXPower", xPower);
@@ -1396,6 +1414,7 @@ ManualActivityPageSummary::initializePage
     }
     addRowString(tr("Objective"), "objective");
     addRowString(tr("Notes"), "notes");
+    addRowString(tr("Workout Description"), "woDescription");
     bool hasActMetricsSection = false;
     QLabel *actMetricsHL = new QLabel(HLO + tr("Activity Metrics") + HLC);
     form->addRow(actMetricsHL);


### PR DESCRIPTION
When planning a workout based on a ErgFile, the description is appended to the Notes (never overwriting what was entered before, only appending). This makes the description available e.g. in the agenda, giving a quick insight of what is ahead