### PR TITLE
linux/51-garmin-usb.rules: use mode 0660 and tag uaccess

### DIFF
--- a/src/Resources/linux/51-garmin-usb.rules
+++ b/src/Resources/linux/51-garmin-usb.rules
@@ -1,8 +1,8 @@
 # Garmin ANT+ - USB1
-ATTRS{idVendor}=="0fcf", ATTRS{idProduct}=="1004", MODE="0666"
+ACTION!="remove", SUBSYSTEMS=="usb", ATTRS{idVendor}=="0fcf", ATTRS{idProduct}=="1004", MODE="0660", TAG+="uaccess"
 # Garmin ANT+ - USB2
-ATTRS{idVendor}=="0fcf", ATTRS{idProduct}=="1008", MODE="0666"
+ACTION!="remove", SUBSYSTEMS=="usb", ATTRS{idVendor}=="0fcf", ATTRS{idProduct}=="1008", MODE="0660", TAG+="uaccess"
 # hLine USB2 ANT2
-ATTRS{idVendor}=="0fcf", ATTRS{idProduct}=="1009", MODE="0666"
+ACTION!="remove", SUBSYSTEMS=="usb", ATTRS{idVendor}=="0fcf", ATTRS{idProduct}=="1009", MODE="0660", TAG+="uaccess"
 
 


### PR DESCRIPTION
Use a more modern approach for device access.

The uaccess tag makes udev apply a dynamic user ACL to the device node, which makes the device usable to logged-in users.

See https://wiki.archlinux.org/title/Udev#Allowing_regular_users_to_use_devices