### PR TITLE
Fix "may be unsafe" warnings for C functions

### DIFF
--- a/src/ANT/ANTChannel.cpp
+++ b/src/ANT/ANTChannel.cpp
@@ -91,9 +91,9 @@ ANTChannel::init()
 void ANTChannel::setId()
 {
     if (channel_type==CHANNEL_TYPE_UNUSED) {
-        strcpy(id, "none");
+        snprintf(id, ID_SIZE, "%s", "none");
     } else {
-        snprintf(id, 10, "%d%c", device_number, parent->ant_sensor_types[channel_type].suffix);
+        snprintf(id, ID_SIZE, "%d%c", device_number, parent->ant_sensor_types[channel_type].suffix);
     }
 }
 

--- a/src/ANT/ANTChannel.h
+++ b/src/ANT/ANTChannel.h
@@ -108,7 +108,8 @@ class ANTChannel : public QObject {
 
         double blanking_timestamp;
         int blanked;
-        char id[10]; // short identifier
+        static constexpr size_t ID_SIZE = 10;
+        char id[ID_SIZE]; // short identifier
         ANTChannelInitialisation mi;
 
         bool sc_speed_active, sc_cadence_active; // for S&C sensor with single magnet

--- a/src/Core/DataFilter.h
+++ b/src/Core/DataFilter.h
@@ -40,6 +40,9 @@ class FieldDefinition;
 class DataFilter;
 class DataFilterRuntime;
 
+// Defines for auto generated code
+static constexpr size_t FUNCTION_STRING_SIZE = 32;
+
 class Result {
     public:
 

--- a/src/Core/DataFilter.l
+++ b/src/Core/DataFilter.l
@@ -79,10 +79,10 @@ int DataFiltercolumn = 1;
 
                                             /* functions identified by name in the lexer is probably
                                               going to limit us in the future */
-[Bb][Ee][Ss][Tt]                            strcpy(DataFilterlval.function, "best"); return BEST;
-[Tt][Ii][Zz]                                strcpy(DataFilterlval.function, "tiz"); return TIZ;
-[Cc][Oo][Nn][Ff][Ii][Gg]                    strcpy(DataFilterlval.function, "config"); return CONFIG;
-[Cc][Oo][Nn][Ss][Tt]                        strcpy(DataFilterlval.function, "const"); return CONST_;
+[Bb][Ee][Ss][Tt]                            snprintf(DataFilterlval.function, FUNCTION_STRING_SIZE, "%s", "best"); return BEST;
+[Tt][Ii][Zz]                                snprintf(DataFilterlval.function, FUNCTION_STRING_SIZE, "%s", "tiz"); return TIZ;
+[Cc][Oo][Nn][Ff][Ii][Gg]                    snprintf(DataFilterlval.function, FUNCTION_STRING_SIZE, "%s", "config"); return CONFIG;
+[Cc][Oo][Nn][Ss][Tt]                        snprintf(DataFilterlval.function, FUNCTION_STRING_SIZE, "%s", "const"); return CONST_;
 
 "&&"                                        DataFilterlval.op = AND; return AND;
 [Aa][nN][Dd]                                DataFilterlval.op = AND; return AND;

--- a/src/Core/DataFilter.y
+++ b/src/Core/DataFilter.y
@@ -67,7 +67,7 @@ extern Leaf *DataFilterroot; // root node for parsed statement
    Leaf *leaf;
    QList<Leaf*> *comp;
    int op;
-   char function[32];
+   char function[FUNCTION_STRING_SIZE];
    char* string;
 }
 

--- a/src/FileIO/JouleDevice.cpp
+++ b/src/FileIO/JouleDevice.cpp
@@ -57,15 +57,16 @@ JouleDevices::newDevice( CommPortPtr dev )
 static QString
 cEscape(char *buf, int len)
 {
-    char *result = new char[4 * len + 1];
+    int resultSize = 4 * len + 1;
+    char *result = new char[resultSize];
     char *tmp = result;
     for (int i = 0; i < len; ++i) {
         if (buf[i] == '"')
-            tmp += sprintf(tmp, "\\\"");
+            tmp += snprintf(tmp, resultSize-(tmp-result), "%s", "\\\"");
         else if (isprint(buf[i]))
             *(tmp++) = buf[i];
         else
-            tmp += sprintf(tmp, "\\x%02x", 0xff & (unsigned) buf[i]);
+            tmp += snprintf(tmp, resultSize-(tmp-result), "\\x%02x", 0xff & (unsigned) buf[i]);
     }
     return result;
 }

--- a/src/FileIO/MacroDevice.cpp
+++ b/src/FileIO/MacroDevice.cpp
@@ -59,15 +59,16 @@ MacroDevices::newDevice( CommPortPtr dev )
 static QString
 cEscape(char *buf, int len)
 {
-    char *result = new char[4 * len + 1];
+    int resultSize = 4 * len + 1;
+    char *result = new char[resultSize];
     char *tmp = result;
     for (int i = 0; i < len; ++i) {
         if (buf[i] == '"')
-            tmp += sprintf(tmp, "\\\"");
+            tmp += snprintf(tmp, resultSize-(tmp-result), "%s", "\\\"");
         else if (isprint(buf[i]))
             *(tmp++) = buf[i];
         else
-            tmp += sprintf(tmp, "\\x%02x", 0xff & (unsigned) buf[i]);
+            tmp += snprintf(tmp, resultSize-(tmp-result), "\\x%02x", 0xff & (unsigned) buf[i]);
     }
     return result;
 }

--- a/src/FileIO/MoxyDevice.cpp
+++ b/src/FileIO/MoxyDevice.cpp
@@ -457,15 +457,16 @@ hasNewline(const char *buf, int len)
 static QString
 cEscape(const char *buf, int len)
 {
-    char *result = new char[4 * len + 1];
+    int resultSize = 4 * len + 1;
+    char *result = new char[resultSize];
     char *tmp = result;
     for (int i = 0; i < len; ++i) {
         if (buf[i] == '"')
-            tmp += sprintf(tmp, "\\\"");
+            tmp += snprintf(tmp, resultSize-(tmp-result), "%s", "\\\"");
         else if (isprint(buf[i]))
             *(tmp++) = buf[i];
         else
-            tmp += sprintf(tmp, "\\x%02x", 0xff & (unsigned) buf[i]);
+            tmp += snprintf(tmp, resultSize-(tmp-result), "\\x%02x", 0xff & (unsigned) buf[i]);
     }
     return result;
 }

--- a/src/FileIO/PowerTapDevice.cpp
+++ b/src/FileIO/PowerTapDevice.cpp
@@ -62,15 +62,16 @@ hasNewline(const char *buf, int len)
 static QString
 cEscape(const char *buf, int len)
 {
-    char *result = new char[4 * len + 1];
+    int resultSize = 4 * len + 1;
+    char *result = new char[resultSize];
     char *tmp = result;
     for (int i = 0; i < len; ++i) {
         if (buf[i] == '"')
-            tmp += sprintf(tmp, "\\\"");
+            tmp += snprintf(tmp, resultSize-(tmp-result), "%s", "\\\"");
         else if (isprint(buf[i]))
             *(tmp++) = buf[i];
         else
-            tmp += sprintf(tmp, "\\x%02x", 0xff & (unsigned) buf[i]);
+            tmp += snprintf(tmp, resultSize-(tmp-result), "\\x%02x", 0xff & (unsigned) buf[i]);
     }
     return result;
 }

--- a/src/FileIO/Serial.cpp
+++ b/src/FileIO/Serial.cpp
@@ -452,8 +452,9 @@ find_devices(char *result[], int capacity)
 
         // If success then add to the list
         if (bSuccess) {
-            result[count] = (char*) malloc(shortCOM.length() + 1); // include '\0' terminator
-            strcpy(result[count], shortCOM.toLatin1().constData());
+            size_t comSize = shortCOM.length() + 1; // include '\0' terminator
+            result[count] = (char*) malloc(comSize);
+            snprintf(result[count], comSize, shortCOM.toLatin1().constData());
             count++;
         }
     }

