### PR TITLE
Fixes so that lupdate doesn't throw warnings (and break on Windows).

### DIFF
--- a/src/Gui/CalendarItemDelegates.h
+++ b/src/Gui/CalendarItemDelegates.h
@@ -115,6 +115,7 @@ private:
 
 
 class CalendarHeadlineDelegate : public QStyledItemDelegate {
+    Q_OBJECT
 public:
     enum Roles {
         DayRole = Qt::UserRole + 1 // [CalendarDay] Calendar day
@@ -153,6 +154,7 @@ private:
 
 
 class CalendarCompactDayDelegate : public QStyledItemDelegate {
+    Q_OBJECT
 public:
     enum Roles {
         DayRole = Qt::UserRole + 1, // [CalendarDay] Calendar day
@@ -191,6 +193,7 @@ private:
 
 
 class AgendaMultiDelegate : public QStyledItemDelegate {
+    Q_OBJECT
 public:
     enum Roles {
         // Qt::DisplayRole            // [QString] The default text to display
@@ -229,6 +232,7 @@ private:
 
 
 class AgendaEntryDelegate : public QStyledItemDelegate {
+    Q_OBJECT
 public:
     enum Roles {
         EntryRole = Qt::UserRole, // [CalendarEntry] Entry to be displayed

--- a/src/Gui/ColorButton.h
+++ b/src/Gui/ColorButton.h
@@ -25,6 +25,9 @@
 #include <QDialog>
 #include <QColor>
 
+// color chooser that also supports the standard colors (CPLOTMARKER, CPOWER)
+// and returns them as a QColor(1,1,1,<int>) where <int> is the color number
+// .e.g CPOWER is 18, see below for full list
 class ColorButton : public QPushButton
 {
     Q_OBJECT

--- a/src/Gui/Colors.h
+++ b/src/Gui/Colors.h
@@ -162,17 +162,6 @@ class GCColor : public QObject
         static QStringList getConfigKeys();
 };
 
-// color chooser that also supports the standard colors (CPLOTMARKER, CPOWER)
-// and returns them as a QColor(1,1,1,<int>) where <int> is the color number
-// .e.g CPOWER is 18, see below for full list
-#if 0
-class GColorDialog : public QDialog
-{
-    GColorDialog(QWidget *parent);
-
-};
-#endif
-
 // return a color for a ride file
 class GlobalContext;
 class ColorEngine : public QObject


### PR DESCRIPTION
This mistake also likely contributes to internationalization problems.

src/Gui/CalendarItemDelegates.h:
  ColumnDelegatingItemDelegate
    - uses tr() so should call Q_OBJECT CalendarDetailedDayDelegate
    - uses tr() so should call Q_OBJECT
    - Moved Q_OBJECT to the top of the class for consistency and this also guarantees it's private (which it has to be).

src/Gui/ColorButton.h:
  - Moved the comment from Colors.h here.

src/Gui/Colors.h:
  - Removed #if 0 code that confused lupdate since it doesn't understand preprocessor macros.