### PR TITLE
Qwt Type Truncation Warnings

### DIFF
--- a/qwt/src/qwt_plot_barchart.cpp
+++ b/qwt/src/qwt_plot_barchart.cpp
@@ -225,7 +225,7 @@ void QwtPlotBarChart::drawSeries( QPainter* painter,
     const QRectF& canvasRect, int from, int to ) const
 {
     if ( to < 0 )
-        to = dataSize() - 1;
+        to = static_cast<int>(dataSize() - 1);
 
     if ( from < 0 )
         from = 0;
@@ -419,10 +419,10 @@ QList< QwtLegendData > QwtPlotBarChart::legendData() const
 
     if ( m_data->legendMode == LegendBarTitles )
     {
-        const size_t numSamples = dataSize();
+        const int numSamples = static_cast<int>(dataSize());
         list.reserve( numSamples );
 
-        for ( size_t i = 0; i < numSamples; i++ )
+        for ( int i = 0; i < numSamples; i++ )
         {
             QwtLegendData data;
 

--- a/qwt/src/qwt_plot_curve.cpp
+++ b/qwt/src/qwt_plot_curve.cpp
@@ -387,7 +387,7 @@ void QwtPlotCurve::drawSeries( QPainter* painter,
     const QwtScaleMap& xMap, const QwtScaleMap& yMap,
     const QRectF& canvasRect, int from, int to ) const
 {
-    const size_t numSamples = dataSize();
+    const int numSamples = static_cast<int>( dataSize() );
 
     if ( !painter || numSamples <= 0 )
         return;
@@ -443,7 +443,7 @@ void QwtPlotCurve::drawCurve( QPainter* painter, int style,
                 // we always need the complete
                 // curve for fitting
                 from = 0;
-                to = dataSize() - 1;
+                to = static_cast<int>( dataSize() - 1 );
             }
             drawLines( painter, xMap, yMap, canvasRect, from, to );
             break;
@@ -1206,7 +1206,7 @@ qreal QwtPlotCurve::interpolatedValueAt( Qt::Orientation orientation, double val
 
         if ( index == -1 )
         {
-            const QPointF last = sample( dataSize() - 1 );
+            const QPointF last = sample( static_cast<int>( dataSize() - 1 ) );
 
             if ( value != last.x() )
                 return qQNaN();
@@ -1228,7 +1228,7 @@ qreal QwtPlotCurve::interpolatedValueAt( Qt::Orientation orientation, double val
 
         if ( index == -1 )
         {
-            const QPointF last = sample( dataSize() - 1 );
+            const QPointF last = sample( static_cast<int>( dataSize() - 1 ) );
 
             if ( value != last.y() )
                 return qQNaN();

--- a/qwt/src/qwt_plot_histogram.cpp
+++ b/qwt/src/qwt_plot_histogram.cpp
@@ -341,7 +341,7 @@ void QwtPlotHistogram::drawSeries( QPainter* painter,
         return;
 
     if ( to < 0 )
-        to = dataSize() - 1;
+        to = static_cast<int>( dataSize() - 1 );
 
     switch ( m_data->style )
     {

--- a/qwt/src/qwt_plot_intervalcurve.cpp
+++ b/qwt/src/qwt_plot_intervalcurve.cpp
@@ -470,8 +470,8 @@ static void qwtDrawTube(
         }
         else
         {
-            QwtPainter::drawPolyline( painter, points, size );
-            QwtPainter::drawPolyline( painter, points + size, size );
+            QwtPainter::drawPolyline( painter, points, static_cast<int>( size ) );
+            QwtPainter::drawPolyline( painter, points + size, static_cast<int>( size ) );
         }
     }
 
@@ -758,7 +758,7 @@ void QwtPlotIntervalCurve::drawSeries( QPainter* painter,
     const QRectF& canvasRect, int from, int to ) const
 {
     if ( to < 0 )
-        to = dataSize() - 1;
+        to = static_cast<int>( dataSize() - 1 );
 
     if ( from < 0 )
         from = 0;

--- a/qwt/src/qwt_plot_multi_barchart.cpp
+++ b/qwt/src/qwt_plot_multi_barchart.cpp
@@ -376,7 +376,7 @@ void QwtPlotMultiBarChart::drawSeries( QPainter* painter,
     const QRectF& canvasRect, int from, int to ) const
 {
     if ( to < 0 )
-        to = dataSize() - 1;
+        to = static_cast<int>( dataSize() - 1 );
 
     if ( from < 0 )
         from = 0;

--- a/qwt/src/qwt_plot_spectrocurve.cpp
+++ b/qwt/src/qwt_plot_spectrocurve.cpp
@@ -243,7 +243,7 @@ void QwtPlotSpectroCurve::drawSeries( QPainter* painter,
         return;
 
     if ( to < 0 )
-        to = dataSize() - 1;
+        to = static_cast<int>( dataSize() - 1 );
 
     if ( from < 0 )
         from = 0;

--- a/qwt/src/qwt_plot_tradingcurve.cpp
+++ b/qwt/src/qwt_plot_tradingcurve.cpp
@@ -389,7 +389,7 @@ void QwtPlotTradingCurve::drawSeries( QPainter* painter,
     const QRectF& canvasRect, int from, int to ) const
 {
     if ( to < 0 )
-        to = dataSize() - 1;
+        to = static_cast<int>( dataSize() - 1 );
 
     if ( from < 0 )
         from = 0;

--- a/qwt/src/qwt_plot_vectorfield.cpp
+++ b/qwt/src/qwt_plot_vectorfield.cpp
@@ -812,7 +812,7 @@ void QwtPlotVectorField::drawSeries( QPainter* painter,
         return;
 
     if ( to < 0 )
-        to = dataSize() - 1;
+        to = static_cast<int>( dataSize() - 1 );
 
     if ( from < 0 )
         from = 0;

--- a/qwt/src/qwt_point_data.cpp
+++ b/qwt/src/qwt_point_data.cpp
@@ -127,7 +127,7 @@ QPointF QwtSyntheticPointData::sample( size_t index ) const
     if ( index >= m_size )
         return QPointF( 0, 0 );
 
-    const double xValue = x( index );
+    const double xValue = x( static_cast<uint>( index ) );
     const double yValue = y( xValue );
 
     return QPointF( xValue, yValue );

--- a/qwt/src/qwt_series_data.cpp
+++ b/qwt/src/qwt_series_data.cpp
@@ -90,7 +90,7 @@ QRectF qwtBoundingRectT( const QwtSeriesData< T >& series, int from, int to )
         from = 0;
 
     if ( to < 0 )
-        to = series.size() - 1;
+        to = static_cast<int>( series.size() - 1 );
 
     if ( to < from )
         return boundingRect;

--- a/qwt/src/qwt_series_data.h
+++ b/qwt/src/qwt_series_data.h
@@ -320,7 +320,7 @@ template< typename T, typename LessThan >
 inline int qwtUpperSampleIndex( const QwtSeriesData< T >& series,
     double value, LessThan lessThan  )
 {
-    const int indexMax = series.size() - 1;
+    const int indexMax = static_cast<int>( series.size() - 1 );
 
     if ( indexMax < 0 || !lessThan( value, series.sample( indexMax ) ) )
         return -1;


### PR DESCRIPTION
Removes the type truncation warnings, I'll see if I can push this to the Qwt project at some point (https://sourceforge.net/projects/qwt/)