### PR TITLE
Update HTTP TLS version

### DIFF
--- a/contrib/httpserver/httpconnectionhandlerpool.cpp
+++ b/contrib/httpserver/httpconnectionhandlerpool.cpp
@@ -123,7 +123,7 @@ void HttpConnectionHandlerPool::loadSslConfig() {
             sslConfiguration->setLocalCertificate(certificate);
             sslConfiguration->setPrivateKey(sslKey);
             sslConfiguration->setPeerVerifyMode(QSslSocket::VerifyNone);
-            sslConfiguration->setProtocol(QSsl::TlsV1_0);
+            sslConfiguration->setProtocol(QSsl::TlsV1_2OrLater);
 
             wDebug("HttpConnectionHandlerPool: SSL settings loaded");
          #endif


### PR DESCRIPTION
The MCVS compiler detects:

..\contrib\httpserver\httpconnectionhandlerpool.cpp(126): warning C4996: 'QSsl::TlsV1_0': Use TlsV1_2OrLater instead.

AI says:

The use of QSsl::TlsV1_0 is discouraged in favor of QSsl::TlsV1_2OrLater for improved security and compatibility. This recommendation stems from the fact that QSsl::TlsV1_0OrLater is not a standard protocol option in Qt, and the intended behavior of allowing TLS 1.0 or higher is better achieved using QSsl::TlsV1_2OrLater, which ensures support for TLS 1.2 and later versions, aligning with modern security standards.