### PR TITLE
Fixes for QT6 warnings

### DIFF
--- a/src/Charts/AllPlot.cpp
+++ b/src/Charts/AllPlot.cpp
@@ -513,7 +513,7 @@ AllPlotObject::parseZoneString(QString zstring)
         double lim=toks[0].toDouble(&ok);
         if (!ok) continue;
         QColor col;
-        col.setNamedColor(toks[1]);
+        col.fromString(toks[1]);
         if (!col.isValid()) continue;
 
         // well that worked!

--- a/src/Charts/GenericChart.cpp
+++ b/src/Charts/GenericChart.cpp
@@ -180,8 +180,8 @@ GenericChart::preprocessData()
     // any series on an axis that is time based
     // will need to have the values scaled from
     // seconds to MSSinceEpoch
-    QDateTime midnight(QDate::currentDate(), QTime(0,0,0), Qt::LocalTime); // we always use LocalTime due to qt-bug 62285
-    QDateTime earliest(QDate(1900,01,01), QTime(0,0,0), Qt::LocalTime);
+    QDateTime midnight(QDate::currentDate(), QTime(0,0,0), QTimeZone::LocalTime); // we always use LocalTime due to qt-bug 62285
+    QDateTime earliest(QDate(1900,01,01), QTime(0,0,0), QTimeZone::LocalTime);
 
     for(int ai=0; ai<newAxes.count(); ai++) {
         GenericAxisInfo &axis=newAxes[ai];

--- a/src/Charts/GenericPlot.cpp
+++ b/src/Charts/GenericPlot.cpp
@@ -1495,9 +1495,9 @@ GenericPlot::plotAnnotations(GenericSeriesInfo &seriesinfo)
                 if ((annotation.type == GenericAnnotationInfo::VLine && axis->name == seriesinfo.xname) ||
                     (annotation.type == GenericAnnotationInfo::HLine && axis->name == seriesinfo.yname)) {
                     // TIME values are seconds from midnight
-                    QDateTime midnight(QDate::currentDate(), QTime(0,0,0), Qt::LocalTime); // we always use LocalTime due to qt-bug 62285
+                    QDateTime midnight(QDate::currentDate(), QTime(0,0,0), QTimeZone::LocalTime); // we always use LocalTime due to qt-bug 62285
                     // DATERANGE values are days from 01-01-1900
-                    QDateTime earliest(QDate(1900,01,01), QTime(0,0,0), Qt::LocalTime);
+                    QDateTime earliest(QDate(1900,01,01), QTime(0,0,0), QTimeZone::LocalTime);
                     switch (axis->type) {
                         case GenericAxisInfo::TIME:
                             line->setValue(midnight.addSecs(annotation.value).toMSecsSinceEpoch());

--- a/src/Charts/OverviewItems.cpp
+++ b/src/Charts/OverviewItems.cpp
@@ -760,7 +760,6 @@ ZoneOverviewItem::configChanged(qint32)
     barseries->append(barset);
     chart->addSeries(barseries);
 
-
     // x-axis labels etc
     barcategoryaxis = new QBarCategoryAxis(this);
     barcategoryaxis->setLabelsFont(parent->midfont);
@@ -772,15 +771,24 @@ ZoneOverviewItem::configChanged(qint32)
     QPen axisPen(GColor(CCARDBACKGROUND));
     axisPen.setWidth(1); // almost invisible
     chart->createDefaultAxes();
-    chart->setAxisX(barcategoryaxis, barseries);
+
+    // add x axis to chart and attach to the series
+    chart->addAxis(barcategoryaxis, Qt::AlignBottom);
+    barseries->attachAxis(barcategoryaxis);
     barcategoryaxis->setLinePen(axisPen);
     barcategoryaxis->setLineVisible(false);
-    chart->axisY(barseries)->setLinePen(axisPen);
-    chart->axisY(barseries)->setLineVisible(false);
-    chart->axisY(barseries)->setLabelsVisible(false);
-    chart->axisY(barseries)->setRange(0,100);
-    chart->axisY(barseries)->setGridLineVisible(false);
 
+    // setup y axis
+    QList<QAbstractAxis*> verticalAxes = chart->axes(Qt::Vertical, barseries);
+    if (verticalAxes.size() == 1) {
+        verticalAxes.first()->setLinePen(axisPen);
+        verticalAxes.first()->setLineVisible(false);
+        verticalAxes.first()->setLabelsVisible(false);
+        verticalAxes.first()->setRange(0,100);
+        verticalAxes.first()->setGridLineVisible(false);
+    } else {
+        qDebug() << "Expecting one vertical axis: " << verticalAxes.size();
+    }
 }
 
 ZoneOverviewItem::~ZoneOverviewItem()

--- a/src/Charts/UserChart.cpp
+++ b/src/Charts/UserChart.cpp
@@ -272,7 +272,7 @@ UserChart::refresh()
             foreach (GenericAxisInfo axis, axisinfo) {
                 if (series.xname == axis.name) {
                     // DATERANGE values are days from 01-01-1900
-                    QDateTime earliest(QDate(1900,01,01), QTime(0,0,0), Qt::LocalTime);
+                    QDateTime earliest(QDate(1900,01,01), QTime(0,0,0), QTimeZone::LocalTime);
                     switch (axis.type) {
                         case GenericAxisInfo::TIME:
                             for(int i=0; i<ucd->x.asNumeric().count(); i++) series.labels << time_to_string(ucd->x.asNumeric()[i], true);
@@ -324,7 +324,7 @@ UserChart::refresh()
         // to the x series values.
         if ((chartinfo.type == GC_CHART_BAR || chartinfo.type == GC_CHART_STACK || chartinfo.type == GC_CHART_PERCENT) && axis.orientation == Qt::Horizontal) {
             // DATERANGE values are days from 01-01-1900
-            QDateTime earliest(QDate(1900,01,01), QTime(0,0,0), Qt::LocalTime);
+            QDateTime earliest(QDate(1900,01,01), QTime(0,0,0), QTimeZone::LocalTime);
 
             // find the first series for axis.name
             foreach(GenericSeriesInfo s, seriesinfo) {

--- a/src/Cloud/Xert.cpp
+++ b/src/Cloud/Xert.cpp
@@ -235,7 +235,7 @@ Xert::readdir(QString path, QStringList &errors, QDateTime from, QDateTime to)
                 // }
 
                 QDateTime startDate = QDateTime::fromString(activity["start_date"].toObject()["date"].toString(), Qt::ISODate);
-                startDate.setTimeSpec(Qt::UTC);
+                startDate.setTimeZone(QTimeZone::UTC);
                 startDate = startDate.toLocalTime();
 
                 add->name = startDate.toString("yyyy_MM_dd_HH_mm_ss")+".json";
@@ -395,7 +395,7 @@ Xert::readFileCompleted()
 
         QJsonObject ride = document.object();
         QDateTime starttime = QDateTime::fromString(ride["start_date"].toString(), Qt::ISODate);
-        starttime.setTimeSpec(Qt::UTC);
+        starttime.setTimeZone(QTimeZone::UTC);
         starttime = starttime.toLocalTime();
 
         // 1s samples with start time as UTC

--- a/src/Core/RideDB.y
+++ b/src/Core/RideDB.y
@@ -158,7 +158,7 @@ ride_tuple: string ':' string                                   {
                                                                      else if ($1 == "pacezonerange") jc->item.paceZoneRange = $3.toInt();
                                                                      else if ($1 == "date") {
                                                                          QDateTime aslocal = QDateTime::fromString($3, DATETIME_FORMAT);
-                                                                         QDateTime asUTC = QDateTime(aslocal.date(), aslocal.time(), Qt::UTC);
+                                                                         QDateTime asUTC = QDateTime(aslocal.date(), aslocal.time(), QTimeZone::UTC);
                                                                          jc->item.dateTime = asUTC.toLocalTime();
                                                                      }
                                                                 }

--- a/src/Core/TimeUtils.cpp
+++ b/src/Core/TimeUtils.cpp
@@ -166,7 +166,7 @@ QDateTime convertToLocalTime(QString timestamp)
 
         // Z at end indicates the time is in fact UTC
         QDateTime datetime = QDateTime::fromString(timestamp, Qt::ISODate);
-        datetime.setTimeSpec(Qt::UTC);
+        datetime.setTimeZone(QTimeZone::UTC);
         datetime=datetime.toLocalTime();
         return datetime;
 

--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -563,7 +563,7 @@ main(int argc, char *argv[])
 
         // install QT Translator to enable QT Dialogs translation
         QTranslator qtTranslator;
-        if (!qtTranslator.load("qt_" + lang.toString(), QLibraryInfo::location(QLibraryInfo::TranslationsPath)))
+        if (!qtTranslator.load("qt_" + lang.toString(), QLibraryInfo::path(QLibraryInfo::TranslationsPath)))
             qDebug()<<"Failed to load Qt translator for "<<lang.toString();
         application->installTranslator(&qtTranslator);
 

--- a/src/FileIO/BinRideFile.cpp
+++ b/src/FileIO/BinRideFile.cpp
@@ -279,7 +279,7 @@ struct BinFileReaderState
         if (sum)
             *sum += (0xff & c1) + (0xff & c2) + (0xff & c3) + (0xff & c4) + (0xff & c5) + (0xff & c6) + (0xff & c7);
 
-        QDateTime dateTime(QDate((0xff & c1)*256+(0xff & c2), (0xff & c3), (0xff & c4)), QTime((0xff & c5), (0xff & c6), (0xff & c7)), Qt::LocalTime);
+        QDateTime dateTime(QDate((0xff & c1)*256+(0xff & c2), (0xff & c3), (0xff & c4)), QTime((0xff & c5), (0xff & c6), (0xff & c7)), QTimeZone::LocalTime);
 
         return dateTime.toSecsSinceEpoch();
     }

--- a/src/FileIO/FitRideFile.cpp
+++ b/src/FileIO/FitRideFile.cpp
@@ -58,7 +58,7 @@ static int fitFileReaderRegistered =
         "fit", "Garmin FIT", new FitFileReader());
 
 // 1989-12-31 00:00:00 UTC
-static const QDateTime qbase_time(QDate(1989, 12, 31), QTime(0, 0, 0), Qt::UTC);
+static const QDateTime qbase_time(QDate(1989, 12, 31), QTime(0, 0, 0), QTimeZone::UTC);
 
 
 //
@@ -1774,7 +1774,7 @@ struct FitFileParser
             }
 
             // adjust the start time
-            rf->setStartTime(QDateTime::fromSecsSinceEpoch(start, Qt::UTC));
+            rf->setStartTime(QDateTime::fromSecsSinceEpoch(start, QTimeZone::UTC));
 
             int idx_start = rideFile->timeIndex(start - start_time);
             int idx_stop = rideFile->timeIndex(stop - start_time);

--- a/src/FileIO/GcRideFile.cpp
+++ b/src/FileIO/GcRideFile.cpp
@@ -61,7 +61,7 @@ GcFileReader::openRideFile(QFile &file, QStringList &errors, QList<RideFile*>*) 
             // by default QDateTime is localtime - the source however is UTC
             QDateTime aslocal = QDateTime::fromString(value, DATETIME_FORMAT);
             // construct in UTC so we can honour the conversion to localtime
-            QDateTime asUTC = QDateTime(aslocal.date(), aslocal.time(), Qt::UTC);
+            QDateTime asUTC = QDateTime(aslocal.date(), aslocal.time(), QTimeZone::UTC);
             // now set in localtime
             rideFile->setStartTime(asUTC.toLocalTime());
         }

--- a/src/FileIO/JsonRideFile.y
+++ b/src/FileIO/JsonRideFile.y
@@ -158,7 +158,7 @@ rideelement: starttime
  */
 starttime: STARTTIME ':' string         {
                                           QDateTime aslocal = QDateTime::fromString(jc->JsonString, DATETIME_FORMAT);
-                                          QDateTime asUTC = QDateTime(aslocal.date(), aslocal.time(), Qt::UTC);
+                                          QDateTime asUTC = QDateTime(aslocal.date(), aslocal.time(), QTimeZone::UTC);
                                           jc->JsonRide->setStartTime(asUTC.toLocalTime());
                                         }
 recordint: RECINTSECS ':' number        { jc->JsonRide->setRecIntSecs(jc->JsonNumber); }
@@ -208,7 +208,7 @@ interval_test:
                 ;
 
 interval_color:
-                | ',' COLOR ':' string      { jc->JsonInterval.color.setNamedColor(jc->JsonString); }
+                | ',' COLOR ':' string      { jc->JsonInterval.color.fromString(jc->JsonString); }
                 ;
 
 interval: '{' NAME ':' string ','       { jc->JsonInterval.name = jc->JsonString; }

--- a/src/Train/BT40Device.cpp
+++ b/src/Train/BT40Device.cpp
@@ -292,7 +292,7 @@ BT40Device::serviceStateChanged(QLowEnergyService::ServiceState s)
 {
     qDebug() << "service state changed " << s << "for device" << m_currentDevice.name() << " " << m_currentDevice.deviceUuid();
 
-    if (s == QLowEnergyService::ServiceDiscovered) {
+    if (s == QLowEnergyService::RemoteServiceDiscovered) {
 
         foreach (QLowEnergyService* const &service, m_services) {
 


### PR DESCRIPTION
Fixes the following Qt6 warnings:

Train\BT40Device.cpp(295): warning C4996: 'QLowEnergyService::ServiceDiscovered': ServiceDiscovered was renamed to RemoteServiceDiscovered.

Charts\OverviewItems.cpp(775): warning C4996: 'QChart::setAxisX': was declared deprecated
Charts\OverviewItems.cpp(778): warning C4996: 'QChart::axisY': was declared deprecated
Charts\OverviewItems.cpp(779): warning C4996: 'QChart::axisY': was declared deprecated
Charts\OverviewItems.cpp(780): warning C4996: 'QChart::axisY': was declared deprecated
Charts\OverviewItems.cpp(781): warning C4996: 'QChart::axisY': was declared deprecated
Charts\OverviewItems.cpp(782): warning C4996: 'QChart::axisY': was declared deprecated

Charts\UserChart.cpp(275): warning C4996: 'QDateTime::QDateTime': Pass QTimeZone instead
Charts\UserChart.cpp(327): warning C4996: 'QDateTime::QDateTime': Pass QTimeZone instead

Charts\GenericPlot.cpp(1498): warning C4996: 'QDateTime::QDateTime': Pass QTimeZone instead
Charts\GenericPlot.cpp(1500): warning C4996: 'QDateTime::QDateTime': Pass QTimeZone instead

Charts\AllPlot.cpp(516): warning C4996: 'QColor::setNamedColor': Use fromString() instead.

Charts\GenericChart.cpp(183): warning C4996: 'QDateTime::QDateTime': Pass QTimeZone instead
Charts\GenericChart.cpp(184): warning C4996: 'QDateTime::QDateTime': Pass QTimeZone instead

Cloud\Xert.cpp(238): warning C4996: 'QDateTime::setTimeSpec': Use setTimeZone() instead
Cloud\Xert.cpp(398): warning C4996: 'QDateTime::setTimeSpec': Use setTimeZone() instead

Core\TimeUtils.cpp(169): warning C4996: 'QDateTime::setTimeSpec': Use setTimeZone() instead

Core\main.cpp(566): warning C4996: 'QLibraryInfo::location': Use path()

FileIO\FitRideFile.cpp(61): warning C4996: 'QDateTime::QDateTime': Pass QTimeZone instead
FileIO\FitRideFile.cpp(1777): warning C4996: 'QDateTime::fromSecsSinceEpoch': Pass QTimeZone instead of time-spec, offset

FileIO\GcRideFile.cpp(64): warning C4996: 'QDateTime::QDateTime': Pass QTimeZone instead

FileIO\BinRideFile.cpp(282): warning C4996: 'QDateTime::QDateTime': Pass QTimeZone instead

../FileIO/JsonRideFile.y(161): warning C4996: 'QDateTime::QDateTime': Pass QTimeZone instead
../FileIO/JsonRideFile.y(211): warning C4996: 'QColor::setNamedColor': Use fromString() instead.

../Core/RideDB.y(161): warning C4996: 'QDateTime::QDateTime': Pass QTimeZone instead