### PR TITLE
Workout Infowidget: Showing real zone name

### DIFF
--- a/src/Gui/ManualActivityWizard.cpp
+++ b/src/Gui/ManualActivityWizard.cpp
@@ -510,7 +510,7 @@ ManualActivityPageWorkout::ManualActivityPageWorkout
             zoneColors << zoneColor(j, numZones);
         }
     }
-    infoWidget = new InfoWidget(zoneColors, context->athlete->zones("Bike")->getZoneDescriptions(zonerange), false, false);
+    infoWidget = new InfoWidget(zoneColors, context->athlete->zones("Bike")->getZoneNames(zonerange), context->athlete->zones("Bike")->getZoneDescriptions(zonerange), false, false);
 
     QWidget *detailsWrapperWidget = new QWidget();
     QHBoxLayout *detailsWrapperLayout = new QHBoxLayout(detailsWrapperWidget);

--- a/src/Train/InfoWidget.cpp
+++ b/src/Train/InfoWidget.cpp
@@ -33,7 +33,7 @@
 
 
 InfoWidget::InfoWidget
-(QList<QColor> powerZoneColors, QList<QString> powerZoneNames, bool showRating, bool showTags, QWidget *parent)
+(const QList<QColor> &powerZoneColors, const QList<QString> &powerZoneShortNames, const QList<QString> &powerZoneNames, bool showRating, bool showTags, QWidget *parent)
 : QFrame(parent)
 {
     QGridLayout *l = new QGridLayout(this);
@@ -71,7 +71,7 @@ InfoWidget::InfoWidget
     l->addWidget(powerInfoWidget, row, 0, 1, -1);
     ++row;
 
-    powerZonesWidget = new PowerZonesWidget(powerZoneColors, powerZoneNames);
+    powerZonesWidget = new PowerZonesWidget(powerZoneColors, powerZoneShortNames, powerZoneNames);
     powerZonesWidget->setContentsMargins(0, 5, 0, 10);
     l->addWidget(powerZonesWidget, row, 0, 1, -1);
     ++row;
@@ -235,7 +235,7 @@ InfoWidget::ergFileSelected
 
 void
 InfoWidget::setPowerZoneColors
-(QList<QColor> colors)
+(const QList<QColor> &colors)
 {
     powerZonesWidget->setColors(colors);
 }
@@ -243,9 +243,9 @@ InfoWidget::setPowerZoneColors
 
 void
 InfoWidget::setPowerZoneNames
-(QList<QString> names)
+(const QList<QString> &shortNames, const QList<QString> &names)
 {
-    powerZonesWidget->setNames(names);
+    powerZonesWidget->setNames(shortNames, names);
 }
 
 

--- a/src/Train/InfoWidget.h
+++ b/src/Train/InfoWidget.h
@@ -40,7 +40,7 @@ class InfoWidget : public QFrame
     Q_OBJECT
 
     public:
-        InfoWidget(QList<QColor> powerZoneColors, QList<QString> powerZoneNames, bool showRating = true, bool showTags = true, QWidget *parent = nullptr);
+        InfoWidget(const QList<QColor> &powerZoneColors, const QList<QString> &powerZoneShortNames, const QList<QString> &powerZoneNames, bool showRating = true, bool showTags = true, QWidget *parent = nullptr);
         ~InfoWidget();
 
         void setContent(const ErgFileBase &ergFileBase, int rating, qlonglong lastRun);
@@ -49,8 +49,8 @@ class InfoWidget : public QFrame
 
     public slots:
         void ergFileSelected(ErgFileBase *ergFileBase);
-        void setPowerZoneColors(QList<QColor> colors);
-        void setPowerZoneNames(QList<QString> names);
+        void setPowerZoneColors(const QList<QColor> &colors);
+        void setPowerZoneNames(const QList<QString> &shortNames, const QList<QString> &names);
 
     signals:
         void relayErgFileSelected(ErgFileBase *ergFileBase);

--- a/src/Train/PowerZonesWidget.cpp
+++ b/src/Train/PowerZonesWidget.cpp
@@ -27,8 +27,8 @@
 
 
 PowerZonesWidget::PowerZonesWidget
-(QList<QColor> colors, QList<QString> names, QWidget *parent)
-: QWidget(parent), colors(colors), names(names), zones(), dominantZone(0), duration(0), collapsed(true)
+(const QList<QColor> &colors, const QList<QString> &shortNames, const QList<QString> &names, QWidget *parent)
+: QWidget(parent), colors(colors), shortNames(shortNames), names(names), zones(), dominantZone(0), duration(0), collapsed(true)
 {
     setContentsMargins(0, 0, 0, 0);
     setCursor(Qt::PointingHandCursor);
@@ -66,7 +66,7 @@ PowerZonesWidget::setContentsMargins
 
 void
 PowerZonesWidget::setPowerZones
-(QList<double> zones, int dominantZone, long duration)
+(const QList<double> &zones, int dominantZone, long duration)
 {
     this->zones = zones;
     this->dominantZone = dominantZone;
@@ -78,7 +78,7 @@ PowerZonesWidget::setPowerZones
 
 void
 PowerZonesWidget::setColors
-(QList<QColor> colors)
+(const QList<QColor> &colors)
 {
     this->colors = colors;
     fillDetailsDoc();
@@ -88,8 +88,9 @@ PowerZonesWidget::setColors
 
 void
 PowerZonesWidget::setNames
-(QList<QString> names)
+(const QList<QString> &shortNames, const QList<QString> &names)
 {
+    this->shortNames = shortNames;
     this->names = names;
     fillDetailsDoc();
     repaint();
@@ -134,7 +135,7 @@ PowerZonesWidget::paintEvent
         }
         painter.fillRect(zoneBarRect, color(i));
         painter.setPen(QPen(GCColor::invertColor(color(i))));
-        painter.drawText(zoneBarRect, Qt::AlignCenter, QString("Z%1").arg(i + 1));
+        painter.drawText(zoneBarRect, Qt::AlignCenter, shortName(i));
         sumPercentLeft += zones[i];
         lastRight = zoneLeft + zoneWidth;
     }
@@ -215,6 +216,18 @@ PowerZonesWidget::color
 
 
 QString
+PowerZonesWidget::shortName
+(int idx) const
+{
+    if (idx >= 0 && idx < shortNames.length()) {
+        return shortNames[idx];
+    } else {
+        return "_out of range_";
+    }
+}
+
+
+QString
 PowerZonesWidget::name
 (int idx) const
 {
@@ -248,12 +261,12 @@ PowerZonesWidget::fillDetailsDoc
         }
         if (i == dominantZone - 1) {
             detailsText.append(QString("<tr><td%6>&nbsp;</td>"
-                                       "    <td><b>Z%1</b></td>"
+                                       "    <td><b>%1</b></td>"
                                        "    <td><b>%2</b></td>"
                                        "    <td><b>%3:%4</b></td>"
                                        "    <td align=\"right\"><b>%5 %</b></td>"
                                        "</tr>")
-                                     .arg(i + 1)
+                                     .arg(shortName(i))
                                      .arg(name(i))
                                      .arg(durationHours, 2, 10, QChar('0'))
                                      .arg(durationMins, 2, 10, QChar('0'))
@@ -261,12 +274,12 @@ PowerZonesWidget::fillDetailsDoc
                                      .arg(cellColor));
         } else {
             detailsText.append(QString("<tr><td%6>&nbsp;</td>"
-                                       "    <td%7>Z%1</td>"
+                                       "    <td%7>%1</td>"
                                        "    <td%7>%2</td>"
                                        "    <td%7>%3:%4</td>"
                                        "    <td align=\"right\" %7>%5 %</td>"
                                        "</tr>")
-                                     .arg(i + 1)
+                                     .arg(shortName(i))
                                      .arg(name(i))
                                      .arg(durationHours, 2, 10, QChar('0'))
                                      .arg(durationMins, 2, 10, QChar('0'))

--- a/src/Train/PowerZonesWidget.h
+++ b/src/Train/PowerZonesWidget.h
@@ -39,17 +39,17 @@ class PowerZonesWidget : public QWidget
     Q_OBJECT
 
     public:
-        PowerZonesWidget(QList<QColor> colors, QList<QString> names, QWidget *parent = nullptr);
+        PowerZonesWidget(const QList<QColor> &colors, const QList<QString> &shortNames, const QList<QString> &names, QWidget *parent = nullptr);
         ~PowerZonesWidget();
 
-        void setPowerZones(QList<double> zones, int dominantZone, long duration);
+        void setPowerZones(const QList<double> &zones, int dominantZone, long duration);
 
         void setContentsMargins(int left, int top, int right, int bottom);
         void setContentsMargins(const QMargins &margins);
 
     public slots:
-        void setColors(QList<QColor> colors);
-        void setNames(QList<QString> names);
+        void setColors(const QList<QColor> &colors);
+        void setNames(const QList<QString> &shortNames, const QList<QString> &names);
 
     protected:
         virtual void paintEvent(QPaintEvent *event);
@@ -59,6 +59,7 @@ class PowerZonesWidget : public QWidget
 
     private:
         QList<QColor> colors;
+        QList<QString> shortNames;
         QList<QString> names;
         QList<double> zones;
         int dominantZone;
@@ -69,6 +70,7 @@ class PowerZonesWidget : public QWidget
 
         int rowTop(int rowHeight, int row) const;
         QColor color(int idx) const;
+        QString shortName(int idx) const;
         QString name(int idx) const;
         void fillDetailsDoc();
         void adjustHeight();

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -292,7 +292,7 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
             zoneColors << zoneColor(i, numZones);
         }
     }
-    workoutInfo = new InfoWidget(zoneColors, context->athlete->zones("Bike")->getZoneDescriptions(zonerange));
+    workoutInfo = new InfoWidget(zoneColors, context->athlete->zones("Bike")->getZoneNames(zonerange), context->athlete->zones("Bike")->getZoneDescriptions(zonerange));
     workoutInfo->setFrameStyle(QFrame::NoFrame);
     workoutInfo->setStyleSheet(GCColor::stylesheet(true));
     connect(context, SIGNAL(ergFileSelected(ErgFileBase*)), workoutInfo, SLOT(ergFileSelected(ErgFileBase*)));
@@ -713,7 +713,7 @@ TrainSidebar::configChanged(qint32 why)
         }
     }
     workoutInfo->setPowerZoneColors(zoneColors);
-    workoutInfo->setPowerZoneNames(context->athlete->zones("Bike")->getZoneDescriptions(zonerange));
+    workoutInfo->setPowerZoneNames(context->athlete->zones("Bike")->getZoneNames(zonerange), context->athlete->zones("Bike")->getZoneDescriptions(zonerange));
 
     // DEVICES
 
@@ -915,6 +915,19 @@ TrainSidebar::workoutTreeWidgetSelectionChanged()
         mode = ergFile->mode();
 
         if (ergFile->isValid()) {
+            // Update shown zone names (short and description) as configChanged
+            // is not triggered when only zones are renamed (name and description
+            // are not considered in Zones::getFingerPrint)
+            int zonerange = context->athlete->zones("Bike")->whichRange(QDateTime::currentDateTime().date());
+            QList<QColor> zoneColors;
+            if (zonerange != -1) {
+                int numZones = context->athlete->zones("Bike")->numZones(zonerange);
+                for (int i = 0; i < numZones; ++i) {
+                    zoneColors << zoneColor(i, numZones);
+                }
+            }
+            workoutInfo->setPowerZoneColors(zoneColors);
+            workoutInfo->setPowerZoneNames(context->athlete->zones("Bike")->getZoneNames(zonerange), context->athlete->zones("Bike")->getZoneDescriptions(zonerange));
 
             setStatusFlags(RT_WORKOUT);
 

--- a/src/Train/TrainerDayAPIDialog.cpp
+++ b/src/Train/TrainerDayAPIDialog.cpp
@@ -359,7 +359,7 @@ TrainerDayAPIDialog::parseWorkoutResults
                     zoneColors << zoneColor(j, numZones);
                 }
             }
-            PowerZonesWidget *powerZones = new PowerZonesWidget(zoneColors, context->athlete->zones("Bike")->getZoneDescriptions(zonerange));
+            PowerZonesWidget *powerZones = new PowerZonesWidget(zoneColors, context->athlete->zones("Bike")->getZoneNames(zonerange), context->athlete->zones("Bike")->getZoneDescriptions(zonerange));
             powerZones->setPowerZones(ergFile->powerZonesPC(), ergFile->dominantZoneInt(), ergFile->duration());
             powerZones->setContentsMargins(0, 5, 0, 10);
 


### PR DESCRIPTION
See #4760
Display the zone names instead of a fixed Z# in the Workout Infowidget. Since configChanged is emitted only when zones are added or modified - but not when their names or descriptions are edited - changes to a zone’s name or description requires selecting a different workout to reflect the change