### PR TITLE
Add missing receiver parameter to lambda signal connections

### DIFF
--- a/src/Gui/ActionButtonBox.cpp
+++ b/src/Gui/ActionButtonBox.cpp
@@ -189,14 +189,14 @@ void
 ActionButtonBox::defaultConnect
 (StandardButtonGroup group, QAbstractItemView *view)
 {
-    connect(view->selectionModel(), &QItemSelectionModel::currentChanged, [=]() {
+    connect(view->selectionModel(), &QItemSelectionModel::currentChanged, this, [this, group, view]() {
         updateButtonState(group, view);
     });
-    // Also listen for rowsRemoved as currentItemChanged fires to early (count of tree not yet reduced)
-    connect(view->model(), &QAbstractItemModel::rowsRemoved, [=]() {
+    // Also listen for rowsRemoved as currentItemChanged fires too early (count of tree not yet reduced)
+    connect(view->model(), &QAbstractItemModel::rowsRemoved, this, [this, group, view]() {
         updateButtonState(group, view);
     });
-    connect(view->model(), &QAbstractItemModel::rowsInserted, [=]() {
+    connect(view->model(), &QAbstractItemModel::rowsInserted, this, [this, group, view]() {
         updateButtonState(group, view);
     });
     updateButtonState(group, view);

--- a/src/Gui/AnalysisSidebar.cpp
+++ b/src/Gui/AnalysisSidebar.cpp
@@ -416,7 +416,7 @@ AnalysisSidebar::showActivityMenu(const QPoint &pos)
             QString filter = buildWorkoutFilter(rideItem);
             if (! filter.isEmpty()) {
                 QAction *actStartWorkout = new QAction(tr("Show in Train Mode..."), rideNavigator);
-                connect(actStartWorkout, &QAction::triggered, [=]() {
+                connect(actStartWorkout, &QAction::triggered, this, [this, filter]() {
                     context->mainWindow->fillinWorkoutFilterBox(filter);
                     context->mainWindow->selectTrain();
                     context->notifySelectWorkout(0);

--- a/src/Gui/AthletePages.cpp
+++ b/src/Gui/AthletePages.cpp
@@ -2040,8 +2040,8 @@ CPPage::mkReviewRow
         grid->addWidget(estimate, row, 4);
 
         connect(
-            accept, &QCheckBox::toggled,
-            [=](bool checked) {
+            accept, &QCheckBox::toggled, this,
+            [this, current, estimate](bool checked) {
                 current->setEnabled(! checked);
                 estimate->setEnabled(checked);
             }
@@ -2066,8 +2066,8 @@ CPPage::connectReviewDialogApplyButton
         if (checkboxes[i] != nullptr) {
             hasChecked |= checkboxes[i]->isChecked();
             connect(
-                checkboxes[i], &QCheckBox::toggled,
-                [=](bool checked) {
+                checkboxes[i], &QCheckBox::toggled, this,
+                [this, checkboxes, applyButton](bool checked) {
                     bool anyChecked = checked;
                     int j = 0;
                     while (! anyChecked && j < checkboxes.size()) {

--- a/src/Gui/Calendar.cpp
+++ b/src/Gui/Calendar.cpp
@@ -741,8 +741,8 @@ CalendarDayTable::makeHeaderMenu
         const CalendarEntry &entry = day.headlineEntries[entryIdx];
         switch (entry.type) {
         case ENTRY_TYPE_EVENT: {
-            QAction *editEventAction = contextMenu->addAction(tr("Edit event..."), this, [=]() { emit editEvent(entry); });
-            QAction *delEventAction = contextMenu->addAction(tr("Delete event"), this, [=]() { emit delEvent(entry); });
+            QAction *editEventAction = contextMenu->addAction(tr("Edit event..."), this, [this, entry]() { emit editEvent(entry); });
+            QAction *delEventAction = contextMenu->addAction(tr("Delete event"), this, [this, entry]() { emit delEvent(entry); });
             if (! isInDateRange(day.date) || ! canHavePhasesOrEvents) {
                 editEventAction->setEnabled(false);
                 delEventAction->setEnabled(false);
@@ -750,8 +750,8 @@ CalendarDayTable::makeHeaderMenu
             break;
         }
         case ENTRY_TYPE_PHASE: {
-            QAction *editPhaseAction = contextMenu->addAction(tr("Edit phase..."), this, [=]() { emit editPhase(entry); });
-            QAction *delPhaseAction = contextMenu->addAction(tr("Delete phase..."), this, [=]() { emit delPhase(entry); });
+            QAction *editPhaseAction = contextMenu->addAction(tr("Edit phase..."), this, [this, entry]() { emit editPhase(entry); });
+            QAction *delPhaseAction = contextMenu->addAction(tr("Delete phase..."), this, [this, entry]() { emit delPhase(entry); });
             if (! isInDateRange(day.date) || ! canHavePhasesOrEvents) {
                 editPhaseAction->setEnabled(false);
                 delPhaseAction->setEnabled(false);
@@ -762,8 +762,8 @@ CalendarDayTable::makeHeaderMenu
             break;
         }
     } else {
-        QAction *addPhaseAction = contextMenu->addAction(tr("Add phase..."), this, [=]() { emit addPhase(day.date); });
-        QAction *addEventAction = contextMenu->addAction(tr("Add event..."), this, [=]() { emit addEvent(day.date); });
+        QAction *addPhaseAction = contextMenu->addAction(tr("Add phase..."), this, [this, day]() { emit addPhase(day.date); });
+        QAction *addEventAction = contextMenu->addAction(tr("Add event..."), this, [this, day]() { emit addEvent(day.date); });
         if (! isInDateRange(day.date) || ! canHavePhasesOrEvents) {
             addPhaseAction->setEnabled(false);
             addEventAction->setEnabled(false);
@@ -786,23 +786,23 @@ CalendarDayTable::makeActivityMenu
         CalendarEntry calEntry = day.entries[entryIdx];
         switch (calEntry.type) {
         case ENTRY_TYPE_ACTIVITY:
-            contextMenu->addAction(tr("View activity..."), this, [=]() {
+            contextMenu->addAction(tr("View activity..."), this, [this, calEntry]() {
                 emit viewActivity(calEntry);
             });
-            contextMenu->addAction(tr("Delete activity"), this, [=]() {
+            contextMenu->addAction(tr("Delete activity"), this, [this, calEntry]() {
                 emit delActivity(calEntry);
             });
             break;
         case ENTRY_TYPE_PLANNED_ACTIVITY:
             if (calEntry.hasTrainMode) {
-                contextMenu->addAction(tr("Show in train node..."), this, [=]() {
+                contextMenu->addAction(tr("Show in train node..."), this, [this, calEntry]() {
                     emit showInTrainMode(calEntry);
                 });
             }
-            contextMenu->addAction(tr("View planned activity..."), this, [=]() {
+            contextMenu->addAction(tr("View planned activity..."), this, [this, calEntry]() {
                 emit viewActivity(calEntry);
             });
-            contextMenu->addAction(tr("Delete planned activity"), this, [=]() {
+            contextMenu->addAction(tr("Delete planned activity"), this, [this, calEntry]() {
                 emit delActivity(calEntry);
             });
             break;
@@ -814,16 +814,16 @@ CalendarDayTable::makeActivityMenu
         if (   day.date < QDate::currentDate()
             || (   day.date == QDate::currentDate()
                 && time < QTime::currentTime())) {
-            contextMenu->addAction(tr("Add activity..."), this, [=]() {
+            contextMenu->addAction(tr("Add activity..."), this, [this, day, time]() {
                 emit addActivity(false, day.date, time);
             });
         } else {
-            contextMenu->addAction(tr("Add planned activity..."), this, [=]() {
+            contextMenu->addAction(tr("Add planned activity..."), this, [this, day, time]() {
                 emit addActivity(true, day.date, time);
             });
         }
-        QAction *addPhaseAction = contextMenu->addAction(tr("Add phase..."), this, [=]() { emit addPhase(day.date); });
-        QAction *addEventAction = contextMenu->addAction(tr("Add event..."), this, [=]() { emit addEvent(day.date); });
+        QAction *addPhaseAction = contextMenu->addAction(tr("Add phase..."), this, [this, day]() { emit addPhase(day.date); });
+        QAction *addEventAction = contextMenu->addAction(tr("Add event..."), this, [this, day]() { emit addEvent(day.date); });
         if (! isInDateRange(day.date) || ! canHavePhasesOrEvents) {
             addPhaseAction->setEnabled(false);
             addEventAction->setEnabled(false);
@@ -858,7 +858,7 @@ CalendarMonthTable::CalendarMonthTable
 
     setContextMenuPolicy(Qt::CustomContextMenu);
     connect(this, &CalendarMonthTable::customContextMenuRequested, this, &CalendarMonthTable::showContextMenu);
-    connect(this, &QTableWidget::itemSelectionChanged, [=]() {
+    connect(this, &QTableWidget::itemSelectionChanged, this, [this]() {
         QList<QTableWidgetItem*> selection = selectedItems();
         if (selection.count() > 0) {
             QTableWidgetItem *item = selection[0];
@@ -1370,23 +1370,23 @@ CalendarMonthTable::showContextMenu
         CalendarEntry calEntry = day.entries[entryIdx];
         switch (calEntry.type) {
         case ENTRY_TYPE_ACTIVITY:
-            contextMenu.addAction(tr("View activity..."), this, [=]() {
+            contextMenu.addAction(tr("View activity..."), this, [this, calEntry]() {
                 emit viewActivity(calEntry);
             });
-            contextMenu.addAction(tr("Delete activity"), this, [=]() {
+            contextMenu.addAction(tr("Delete activity"), this, [this, calEntry]() {
                 emit delActivity(calEntry);
             });
             break;
         case ENTRY_TYPE_PLANNED_ACTIVITY:
             if (calEntry.hasTrainMode) {
-                contextMenu.addAction(tr("Show in train mode..."), this, [=]() {
+                contextMenu.addAction(tr("Show in train mode..."), this, [this, calEntry]() {
                     emit showInTrainMode(calEntry);
                 });
             }
-            contextMenu.addAction(tr("View planned activity..."), this, [=]() {
+            contextMenu.addAction(tr("View planned activity..."), this, [this, calEntry]() {
                 emit viewActivity(calEntry);
             });
-            contextMenu.addAction(tr("Delete planned activity"), this, [=]() {
+            contextMenu.addAction(tr("Delete planned activity"), this, [this, calEntry]() {
                 emit delActivity(calEntry);
             });
             break;
@@ -1397,8 +1397,8 @@ CalendarMonthTable::showContextMenu
         const CalendarEntry &entry = day.headlineEntries[headlineEntryIdx];
         switch (entry.type) {
         case ENTRY_TYPE_EVENT: {
-            QAction *editEventAction = contextMenu.addAction(tr("Edit event..."), this, [=]() { emit editEvent(entry); });
-            QAction *delEventAction = contextMenu.addAction(tr("Delete event"), this, [=]() { emit delEvent(entry); });
+            QAction *editEventAction = contextMenu.addAction(tr("Edit event..."), this, [this, entry]() { emit editEvent(entry); });
+            QAction *delEventAction = contextMenu.addAction(tr("Delete event"), this, [this, entry]() { emit delEvent(entry); });
             if (! isInDateRange(day.date) || ! canHavePhasesOrEvents) {
                 editEventAction->setEnabled(false);
                 delEventAction->setEnabled(false);
@@ -1406,8 +1406,8 @@ CalendarMonthTable::showContextMenu
             break;
         }
         case ENTRY_TYPE_PHASE: {
-            QAction *editPhaseAction = contextMenu.addAction(tr("Edit phase..."), this, [=]() { emit editPhase(entry); });
-            QAction *delPhaseAction = contextMenu.addAction(tr("Delete phase"), this, [=]() { emit delPhase(entry); });
+            QAction *editPhaseAction = contextMenu.addAction(tr("Edit phase..."), this, [this, entry]() { emit editPhase(entry); });
+            QAction *delPhaseAction = contextMenu.addAction(tr("Delete phase"), this, [this, entry]() { emit delPhase(entry); });
             if (! isInDateRange(day.date) || ! canHavePhasesOrEvents) {
                 editPhaseAction->setEnabled(false);
                 delPhaseAction->setEnabled(false);
@@ -1419,7 +1419,7 @@ CalendarMonthTable::showContextMenu
         }
     } else {
         if (day.date <= QDate::currentDate()) {
-            contextMenu.addAction(tr("Add activity..."), this, [=]() {
+            contextMenu.addAction(tr("Add activity..."), this, [this, day]() {
                 QTime time = QTime::currentTime();
                 if (day.date == QDate::currentDate()) {
                     time = time.addSecs(std::max(-4 * 3600, time.secsTo(QTime(0, 0))));
@@ -1428,7 +1428,7 @@ CalendarMonthTable::showContextMenu
             });
         }
         if (day.date >= QDate::currentDate()) {
-            contextMenu.addAction(tr("Add planned activity..."), this, [=]() {
+            contextMenu.addAction(tr("Add planned activity..."), this, [this, day]() {
                 QTime time = QTime::currentTime();
                 if (day.date == QDate::currentDate()) {
                     time = time.addSecs(std::min(4 * 3600, time.secsTo(QTime(23, 59, 59))));
@@ -1436,15 +1436,15 @@ CalendarMonthTable::showContextMenu
                 emit addActivity(true, day.date, time);
             });
         }
-        QAction *addPhaseAction = contextMenu.addAction(tr("Add phase..."), this, [=]() { emit addPhase(day.date); });
-        QAction *addEventAction = contextMenu.addAction(tr("Add event..."), this, [=]() { emit addEvent(day.date); });
+        QAction *addPhaseAction = contextMenu.addAction(tr("Add phase..."), this, [this, day]() { emit addPhase(day.date); });
+        QAction *addEventAction = contextMenu.addAction(tr("Add event..."), this, [this, day]() { emit addEvent(day.date); });
         if (! isInDateRange(day.date) || ! canHavePhasesOrEvents) {
             addPhaseAction->setEnabled(false);
             addEventAction->setEnabled(false);
         }
         if (day.date >= QDate::currentDate()) {
             contextMenu.addSeparator();
-            contextMenu.addAction(tr("Repeat schedule..."), this, [=]() {
+            contextMenu.addAction(tr("Repeat schedule..."), this, [this, day]() {
                 emit repeatSchedule(day.date);
             });
             bool hasPlannedActivity = false;
@@ -1455,11 +1455,11 @@ CalendarMonthTable::showContextMenu
                 }
             }
             if (hasPlannedActivity) {
-                contextMenu.addAction(tr("Insert restday"), this, [=]() {
+                contextMenu.addAction(tr("Insert restday"), this, [this, day]() {
                     emit insertRestday(day.date);
                 });
             } else {
-                contextMenu.addAction(tr("Delete restday"), this, [=]() {
+                contextMenu.addAction(tr("Delete restday"), this, [this, day]() {
                     emit delRestday(day.date);
                 });
             }
@@ -1500,12 +1500,12 @@ CalendarDayView::CalendarDayView
     dayLayout->addWidget(dayLeftPane);
     dayLayout->addWidget(dayTable);
 
-    connect(dayDateSelector, &QCalendarWidget::selectionChanged, [=]() {
+    connect(dayDateSelector, &QCalendarWidget::selectionChanged, this, [this]() {
         if (dayTable->selectedDate() != dayDateSelector->selectedDate()) {
             setDay(dayDateSelector->selectedDate());
         }
     });
-    connect(dayTable, &CalendarDayTable::dayChanged, [=](const QDate &date) {
+    connect(dayTable, &CalendarDayTable::dayChanged, this, [this](const QDate &date) {
         dayDateSelector->setSelectedDate(date);
         emit dayChanged(date);
     });
@@ -1681,9 +1681,9 @@ CalendarDayView::updateMeasures
         }
         if (buttonType == 0) {
             QPushButton *addButton = new QPushButton(tr("Add Measure"));
-            connect(addButton, &QPushButton::clicked, [=]() {
+            connect(addButton, &QPushButton::clicked, this, [this, date, measuresGroup]() {
                 if (measureDialog(QDateTime(date, QTime::currentTime()), measuresGroup, false)) {
-                    QTimer::singleShot(0, this, [=]() {
+                    QTimer::singleShot(0, this, [this, date]() {
                         updateMeasures(date);
                     });
                 }
@@ -1691,9 +1691,9 @@ CalendarDayView::updateMeasures
             measureLayout->addWidget(addButton);
         } else {
             QPushButton *editButton = new QPushButton(tr("Edit Measure"));
-            connect(editButton, &QPushButton::clicked, [=]() {
+            connect(editButton, &QPushButton::clicked, this, [this, date, measure, measuresGroup]() {
                 if (measureDialog(measure.when, measuresGroup, true)) {
-                    QTimer::singleShot(0, this, [=]() {
+                    QTimer::singleShot(0, this, [this, date]() {
                         updateMeasures(date);
                     });
                 }
@@ -1966,21 +1966,21 @@ Calendar::Calendar
     dayAction->setCheckable(true);
     dayAction->setActionGroup(viewGroup);
 
-    connect(dayAction, &QAction::triggered, [=]() { setView(CalendarView::Day); });
+    connect(dayAction, &QAction::triggered, this, [this]() { setView(CalendarView::Day); });
 
     weekAction = toolbar->addAction(tr("Week"));
     weekAction->setCheckable(true);
     weekAction->setActionGroup(viewGroup);
-    connect(weekAction, &QAction::triggered, [=]() { setView(CalendarView::Week); });
+    connect(weekAction, &QAction::triggered, this, [this]() { setView(CalendarView::Week); });
 
     monthAction = toolbar->addAction(tr("Month"));
     monthAction->setCheckable(true);
     monthAction->setActionGroup(viewGroup);
-    connect(monthAction, &QAction::triggered, [=]() { setView(CalendarView::Month); });
+    connect(monthAction, &QAction::triggered, this, [this]() { setView(CalendarView::Month); });
 
     applyNavIcons();
 
-    connect(dayView, &CalendarDayView::dayChanged, [=](const QDate &date) {
+    connect(dayView, &CalendarDayView::dayChanged, this, [this](const QDate &date) {
         if (currentView() == CalendarView::Day) {
             emit dayChanged(date);
             updateHeader();
@@ -1999,7 +1999,7 @@ Calendar::Calendar
     connect(dayView, &CalendarDayView::editEvent, this, &Calendar::editEvent);
     connect(dayView, &CalendarDayView::delEvent, this, &Calendar::delEvent);
 
-    connect(weekView, &CalendarWeekView::dayChanged, [=](const QDate &date) {
+    connect(weekView, &CalendarWeekView::dayChanged, this, [this](const QDate &date) {
         if (currentView() == CalendarView::Week) {
             emit dayChanged(date);
             updateHeader();
@@ -2018,16 +2018,16 @@ Calendar::Calendar
     connect(weekView, &CalendarWeekView::editEvent, this, &Calendar::editEvent);
     connect(weekView, &CalendarWeekView::delEvent, this, &Calendar::delEvent);
 
-    connect(monthView, &CalendarMonthTable::entryDblClicked, [=](const CalendarDay &day, int entryIdx) {
+    connect(monthView, &CalendarMonthTable::entryDblClicked, this, [this](const CalendarDay &day, int entryIdx) {
         viewActivity(day.entries[entryIdx]);
     });
-    connect(monthView, &CalendarMonthTable::daySelected, [=](const CalendarDay &day) {
+    connect(monthView, &CalendarMonthTable::daySelected, this, [this](const CalendarDay &day) {
         emit daySelected(day.date);
     });
-    connect(monthView, &CalendarMonthTable::moreClicked, [=]() {
+    connect(monthView, &CalendarMonthTable::moreClicked, this, [this]() {
         setView(CalendarView::Day);
     });
-    connect(monthView, &CalendarMonthTable::dayDblClicked, [=]() {
+    connect(monthView, &CalendarMonthTable::dayDblClicked, this, [this]() {
         setView(CalendarView::Day);
     });
     connect(monthView, &CalendarMonthTable::showInTrainMode, this, &Calendar::showInTrainMode);
@@ -2044,7 +2044,7 @@ Calendar::Calendar
     connect(monthView, &CalendarMonthTable::delEvent, this, &Calendar::delEvent);
     connect(monthView, &CalendarMonthTable::insertRestday, this, &Calendar::insertRestday);
     connect(monthView, &CalendarMonthTable::delRestday, this, &Calendar::delRestday);
-    connect(monthView, &CalendarMonthTable::monthChanged, [=](const QDate &month, const QDate &firstVisible, const QDate &lastVisible) {
+    connect(monthView, &CalendarMonthTable::monthChanged, this, [this](const QDate &month, const QDate &firstVisible, const QDate &lastVisible) {
         if (currentView() == CalendarView::Month) {
             emit monthChanged(month, firstVisible, lastVisible);
             updateHeader();
@@ -2052,9 +2052,9 @@ Calendar::Calendar
         }
     });
 
-    connect(prevAction, &QAction::triggered, [=]() { goNext(-1); });
-    connect(nextAction, &QAction::triggered, [=]() { goNext(1); });
-    connect(todayAction, &QAction::triggered, [=]() { setDate(QDate::currentDate()); });
+    connect(prevAction, &QAction::triggered, this, [this]() { goNext(-1); });
+    connect(nextAction, &QAction::triggered, this, [this]() { goNext(1); });
+    connect(todayAction, &QAction::triggered, this, [this]() { setDate(QDate::currentDate()); });
 
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
     mainLayout->addWidget(toolbar);
@@ -2464,7 +2464,7 @@ Calendar::populateDateMenu
                     }
                 }
                 if (actualDate.month() == date.month()) {
-                    connect(action, &QAction::triggered, [=]() {
+                    connect(action, &QAction::triggered, this, [this, actualDate]() {
                         setDate(actualDate);
                     });
                 }
@@ -2486,7 +2486,7 @@ Calendar::populateDateMenu
                         date = dateRange.to;
                     }
                 }
-                connect(action, &QAction::triggered, [=]() {
+                connect(action, &QAction::triggered, this, [this, date]() {
                     setDate(date);
                 });
             }

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -531,9 +531,9 @@ MainWindow::MainWindow(const QDir &home)
     rideMenu->addAction(tr("&Import from file..."), this, SLOT (importFile()), QKeySequence("Ctrl+I"));
     rideMenu->addAction(tr("&Manual entry..."), this, SLOT(manualRide()), QKeySequence("Ctrl+M"));
     QAction *actionPlan = new QAction(tr("&Plan activity..."));
-    connect(context, &Context::start, this, [=]() { actionPlan->setEnabled(false); }); // The dialog can change the contexts workout
-    connect(context, &Context::stop, this, [=]() { actionPlan->setEnabled(true); });   // temporarily which might cause unwanted effects
-    connect(actionPlan, &QAction::triggered, this, [=]() { planActivity(); });
+    connect(context, &Context::start, this, [this, actionPlan]() { actionPlan->setEnabled(false); }); // The dialog can change the contexts workout
+    connect(context, &Context::stop, this, [this, actionPlan]() { actionPlan->setEnabled(true); });   // temporarily which might cause unwanted effects
+    connect(actionPlan, &QAction::triggered, this, [this]() { planActivity(); });
     rideMenu->addAction(actionPlan);
     rideMenu->addSeparator ();
     rideMenu->addAction(tr("&Export..."), this, SLOT(exportRide()), QKeySequence("Ctrl+E"));

--- a/src/Gui/ManualActivityWizard.cpp
+++ b/src/Gui/ManualActivityWizard.cpp
@@ -302,9 +302,9 @@ ManualActivityPageBasics::ManualActivityPageBasics
     if (plan) {
 
 #if QT_VERSION >= 0x060000
-        connect(woTypeEdit, &QComboBox::currentIndexChanged, [=](int index) {
+        connect(woTypeEdit, &QComboBox::currentIndexChanged, this, [this, sportEdit](int index) {
 #else
-        connect(woTypeEdit, QOverload<int>::of(&QComboBox::currentIndexChanged), [=](int index) {
+        connect(woTypeEdit, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this, sportEdit](int index) {
 #endif
             sportEdit->setEnabled(index != 0);
             if (index == 0) {
@@ -562,10 +562,10 @@ ManualActivityPageWorkout::ManualActivityPageWorkout
     registerField("woIsoPower", woIsoPower);
     registerField("woXPower", woXPower);
 
-    connect(workoutFilterBox, &WorkoutFilterBox::workoutFiltersChanged, [=](QList<ModelFilter*> &f) {
+    connect(workoutFilterBox, &WorkoutFilterBox::workoutFiltersChanged, this, [this](QList<ModelFilter*> &f) {
         sortModel->setFilters(f);
     });
-    connect(workoutFilterBox, &WorkoutFilterBox::workoutFiltersRemoved, [=]() {
+    connect(workoutFilterBox, &WorkoutFilterBox::workoutFiltersRemoved, this, [this]() {
         sortModel->removeFilters();
     });
     connect(workoutTree->selectionModel(), &QItemSelectionModel::selectionChanged, this, &ManualActivityPageWorkout::selectionChanged);

--- a/src/Gui/Pages.cpp
+++ b/src/Gui/Pages.cpp
@@ -134,7 +134,7 @@ GeneralPage::GeneralPage(Context *context) : context(context)
     garminHWMarkedit->setSuffix(" " + tr("s"));
     garminHWMarkedit->setValue(garminHWMark.toInt());
 
-    connect(garminSmartRecord, &QCheckBox::stateChanged, [=](int state) { garminHWMarkedit->setEnabled(state); });
+    connect(garminSmartRecord, &QCheckBox::stateChanged, this, [this](int state) { garminHWMarkedit->setEnabled(state); });
     garminSmartRecord->setCheckState(! (isGarminSmartRecording.toInt() > 0) ? Qt::Checked : Qt::Unchecked);
     garminSmartRecord->setCheckState(isGarminSmartRecording.toInt() > 0 ? Qt::Checked : Qt::Unchecked);
 
@@ -193,7 +193,7 @@ GeneralPage::GeneralPage(Context *context) : context(context)
     //XXrBrowseButton->setFixedWidth(120);
 
     connect(rBrowseButton, SIGNAL(clicked()), this, SLOT(browseRDir()));
-    connect(embedR, &QCheckBox::stateChanged, [=](int state) { rDirectorySel->setEnabled(state); });
+    connect(embedR, &QCheckBox::stateChanged, this, [this](int state) { rDirectorySel->setEnabled(state); });
 
     embedR->setChecked(! appsettings->value(NULL, GC_EMBED_R, true).toBool());
     embedR->setChecked(appsettings->value(NULL, GC_EMBED_R, true).toBool());
@@ -216,7 +216,7 @@ GeneralPage::GeneralPage(Context *context) : context(context)
     pythonDirectoryLayout->addWidget(pythonBrowseButton);
 
     connect(pythonBrowseButton, SIGNAL(clicked()), this, SLOT(browsePythonDir()));
-    connect(embedPython, &QCheckBox::stateChanged, [=](int state) { pythonDirectorySel->setEnabled(state); });
+    connect(embedPython, &QCheckBox::stateChanged, this, [this](int state) { pythonDirectorySel->setEnabled(state); });
 
     embedPython->setChecked(! appsettings->value(NULL, GC_EMBED_PYTHON, true).toBool());
     embedPython->setChecked(appsettings->value(NULL, GC_EMBED_PYTHON, true).toBool());
@@ -1607,7 +1607,7 @@ FavouriteMetricsPage::FavouriteMetricsPage(QWidget *parent) :
     QHBoxLayout *hlayout = new QHBoxLayout(this);
     hlayout->addWidget(multiMetricSelector);
 
-    connect(multiMetricSelector, &MultiMetricSelector::selectedChanged, [=]() { changed = true; });
+    connect(multiMetricSelector, &MultiMetricSelector::selectedChanged, this, [this]() { changed = true; });
 }
 
 qint32
@@ -1674,7 +1674,7 @@ CustomMetricsPage::CustomMetricsPage(QWidget *parent, Context *context) :
     layout->addWidget(actionButtons);
 
     connect(table, SIGNAL(itemDoubleClicked(QTreeWidgetItem*, int)), this, SLOT(doubleClicked(QTreeWidgetItem*, int)));
-    connect(table, &QTreeWidget::currentItemChanged, [=] (QTreeWidgetItem*) {
+    connect(table, &QTreeWidget::currentItemChanged, this, [this, actionButtons] (QTreeWidgetItem*) {
             bool selected = table->currentItem() != nullptr;
             actionButtons->setButtonEnabled(ActionButtonBox::Edit, selected);
             exportButton->setEnabled(selected);
@@ -2370,7 +2370,7 @@ IconsPage::IconsPage
     mainLayout->addLayout(contentLayout);
     mainLayout->addLayout(actionLayout);
 
-    connect(downloadButton, &QPushButton::clicked, [=]() {
+    connect(downloadButton, &QPushButton::clicked, this, [this]() {
         QUrl url(QString("%1/icons.zip").arg(VERSION_CONFIG_PREFIX));
         if (IconManager::instance().importBundle(url)) {
             initSportTree();
@@ -2379,7 +2379,7 @@ IconsPage::IconsPage
             QMessageBox::warning(nullptr, tr("Icon Bundle"), tr("Bundle file %1 cannot be imported.").arg(url.toString()));
         }
     });
-    connect(importButton, &QPushButton::clicked, [=]() {
+    connect(importButton, &QPushButton::clicked, this, [this]() {
         QString zipFile = QFileDialog::getOpenFileName(this, tr("Import Icons"), "", tr("Zip Files (*.zip)"));
         if (! zipFile.isEmpty() && IconManager::instance().importBundle(zipFile)) {
             initSportTree();
@@ -2388,7 +2388,7 @@ IconsPage::IconsPage
             QMessageBox::warning(nullptr, tr("Icon Bundle"), tr("Bundle file %1 cannot be imported.").arg(zipFile));
         }
     });
-    connect(exportButton, &QPushButton::clicked, [=]() {
+    connect(exportButton, &QPushButton::clicked, this, [this]() {
         QString zipFile = QFileDialog::getSaveFileName(this, tr("Export Icons"), "", tr("Zip Files (*.zip)"));
         if (zipFile.isEmpty() || ! IconManager::instance().exportBundle(zipFile)) {
             QMessageBox::warning(nullptr, tr("Icon Bundle"), tr("Bundle file %1 cannot be created.").arg(zipFile));

--- a/src/Gui/RepeatScheduleWizard.cpp
+++ b/src/Gui/RepeatScheduleWizard.cpp
@@ -183,7 +183,7 @@ RepeatSchedulePageSetup::RepeatSchedulePageSetup
     all->addWidget(scrollArea);
     setLayout(all);
 
-    connect(seasonTree, &QTreeWidget::currentItemChanged, [=](QTreeWidgetItem *current) {
+    connect(seasonTree, &QTreeWidget::currentItemChanged, this, [this, startDate, endDate, when](QTreeWidgetItem *current) {
         if (current != nullptr) {
             QDate seasonStart(current->data(0, Qt::UserRole).toDate());
             QDate seasonEnd(current->data(0, Qt::UserRole + 1).toDate());
@@ -197,10 +197,10 @@ RepeatSchedulePageSetup::RepeatSchedulePageSetup
             endDate->setDate(seasonEnd);
         }
     });
-    connect(startDate, &QDateEdit::dateChanged, [=](QDate date) {
+    connect(startDate, &QDateEdit::dateChanged, this, [this, endDate](QDate date) {
         endDate->setMinimumDate(date);
     });
-    connect(endDate, &QDateEdit::dateChanged, [=](QDate date) {
+    connect(endDate, &QDateEdit::dateChanged, this, [this, startDate](QDate date) {
         startDate->setMaximumDate(date);
     });
 
@@ -299,7 +299,7 @@ RepeatSchedulePageActivities::initializePage
         QVBoxLayout *layout = new QVBoxLayout(selectionWidget);
         layout->addWidget(selectionBox, 0, Qt::AlignCenter);
         activityTree->setItemWidget(item, 0, selectionWidget);
-        connect(selectionBox, &QCheckBox::toggled, [=](bool checked) {
+        connect(selectionBox, &QCheckBox::toggled, this, [this, item](bool checked) {
             item->setData(1, Qt::UserRole + 1, checked);
             numSelected += checked ? 1 : -1;
             emit completeChanged();

--- a/src/Train/TagWidget.cpp
+++ b/src/Train/TagWidget.cpp
@@ -47,7 +47,7 @@ TagWidget::TagWidget
 
     delButton = new QPushButton("✖");
     delButton->setFlat(true);
-    connect(delButton, &QPushButton::clicked, [=] { deleteScheduled = true; deleteAnimation(); });
+    connect(delButton, &QPushButton::clicked, this, [this] { deleteScheduled = true; deleteAnimation(); });
 
     setColor(color);
 

--- a/src/Train/WorkoutFilterBox.cpp
+++ b/src/Train/WorkoutFilterBox.cpp
@@ -31,10 +31,10 @@ WorkoutFilterBox::WorkoutFilterBox(QWidget *parent, Context *context) : FilterEd
     QIcon workoutFilterClearIcon = QPixmap::fromImage(QImage(":images/toolbar/clear.png"));
     QAction *workoutFilterClearAction = this->addAction(workoutFilterClearIcon, FilterEditor::TrailingPosition);
     workoutFilterClearAction->setVisible(! text().isEmpty());
-    connect(this, &FilterEditor::textChanged, this, [=](const QString &text) {
+    connect(this, &FilterEditor::textChanged, this, [workoutFilterClearAction](const QString &text) {
         workoutFilterClearAction->setVisible(! text.isEmpty());
     });
-    connect(workoutFilterClearAction, &QAction::triggered, this, [=]() {
+    connect(workoutFilterClearAction, &QAction::triggered, this, [this]() {
         setText("");
     });
 

--- a/src/Train/WorkoutPlotWindow.cpp
+++ b/src/Train/WorkoutPlotWindow.cpp
@@ -74,10 +74,10 @@ WorkoutPlotWindow::WorkoutPlotWindow(Context *context) :
     connect(context, SIGNAL(start()), ergPlot, SLOT(start()));
     connect(context, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));
 
-    connect(notificationTimer, &QTimer::timeout, this, [=]() {
+    connect(notificationTimer, &QTimer::timeout, this, [this]() {
         setProperty("subtitle", title);
     });
-    connect(context, &Context::setNotification, this, [=](QString notification, int timeout) {
+    connect(context, &Context::setNotification, this, [this, notificationTimer](QString notification, int timeout) {
         if (! showNotifications()) {
             return;
         }
@@ -91,7 +91,7 @@ WorkoutPlotWindow::WorkoutPlotWindow(Context *context) :
 
         setProperty("subtitle", notification);
     });
-    connect(context, &Context::clearNotification, this, [=]() {
+    connect(context, &Context::clearNotification, this, [this]() {
         setProperty("subtitle", title);
     });
 


### PR DESCRIPTION
PR #4690 reveals a bug in the calendar:
* Go to plan view
* Add a calendar
* Reset the layout
* Switch date range -> crash

Root cause: Lambda-connections without a dedicated receiver don't get automatically disconnected on destruction if the sender lives longer. When resetting the layout, the old is destroyed but the connection is still triggered -> crash

This PR adds receivers and additionally narrows down the captures ([=] -> [this, whatever I really need]