### PR TITLE
WindowsCrashHandler warning

### DIFF
--- a/src/Core/WindowsCrashHandler.cpp
+++ b/src/Core/WindowsCrashHandler.cpp
@@ -43,7 +43,11 @@ static std::string getCrashFileName()
     if (installation_crash_path.length() > 0 ) {
       ret << installation_crash_path << "\\";
     }
-    ret << "crash_" << std::put_time(std::localtime(&nowTimeT), "%H%M_%d%m%y");
+
+    struct tm timeInfo;
+    if (localtime_s(&timeInfo, &nowTimeT) == 0) {
+        ret << "crash_" << std::put_time(&timeInfo, "%H%M_%d%m%y");
+    }
     return ret.str();
 }
 


### PR DESCRIPTION
Remove windows build warning:

C:\Coding\GC\GoldenCheetah\src\Core\WindowsCrashHandler.cpp(46): warning C4996: 'localtime': This function or variable may be unsafe. Consider using localtime_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.