### PR TITLE
Fixes Qt6 standard buttons warnings

### DIFF
--- a/src/Gui/DownloadRideDialog.cpp
+++ b/src/Gui/DownloadRideDialog.cpp
@@ -378,8 +378,8 @@ DownloadRideDialog::downloadClicked()
                         "been downloaded.  Do you want to overwrite the "
                         "previous download?")
                         .arg(files.at(i).startTime.toString()),
-                    tr("&Overwrite"), tr("&Skip"),
-                    QString(), 1, 1) == 1) {
+                    QMessageBox::Yes | QMessageBox::No,
+                    QMessageBox::No) == QMessageBox::Yes) {
                 QFile::remove(files.at(i).name);
                 updateStatus(tr("skipped file %1")
                     .arg( files.at(i).name ));

--- a/src/Gui/NewAthleteWizard.cpp
+++ b/src/Gui/NewAthleteWizard.cpp
@@ -172,10 +172,10 @@ NewAthleteWizard::done
                     }
                 }
             } else {
-                QMessageBox::critical(0, tr("Fatal Error"), tr("Can't create new directory ") + home.canonicalPath() + "/" + name, "OK");
+                QMessageBox::critical(this, tr("Fatal Error"), tr("Can't create new directory ") + home.canonicalPath() + "/" + name);
             }
         } else {
-            QMessageBox::critical(0, tr("Fatal Error"), tr("Athlete already exists ")  + name, "OK");
+            QMessageBox::critical(this, tr("Fatal Error"), tr("Athlete already exists ")  + name);
         }
     }
     QWizard::done(result);


### PR DESCRIPTION
Fixes Qt6 standard buttons warnings

Gui\NewAthleteWizard.cpp(175): warning C4996: 'QMessageBox::critical': Use the overload taking StandardButtons instead.
Gui\NewAthleteWizard.cpp(178): warning C4996: 'QMessageBox::critical': Use the overload taking StandardButtons instead.

Gui\DownloadRideDialog.cpp(375): warning C4996: 'QMessageBox::warning': Use the overload taking StandardButtons instead.