--- a/src/FileIO/SyncRideFile.cpp
+++ b/src/FileIO/SyncRideFile.cpp
@@ -93,15 +93,16 @@ struct SyncFileReaderState
     QString
     cEscape(char *buf, int len)
     {
-        char *result = new char[4 * len + 1];
+        int resultSize = 4 * len + 1;
+        char *result = new char[resultSize];
         char *tmp = result;
         for (int i = 0; i < len; ++i) {
             if (buf[i] == '"')
-                tmp += sprintf(tmp, "\\\"");
+                tmp += snprintf(tmp, resultSize-(tmp-result), "%s", "\\\"");
             else if (isprint(buf[i]))
                 *(tmp++) = buf[i];
             else
-                tmp += sprintf(tmp, "\\x%02x", 0xff & (unsigned) buf[i]);
+                tmp += snprintf(tmp, resultSize-(tmp-result), "\\x%02x", 0xff & (unsigned) buf[i]);
         }
         return result;
     }

--- a/src/Gui/DownloadRideDialog.cpp
+++ b/src/Gui/DownloadRideDialog.cpp
@@ -410,11 +410,17 @@ DownloadRideDialog::downloadClicked()
         if (rename(QFile::encodeName(files.at(i).name),
             QFile::encodeName(filepath)) < 0) {
 
+            char errBuffer[128];
+#ifdef Q_CC_MSVC
+            strerror_s(errBuffer, 128, errno);
+#else
+            strerror_r(errno, errBuffer, 128);
+#endif
             QMessageBox::critical(this, tr("Error"),
                 tr("Failed to rename %1 to %2: %3")
                     .arg(files.at(i).name)
                     .arg(filepath)
-                    .arg(strerror(errno)) );
+                    .arg(errBuffer) );
                 updateStatus(tr("Failed to rename %1 to %2")
                     .arg( files.at(i).name )
                     .arg( filename ));

