### PR TITLE
QSqlQuery copy constructor deprecated in Qt6.2

### DIFF
--- a/src/Train/TrainDB.cpp
+++ b/src/Train/TrainDB.cpp
@@ -818,7 +818,7 @@ TrainDB::getWorkoutModel
 
     query.exec();
     QSqlQueryModel *model = new QSqlQueryModel();
-    model->setQuery(query);
+    model->setQuery(std::move(query));
     while (model->canFetchMore(QModelIndex())) {
         model->fetchMore(QModelIndex());
     }


### PR DESCRIPTION
The QSqlQuery assignment and copy constructor are deprecated since Qt6.2, and will be removed in Qt7, see https://doc.qt.io/qt-6/qsqlquery-obsolete.html

Train\TrainDB.cpp(821): warning C4996: 'QSqlQueryModel::setQuery': QSqlQuery is not meant to be copied. Pass it by move instead.
