### PR TITLE
Athlete folder change confirmation

### DIFF
--- a/src/Gui/ConfigDialog.cpp
+++ b/src/Gui/ConfigDialog.cpp
@@ -268,10 +268,11 @@ void ConfigDialog::saveClicked()
 
         // we want our own buttons...
         msgBox.addButton(tr("No, Keep current"), QMessageBox::RejectRole);
-        msgBox.addButton(tr("Yes, Apply and Restart"), QMessageBox::AcceptRole);
+        QAbstractButton *acceptButton = msgBox.addButton(tr("Yes, Apply and Restart"), QMessageBox::AcceptRole);
         msgBox.setDefaultButton(QMessageBox::Abort);
+        msgBox.exec();
 
-        if (msgBox.exec() == 1) { // accept!
+        if (msgBox.clickedButton() == acceptButton) {
 
             // lets restart
             restarting = true;


### PR DESCRIPTION
Looking at the recent discussions on changing the Athlete's home directory, I think I might have found an issue with the confirmation dialog. After the user clicks save on the general page changes, if the athlete folder has changed, the config dialog asks for confirmation, but when the use clicks "Yes, Apply and Restart" the msgBox.exec() function returns 3 rather than the expected 1, so it always reverts the change.

<img width="681" height="249" alt="image" src="https://github.com/user-attachments/assets/767d208a-5e30-4cd1-83a1-9c7d7e954827" />

I have updated the code to use the QAbstractButton and clickButton() approach which is widely used within GC. Testing confimrs this correctly commits the change and restarts GC with the new athlete folder. 

Possibly the return value has changed between Qt6 & 5, it must have worked in the past, but why not now?