### PR TITLE
Multi Metrics support for Agenda

### DIFF
--- a/src/Charts/AgendaWindow.h
+++ b/src/Charts/AgendaWindow.h
@@ -42,7 +42,9 @@ class AgendaWindow : public GcChartWindow
     Q_PROPERTY(int agendaFutureDays READ getAgendaFutureDays WRITE setAgendaFutureDays USER true)
     Q_PROPERTY(QString primaryMainField READ getPrimaryMainField WRITE setPrimaryMainField USER true)
     Q_PROPERTY(QString primaryFallbackField READ getPrimaryFallbackField WRITE setPrimaryFallbackField USER true)
-    Q_PROPERTY(QString secondaryMetric READ getSecondaryMetric WRITE setSecondaryMetric USER true)
+
+    Q_PROPERTY(QString secondaryMetrics READ getSecondaryMetrics WRITE setSecondaryMetrics USER true)
+
     Q_PROPERTY(bool showSecondaryLabel READ isShowSecondaryLabel WRITE setShowSecondaryLabel USER true)
     Q_PROPERTY(int showTertiaryFor READ getShowTertiaryFor WRITE setShowTertiaryFor USER true)
     Q_PROPERTY(QString tertiaryField READ getTertiaryField WRITE setTertiaryField USER true)
@@ -59,7 +61,8 @@ class AgendaWindow : public GcChartWindow
 
         QString getPrimaryMainField() const;
         QString getPrimaryFallbackField() const;
-        QString getSecondaryMetric() const;
+        QString getSecondaryMetrics() const;
+        QStringList getSecondaryMetricsList() const;
         bool isShowSecondaryLabel() const;
         int getShowTertiaryFor() const;
         QString getTertiaryField() const;
@@ -71,7 +74,8 @@ class AgendaWindow : public GcChartWindow
         void setAgendaFutureDays(int days);
         void setPrimaryMainField(const QString &name);
         void setPrimaryFallbackField(const QString &name);
-        void setSecondaryMetric(const QString &name);
+        void setSecondaryMetrics(const QString &metrics);
+        void setSecondaryMetrics(const QStringList &metrics);
         void setShowSecondaryLabel(bool showSecondaryLabel);
         void setShowTertiaryFor(int showFor);
         void setTertiaryField(const QString &name);
@@ -90,7 +94,7 @@ class AgendaWindow : public GcChartWindow
         QSpinBox *agendaFutureDaysSpin;
         QComboBox *primaryMainCombo;
         QComboBox *primaryFallbackCombo;
-        QComboBox *secondaryCombo;
+        MultiMetricSelector *multiMetricSelector;
         QCheckBox *showSecondaryLabelCheck;
         QComboBox *showTertiaryForCombo;
         QComboBox *tertiaryCombo;
@@ -100,17 +104,16 @@ class AgendaWindow : public GcChartWindow
 
         void mkControls();
         void updatePrimaryConfigCombos();
-        void updateSecondaryConfigCombo();
         void updateTertiaryConfigCombo();
-        QHash<QDate, QList<CalendarEntry>> getActivities(const QDate &firstDay, const QDate &today, const QDate &lastDay) const;
-        std::pair<QList<CalendarEntry>, QList<CalendarEntry>> getPhases(const Season &season, const QDate &firstDay) const;
-        QHash<QDate, QList<CalendarEntry>> getEvents(const QDate &firstDay) const;
+        QHash<QDate, QList<AgendaEntry>> getActivities(const QDate &firstDay, const QDate &today, const QDate &lastDay) const;
+        std::pair<QList<AgendaEntry>, QList<AgendaEntry>> getPhases(const Season &season, const QDate &firstDay) const;
+        QHash<QDate, QList<AgendaEntry>> getEvents(const QDate &firstDay) const;
 
     private slots:
         void updateActivities();
         void updateActivitiesIfInRange(RideItem *rideItem);
-        void editPhaseEntry(const CalendarEntry &entry);
-        void editEventEntry(const CalendarEntry &entry);
+        void editPhaseEntry(const AgendaEntry &entry);
+        void editEventEntry(const AgendaEntry &entry);
 };
 
 #endif