--- a/src/Train/AddDeviceWizard.cpp
+++ b/src/Train/AddDeviceWizard.cpp
@@ -1267,8 +1267,9 @@ AddVirtualPower::myCreateCustomPowerCurve() {
     QStringList namePieces = virtualPowerNameEdit->text().split("|");
 
     // No point being fancy, simply take the name before the '|'.
-    char* pNameCopy = new char[strlen(namePieces.at(0).toStdString().c_str()) + 1];
-    strcpy(pNameCopy, namePieces.at(0).toStdString().c_str());
+    size_t nameSize = strlen(namePieces.at(0).toStdString().c_str()) + 1;
+    char* pNameCopy = new char[nameSize];
+    snprintf(pNameCopy, nameSize, "%s", namePieces.at(0).toStdString().c_str());
 
     p->m_pName = pNameCopy; // freed by manager when manager is destroyed.
     p->m_pf = pf;

--- a/src/Train/RealtimeController.cpp
+++ b/src/Train/RealtimeController.cpp
@@ -708,8 +708,9 @@ int VirtualPowerTrainerManager::PushCustomVirtualPowerTrainer(const QString& str
         // VirtualPowerTrainer and freed by manager when manager is destroyed.
 
         std::string name = namePiece.toStdString();
-        char* pNameCopy = new char[name.size() + 1];
-        strcpy(pNameCopy, name.c_str());
+        size_t nameSize = name.size() + 1;
+        char* pNameCopy = new char[nameSize];
+        snprintf(pNameCopy, nameSize, "%s", name.c_str());
 
         VirtualPowerTrainer* p = new VirtualPowerTrainer();
 

--- a/src/Train/RealtimeData.cpp
+++ b/src/Train/RealtimeData.cpp
@@ -51,7 +51,7 @@ RealtimeData::RealtimeData()
 
 void RealtimeData::setName(char *name)
 {
-    strcpy(this->name, name);
+    snprintf(this->name, NAME_SIZE, "%s", name);
 }
 void RealtimeData::setAltWatts(double watts)
 {

--- a/src/Train/RealtimeData.h
+++ b/src/Train/RealtimeData.h
@@ -209,7 +209,9 @@ public:
     uint8_t spinScan[24];
 
 private:
-    char name[64];
+
+    static constexpr size_t NAME_SIZE = 64;
+    char name[NAME_SIZE];
 
     // realtime telemetry
     double hr, watts, altWatts, altDistance, speed, wheelRpm, load, slope, lrbalance;


### PR DESCRIPTION
The MCVS compiler complains about the unsafe C functions, this PR aims to fix these issues by replacing the C functions with their more secure versions: 

- sprintf does not check the size of the destination buffer, so sprintf has been changed to use snprintf. The windows snprintf_s has not been used as this has different return values, and failure behaviour to sprintf and snprintf.

- strcpy does not check the size of the destination buffer, so strcpy has been changed to use snprintf

- strncpy does not guarantee null termination of the destination string if the source string is as long or longer than the specified size, so strncpy has been changed to use snprintf

- strerror is not thread safe, as it relies upon a static internal buffer that can be overwritten by subsequent calls, so strerror has been changed to use strerror_s (windows) and strerror_r (unix/mac)

**Note: This PR needs careful review**

Also the same cEscape() functionality is defined in the following files:
FileIO\JouleDevice.cpp(64): 
FileIO\MacroDevice.cpp(66)
FileIO\MoxyDevice.cpp(464)
FileIO\PowerTapDevice.cpp(69)


**C function warnings:**

Core\main.cpp(168): warning C4996: 'freopen': This function or variable may be unsafe. Consider using freopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
Core\main.cpp(174): warning C4996: 'fileno': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _fileno. See online help for details.
Core\main.cpp(183): warning C4996: 'dup2': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _dup2. See online help for details.
Core\main.cpp(222): warning C4996: 'freopen': This function or variable may be unsafe. Consider using freopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
Core\main.cpp(223): warning C4996: 'freopen': This function or variable may be unsafe. Consider using freopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.

FileIO\MacroDevice.cpp(66): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\MacroDevice.cpp(70): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.

FileIO\MoxyDevice.cpp(464): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\MoxyDevice.cpp(468): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.

FileIO\PowerTapDevice.cpp(69): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\PowerTapDevice.cpp(73): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.

FileIO\JouleDevice.cpp(64): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\JouleDevice.cpp(68): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
.
FileIO\Serial.cpp(456): warning C4996: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.

FileIO\RawRideFile.cpp(156): warning C4996: 'fscanf': This function or variable may be unsafe. Consider using fscanf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\RawRideFile.cpp(175): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\RawRideFile.cpp(180): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\RawRideFile.cpp(198): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\RawRideFile.cpp(208): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\RawRideFile.cpp(220): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\RawRideFile.cpp(226): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\RawRideFile.cpp(242): warning C4996: 'fdopen': The POSIX name for this item is deprecated. Instead, use the ISO C and C++ conformant name: _fdopen. See online help for details.

FileIO\SyncRideFile.cpp(100): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\SyncRideFile.cpp(104): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.

FileIO\WkoRideFile.cpp(349): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\WkoRideFile.cpp(378): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\WkoRideFile.cpp(384): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\WkoRideFile.cpp(405): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\WkoRideFile.cpp(428): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\WkoRideFile.cpp(455): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\WkoRideFile.cpp(456): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\WkoRideFile.cpp(458): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\WkoRideFile.cpp(465): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\WkoRideFile.cpp(471): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\WkoRideFile.cpp(477): warning C4996: 'sprintf': This function or variable may be unsafe. Consider using sprintf_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\WkoRideFile.cpp(580): warning C4996: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\WkoRideFile.cpp(835): warning C4996: 'strncpy': This function or variable may be unsafe. Consider using strncpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\WkoRideFile.cpp(1504): warning C4996: 'strncpy': This function or variable may be unsafe. Consider using strncpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\WkoRideFile.cpp(1510): warning C4996: 'strncpy': This function or variable may be unsafe. Consider using strncpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.

FileIO\SrdRideFile.cpp(254): warning C4996: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\SrdRideFile.cpp(715): warning C4996: 'strerror': This function or variable may be unsafe. Consider using strerror_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\SrdRideFile.cpp(852): warning C4996: '_open': This function or variable may be unsafe. Consider using _sopen_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\SrdRideFile.cpp(886): warning C4996: 'strerror': This function or variable may be unsafe. Consider using strerror_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\SrdRideFile.cpp(898): warning C4996: 'strerror': This function or variable may be unsafe. Consider using strerror_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\SrdRideFile.cpp(901): warning C4996: 'strerror': This function or variable may be unsafe. Consider using strerror_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\SrdRideFile.cpp(975): warning C4996: 'strerror': This function or variable may be unsafe. Consider using strerror_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\SrdRideFile.cpp(976): warning C4996: 'strerror': This function or variable may be unsafe. Consider using strerror_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\SrdRideFile.cpp(978): warning C4996: 'strerror': This function or variable may be unsafe. Consider using strerror_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\SrdRideFile.cpp(979): warning C4996: 'strerror': This function or variable may be unsafe. Consider using strerror_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\SrdRideFile.cpp(980): warning C4996: 'strerror': This function or variable may be unsafe. Consider using strerror_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
FileIO\SrdRideFile.cpp(981): warning C4996: 'strerror': This function or variable may be unsafe. Consider using strerror_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.

Gui\DownloadRideDialog.cpp(417): warning C4996: 'strerror': This function or variable may be unsafe. Consider using strerror_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.

../Core/DataFilter.l(82): warning C4996: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
../Core/DataFilter.l(83): warning C4996: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
../Core/DataFilter.l(84): warning C4996: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.
../Core/DataFilter.l(85): warning C4996: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.

Train\RealtimeController.cpp(712): warning C4996: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.

Train\RealtimeData.cpp(54): warning C4996: 'strcpy': This function or variable may be unsafe. Consider using strcpy_s instead. To disable deprecation, use _CRT_SECURE_NO_WARNINGS. See online help for details.