### PR TITLE
Fix to prevent view pages being collapsed by the splitter

### DIFF
--- a/src/Gui/AbstractView.cpp
+++ b/src/Gui/AbstractView.cpp
@@ -581,6 +581,10 @@ AbstractView::setPages(QStackedWidget *pages)
     mainSplitter->setCollapsible(0, false);
     splitter->insertWidget(-1, mainSplitter);
 
+    // prevent the pages being collapsed by the splitter
+    int index = splitter->indexOf(mainSplitter);
+    splitter->setCollapsible(index, false);
+
     // restore sizes
     QString setting = QString("%1/%2").arg(GC_SETTINGS_SPLITTER_SIZES).arg(type);
     QVariant splitterSizes = appsettings->cvalue(context->athlete->cyclist, setting); 


### PR DESCRIPTION
When the view's sidebar splitter is dragged to the right far enough this causes the view's pages to collapse, getting them displayed again isn't straightforward, so this PR prevents them from collapsing.