--- a/src/Gui/Agenda.h
+++ b/src/Gui/Agenda.h
@@ -92,13 +92,13 @@ public:
 
     void setPastDays(int days);
     void setFutureDays(int days);
-    void fillEntries(const QHash<QDate, QList<CalendarEntry>> &activities);
+    void fillEntries(const QHash<QDate, QList<AgendaEntry>> &activities);
     QDate firstVisibleDay() const;
     QDate lastVisibleDay() const;
 
 signals:
-    void showInTrainMode(const CalendarEntry &activity);
-    void viewActivity(const CalendarEntry &activity);
+    void showInTrainMode(const AgendaEntry &activity);
+    void viewActivity(const AgendaEntry &activity);
 
 protected:
     QMenu *createContextMenu(const QModelIndex &index) override;
@@ -107,7 +107,7 @@ private:
     int pastDays = 7;
     int futureDays = 7;
 
-    void addEntries(const QDate &today, const QDate &date, const QList<CalendarEntry> &activities, QTreeWidgetItem *parent, const Fonts &fonts);
+    void addEntries(const QDate &today, const QDate &date, const QList<AgendaEntry> &activities, QTreeWidgetItem *parent, const Fonts &fonts);
 };
 
 
@@ -115,16 +115,16 @@ class PhaseTree : public AgendaTree {
     Q_OBJECT
 
 public:
-    void fillEntries(const std::pair<QList<CalendarEntry>, QList<CalendarEntry>> &phases);
+    void fillEntries(const std::pair<QList<AgendaEntry>, QList<AgendaEntry>> &phases);
 
 signals:
-    void editPhaseEntry(const CalendarEntry &entry);
+    void editPhaseEntry(const AgendaEntry &entry);
 
 protected:
     QMenu *createContextMenu(const QModelIndex &index) override;
 
 private:
-    void addEntries(const QDate &today, const QList<CalendarEntry> &phases, QTreeWidgetItem *parent, const Fonts &fonts);
+    void addEntries(const QDate &today, const QList<AgendaEntry> &phases, QTreeWidgetItem *parent, const Fonts &fonts);
 };
 
 
@@ -132,16 +132,16 @@ class EventTree : public AgendaTree {
     Q_OBJECT
 
 public:
-    void fillEntries(const QHash<QDate, QList<CalendarEntry>> &events);
+    void fillEntries(const QHash<QDate, QList<AgendaEntry>> &events);
 
 signals:
-    void editEventEntry(const CalendarEntry &entry);
+    void editEventEntry(const AgendaEntry &entry);
 
 protected:
     virtual QMenu *createContextMenu(const QModelIndex &index);
 
 private:
-    void addEntries(const QDate &today, const QList<CalendarEntry> &phases, QTreeWidgetItem *parent, const Fonts &fonts);
+    void addEntries(const QDate &today, const QList<AgendaEntry> &phases, QTreeWidgetItem *parent, const Fonts &fonts);
 };
 
 
@@ -155,7 +155,7 @@ public:
     void setDateRange(const DateRange &dateRange);
     void setPastDays(int days);
     void setFutureDays(int days);
-    void fillEntries(const QHash<QDate, QList<CalendarEntry>> &activities, std::pair<QList<CalendarEntry>, QList<CalendarEntry>> &phases, const QHash<QDate, QList<CalendarEntry>> &events, const QString &seasonName, bool isFiltered);
+    void fillEntries(const QHash<QDate, QList<AgendaEntry>> &activities, std::pair<QList<AgendaEntry>, QList<AgendaEntry>> &phases, const QHash<QDate, QList<AgendaEntry>> &events, const QString &seasonName, bool isFiltered);
 
     QDate firstVisibleDay() const;
     QDate lastVisibleDay() const;
@@ -166,10 +166,10 @@ public slots:
     void setEventMaxTertiaryLines(int maxTertiaryLines);
 
 signals:
-    void showInTrainMode(const CalendarEntry &activity);
-    void viewActivity(const CalendarEntry &activity);
-    void editPhaseEntry(const CalendarEntry &entry);
-    void editEventEntry(const CalendarEntry &entry);
+    void showInTrainMode(const AgendaEntry &activity);
+    void viewActivity(const AgendaEntry &activity);
+    void editPhaseEntry(const AgendaEntry &entry);
+    void editEventEntry(const AgendaEntry &entry);
     void dayChanged(const QDate &date);
 
 protected:

--- a/src/Gui/CalendarData.h
+++ b/src/Gui/CalendarData.h
@@ -35,6 +35,22 @@
 #define ENTRY_TYPE_OTHER 99
 
 
+struct AgendaEntry {
+    QString primary;
+    QStringList secondaryValues;
+    QStringList secondaryLabels;
+    QString tertiary;
+    QString iconFile;
+    QColor color;
+    QString reference;
+    QTime start;
+    int type = 0;
+    bool hasTrainMode = false;
+    QDate spanStart = QDate();
+    QDate spanEnd = QDate();
+};
+
+
 struct CalendarEntry {
     QString primary;
     QString secondary;
@@ -80,6 +96,7 @@ struct CalendarSummary {
     QList<std::pair<QString, QString>> keyValues;
 };
 
+Q_DECLARE_METATYPE(AgendaEntry)
 Q_DECLARE_METATYPE(CalendarEntry)
 Q_DECLARE_METATYPE(CalendarEntryLayout)
 Q_DECLARE_METATYPE(CalendarDay)

--- a/src/Gui/CalendarItemDelegates.h
+++ b/src/Gui/CalendarItemDelegates.h
@@ -239,18 +239,18 @@ class AgendaEntryDelegate : public QStyledItemDelegate {
     Q_OBJECT
 public:
     enum Roles {
-        EntryRole = Qt::UserRole, // [CalendarEntry] Entry to be displayed
-        EntryDateRole             // [bool] Date of the CalendarEntry
+        EntryRole = Qt::UserRole, // [AgendaEntry] Entry to be displayed
+        EntryDateRole             // [bool] Date of the AgendaEntry
     };
 
     struct Attributes {
         QMargins padding;                                         // Padding of the element
         QFont::Weight primaryWeight = QFont::Medium;              // Primary row
-        QFont::Weight primaryHoverWeight = QFont::DemiBold;       // Primary row (hovered)
-        QFont::Weight secondaryWeight = QFont::Light;             // Secondary row
-        QFont::Weight secondaryHoverWeight = QFont::DemiBold;     // Secondary row (hovered)
+        QFont::Weight primaryHoverWeight = QFont::Medium;         // Primary row (hovered)
+        QFont::Weight secondaryWeight = QFont::Medium;            // Secondary row
+        QFont::Weight secondaryHoverWeight = QFont::Medium;       // Secondary row (hovered)
         QFont::Weight secondaryMetricWeight = QFont::ExtraLight;  // Metric in the secondary row
-        QFont::Weight secondaryMetricHoverWeight = QFont::Normal; // Metric in the secondary row (hovered)
+        QFont::Weight secondaryMetricHoverWeight = QFont::ExtraLight; // Metric in the secondary row (hovered)
         int lineSpacing = 2;                                      // Vertical spacing between primary and secondary row (dpiYFactor not applied)
         int iconTextSpacing = 10;                                 // Horizontal spacing between icon and text (dpiXFactor not applied)
         float tertiaryDimLevel = 0.5;                             // Dimming amount for tertiary row

--- a/src/Gui/MetricSelect.cpp
+++ b/src/Gui/MetricSelect.cpp
@@ -199,6 +199,7 @@ MultiMetricSelector::MultiMetricSelector
 : QWidget(parent)
 {
     filterEdit = new QLineEdit();
+    filterEdit->setClearButtonEnabled(true);
     filterEdit->setPlaceholderText(tr("Filter..."));
 
     availList = new QListWidget();


### PR DESCRIPTION
Agenda used to display entries similar to the Calendar: Primary line for a field, secondary line for one metric, tertiary line for a multi-line field.
As the agenda has more space available per line, this change adds support for multiple metrics in the secondary line. Defaults are Duration and TriScore.