### PR TITLE
Updating power values of planned activities with linked workouts

### DIFF
--- a/src/Core/RideCache.h
+++ b/src/Core/RideCache.h
@@ -150,6 +150,9 @@ class RideCache : public QObject
         RideItem *getLinkedActivity(RideItem *item);
         RideItem *findSuggestion(RideItem *rideItem);
 
+        bool updateFromWorkout(RideItem *item, bool autoSave = false);
+        bool updateFromWorkoutAfter(const QDate &when, bool autoSave = false);
+
     public slots:
 
         // restore / dump cache to disk (json)

--- a/src/Gui/Calendar.cpp
+++ b/src/Gui/Calendar.cpp
@@ -205,7 +205,7 @@ CalendarBaseTable::buildContextMenu
             }
             if (entry.hasTrainMode) {
                 contextMenu->addSeparator();
-                contextMenu->addAction(tr("Show in train node..."), this, [this, entry]() { emit showInTrainMode(entry); });
+                contextMenu->addAction(tr("Show in train mode..."), this, [this, entry]() { emit showInTrainMode(entry); });
             }
             contextMenu->addSeparator();
             contextMenu->addAction(tr("Delete planned activity"), this, [this, entry]() { emit delActivity(entry); });

--- a/src/Gui/LTMSidebar.cpp
+++ b/src/Gui/LTMSidebar.cpp
@@ -26,6 +26,7 @@
 #include "Colors.h"
 #include "Units.h"
 #include "HelpWhatsThis.h"
+#include "ErgFile.h"
 
 #include "GcWindowRegistry.h" // for GcWinID types
 #include "Perspective.h" // for GcWindowDialog
@@ -329,7 +330,7 @@ LTMSidebar::presetSelectionChanged()
 }
 
 void
