### PR TITLE
Fix the WebEngine data path warning

### DIFF
--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1981,6 +1981,11 @@ MainWindow::loadCompleted(QString name, Context *context)
     // clear splash - progress whilst loading tab
     //clearSplash();
 
+    // setup the WebEngine paths
+    QString temp = const_cast<AthleteDirectoryStructure*>(context->athlete->directoryStructure())->temp().absolutePath();
+    context->webEngineProfile->setCachePath(temp);
+    context->webEngineProfile->setPersistentStoragePath(temp);
+ 
     // first tab
     athletetabs.insert(currentAthleteTab->context->athlete->home->root().dirName(), currentAthleteTab);
 


### PR DESCRIPTION
PR to fix the warning discussed in:  https://groups.google.com/g/golden-cheetah-developers/c/MefPbOsAUns/m/2c_rofoHBgAJ

I have ensured the WebEngine paths are initialised for new Athletes in MainWindow::loadCompleted() , previously they were only initialised for the bootstrap athlete, this has removed the data path warning.