-LTMSidebar::configChanged(qint32)
+LTMSidebar::configChanged(qint32 why)
 {
     seasonsWidget->setStyleSheet(GCColor::stylesheet());
     eventsWidget->setStyleSheet(GCColor::stylesheet());
@@ -343,6 +344,9 @@ LTMSidebar::configChanged(qint32)
     // let everyone know what date range we are starting with
     dateRangeTreeWidgetSelectionChanged();
 
+    if (why & CONFIG_ZONES) {
+        context->athlete->rideCache->updateFromWorkoutAfter(QDate::currentDate(), true);
+    }
 }
 
 /*----------------------------------------------------------------------

--- a/src/Train/ErgFile.cpp
+++ b/src/Train/ErgFile.cpp
@@ -62,28 +62,38 @@ bool ErgFile::isWorkout(QString name)
     return false;
 }
 
-ErgFile::ErgFile(QString filename, ErgFileFormat mode, Context *context)
+ErgFile::ErgFile(QString filename, ErgFileFormat mode, Context *context, QDate when)
 : context(context)
 {
+    if (when.isValid()) {
+        this->when = when;
+    } else {
+        this->when = QDate::currentDate();
+    }
     this->filename(filename);
     this->mode(mode);
     strictGradient(true);
     fHasGPS(false);
     if (context->athlete->zones("Bike")) {
-        int zonerange = context->athlete->zones("Bike")->whichRange(QDateTime::currentDateTime().date());
+        int zonerange = context->athlete->zones("Bike")->whichRange(this->when);
         if (zonerange >= 0) CP(context->athlete->zones("Bike")->getCP(zonerange));
     }
     reload();
 }
 
-ErgFile::ErgFile(Context *context)
+ErgFile::ErgFile(Context *context, QDate when)
 : context(context)
 {
+    if (when.isValid()) {
+        this->when = when;
+    } else {
+        this->when = QDate::currentDate();
+    }
     mode(ErgFileFormat::unknown);
     strictGradient(true);
     fHasGPS(false);
     if (context->athlete->zones("Bike")) {
-        int zonerange = context->athlete->zones("Bike")->whichRange(QDateTime::currentDateTime().date());
+        int zonerange = context->athlete->zones("Bike")->whichRange(this->when);
         if (zonerange >= 0) CP(context->athlete->zones("Bike")->getCP(zonerange));
     } else {
         CP(300);
@@ -107,9 +117,9 @@ ErgFile::setFrom(ErgFile *f)
 }
 
 ErgFile *
-ErgFile::fromContent(QString contents, Context *context)
+ErgFile::fromContent(QString contents, Context *context, QDate when)
 {
-    ErgFile *p = new ErgFile(context);
+    ErgFile *p = new ErgFile(context, when);
 
     p->parseComputrainer(contents);
     p->finalize();
@@ -118,9 +128,9 @@ ErgFile::fromContent(QString contents, Context *context)
 }
 
 ErgFile *
-ErgFile::fromContent2(QString contents, Context *context)
+ErgFile::fromContent2(QString contents, Context *context, QDate when)
 {
-    ErgFile *p = new ErgFile(context);
+    ErgFile *p = new ErgFile(context, when);
 
     p->parseErg2(contents);
     p->finalize();
@@ -1235,7 +1245,7 @@ ErgFile::ZoneSections()
     QList<ErgFileZoneSection> ret;
 
     const Zones *zones = context->athlete->zones("Bike");
-    int zoneRange = zones->whichRange(QDate::currentDate());
+    int zoneRange = zones->whichRange(when);
     QList<QString> zoneNames = zones->getZoneNames(zoneRange);
     if (hasWatts() && duration() > 0) {
         for (int i = 0; i < Points.size() - 1; ++i) {
@@ -1302,7 +1312,7 @@ ErgFile::save(QStringList &errors)
     // get CP so we can scale back etc
     int lCP=0;
     if (context->athlete->zones("Bike")) {
-        int zonerange = context->athlete->zones("Bike")->whichRange(QDateTime::currentDateTime().date());
+        int zonerange = context->athlete->zones("Bike")->whichRange(when);
         if (zonerange >= 0) lCP = context->athlete->zones("Bike")->getCP(zonerange);
     }
 
@@ -1934,7 +1944,7 @@ ErgFile::calculateMetrics()
         bool first = true;
 
         // CP
-        int zonerange = context->athlete->zones("Bike")->whichRange(QDateTime::currentDateTime().date());
+        int zonerange = context->athlete->zones("Bike")->whichRange(when);
         if (context->athlete->zones("Bike")) {
             if (zonerange >= 0) CP(context->athlete->zones("Bike")->getCP(zonerange));
         }

--- a/src/Train/ErgFile.h
+++ b/src/Train/ErgFile.h
@@ -118,8 +118,8 @@ class ErgFileLap
 class ErgFile : public ErgFileBase
 {
     public:
-        ErgFile(QString, ErgFileFormat, Context *context);       // constructor uses filename
-        ErgFile(Context *context); // no filename, going to use a string
+        ErgFile(QString, ErgFileFormat, Context *context, QDate when = QDate());       // constructor uses filename
+        ErgFile(Context *context, QDate when = QDate()); // no filename, going to use a string
 
         ~ErgFile();             // delete the contents
 
@@ -128,8 +128,8 @@ class ErgFile : public ErgFileBase
         void setFrom(ErgFile *f); // clone an existing workout
         bool save(QStringList &errors); // save back, with changes
 
-        static ErgFile *fromContent(QString, Context *); // read from memory *.erg
-        static ErgFile *fromContent2(QString, Context *); // read from memory *.erg2
+        static ErgFile *fromContent(QString, Context *, QDate when = QDate()); // read from memory *.erg
+        static ErgFile *fromContent2(QString, Context *, QDate when = QDate()); // read from memory *.erg2
 
         static bool isWorkout(QString);  // is this a supported workout?
 
@@ -149,6 +149,8 @@ private:
         void sortTexts() const;
 
         bool coalescedSections = false;
+
+        QDate when;
 
 public:
         void coalesceSections();


### PR DESCRIPTION
* Updating power values of workout based planned activities when they fall into a timerange with different CP
* Triggers:
  * CP configuration changes (future activities only)
  * planned activities are moved (calendar)
  * schedules are repeated (calendar)
  * rest days are inserted or removed (calendar)
* Additional: Typo in Calendar (show in train _n_ode -> mode)