### PR TITLE
Athlete View's tiles functionality, plus removal of bootstrap athlete code

### DIFF
--- a/src/Charts/AgendaWindow.cpp
+++ b/src/Charts/AgendaWindow.cpp
@@ -519,6 +519,14 @@ AgendaWindow::getActivities
 (const QDate &firstDay, const QDate &today, const QDate &lastDay) const
 {
     QHash<QDate, QList<AgendaEntry>> activities;
+    if (! context || ! context->athlete || ! context->athlete->rideCache) {
+        return activities;
+    }
+    const QList<RideItem*> rides = context->athlete->rideCache->rides();
+    if (rides.isEmpty()) {
+        return activities;
+    }
+
     const RideMetricFactory &factory = RideMetricFactory::instance();
     QList<RideMetric const *> rideMetrics;
     QStringList rideMetricNames;
@@ -538,11 +546,15 @@ AgendaWindow::getActivities
     }
 
     int showTertiaryFor = getShowTertiaryFor();
-    for (RideItem *rideItem : context->athlete->rideCache->rides()) {
+    for (RideItem *rideItem : rides) {
         if (   rideItem == nullptr
-            || ! rideItem->planned
-            || rideItem->dateTime.date() < firstDay
-            || rideItem->dateTime.date() > lastDay
+            || ! rideItem->dateTime.isValid()) {
+            continue;
+        }
+        QDate rideDate = rideItem->dateTime.date();
+        if (   ! rideItem->planned
+            || rideDate < firstDay
+            || rideDate > lastDay
             || rideItem->hasLinkedActivity()) {
             continue;
         }
@@ -586,7 +598,7 @@ AgendaWindow::getActivities
             activity.secondaryValues << tr("N/A");
             activity.secondaryLabels << "";
         }
-        if (showTertiaryFor == 0 || (showTertiaryFor == 1 && rideItem->dateTime.date() == today)) {
+        if (showTertiaryFor == 0 || (showTertiaryFor == 1 && rideDate == today)) {
             activity.tertiary = rideItem->getText(getTertiaryField(), "").trimmed();
             activity.tertiary = Utils::unprotect(activity.tertiary);
         }
@@ -598,7 +610,7 @@ AgendaWindow::getActivities
         activity.start = rideItem->dateTime.time();
         activity.type = ENTRY_TYPE_PLANNED_ACTIVITY;
         activity.hasTrainMode = sport == "Bike" && ! buildWorkoutFilter(rideItem).isEmpty();
-        activities[rideItem->dateTime.date()] << activity;
+        activities[rideDate] << activity;
     }
     for (auto dayIt = activities.begin(); dayIt != activities.end(); ++dayIt) {
         std::sort(dayIt.value().begin(), dayIt.value().end(), [](const AgendaEntry &a, const AgendaEntry &b) {

--- a/src/Charts/AllPlotWindow.cpp
+++ b/src/Charts/AllPlotWindow.cpp
@@ -2049,7 +2049,7 @@ AllPlotWindow::setAllPlotWidgets(RideItem *ride)
             showCad->setEnabled(dataPresent->cad);
             showTorque->setEnabled(dataPresent->nm);
             showHr->setEnabled(dataPresent->hr);
-            showTcore->setEnabled(dataPresent->tcore);
+            showTcore->setEnabled(dataPresent->tcore || dataPresent->hr);
             showSpeed->setEnabled(dataPresent->kph);
             showAccel->setEnabled(dataPresent->kph);
             showAlt->setEnabled(dataPresent->alt);

--- a/src/Charts/CPPlot.cpp
+++ b/src/Charts/CPPlot.cpp
@@ -355,21 +355,21 @@ CPPlot::initModel()
         pdModel = NULL;
         break;
     case 1 : // 2 param
-        pdModel = new CP2Model(context);
+        pdModel = new CP2Model();
         break;
     case 2 : // 3 param
-        pdModel = new CP3Model(context);
+        pdModel = new CP3Model();
         static_cast<CP3Model*>(pdModel)->modelDecay = modelDecay;
         break;
     case 3 : // extended model
-        pdModel = new ExtendedModel(context);
+        pdModel = new ExtendedModel();
         break;
     case 4 : // multimodel
-        pdModel = new MultiModel(context);
+        pdModel = new MultiModel();
         pdModel->setVariant(modelVariant);
         break;
     case 5 : // ward smith
-        pdModel = new WSModel(context);
+        pdModel = new WSModel();
         pdModel->setVariant(modelVariant);
         break;
     }
@@ -890,20 +890,20 @@ CPPlot::plotModel(QVector<double> vector, QColor plotColor, PDModel *baseline)
     switch (model) {
 
     case 1 : // 2 param
-        pdmodel = new CP2Model(context);
+        pdmodel = new CP2Model();
         break;
     case 2 : // 3 param
-        pdmodel = new CP3Model(context);
+        pdmodel = new CP3Model();
         break;
     case 3 : // extended model
-        pdmodel = new ExtendedModel(context);
+        pdmodel = new ExtendedModel();
         break;
     case 4 : // multimodel
-        pdmodel = new MultiModel(context);
+        pdmodel = new MultiModel();
         pdmodel->setVariant(modelVariant);
         break;
     case 5 : // ward smith model
-        pdmodel = new WSModel(context);
+        pdmodel = new WSModel();
         pdmodel->setVariant(modelVariant);
         break;
     }
@@ -2751,20 +2751,20 @@ CPPlot::calculateForDateRanges(QList<CompareDateRange> compareDateRanges)
             // get a model
             switch (model) {
             case 1 : // 2 param
-                baselineModel = new CP2Model(context);
+                baselineModel = new CP2Model();
                 break;
             case 2 : // 3 param
-                baselineModel = new CP3Model(context);
+                baselineModel = new CP3Model();
                 break;
             case 3 : // extended model
-                baselineModel = new ExtendedModel(context);
+                baselineModel = new ExtendedModel();
                 break;
             case 4 : // multimodel
-                baselineModel = new MultiModel(context);
+                baselineModel = new MultiModel();
                 baselineModel->setVariant(modelVariant);
                 break;
             case 5 : // ward smith
-                baselineModel = new WSModel(context);
+                baselineModel = new WSModel();
                 baselineModel->setVariant(modelVariant);
                 break;
             }

--- a/src/Charts/CalendarWindow.cpp
+++ b/src/Charts/CalendarWindow.cpp
@@ -948,6 +948,15 @@ CalendarWindow::getActivities
 (const QDate &firstDay, const QDate &lastDay) const
 {
     QHash<QDate, QList<CalendarEntry>> activities;
+
+    if (! context || ! context->athlete || ! context->athlete->rideCache) {
+        return activities;
+    }
+    const QList<RideItem*> rides = context->athlete->rideCache->rides();
+    if (rides.isEmpty()) {
+        return activities;
+    }
+
     const RideMetricFactory &factory = RideMetricFactory::instance();
     const RideMetric *rideMetric = factory.rideMetric(getSecondaryMetric());
     QString rideMetricName;
@@ -960,10 +969,14 @@ CalendarWindow::getActivities
         }
     }
 
-    for (RideItem *rideItem : context->athlete->rideCache->rides()) {
-        if (   rideItem->dateTime.date() < firstDay
-            || rideItem->dateTime.date() > lastDay
-            || rideItem == nullptr) {
+    for (RideItem *rideItem : rides) {
+        if (   rideItem == nullptr
+            || ! rideItem->dateTime.isValid()) {
+            continue;
+        }
+        QDate rideDate = rideItem->dateTime.date();
+        if (   rideDate < firstDay
+            || rideDate > lastDay) {
             continue;
         }
         if (   (context->isfiltered && ! context->filters.contains(rideItem->fileName))
@@ -1011,7 +1024,7 @@ CalendarWindow::getActivities
         }
 
         RideItem *linkedRide = context->athlete->rideCache->getLinkedActivity(rideItem);
-        if (linkedRide != nullptr) {
+        if (linkedRide != nullptr && linkedRide->dateTime.isValid()) {
             activity.linkedReference = linkedRide->fileName;
             activity.linkedPrimary = getPrimary(linkedRide);
             activity.linkedStartDT = linkedRide->dateTime;
@@ -1020,7 +1033,7 @@ CalendarWindow::getActivities
             }
         }
 
-        activities[rideItem->dateTime.date()] << activity;
+        activities[rideDate] << activity;
     }
     for (auto dayIt = activities.begin(); dayIt != activities.end(); ++dayIt) {
         std::sort(dayIt.value().begin(), dayIt.value().end(), [](const CalendarEntry &a, const CalendarEntry &b) {

--- a/src/Charts/LTMPlot.cpp
+++ b/src/Charts/LTMPlot.cpp
@@ -68,11 +68,11 @@ LTMPlot::LTMPlot(LTMWindow *parent, Context *context, int position) :
     setAutoFillBackground(true);
 
     // set up the models we support
-    models << new CP2Model(context);
-    models << new CP3Model(context);
-    models << new MultiModel(context);
-    models << new ExtendedModel(context);
-    models << new WSModel(context);
+    models << new CP2Model();
+    models << new CP3Model();
+    models << new MultiModel();
+    models << new ExtendedModel();
+    models << new WSModel();
 
     // setup my axes
     // for now we limit to 4 on left and 4 on right

--- a/src/Charts/LTMTool.cpp
+++ b/src/Charts/LTMTool.cpp
@@ -1741,10 +1741,10 @@ EditMetricDetailDialog::EditMetricDetailDialog(Context *context, LTMTool *ltmToo
     estimateSelect = new QComboBox(this);
 
     // working with estimates, local utility functions
-    models << new CP2Model(context);
-    models << new CP3Model(context);
+    models << new CP2Model();
+    models << new CP3Model();
     //models << new MultiModel(context); disabled in v3.6
-    models << new ExtendedModel(context);
+    models << new ExtendedModel();
     //models << new WSModel(context); disabled in v3.6
     foreach(PDModel *model, models) {
         modelSelect->addItem(model->name(), model->code());

--- a/src/Charts/OverviewItems.cpp
+++ b/src/Charts/OverviewItems.cpp
@@ -5363,7 +5363,7 @@ ProgressBar::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
 
 }
 
-Button::Button(QGraphicsItem*parent, QString text) : QGraphicsItem(parent), text(text), state(None)
+Button::Button(QGraphicsItem*parent, QString text) : QGraphicsItem(parent), text(text), state(None), bkgdColor(GColor(CCARDBACKGROUND))
 {
     // not much really
     setZValue(11);
@@ -5386,7 +5386,7 @@ Button::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
     painter->setRenderHint(QPainter::Antialiasing);
 
     // button background
-    QColor pc = GCColor::invertColor(GColor(CCARDBACKGROUND));
+    QColor pc = GCColor::invertColor(bkgdColor);
     pc.setAlpha(64);
     QPen line(pc,gl_border, Qt::SolidLine);
     line.setJoinStyle(Qt::RoundJoin);
@@ -5397,7 +5397,7 @@ Button::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
         if (state==Clicked) hover.setAlpha(200);
         else hover.setAlpha(100);
         painter->setBrush(QBrush(hover));
-    } else painter->setBrush(QBrush(GColor(CCARDBACKGROUND)));
+    } else painter->setBrush(QBrush(bkgdColor));
     painter->drawRoundedRect(pos.x()+gl_border, pos.y()+gl_border, geom.width()-(gl_border*2), geom.height()-(gl_border*2), gl_radius, gl_radius);
 
     // text using large font clipped
@@ -5406,7 +5406,7 @@ Button::paint(QPainter*painter, const QStyleOptionGraphicsItem *, QWidget*)
         tc.setAlpha(200);
         painter->setPen(tc);
     } else {
-        QColor tc = GCColor::invertColor(GColor(CCARDBACKGROUND));
+        QColor tc = GCColor::invertColor(bkgdColor);
         tc.setAlpha(200);
         painter->setPen(tc);
     }

--- a/src/Charts/OverviewItems.h
+++ b/src/Charts/OverviewItems.h
@@ -26,6 +26,7 @@
 #include <QGraphicsItem>
 #include "MetadataDialog.h"
 #include "MetricOverrideDialog.h"
+#include "Colors.h"
 
 // qt charts for zone chart
 #include <QtCharts>
@@ -888,6 +889,8 @@ class Button : public QObject, public QGraphicsItem
 
         void setText(QString text) { this->text = text; update(); }
         void setFont(QFont font) { this->font = font; }
+        void setBkgdColor(const QColor& color) { bkgdColor = color; update(); }
+        void resetBkgdColor() { bkgdColor = GColor(CCARDBACKGROUND); update(); }
 
         // we monkey around with this *A LOT*
         void setGeometry(double x, double y, double width, double height);
@@ -912,6 +915,7 @@ class Button : public QObject, public QGraphicsItem
         QGraphicsItem *parent;
         QString text;
         QFont font;
+        QColor bkgdColor;
 
         QRectF geom;
         enum { None, Clicked } state;

--- a/src/Cloud/CloudService.cpp
+++ b/src/Cloud/CloudService.cpp
@@ -1748,6 +1748,10 @@ CloudServiceAutoDownload::checkDownload()
 void
 CloudServiceAutoDownload::run()
 {
+    // There are cases when athletes are opened and closed in quick succession that lead
+    // to the context becoming invalid, so we need to protect all uses of context.
+    if (!Context::isValid(context)) exit(0);
+
     // this is a separate thread and can run in parallel with the main gui
     // so we can loop through services and download the data needed.
     // we notify the main gui via the usual signals.
@@ -1755,6 +1759,7 @@ CloudServiceAutoDownload::run()
     // get a list of services to sync from
     QStringList worklist;
     foreach(QString name, CloudServiceFactory::instance().serviceNames()) {
+        if (!Context::isValid(context)) exit(0);
         if (appsettings->cvalue(context->athlete->cyclist, CloudServiceFactory::instance().service(name)->syncOnStartupSettingName(), "false").toString() == "true") {
             worklist << name;
         }
@@ -1766,13 +1771,14 @@ CloudServiceAutoDownload::run()
     if (worklist.count()) {
 
         // Start means we are looking for downloads to do
-        context->notifyAutoDownloadStart();
+        if (Context::isValid(context)) context->notifyAutoDownloadStart();
 
         // workthrough
         for(int i=0; i<worklist.count(); i++) {
 
             // instantiate
-            CloudService *service = CloudServiceFactory::instance().newService(worklist[i], context);
+            CloudService *service = (Context::isValid(context)) ? CloudServiceFactory::instance().newService(worklist[i], context) : nullptr;
+            if (service == nullptr) continue;
 
             // we want to trap received files
             connect(service, SIGNAL(readComplete(QByteArray*,QString,QString)), this, SLOT(readComplete(QByteArray*,QString,QString)));
@@ -1795,7 +1801,9 @@ CloudServiceAutoDownload::run()
 
                 Specification specification;
                 specification.setDateRange(DateRange(now.addDays(-30).date(), now.date()));
-                foreach(RideItem *item, context->athlete->rideCache->rides()) {
+
+                QVector<RideItem*> rides = (Context::isValid(context)) ? context->athlete->rideCache->rides() : QVector<RideItem*> {};
+                foreach(RideItem *item, rides) {
                     if (specification.pass(item))
                         rideFiles << QFileInfo(item->fileName).baseName().mid(0,16);
                 }
@@ -1861,7 +1869,7 @@ CloudServiceAutoDownload::run()
     for(int i=0; i<downloadlist.count(); i++) {
 
         // update progress indicator
-        context->notifyAutoDownloadProgress(downloadlist[i].provider->uiName(), progress, i, downloadlist.count());
+        if (Context::isValid(context)) context->notifyAutoDownloadProgress(downloadlist[i].provider->uiName(), progress, i, downloadlist.count());
 
         CloudServiceDownloadEntry download= downloadlist[i];
 
@@ -1882,14 +1890,16 @@ CloudServiceAutoDownload::run()
         progress += inc;
 
         // if last one we need to signal done.
-        if ((i+1) == downloadlist.count()) context->notifyAutoDownloadProgress(download.provider->uiName(), progress, i+1, downloadlist.count());
+        if ((i+1) == downloadlist.count()) {
+            if (Context::isValid(context)) context->notifyAutoDownloadProgress(download.provider->uiName(), progress, i+1, downloadlist.count());
+        }
     }
 
     // time to see completion
     sleep(3);
 
     // all done, close the sync notification, regardless of if anything was downloaded
-    context->notifyAutoDownloadEnd();
+    if (Context::isValid(context)) context->notifyAutoDownloadEnd();
 
     // remove providers
     foreach(CloudService *s, providers) {
@@ -1949,7 +1959,7 @@ CloudServiceAutoDownload::readComplete(QByteArray*data,QString name,QString)
                            .arg ( ridedatetime.time().minute(), 2, 10, zero )
                            .arg ( ridedatetime.time().second(), 2, 10, zero );
 
-    QString filename = context->athlete->home->activities().canonicalPath() + "/" + targetnosuffix + ".json";
+    QString filename = (Context::isValid(context)) ? context->athlete->home->activities().canonicalPath() + "/" + targetnosuffix + ".json" : "";
 
     // exists? -- totally should never happen unless readdir timestamp mismatches actual ride
     //            could happen if same file available at two services XXX should check above... XXX
@@ -1977,7 +1987,7 @@ CloudServiceAutoDownload::readComplete(QByteArray*data,QString name,QString)
     delete ride;
 
     // add to the ride list -- but don't select it
-    context->athlete->addRide(fileinfo.fileName(), true, false);
+    if (Context::isValid(context)) context->athlete->addRide(fileinfo.fileName(), true, false);
 
 }
 

--- a/src/Core/Athlete.cpp
+++ b/src/Core/Athlete.cpp
@@ -144,7 +144,6 @@ Athlete::Athlete(Context *context, const QDir &homeDir)
 
     // read athlete's autoimport configuration and initialize the autoimport process
     autoImportConfig = new RideAutoImportConfig(home->config());
-    autoImport = NULL;
 
     // Search / filter
     namedSearches = new NamedSearches(this); // must be before navigator
@@ -259,7 +258,6 @@ Athlete::~Athlete()
     foreach (HrZones* hrzones, hrzones_) delete hrzones;
     for (int i=0; i<2; i++) delete pacezones_[i];
     delete autoImportConfig;
-    delete autoImport;
 
 }
 
@@ -371,15 +369,17 @@ Athlete::configChanged(qint32 state)
 void
 Athlete::importFilesWhenOpeningAthlete() {
 
-    autoImport = NULL;
     // just do it if something is configured
     if (autoImportConfig->hasRules()) {
 
-        autoImport = new RideImportWizard(autoImportConfig, context);
+        // memory deleted on closure by Qt::WA_DeleteOnClose attribute
+        RideImportWizard* autoImport = new RideImportWizard(autoImportConfig, context);
 
         // only process the popup if we have any files available at all
-        if ( autoImport->getNumberOfFiles() > 0) {
+        if (autoImport->getNumberOfFiles() > 0) {
            autoImport->process();
+        } else {
+            autoImport->close();
         }
     }
 }

--- a/src/Core/Athlete.h
+++ b/src/Core/Athlete.h
@@ -126,7 +126,6 @@ class Athlete : public QObject
 #endif
 
         // Athlete's autoimport handling
-        RideImportWizard *autoImport;
         RideAutoImportConfig *autoImportConfig;
 
         // preset charts

--- a/src/Core/Context.cpp
+++ b/src/Core/Context.cpp
@@ -140,17 +140,26 @@ GlobalContext::userMetricsConfigChanged()
 
 bool Context::isValid(Context *p) { return p != NULL &&_contexts.contains(p); }
 
-Context::Context(MainWindow *mainWindow): mainWindow(mainWindow)
+Context::Context(MainWindow *mainWindow)
+    : mainWindow(mainWindow), nav(nullptr), rideNavigator(nullptr), tab(nullptr),
+      athlete(nullptr), ride(nullptr), season(nullptr), workout(nullptr), videosync(nullptr),
+      now(0) 
 {
-    ride = NULL;
-    workout = NULL;
-    videosync = NULL;
-    isfiltered = ishomefiltered = false;
-    isCompareIntervals = isCompareDateRanges = false;
-    isRunning = isPaused = false;
+    // mainwindow state
     viewType = GcViewType::NO_VIEW_SET;
+    showSidebar = showLowbar = false;
+    showToolbar = true;
+    style = 2;
+    scopehighlighted = false;
 
-    connect(this, SIGNAL(loadProgress(QString, double)), mainWindow, SLOT(loadProgress(QString, double)));
+    // search filter
+    isfiltered = ishomefiltered = false;
+
+    // train mode state
+    isRunning = isPaused = false;
+
+    // comparing things
+    isCompareIntervals = isCompareDateRanges = false;
 
 #ifdef GC_HAS_CLOUD_DB
     cdbChartListDialog = NULL;

--- a/src/Core/Context.cpp
+++ b/src/Core/Context.cpp
@@ -143,7 +143,7 @@ bool Context::isValid(Context *p) { return p != NULL &&_contexts.contains(p); }
 Context::Context(MainWindow *mainWindow)
     : mainWindow(mainWindow), nav(nullptr), rideNavigator(nullptr), tab(nullptr),
       athlete(nullptr), ride(nullptr), season(nullptr), workout(nullptr), videosync(nullptr),
-      now(0) 
+      now(0), activityImportInProgress(0)
 {
     // mainwindow state
     viewType = GcViewType::NO_VIEW_SET;

--- a/src/Core/Context.cpp
+++ b/src/Core/Context.cpp
@@ -147,9 +147,7 @@ Context::Context(MainWindow *mainWindow)
 {
     // mainwindow state
     viewType = GcViewType::NO_VIEW_SET;
-    showSidebar = showLowbar = false;
     showToolbar = true;
-    style = 2;
     scopehighlighted = false;
 
     // search filter

--- a/src/Core/Context.h
+++ b/src/Core/Context.h
@@ -97,8 +97,15 @@ class GlobalContext : public QObject
         void readConfig(qint32);
         void userMetricsConfigChanged();
 
+        void notifyStart() { emit start(); }
+        void notifyStop() { emit stop(); }
+
     signals:
         void configChanged(qint32); // for global widgets that aren't athlete specific
+
+        // realtime signals global widgets that aren't athlete specific
+        void start();
+        void stop();
 
     private:
         // singleton pattern
@@ -122,7 +129,7 @@ class Context : public QObject
         // mainwindow state
         NavigationModel *nav;
         GcViewType viewType;
-        bool showSidebar, showLowbar, showToolbar, showTabbar;
+        bool showSidebar, showLowbar, showToolbar;
         int style;
         QString searchText;
         QString workoutFilterText;
@@ -141,7 +148,7 @@ class Context : public QObject
         Athlete *athlete;
         RideItem *ride;  // the currently selected ride
         DateRange dr_;
-        Season const *season = nullptr;
+        Season const *season;
         ErgFile *workout; // the currently selected workout file
         VideoSyncFile *videosync; // the currently selected videosync file
         QString videoFilename;
@@ -222,10 +229,10 @@ class Context : public QObject
         void notifySetNow(long x) { now = x; setNow(x); }
         long getNow() { return now; }
         void notifyNewLap() { emit newLap(); }
-        void notifyStart() { emit start(); }
+        void notifyStart() { GlobalContext::context()->notifyStart(); emit start(); }
         void notifyUnPause() { emit unpause(); }
         void notifyPause() { emit pause(); }
-        void notifyStop() { emit stop(); }
+        void notifyStop() { GlobalContext::context()->notifyStop(); emit stop(); }
         void notifySeek(long x) { emit seek(x); }
         void notifyIntensityChanged(int intensity) { emit intensityChanged(intensity); };
 

--- a/src/Core/Context.h
+++ b/src/Core/Context.h
@@ -129,8 +129,7 @@ class Context : public QObject
         // mainwindow state
         NavigationModel *nav;
         GcViewType viewType;
-        bool showSidebar, showLowbar, showToolbar;
-        int style;
+        bool showToolbar;
         QString searchText;
         QString workoutFilterText;
         bool scopehighlighted;

--- a/src/Core/Context.h
+++ b/src/Core/Context.h
@@ -152,6 +152,7 @@ class Context : public QObject
         VideoSyncFile *videosync; // the currently selected videosync file
         QString videoFilename;
         long now; // point in time during train session
+        unsigned int activityImportInProgress;
 
         // search filter
         bool isfiltered;

--- a/src/Core/DataFilter.h
+++ b/src/Core/DataFilter.h
@@ -221,6 +221,8 @@ class DataFilter : public QObject
         DataFilter(QObject *parent, Context *context, QString formula);
         ~DataFilter() { clearFilter(); }
 
+        void setContext(Context *con);
+
         // runtime passed by datafilter
         DataFilterRuntime rt;
         QObject *parent() { return parent_; }
@@ -248,7 +250,7 @@ class DataFilter : public QObject
         void colorSyntax(QTextDocument *content, int pos);
 
         static QStringList completerList(Context *, bool); // return list of names for auto-completers
-        static QStringList builtins(Context *); // return list of functions supported
+        static QStringList builtins(); // return list of functions supported
 
         int refcount; // used by user metrics
 

--- a/src/Core/ICalendar.cpp
+++ b/src/Core/ICalendar.cpp
@@ -164,7 +164,7 @@ static QDateTime propertyToDate(icalproperty *p)
     }
 }
 
-ICalendar::ICalendar(Context *context) : QWidget(context->mainWindow), context(context)
+ICalendar::ICalendar(Context *context) : QObject(context->mainWindow), context(context)
 {
     // get from local and remote calendar
 

--- a/src/Core/ICalendar.h
+++ b/src/Core/ICalendar.h
@@ -20,12 +20,12 @@
 #define _GC_ICalendar_h 1
 #include "GoldenCheetah.h"
 
-#include <QtGui>
+#include <QObject>
 #include "Context.h"
 #include "RideMetric.h"
 #include <libical/ical.h>
 
-class ICalendar : public QWidget
+class ICalendar : public QObject
 {
     Q_OBJECT
     G_OBJECT

--- a/src/Core/NamedSearch.cpp
+++ b/src/Core/NamedSearch.cpp
@@ -201,7 +201,7 @@ NamedSearchParser::serialize(QString filename, QList<NamedSearch>NamedSearches)
         msgBox.setInformativeText(QObject::tr("File: %1 cannot be opened for 'Writing'. Please check file properties.").arg(filename));
         msgBox.exec();
         return false;
-    };
+    }
     file.resize(0);
     QTextStream out(&file);
 
@@ -259,7 +259,7 @@ EditNamedSearches::EditNamedSearches(QWidget *parent, Context *context) : QDialo
     layout->addLayout(row2);
     QLabel *filter = new QLabel(tr("Filter"), this);
     row2->addWidget(filter);
-    editSearch = new SearchBox(context, this, true);
+    editSearch = new SearchBox(this, context);
     row2->addWidget(editSearch);
 
     // add/update buttons

--- a/src/Core/RideCache.cpp
+++ b/src/Core/RideCache.cpp
@@ -474,7 +474,7 @@ RideCache::writeAsCSV(QString filename)
         msgBox.setInformativeText(tr("File: %1 cannot be opened for 'Writing'. Please check file properties.").arg(filename));
         msgBox.exec();
         return;
-    };
+    }
     file.resize(0);
     QTextStream out(&file);
 

--- a/src/Core/TimeUtils.cpp
+++ b/src/Core/TimeUtils.cpp
@@ -189,7 +189,7 @@ QDateTime convertToLocalTime(QString timestamp)
     return QDateTime::fromString(timestamp);
 }
 
-DateRange::DateRange(QDate from, QDate to, QString name, QColor color) : QObject()
+DateRange::DateRange(QDate from, QDate to, QString name, QColor color)
 {
     this->from=from;
     this->to=to;
@@ -198,7 +198,7 @@ DateRange::DateRange(QDate from, QDate to, QString name, QColor color) : QObject
     valid = from.isValid() && to.isValid();
 }
 
-DateRange::DateRange(const DateRange &other) : QObject()
+DateRange::DateRange(const DateRange &other)
 {
     from=other.from;
     to=other.to;
@@ -215,7 +215,6 @@ DateRange& DateRange::operator=(const DateRange &other)
     name=other.name;
     color=other.color;
     valid = from.isValid() && to.isValid();
-    emit changed(from, to);
 
     return *this;
 }

--- a/src/Core/TimeUtils.h
+++ b/src/Core/TimeUtils.h
@@ -49,10 +49,8 @@ extern ShowDaysAsUnit showDaysAs(int days);
 */
 QDateTime convertToLocalTime(QString timestamp);
 
-class DateRange : QObject
+class DateRange
 {
-    Q_OBJECT
-
     public:
         DateRange(const DateRange& other);
         DateRange(QDate from = QDate(), QDate to = QDate(), QString name ="", QColor=QColor(127,127,127));
@@ -81,14 +79,9 @@ class DateRange : QObject
         }
         bool isValid() const { return valid; }
 
-
-    Q_SIGNALS:
-        void changed(QDate from, QDate to);
-
     protected:
         bool valid;
 };
-Q_DECLARE_METATYPE(DateRange)
 
 class DateSettingsEdit : public QWidget
 {

--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -720,12 +720,12 @@ main(int argc, char *argv[])
                     appsettings->initializeQSettingsAthlete(homeDir, cyclist);
                     GcUpgrade v3;
                     if (v3.upgradeConfirmedByUser(home)) {
-                        MainWindow *mainWindow = new MainWindow(home);
-                        mainWindow->show();
-                        mainWindow->ridesAutoImport();
-                        gc_opened++;
+                        MainWindow *mainWindow = new MainWindow();
+                        if (mainWindow->openAthleteTab(cyclist)) {
+                            gc_opened++;
+                            anyOpened = true;
+                        }
                         home.cdUp();
-                        anyOpened = true;
                     } else {
                         delete trainDB;
                         terminate(0);
@@ -759,10 +759,8 @@ main(int argc, char *argv[])
             // .. and open a mainwindow
             GcUpgrade v3;
             if (v3.upgradeConfirmedByUser(home)) {
-                MainWindow *mainWindow = new MainWindow(home);
-                mainWindow->show();
-                mainWindow->ridesAutoImport();
-                gc_opened++;
+                MainWindow *mainWindow = new MainWindow();
+                if (mainWindow->openAthleteTab(home.dirName())) gc_opened++;
             } else {
                 delete trainDB;
                 terminate(0);

--- a/src/Gui/AbstractView.cpp
+++ b/src/Gui/AbstractView.cpp
@@ -304,7 +304,7 @@ AbstractView::saveState()
         msgBox.setInformativeText(tr("File: %1 cannot be opened for 'Writing'. Please check file properties.").arg(filename));
         msgBox.exec();
         return;
-    };
+    }
     file.resize(0);
     QTextStream out(&file);
 

--- a/src/Gui/AthleteTab.h
+++ b/src/Gui/AthleteTab.h
@@ -141,4 +141,4 @@ class ProgressLine : public QWidget
     private:
         Context *context;
 };
-#endif // _GC_TabView_h
+#endif // _GC_Tab_h

--- a/src/Gui/AthleteView.cpp
+++ b/src/Gui/AthleteView.cpp
@@ -196,6 +196,20 @@ AthleteView::configItem(ChartSpaceItem *item, QPoint)
     card->configAthlete();
 }
 
+bool
+AthleteView::clickOverride(ChartSpaceItem *item, QGraphicsSceneMouseEvent* event)
+{
+    // is the click within the athlete card's override region?
+    if (static_cast<AthleteCard*>(item)->clickWithinAthleteSwitchRegion(event->scenePos())) {
+
+        // if the athlete is open, then switch
+        if (static_cast<AthleteCard*>(item)->isAthleteOpen()) {
+            mainWindow_->switchAthleteTab(item->name);
+        }
+        return true; // the click was within the override region
+    }
+    return false; // the click was outside the override region
+}
 
 AthleteCard::AthleteCard(ChartSpace *parent, QString name) :
     ChartSpaceItem(parent, name),loadProgress_(0), context_(NULL), refresh_(false), actualActivities(0),
@@ -312,6 +326,16 @@ AthleteCard::refreshStats(RideItem * /* item = nullptr */ )
     }
 }
 
+bool
+AthleteCard::clickWithinAthleteSwitchRegion(const QPointF& scenePos)
+{
+    QPointF click(scenePos.x()-geometry().x(), scenePos.y()-geometry().y());
+
+    QRectF avatarImg(ROWHEIGHT,ROWHEIGHT*2,ROWHEIGHT* gl_avatar_width, ROWHEIGHT* gl_avatar_width);
+
+    return (avatarImg.contains(click));
+}
+
 void
 AthleteCard::setCurrentAthlete(bool status)
 {
@@ -325,9 +349,7 @@ AthleteCard::setCurrentAthlete(bool status)
     backupButton->setBkgdColor(cardBkgdColor);
     deleteButton->setBkgdColor(cardBkgdColor);
 
-    if ((currentAthlete_) && (static_cast<AthleteView*>(parent)->openAthletes() == 1)) {  // current athlete must be loaded
-        openCloseButton->setText((unsavedActivities != 0) ? tr("Shutdown...") : tr("Shutdown"));
-    } else if (loadProgress_ == 0) {
+    if (loadProgress_ == 0) {
         openCloseButton->setText(tr("Open"));
     } else if (loadProgress_ == 100) {
         openCloseButton->setText((unsavedActivities != 0) ? tr("Close...") : tr("Close"));

--- a/src/Gui/AthleteView.h
+++ b/src/Gui/AthleteView.h
@@ -1,22 +1,53 @@
+/*
+ * Copyright (c) 2020 Mark Liversedge <liversedge@gmail.com>
+ * Additional functionality Copyright (c) 2026 Paul Johnson (paulj49457@gmail.com)
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the Free
+ * Software Foundation; either version 2 of the License, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc., 51
+ * Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ */
+
 #include "ChartSpace.h"
 #include "OverviewItems.h"
 #include <QPoint>
+
+class AthleteCard;
 
 class AthleteView : public ChartSpace
 {
     Q_OBJECT
 
-public:
-    AthleteView(Context *context);
+        friend AthleteCard;
 
-public slots:
+public:
+    // only mainWindow is used from the provided context in AthleteView & ChartSpace
+    AthleteView(Context *mainWindowContext);
+
+protected:
+
+    MainWindow* mainWindow_;
+
+    uint32_t openAthletes();
+
+protected slots:
+
     void configChanged(qint32);
     void configItem(ChartSpaceItem*, QPoint);
     void newAthlete(QString);
     void deleteAthlete(QString);
-
-private:
-    int row, col;
+    void openingAthlete(QString, Context*);
+    void closingAthlete(QString, Context*);
+    void currentAthlete(QString name);
 };
 
 // the athlete display
@@ -24,27 +55,35 @@ class AthleteCard : public ChartSpaceItem
 {
     Q_OBJECT
 
+        friend AthleteView;
+
     public:
 
-        AthleteCard(ChartSpace *parent, QString path);
-
-        void itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget *);
-        void dragChanged(bool);
-        void itemGeometryChanged();
-        void setData(RideItem *) {}
-        void setDateRange(DateRange) {}
-        QWidget *config() { return new OverviewItemConfig(this); }
-
-        // refresh stats on last workouts etc
-        void refreshStats();
+        AthleteCard(ChartSpace *parent, QString name);
 
         // create and config
         static ChartSpaceItem *create(ChartSpace *parent) { return new AthleteCard(parent, ""); }
 
-    public slots:
-        // opening/closing etc
-        void opening(QString, Context*);
-        void closing(QString, Context*);
+    protected:
+
+        void itemPaint(QPainter *painter, const QStyleOptionGraphicsItem *, QWidget *);
+        void dragChanged(bool) override;
+        void itemGeometryChanged() override;
+        void setData(RideItem *) override {}
+        void setDateRange(DateRange) override {}
+        void configChanged(qint32) override;
+        QWidget *config() { return new OverviewItemConfig(this); }
+
+        void configAthlete();
+        bool isAthleteClosed() const { return loadProgress_ == 0; }
+        void openingAthlete(QString, Context*);
+        void closingAthlete(QString, Context*);
+
+        // accessible via AthleteView equivalents
+        void setCurrentAthlete(bool status);
+
+    protected slots:
+
         void loadProgress(QString, double);
         void loadDone(QString, Context*);
 
@@ -53,21 +92,29 @@ class AthleteCard : public ChartSpaceItem
         void refreshEnd();
         void refreshUpdate(QDate);
 
-        void clicked();
-        void configAthlete();
+        // refresh stats on last workouts etc
+        void refreshStats(RideItem * item = nullptr);
+
+        void openCloseAthlete();
 
     private:
-        double loadprogress;
-        Context *context;
-        QString path;
+        double loadProgress_; // 0=closed, 100=open, otherwise loading
+        Context *context_; // nullptr when the athlete is closed
         QImage avatar;
-        Button *button;
 
-        bool anchor; // holds app context so not allowed to close it
+        Button *openCloseButton;
+        Button *deleteButton;
+        Button *backupButton;
+        Button *saveAllUnsavedRidesButton;
 
-        // little graph of last 90 days
-        int count; // total activities
-        QDateTime last; // date of last activity recorded
-        bool refresh;
+        bool refresh_;
+        int actualActivities; // total actual activities
+        int plannedActivities; // total planned activities
+        int unsavedActivities; // number of unsaved activities
+        QDateTime lastActivity; // date of last activity recorded
+
+        bool currentAthlete_;
+
+        void registerRideEvents(bool enable);
 };
 

--- a/src/Gui/AthleteView.h
+++ b/src/Gui/AthleteView.h
@@ -39,6 +39,8 @@ protected:
 
     uint32_t openAthletes();
 
+    bool clickOverride(ChartSpaceItem*, QGraphicsSceneMouseEvent*) override;
+
 protected slots:
 
     void configChanged(qint32);
@@ -76,8 +78,11 @@ class AthleteCard : public ChartSpaceItem
 
         void configAthlete();
         bool isAthleteClosed() const { return loadProgress_ == 0; }
+        bool isAthleteOpen() const { return loadProgress_ == 100; }
         void openingAthlete(QString, Context*);
         void closingAthlete(QString, Context*);
+
+        bool clickWithinAthleteSwitchRegion(const QPointF& scenePos);
 
         // accessible via AthleteView equivalents
         void setCurrentAthlete(bool status);

--- a/src/Gui/Calendar.cpp
+++ b/src/Gui/Calendar.cpp
@@ -2350,6 +2350,9 @@ void
 Calendar::activateDateRange
 (const DateRange &dr, bool allowKeepMonth, bool canHavePhasesOrEvents)
 {
+    if (dateRange == dr) {
+        return;
+    }
     QDate currentDate = selectedDate();
     dateRange = dr;
     monthView->limitDateRange(dr, allowKeepMonth, canHavePhasesOrEvents);

--- a/src/Gui/ChartSpace.cpp
+++ b/src/Gui/ChartSpace.cpp
@@ -52,7 +52,7 @@ ChartSpace::ChartSpace(Context *context, OverviewScope scope, GcWindow *window) 
 
     // add a view and scene and centre
     scene = new QGraphicsScene(this);
-    view = new GGraphicsView(context, this);
+    view = new GGraphicsView(context->mainWindow, this);
 
     view->viewport()->setAttribute(Qt::WA_AcceptTouchEvents, false); // stops it stealing focus on mouseover
     scrollbar = new QScrollBar(Qt::Vertical, this);
@@ -88,7 +88,12 @@ ChartSpace::ChartSpace(Context *context, OverviewScope scope, GcWindow *window) 
     scene->installEventFilter(this);
 
     // once all widgets created we can connect the signals
-    connect(context, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));
+    if (context->athlete) {
+        connect(context, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));
+    } else {
+        // as no athlete exists within the context, register a global configChanged signal registration instead 
+        connect(GlobalContext::context(), &GlobalContext::configChanged, this, &ChartSpace::configChanged);
+    }
     connect(scroller, SIGNAL(finished()), this, SLOT(scrollFinished()));
     connect(scrollbar, SIGNAL(valueChanged(int)), this, SLOT(scrollbarMoved(int)));
 

--- a/src/Gui/ChartSpace.cpp
+++ b/src/Gui/ChartSpace.cpp
@@ -1012,8 +1012,13 @@ ChartSpace::eventFilter(QObject *, QEvent *event)
                double offx = pos.x()-item->geometry().x();
                double offy = pos.y()-item->geometry().y();
 
+               if (clickOverride(item, static_cast<QGraphicsSceneMouseEvent*>(event))) {
 
-               if (item->geometry().height()-offy < (gl_near*dpiXFactor)) {
+                    // thanks we'll take that
+                    event->accept();
+                    returning = true;
+
+               } else if (item->geometry().height()-offy < (gl_near*dpiXFactor)) {
 
                     // We can span resize a specific chartspaceitem
                     // by pressing SHIFT when we click

--- a/src/Gui/ChartSpace.h
+++ b/src/Gui/ChartSpace.h
@@ -66,18 +66,18 @@ inline constexpr bool operator&(OverviewScope Lhs, OverviewScope Rhs) {
 class GGraphicsView : public QGraphicsView
 {
     public:
-        GGraphicsView(Context *context, QWidget *parent) : QGraphicsView(parent), context(context) {
+        GGraphicsView(MainWindow *mainWindow, QWidget *parent) : QGraphicsView(parent), mainWindow_(mainWindow) {
             setAcceptDrops(true);
         }
 
     protected:
-        void dragEnterEvent(QDragEnterEvent *event) { context->mainWindow->dragEnterEvent(event); }
-        void dragLeaveEvent(QDragLeaveEvent *event) { context->mainWindow->dragLeaveEvent(event); }
-        void dropEvent(QDropEvent *event) { context->mainWindow->dropEvent(event); }
-        void dragMoveEvent(QDragMoveEvent *event) { context->mainWindow->dragMoveEvent(event); }
+        void dragEnterEvent(QDragEnterEvent *event) { mainWindow_->dragEnterEvent(event); }
+        void dragLeaveEvent(QDragLeaveEvent *event) { mainWindow_->dragLeaveEvent(event); }
+        void dropEvent(QDropEvent *event) { mainWindow_->dropEvent(event); }
+        void dragMoveEvent(QDragMoveEvent *event) { mainWindow_->dragMoveEvent(event); }
 
     private:
-        Context *context;
+        MainWindow *mainWindow_;
 };
 
 // must be subclassed to add items to a ChartSpace

--- a/src/Gui/ChartSpace.h
+++ b/src/Gui/ChartSpace.h
@@ -324,6 +324,8 @@ class ChartSpace : public QWidget
         // process events
         bool eventFilter(QObject *, QEvent *event);
 
+        virtual bool clickOverride(ChartSpaceItem*, QGraphicsSceneMouseEvent*) { return false; }
+
     private:
 
         // gui setup

--- a/src/Gui/LTMSidebar.cpp
+++ b/src/Gui/LTMSidebar.cpp
@@ -61,8 +61,9 @@
 #include "RideMetadata.h"
 #include "SpecialFields.h"
 
-
-LTMSidebar::LTMSidebar(Context *context) : QWidget(context->mainWindow), context(context), active(false),
+// initially create LTMSidebar without a parent widget, the first display
+// of a view (trends, plan) will attach LTMSidebar's mainLayout to the view.
+LTMSidebar::LTMSidebar(Context *context) : QWidget(nullptr), context(context), active(false),
                                            isqueryfilter(false), isautofilter(false)
 {
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
@@ -590,7 +591,6 @@ LTMSidebar::buildDateRangeMenu
         menu.addAction(tr("Add season") % ellipsis, this, &LTMSidebar::addRange);
     } else if (isPhase) {
         QString seasonName = season->getName();
-        const int maxLength = 30;
         menu.addAction(tr("Edit phase") % ellipsis, this, &LTMSidebar::editRange);
         menu.addAction(tr("Delete phase"), this, &LTMSidebar::deleteRange);
         menu.addSeparator();

--- a/src/Gui/LTMSidebar.cpp
+++ b/src/Gui/LTMSidebar.cpp
@@ -400,6 +400,9 @@ LTMSidebar::dateRangeTreeWidgetSelectionChanged()
                 phase = NULL;
             }
         } else if (which->type() >= Phase::phase) {
+            if (which->parent() == nullptr) {
+                return;
+            }
             int seasonIdx = allDateRanges->indexOfChild(which->parent());
             int phaseIdx = which->parent()->indexOfChild(which);
             if (which != allDateRanges) {
@@ -492,7 +495,7 @@ LTMSidebar::resetSeasons()
                 addSeason->setExpanded(true);
                 addPhase->setSelected(true);
             }
-            addPhase->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsDragEnabled);
+            addPhase->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
             addPhase->setText(0, phase.getName());
         }
 
@@ -1091,6 +1094,14 @@ LTMSidebar::deleteFilter()
 void
 LTMSidebar::dateRangeMoved(QTreeWidgetItem*item, int oldposition, int newposition)
 {
+    if (   oldposition < 0
+        || oldposition >= seasons->seasons.count()
+        || newposition < 0
+        || newposition >= seasons->seasons.count()) {
+        return;
+    }
+    QSignalBlocker blocker(dateRangeTree);
+
     // report the move in the seasons
     seasons->seasons.move(oldposition, newposition);
 
@@ -1100,9 +1111,15 @@ LTMSidebar::dateRangeMoved(QTreeWidgetItem*item, int oldposition, int newpositio
     active = false;
 
     // deselect actual selection
-    dateRangeTree->selectedItems().first()->setSelected(false);
+    dateRangeTree->clearSelection();
     // select the move/drop item
-    item->setSelected(true);
+    if (item) {
+        item->setSelected(true);
+        dateRangeTree->setCurrentItem(item);
+    }
+
+    blocker.unblock();
+    dateRangeTreeWidgetSelectionChanged();
 }
 
 void
@@ -1123,11 +1140,22 @@ LTMSidebar::addRange()
             newOne.setAbsoluteEnd(temp);
         }
 
+        // Ensure the current season is nullptr during creation of the new season
+        // to prevent usage of a dangling pointer (see comment #ref1# below)
+        context->notifySeasonChanged(nullptr);
+
         // save
         seasons->seasons.insert(0, newOne);
         seasons->writeSeasons();
         active = false;
 
+        if (seasons->seasons.count() > 0) {
+            // #ref1#
+            // Ensure the pointer to the season is guaranteed to be valid if the
+            // QList<Season> (Seasons::seasons) was reorganized during insertion
+            // and its objects were relocated
+            context->notifySeasonChanged(&seasons->seasons[0]);
+        }
         // signal its changed!
         resetSeasons();
     }
@@ -1426,7 +1454,7 @@ LTMSidebar::addPhase()
 
         QTreeWidgetItem *addPhase = new QTreeWidgetItem(selectedDateRange, myphase.getType());
         addPhase->setSelected(true);
-        addPhase->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled | Qt::ItemIsDragEnabled);
+        addPhase->setFlags(Qt::ItemIsSelectable | Qt::ItemIsEnabled);
         addPhase->setText(0, myphase.getName());
 
         // save changes away

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1005,13 +1005,15 @@ MainWindow::closeEvent(QCloseEvent* event)
     QGuiApplication::setOverrideCursor(Qt::WaitCursor);
     bool importRunningOrUnsaved(false);
 
-    // close all the tabs without changing positions, if any refuse we need to ignore the close event
+    // if the closure is due to main menu quit or the window decoration close X button, then there will be athlete's to
+    // close, so close them without changing their positions and without updating the last open athlete,
+    // if any refuse we need to ignore the close event
     for(int i=tabbar->count()-1; i > -1; i--) {
 
         QGuiApplication::restoreOverrideCursor();
 
         if (checkImportAndUnsaved(i)) {
-            removeAthleteTab(tabList[i]);
+            removeAthleteTab(tabList[i], false); // don't update the last open athlete
         } else {
             importRunningOrUnsaved = true;
         }
@@ -2056,7 +2058,7 @@ MainWindow::checkImportAndUnsaved(int index)
 
 // no questions asked just wipe away the current tab
 void
-MainWindow::removeAthleteTab(AthleteTab *tab)
+MainWindow::removeAthleteTab(AthleteTab *tab, bool updateLastAthlete /* = true */)
 {
     blockTabbarUpdates = true;
 
@@ -2090,7 +2092,7 @@ MainWindow::removeAthleteTab(AthleteTab *tab)
         // if this is not the last athlete and we are removing the current 
         // athlete tab then we need to select another athlete
         if ((tabList.count() > 1) && (tab == currentAthleteTab)) {
-            switchAthleteTab((index == 0) ? index+1 : index-1);
+            switchAthleteTab((index == 0) ? index+1 : index-1, updateLastAthlete);
         }
     }
  
@@ -2309,7 +2311,7 @@ MainWindow::switchAthleteTab(QString name)
 }
 
 void
-MainWindow::switchAthleteTab(int index)
+MainWindow::switchAthleteTab(int index, bool updateLastAthlete /* = true */)
 {
     if (index < 0) return;
 
@@ -2337,8 +2339,8 @@ MainWindow::switchAthleteTab(int index)
     // restore new athlete's settings
     restoreGCState(currentAthleteTab->context);
 
-    // store "last_openend" athlete for next time
-    appsettings->setValue(GC_SETTINGS_LAST, currentAthleteTab->context->athlete->cyclist);
+    // store the new athlete as the "last_openend" athlete for next time
+    if (updateLastAthlete) appsettings->setValue(GC_SETTINGS_LAST, currentAthleteTab->context->athlete->cyclist);
 
     // refresh the athlete's card button labels
     emit currentAthlete(currentAthleteTab->context->athlete->cyclist);

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -1,6 +1,7 @@
 /*
  * Copyright (c) 2006 Sean C. Rhea (srhea@srhea.net)
  * Copyright (c) 2013 Mark Liversedge (liversedge@gmail.com)
+ * Remove Bootstrap Athlete Copyright (c) 2026 Paul Johnson (paulj49457@gmail.com)
  *
  * This program is free software; you can redistribute it and/or modify it
  * under the terms of the GNU General Public License as published by the Free
@@ -408,7 +409,7 @@ MainWindow::MainWindow()
     }
 
     tabbar = new DragBar(this);
-    tabbar->setTabsClosable(false); // use athlete view
+    tabbar->setTabsClosable(true);
 #ifdef Q_OS_MAC
     tabbar->setDocumentMode(true);
 #endif
@@ -420,8 +421,9 @@ MainWindow::MainWindow()
     tabStack = new QStackedWidget(this);
     viewStack->addWidget(tabStack);
 
-    connect(tabbar, SIGNAL(dragTab(int)), this, SLOT(tabbarAthleteChange(int)));
-    connect(tabbar, SIGNAL(currentChanged(int)), this, SLOT(tabbarAthleteChange(int)));
+    connect(tabbar, &DragBar::dragTab, this, &MainWindow::tabbarAthleteChange);
+    connect(tabbar, &DragBar::currentChanged, this, &MainWindow::tabbarAthleteChange);
+    connect(tabbar, &DragBar::tabCloseRequested, this, &MainWindow::closeTabClicked);
 
     /*----------------------------------------------------------------------
      * Central Widget
@@ -2292,11 +2294,32 @@ MainWindow::tabbarAthleteChange(int index)
 }
 
 void
+MainWindow::switchAthleteTab(QString name)
+{
+    for (int i=0; i<tabbar->count(); i++) {
+        if (name == tabbar->tabText(i)) {
+            switchAthleteTab(i);
+            break;
+        }
+    }
+}
+
+void
 MainWindow::switchAthleteTab(int index)
 {
     if (index < 0) return;
 
     setUpdatesEnabled(false);
+
+#ifdef Q_OS_MAC // close buttons on the left on Mac
+    // Only have close button on current tab (prettier)
+    for(int i=0; i<tabbar->count(); i++) tabbar->tabButton(i, QTabBar::LeftSide)->hide();
+    tabbar->tabButton(index, QTabBar::LeftSide)->show();
+#else
+    // Only have close button on current tab (prettier)
+    for(int i=0; i<tabbar->count(); i++) tabbar->tabButton(i, QTabBar::RightSide)->hide();
+    tabbar->tabButton(index, QTabBar::RightSide)->show();
+#endif
 
     // save the previous athlete's settings (there isn't one at startup)
     if (currentAthleteTab) saveGCState(currentAthleteTab->context);

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -2005,9 +2005,6 @@ MainWindow::loadCompleted(QString name, Context *context)
     // to show it to avoid crappy paint artefacts
     if (tabList.count() > 1) showTabbar(true); // need it for more than one!
 
-    // clear the workout filter box text
-    // workoutFilterBox->clear();
-
     // splash is a proxy for first startup, so now display the main window
     if (splash) displayMainWindow();
 

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -652,17 +652,17 @@ MainWindow::MainWindow()
     viewMenu->addAction(tr("Activities"), this, SLOT(selectAnalysis()));
     viewMenu->addAction(tr("Train"), this, SLOT(selectTrain()));
     viewMenu->addSeparator();
-    viewMenu->addAction(tr("Import Perspective..."), this, SLOT(importPerspective()));
-    viewMenu->addAction(tr("Export Perspective..."), this, SLOT(exportPerspective()));
+    importPerspectiveAction = viewMenu->addAction(tr("Import Perspective..."), this, SLOT(importPerspective()));
+    exportPerspectiveAction = viewMenu->addAction(tr("Export Perspective..."), this, SLOT(exportPerspective()));
     viewMenu->addSeparator();
     subChartMenu = viewMenu->addMenu(tr("Add Chart"));
-    viewMenu->addAction(tr("Import Chart..."), this, SLOT(importChart()));
+    importChartAction = viewMenu->addAction(tr("Import Chart..."), this, SLOT(importChart()));
 #ifdef GC_HAS_CLOUD_DB
-    viewMenu->addAction(tr("Upload Chart..."), this, SLOT(exportChartToCloudDB()));
-    viewMenu->addAction(tr("Download Chart..."), this, SLOT(addChartFromCloudDB()));
+    uploadChartAction = viewMenu->addAction(tr("Upload Chart..."), this, SLOT(exportChartToCloudDB()));
+    downloadChartAction = viewMenu->addAction(tr("Download Chart..."), this, SLOT(addChartFromCloudDB()));
     viewMenu->addSeparator();
 #endif
-    viewMenu->addAction(tr("Reset Layout"), this, SLOT(resetWindowLayout()));
+    resetLayoutAction = viewMenu->addAction(tr("Reset Layout"), this, SLOT(resetWindowLayout()));
     styleAction = viewMenu->addAction(tr("Tabbed not Tiled"), this, SLOT(toggleStyle()));
     styleAction->setCheckable(true);
     styleAction->setChecked(true);
@@ -733,9 +733,13 @@ MainWindow::MainWindow()
 void
 MainWindow::toggleSidebar()
 {
-    currentAthleteTab->toggleSidebar();
+    // only applicable to athlete views
+    if (viewStack->currentIndex() == GcViewStackIdx::SELECT_ATHLETE_VIEW) return;
+
+    currentAthleteTab->currentView()->setSidebarEnabled(!currentAthleteTab->currentView()->sidebarEnabled());
     setToolButtons();
 }
+
 void
 MainWindow::showViewbar(bool want)
 {
@@ -743,25 +747,36 @@ MainWindow::showViewbar(bool want)
     showhideViewbar->setChecked(want);
     setToolButtons();
 }
+
 void
 MainWindow::showSidebar(bool want)
 {
-    currentAthleteTab->setSidebarEnabled(want);
-    showhideSidebar->setChecked(want);
+    // only applicable to athlete views
+    if (viewStack->currentIndex() == GcViewStackIdx::SELECT_ATHLETE_VIEW) return;
+
+    currentAthleteTab->currentView()->setSidebarEnabled(want);
     setToolButtons();
 }
 
 void
 MainWindow::toggleLowbar()
 {
-    if (currentAthleteTab->hasBottom()) currentAthleteTab->setBottomRequested(!currentAthleteTab->isBottomRequested());
-    setToolButtons();
+    // only applicable to athlete views
+    if (viewStack->currentIndex() == GcViewStackIdx::SELECT_ATHLETE_VIEW) return;
+
+    if (currentAthleteTab->currentView()->hasBottom()) {
+        currentAthleteTab->currentView()->setBottomRequested(!currentAthleteTab->currentView()->isBottomRequested());
+        setToolButtons();
+    }
 }
 
 void
 MainWindow::showLowbar(bool want)
 {
-    if (currentAthleteTab->hasBottom()) currentAthleteTab->setBottomRequested(want);
+    // only applicable to athlete views
+    if (viewStack->currentIndex() == GcViewStackIdx::SELECT_ATHLETE_VIEW) return;
+
+    if (currentAthleteTab->currentView()->hasBottom()) currentAthleteTab->currentView()->setBottomRequested(want);
     showhideLowbar->setChecked(want);
     setToolButtons();
 }
@@ -826,6 +841,9 @@ MainWindow::setChartMenu(QMenu *menu)
 void
 MainWindow::addChart(QAction*action)
 {
+    // only applicable to athlete views
+    if (viewStack->currentIndex() == GcViewStackIdx::SELECT_ATHLETE_VIEW) return;
+
     // & removed to avoid issues with kde AutoCheckAccelerators
     QString actionText = QString(action->text()).replace("&", "");
     GcWinID id = GcWindowTypes::None;
@@ -836,12 +854,15 @@ MainWindow::addChart(QAction*action)
         }
     }
     if (id != GcWindowTypes::None)
-        currentAthleteTab->addChart(id); // called from MainWindow to inset chart
+        currentAthleteTab->currentView()->addChart(id); // called from MainWindow to inset chart
 }
 
 void
 MainWindow::importChart()
 {
+    // only applicable to athlete views
+    if (viewStack->currentIndex() == GcViewStackIdx::SELECT_ATHLETE_VIEW) return;
+
     QString fileName = QFileDialog::getOpenFileName(this, tr("Select Chart file to import"), "", tr("GoldenCheetah Chart Files (*.gchart)"));
 
     if (!fileName.isEmpty()) {
@@ -852,6 +873,9 @@ MainWindow::importChart()
 void
 MainWindow::exportPerspective()
 {
+    // only applicable to athlete views
+    if (viewStack->currentIndex() == GcViewStackIdx::SELECT_ATHLETE_VIEW) return;
+
     AbstractView * current = currentAthleteTab->currentView();
 
     // export the current perspective to a file
@@ -870,6 +894,9 @@ MainWindow::exportPerspective()
 void
 MainWindow::importPerspective()
 {
+    // only applicable to athlete views
+    if (viewStack->currentIndex() == GcViewStackIdx::SELECT_ATHLETE_VIEW) return;
+
     // import a new perspective from a file
     QString fileName = QFileDialog::getOpenFileName(this, tr("Select Perspective file to import"), "", tr("GoldenCheetah Perspective Files (*.gchartset)"));
     if (fileName.isEmpty()) {
@@ -899,6 +926,9 @@ MainWindow::importPerspective()
 void
 MainWindow::exportChartToCloudDB()
 {
+    // only applicable to athlete views
+    if (viewStack->currentIndex() == GcViewStackIdx::SELECT_ATHLETE_VIEW) return;
+
     // upload the current chart selected to the chart db
     // called from the sidebar menu
     Perspective *page=currentAthleteTab->currentView()->page();
@@ -909,6 +939,9 @@ MainWindow::exportChartToCloudDB()
 void
 MainWindow::addChartFromCloudDB()
 {
+    // only applicable to athlete views
+    if (viewStack->currentIndex() == GcViewStackIdx::SELECT_ATHLETE_VIEW) return;
+
     if (!(appsettings->cvalue(currentAthleteTab->context->athlete->cyclist, GC_CLOUDDB_TC_ACCEPTANCE, false).toBool())) {
        CloudDBAcceptConditionsDialog acceptDialog(currentAthleteTab->context->athlete->cyclist);
        acceptDialog.setModal(true);
@@ -942,8 +975,11 @@ MainWindow::addChartFromCloudDB()
 void
 MainWindow::toggleStyle()
 {
-    currentAthleteTab->toggleTile();
-    styleAction->setChecked(currentAthleteTab->isTiled());
+    // only applicable to athlete views
+    if (viewStack->currentIndex() == GcViewStackIdx::SELECT_ATHLETE_VIEW) return;
+
+    currentAthleteTab->currentView()->setTiled(!currentAthleteTab->currentView()->isTiled());
+    styleAction->setChecked(currentAthleteTab->currentView()->isTiled());
     setToolButtons();
 }
 
@@ -1110,6 +1146,9 @@ void MainWindow::showWorkoutWizard()
 
 void MainWindow::resetWindowLayout()
 {
+    // only applicable to athlete views
+    if (viewStack->currentIndex() == GcViewStackIdx::SELECT_ATHLETE_VIEW) return;
+
     QMessageBox msgBox;
     msgBox.setText(tr("You are about to reset all charts to the default setup"));
     msgBox.setInformativeText(tr("Do you want to continue?"));
@@ -1119,7 +1158,7 @@ void MainWindow::resetWindowLayout()
     msgBox.exec();
 
     if(msgBox.clickedButton() == msgBox.button(QMessageBox::Ok))
-        currentAthleteTab->resetLayout(perspectiveSelector);
+        currentAthleteTab->currentView()->resetLayout(perspectiveSelector);
 }
 
 void MainWindow::manualProcess(QString name)
@@ -1201,6 +1240,7 @@ MainWindow::selectAthlete()
     perspectiveSelector->hide();
     searchBox->hide();
     workoutFilterBox->hide();
+    setToolButtons();
 }
 
 void
@@ -1341,18 +1381,56 @@ MainWindow::filenameWillChange(RideItem *rideItem, QString *newName) const
 void
 MainWindow::setToolButtons()
 {
-    int select = currentAthleteTab->isTiled() ? 1 : 0;
-    int lowselected = currentAthleteTab->isBottomRequested() ? 1 : 0;
-    int sidebarselected = currentAthleteTab->isSidebarEnabled() ? 1 : 0;
+    if (viewStack->currentIndex() == GcViewStackIdx::SELECT_ATHLETE_VIEW) {
 
-    styleAction->setChecked(select);
-    showhideLowbar->setChecked(lowselected);
-    showhideSidebar->setChecked(sidebarselected);
+        styleAction->setDisabled(true);
+        styleAction->setChecked(false);
 
-    //if (styleSelector->isSegmentSelected(select) == false)
-        //styleSelector->setSegmentSelected(select, true);
+        showhideLowbar->setDisabled(true);
+        showhideLowbar->setChecked(false);
 
-#ifdef Q_OS_MAC // bizarre issue with searchbox focus on tab voew change
+        showhideSidebar->setDisabled(true);
+        showhideSidebar->setChecked(false);
+
+        importPerspectiveAction->setDisabled(true);
+        exportPerspectiveAction->setDisabled(true);
+
+        subChartMenu->setDisabled(true);
+
+        importChartAction->setDisabled(true);
+        resetLayoutAction->setDisabled(true);
+
+#ifdef GC_HAS_CLOUD_DB
+        uploadChartAction->setDisabled(true);
+        downloadChartAction->setDisabled(true);
+#endif
+
+    } else { // set athlete view specific settings
+
+        styleAction->setDisabled(false);
+        styleAction->setChecked(currentAthleteTab->currentView()->isTiled());
+
+        showhideLowbar->setDisabled(false);
+        showhideLowbar->setChecked(currentAthleteTab->currentView()->isBottomRequested());
+
+        showhideSidebar->setDisabled(false);
+        showhideSidebar->setChecked(currentAthleteTab->currentView()->sidebarEnabled());
+
+        importPerspectiveAction->setDisabled(false);
+        exportPerspectiveAction->setDisabled(false);
+
+        subChartMenu->setDisabled(false);
+
+        importChartAction->setDisabled(false);
+        resetLayoutAction->setDisabled(false);
+
+#ifdef GC_HAS_CLOUD_DB
+        uploadChartAction->setDisabled(false);
+        downloadChartAction->setDisabled(false);
+#endif
+    }
+
+#ifdef Q_OS_MAC // bizarre issue with searchbox focus on tab view change
     searchBox->clearFocus();
 #endif
 }
@@ -1509,6 +1587,9 @@ MainWindow::dragEnterEvent(QDragEnterEvent *event)
 void
 MainWindow::dropEvent(QDropEvent *event)
 {
+    // only applicable to athlete views
+    if (viewStack->currentIndex() == GcViewStackIdx::SELECT_ATHLETE_VIEW) return;
+
     QList<QUrl> urls = event->mimeData()->urls();
     if (urls.isEmpty()) return;
 
@@ -2085,7 +2166,7 @@ MainWindow::removeAthleteTab(AthleteTab *tab, bool updateLastAthlete /* = true *
     if (tabList.count() == 1) { // last athlete so save the settings, don't switch
 
         // save the previous athlete's settings
-        saveGCState(tab->context);
+        saveGCState(tab);
 
     } else { // switching athlete
 
@@ -2252,27 +2333,31 @@ MainWindow::deleteAthlete(QString name)
 }
 
 void
-MainWindow::saveGCState(Context *context)
+MainWindow::saveGCState(AthleteTab *athleteTab)
 {
-    // save all the current state to the supplied context
-    context->showSidebar = showhideSidebar->isChecked();
-    context->showLowbar = showhideLowbar->isChecked();
-    context->showToolbar = showhideToolbar->isChecked();
-    context->searchText = searchBox->text();
-    context->workoutFilterText = workoutFilterBox->text();
-    context->style = styleAction->isChecked();
+    // save the view related state to the athleteTab's view
+    athleteTab->currentView()->setSidebarEnabled(showhideSidebar->isChecked());
+    athleteTab->currentView()->setShowBottom(showhideLowbar->isChecked());
+    athleteTab->currentView()->setTiled(styleAction->isChecked());
+
+    Context* tabContext(athleteTab->context);
+
+    // save the athlete related state to the athleteTab's context
+    tabContext->showToolbar = showhideToolbar->isChecked();
+    tabContext->searchText = searchBox->text();
+    tabContext->workoutFilterText = workoutFilterBox->text();
 }
 
 void
-MainWindow::restoreGCState(Context *context)
+MainWindow::restoreGCState(AthleteTab *athleteTab)
 {
     if (viewStack->currentIndex() != GcViewStackIdx::SELECT_ATHLETE_VIEW) {
 
         // not on athlete view...
-        GcViewType viewType = currentAthleteTab->currentViewType();
+        GcViewType viewType = athleteTab->currentViewType();
         resetPerspective(viewType); // will lazy load, hence doing it first
 
-        // restore window state from the supplied context
+        // restore window state from the supplied athleteTab view
         switch(viewType) {
         case GcViewType::VIEW_TRENDS: sidebar->setItemSelected(GcSideBarBtnId::TRENDS_BTN,true); break;
         case GcViewType::VIEW_ANALYSIS: sidebar->setItemSelected(GcSideBarBtnId::ACTIVITIES_BTN,true); break;
@@ -2280,16 +2365,24 @@ MainWindow::restoreGCState(Context *context)
         case GcViewType::VIEW_TRAIN: sidebar->setItemSelected(GcSideBarBtnId::TRAIN_BTN, true); break;
         default: sidebar->setItemSelected(GcSideBarBtnId::SELECT_ATHLETE_BTN, true); break;
         }
+
+        // restore the view related state from the provided athleteTab's view
+        showSidebar(athleteTab->currentView()->sidebarEnabled());
+        showLowbar(athleteTab->currentView()->hasBottom());
+        // there is no set style action, so...
+        styleAction->setChecked(athleteTab->currentView()->isTiled());
+        setToolButtons();
     }
 
-    showSidebar(context->showSidebar);
-    showToolbar(context->showToolbar);
-    showLowbar(context->showLowbar);
-    searchBox->setContext(context);
-    searchBox->setText(context->searchText);
-    workoutFilterBox->setContext(context);
-    workoutFilterBox->setText(context->workoutFilterText);
-    setWindowTitle(context->athlete->cyclist);
+    Context* tabContext(athleteTab->context);
+
+    // restore the context related state from the athleteTab's context
+    showToolbar(tabContext->showToolbar);
+    searchBox->setContext(tabContext);
+    searchBox->setText(tabContext->searchText);
+    workoutFilterBox->setContext(tabContext);
+    workoutFilterBox->setText(tabContext->workoutFilterText);
+    setWindowTitle(tabContext->athlete->cyclist);
 }
 
 void
@@ -2328,7 +2421,7 @@ MainWindow::switchAthleteTab(int index, bool updateLastAthlete /* = true */)
 #endif
 
     // save the previous athlete's settings (there isn't one at startup)
-    if (currentAthleteTab) saveGCState(currentAthleteTab->context);
+    if (currentAthleteTab) saveGCState(currentAthleteTab);
 
     // switch to the new athlete
     currentAthleteTab = tabList[index];
@@ -2337,7 +2430,7 @@ MainWindow::switchAthleteTab(int index, bool updateLastAthlete /* = true */)
     tabbar->setCurrentIndex(index);
 
     // restore new athlete's settings
-    restoreGCState(currentAthleteTab->context);
+    restoreGCState(currentAthleteTab);
 
     // store the new athlete as the "last_openend" athlete for next time
     if (updateLastAthlete) appsettings->setValue(GC_SETTINGS_LAST, currentAthleteTab->context->athlete->cyclist);

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -423,7 +423,10 @@ MainWindow::MainWindow()
 
     connect(tabbar, &DragBar::dragTab, this, &MainWindow::tabbarAthleteChange);
     connect(tabbar, &DragBar::currentChanged, this, &MainWindow::tabbarAthleteChange);
-    connect(tabbar, &DragBar::tabCloseRequested, this, &MainWindow::closeTabClicked);
+    connect(tabbar, &DragBar::tabCloseRequested, this, [this](int index) {
+        closeAthleteTab(tabList[index]->context->athlete->cyclist);
+    });
+
 
     /*----------------------------------------------------------------------
      * Central Widget
@@ -1000,38 +1003,24 @@ void
 MainWindow::closeEvent(QCloseEvent* event)
 {
     QGuiApplication::setOverrideCursor(Qt::WaitCursor);
-    QList<AthleteTab*> closing = tabList;
-    bool needtosave = false;
-    bool importrunning = false;
+    bool importRunningOrUnsaved(false);
 
-    // close all the tabs .. if any refuse we need to ignore
-    //                       the close event
-    foreach(AthleteTab *tab, closing) {
+    // close all the tabs without changing positions, if any refuse we need to ignore the close event
+    for(int i=tabbar->count()-1; i > -1; i--) {
 
-        // check for if RideImport is is process and let it finalize / or be stopped by the user
-        if (tab->context->athlete->autoImport) {
-            if (tab->context->athlete->autoImport->importInProcess() ) {
-                importrunning = true;
-                QGuiApplication::restoreOverrideCursor();
-                QMessageBox::information(this, tr("Activity Import"),
-                        tr("INFO for athlete %1\n\nClosing of athlete window not possible while background activity import is in progress...")
-                            .arg(tab->context->athlete->cyclist));
-                QGuiApplication::setOverrideCursor(Qt::WaitCursor);
-            }
+        QGuiApplication::restoreOverrideCursor();
+
+        if (checkImportAndUnsaved(i)) {
+            removeAthleteTab(tabList[i]);
+        } else {
+            importRunningOrUnsaved = true;
         }
 
-        // only check for unsaved if autoimport is not running any more
-        if (!importrunning) {
-            // do we need to save?
-            if (tab->context->mainWindow->saveRideExitDialog(tab->context) == true)
-                removeAthleteTab(tab);
-            else
-                needtosave = true;
-        }
+        QGuiApplication::setOverrideCursor(Qt::WaitCursor);
     }
 
     // were any left hanging around? or autoimport in action on any windows, then don't close any
-    if (needtosave || importrunning) event->ignore();
+    if (importRunningOrUnsaved) event->ignore();
     else {
 
         // finish off the job and leave
@@ -1044,6 +1033,7 @@ MainWindow::closeEvent(QCloseEvent* event)
 
         // save global mainwindow settings
         appsettings->setValue(GC_TABBAR, showhideTabbar->isChecked());
+
         // wait for threads.. max of 10 seconds before just exiting anyway
         for (int i=0; i<10 && QThreadPool::globalInstance()->activeThreadCount(); i++) {
             QThread::sleep(1);
@@ -2018,7 +2008,34 @@ MainWindow::loadCompleted(QString name, Context *context)
 }
 
 bool
-MainWindow::closeTabClicked(int index)
+MainWindow::closeAthleteTab(QString name)
+{
+    int athleteCanBeClosed(-1);
+
+    for(int i=0; i<tabbar->count(); i++) {
+        if (name == tabbar->tabText(i)) {
+
+            if (checkImportAndUnsaved(i)) athleteCanBeClosed = i;
+            break;
+        }
+    }
+
+    if (athleteCanBeClosed != -1) {
+
+        // lets wipe it
+        removeAthleteTab(tabList[athleteCanBeClosed]);
+
+        // if its the last athlete tab we must close GoldenCheetah
+        if (tabList.count() == 0) closeWindow();
+
+        return true;
+    }
+
+    return false;
+}
+
+bool
+MainWindow::checkImportAndUnsaved(int index)
 {
     AthleteTab *tab = tabList[index];
 
@@ -2032,28 +2049,9 @@ MainWindow::closeTabClicked(int index)
         }
     }
 
-    if (saveRideExitDialog(tab->context) == false) return false;
+    // now check for unsaved activities
+    return saveRideExitDialog(tab->context);
 
-    // lets wipe it
-    removeAthleteTab(tab);
-
-    return true;
-}
-
-bool
-MainWindow::closeAthleteTab(QString name)
-{
-    // if its the last athlete tab we close GoldenCheetah
-    if (tabbar->count() == 1) {
-        closeWindow();
-    } else {
-        for(int i=0; i<tabbar->count(); i++) {
-            if (name == tabbar->tabText(i)) {
-                return closeTabClicked(i);
-            }
-        }
-    }
-    return false;
 }
 
 // no questions asked just wipe away the current tab
@@ -2066,7 +2064,8 @@ MainWindow::removeAthleteTab(AthleteTab *tab)
 
     if (tabList.count() == 2) showTabbar(false); // don't need it for one!
 
-    // cancel ridecache refresh if its in progress
+    // cancel ridecache refresh if its in progress, this is some what belt and braces as
+    // import in progress is always checked before removeAthleteTab() is called
     tab->context->athlete->rideCache->cancel();
 
     // save the named searches
@@ -2081,20 +2080,28 @@ MainWindow::removeAthleteTab(AthleteTab *tab)
     // switch to neighbour (currentTab will change)
     int index = tabList.indexOf(tab);
 
-    // if this is not the last athlete and we are removing the current 
-    // athlete tab then we need to select another athlete
-    if ((tabList.count() > 1) && (tab == currentAthleteTab)) {
-        switchAthleteTab((index == 0) ? index+1 : index-1);
-    } 
-    
+    if (tabList.count() == 1) { // last athlete so save the settings, don't switch
+
+        // save the previous athlete's settings
+        saveGCState(tab->context);
+
+    } else { // switching athlete
+
+        // if this is not the last athlete and we are removing the current 
+        // athlete tab then we need to select another athlete
+        if ((tabList.count() > 1) && (tab == currentAthleteTab)) {
+            switchAthleteTab((index == 0) ? index+1 : index-1);
+        }
+    }
+ 
     // close the athlete's card
     emit closingAthlete(name, tab->context);
 
-    // close gracefully
+    // close athlete gracefully
     tab->close();
     tab->context->athlete->close();
 
-    // remove from state
+    // remove athlete from state
     athletetabs.remove(name);
     tabList.removeAt(index);
     tabbar->removeTab(index);

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -2122,19 +2122,22 @@ MainWindow::checkImportAndUnsaved(int index)
 {
     AthleteTab *tab = tabList[index];
 
-    // check for autoimport and let it finalize
-    if (tab->context->athlete->autoImport) {
-        if (tab->context->athlete->autoImport->importInProcess() ) {
-            QMessageBox::information(this, tr("Activity Import"),
-                    tr("INFO for athlete %1\n\nClosing of athlete window not possible while background activity import is in progress...")
-                        .arg(tab->context->athlete->cyclist));
-            return false;
-        }
+    // check for any ride import process in progress
+    if (tab->context->activityImportInProgress > 0) {
+
+        QMessageBox msgBox;
+        msgBox.setWindowTitle("Information");
+        msgBox.setText(tr("INFO for athlete %1\n\nClosing the athlete window is not possible while file import is in progress...")
+                            .arg(tab->context->athlete->cyclist));
+        msgBox.setIcon(QMessageBox::Information);
+        msgBox.setWindowFlags(msgBox.windowFlags() | Qt::WindowStaysOnTopHint);
+        msgBox.exec();
+
+        return false;
     }
 
     // now check for unsaved activities
     return saveRideExitDialog(tab->context);
-
 }
 
 // no questions asked just wipe away the current tab

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -89,7 +89,7 @@ class MainWindow : public QMainWindow
 
     public:
 
-        MainWindow(const QDir &home);
+        MainWindow();
         ~MainWindow(); // temp to zap db - will move to tab //
 
         void byebye() { close(); } // go bye bye for a restart
@@ -133,8 +133,10 @@ class MainWindow : public QMainWindow
         void backClicked();
         void forwardClicked();
         void openingAthlete(QString, Context *);
+        void closingAthlete(QString, Context *);
         void newAthlete(QString);
         void deletedAthlete(QString);
+        void currentAthlete(QString);
 
     public slots:
         bool eventFilter(QObject*,QEvent*);
@@ -146,9 +148,6 @@ class MainWindow : public QMainWindow
         void helpView();
         void logBug();
         void support();
-
-        void loadProgress(QString folder, double progress);
-
 
         // perspective selected
         void perspectiveSelected(int index);
@@ -170,14 +169,11 @@ class MainWindow : public QMainWindow
 
         void setOpenTabMenu(); // set the Open Tab menu
         void newCyclistTab();  // create a new Cyclist
-        void openAthleteTab(QString name);
+        bool openAthleteTab(QString name);
         void loadCompleted(QString name, Context *context);
-        void closeTabClicked(int index); // user clicked to close tab
+        bool closeTabClicked(int index); // user clicked to close tab
         bool closeAthleteTab(QString name); // close named athlete
-        bool closeAthleteTab();       // close current, might not if the user
-                               // changes mind if there are unsaved changes.
-        void removeAthleteTab(AthleteTab*);  // remove without question
-        void switchAthleteTab(int index); // for switching between one tab and another
+        void tabbarAthleteChange(int index); // blockable tabbar generated athlete switching
 
         // sidebar selecting views and actions
         void sidebarClicked(GcSideBarBtnId id);
@@ -274,12 +270,9 @@ class MainWindow : public QMainWindow
         void mergeRide();
         void deleteRide();
         void saveRide();                        // save current ride menu item
-        void saveAllUnsavedRides();
+        void saveAllUnsavedRides(Context *);
         void revertRide();
         bool saveRideExitDialog(Context *);              // save dirty rides on exit dialog
-
-        // autoload rides from athlete specific directory (preferences)
-        void ridesAutoImport();
 
 #ifdef GC_HAS_CLOUD_DB
         // CloudDB actions
@@ -297,6 +290,13 @@ class MainWindow : public QMainWindow
 
         void configChanged(qint32);
         void onEditMenuAboutToShow();
+
+    protected:
+
+        void displayMainWindow();
+
+        void switchAthleteTab(int index); // athlete switching for change & athlete closure
+        void removeAthleteTab(AthleteTab*);  // remove without question
 
     private:
 
@@ -362,6 +362,8 @@ class MainWindow : public QMainWindow
         CloudDBVersionClient *versionClient;
         CloudDBTelemetryClient *telemetryClient;
 #endif
+
+        bool blockTabbarUpdates;
 
 };
 

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -295,9 +295,9 @@ class MainWindow : public QMainWindow
 
         void displayMainWindow();
 
-        void switchAthleteTab(int index); // athlete switching for change & athlete closure
+        void switchAthleteTab(int index, bool updateLastAthlete = true); // athlete switching for change & athlete closure
         bool checkImportAndUnsaved(int index);
-        void removeAthleteTab(AthleteTab*);  // remove without question
+        void removeAthleteTab(AthleteTab*, bool updateLastAthlete = true);  // remove without question
 
     private:
 

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -173,6 +173,7 @@ class MainWindow : public QMainWindow
         void loadCompleted(QString name, Context *context);
         bool closeTabClicked(int index); // user clicked to close tab
         bool closeAthleteTab(QString name); // close named athlete
+        void switchAthleteTab(QString name); // athlete switching for change
         void tabbarAthleteChange(int index); // blockable tabbar generated athlete switching
 
         // sidebar selecting views and actions

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -285,8 +285,8 @@ class MainWindow : public QMainWindow
         void exportChartToCloudDB();
 #endif
         // save and restore state to context
-        void saveGCState(Context *);
-        void restoreGCState(Context *);
+        void saveGCState(AthleteTab *);
+        void restoreGCState(AthleteTab *);
 
         void configChanged(qint32);
         void onEditMenuAboutToShow();
@@ -356,6 +356,16 @@ class MainWindow : public QMainWindow
 
         QAction *shareAction;
         QAction *checkAction;
+
+        QAction *importPerspectiveAction;
+        QAction *exportPerspectiveAction;
+        QAction *importChartAction;
+        QAction *resetLayoutAction;
+
+#ifdef GC_HAS_CLOUD_DB
+        QAction *uploadChartAction;
+        QAction *downloadChartAction;
+#endif
 
         // Miscellany
         std::unique_ptr<QSignalMapper> toolMapper;

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -171,7 +171,6 @@ class MainWindow : public QMainWindow
         void newCyclistTab();  // create a new Cyclist
         bool openAthleteTab(QString name);
         void loadCompleted(QString name, Context *context);
-        bool closeTabClicked(int index); // user clicked to close tab
         bool closeAthleteTab(QString name); // close named athlete
         void switchAthleteTab(QString name); // athlete switching for change
         void tabbarAthleteChange(int index); // blockable tabbar generated athlete switching
@@ -297,6 +296,7 @@ class MainWindow : public QMainWindow
         void displayMainWindow();
 
         void switchAthleteTab(int index); // athlete switching for change & athlete closure
+        bool checkImportAndUnsaved(int index);
         void removeAthleteTab(AthleteTab*);  // remove without question
 
     private:

--- a/src/Gui/NewSideBar.cpp
+++ b/src/Gui/NewSideBar.cpp
@@ -24,7 +24,7 @@ static constexpr int gl_itemwidth = 70;
 static constexpr int gl_itemheight = 50;
 static constexpr int gl_margin = 0;
 
-NewSideBar::NewSideBar(Context *context, QWidget *parent) : QWidget(parent), context(context)
+NewSideBar::NewSideBar(QWidget *parent) : QWidget(parent)
 
 {
     setFixedWidth(gl_itemwidth *dpiXFactor);
@@ -46,7 +46,7 @@ NewSideBar::NewSideBar(Context *context, QWidget *parent) : QWidget(parent), con
     layout->setSpacing(0);
     layout->setContentsMargins(0,gl_margin *dpiXFactor,0,gl_margin*dpiYFactor);
 
-    connect(context, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));
+    connect(GlobalContext::context(), &GlobalContext::configChanged, this, &NewSideBar::configChanged);
     configChanged(0);
 
     show();
@@ -159,7 +159,7 @@ NewSideBarItem::NewSideBarItem(NewSideBar *sidebar, GcSideBarBtnId id, QImage ic
 
     // trap events
     installEventFilter(this);
-    connect(GlobalContext::context(), SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));
+    connect(GlobalContext::context(), &GlobalContext::configChanged, this, &NewSideBarItem::configChanged);
 
     configChanged(0);
 

--- a/src/Gui/NewSideBar.h
+++ b/src/Gui/NewSideBar.h
@@ -36,7 +36,6 @@ enum class GcSideBarBtnId : int {
     OPTIONS_BTN = 8
 };
 
-class Context;
 class NewSideBarItem;
 class NewSideBar : public QWidget
 {
@@ -47,7 +46,7 @@ class NewSideBar : public QWidget
     friend class ::NewSideBarItem;
 
     public:
-        NewSideBar(Context *context, QWidget *parent);
+        NewSideBar(QWidget *parent);
 
     public slots:
 
@@ -76,9 +75,6 @@ class NewSideBar : public QWidget
 
         void itemSelected(GcSideBarBtnId id);
         void itemClicked(GcSideBarBtnId id);
-
-    protected:
-        Context *context;
 
     private:
 

--- a/src/Gui/Perspective.cpp
+++ b/src/Gui/Perspective.cpp
@@ -1889,7 +1889,7 @@ AddPerspectiveDialog::AddPerspectiveDialog(QWidget *parent, Context *context, QS
     layout->addLayout(form);
 
     if (viewType == GcViewType::VIEW_ANALYSIS || viewType == GcViewType::VIEW_TRENDS) {
-        filterEdit = new SearchBox(context, this);
+        filterEdit = new SearchBox(this, context);
         filterEdit->setFixedMode(true);
         filterEdit->setMode(SearchBox::Filter);
         filterEdit->setText(expression);

--- a/src/Gui/RideImportWizard.cpp
+++ b/src/Gui/RideImportWizard.cpp
@@ -983,7 +983,7 @@ RideImportWizard::abortClicked()
        hide();
        if (autoImportStealth) {
            // inform the user that the work is done
-           QMessageBox::information(NULL, tr("Auto Import"), tr("Automatic import from defined directories is completed."));
+           QMessageBox::information(NULL, tr("Auto Import"), tr("INFO for athlete %1\n\nAutomatic import from defined directories is completed.").arg(context->athlete->cyclist));
        }
        done(0);
        return;

--- a/src/Gui/RideImportWizard.cpp
+++ b/src/Gui/RideImportWizard.cpp
@@ -55,6 +55,7 @@ enum WizardTable {
 // drag and drop passes urls ... convert to a list of files and call main constructor
 RideImportWizard::RideImportWizard(QList<QUrl> *urls, Context *context, QWidget *parent) : QDialog(parent), context(context)
 {
+    context->activityImportInProgress++;
     _importInProcess = true;
     setAttribute(Qt::WA_DeleteOnClose);
     setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
@@ -71,8 +72,10 @@ RideImportWizard::RideImportWizard(QList<QUrl> *urls, Context *context, QWidget 
 
 RideImportWizard::RideImportWizard(QList<QString> files, Context *context, QWidget *parent) : QDialog(parent), context(context)
 {
+    context->activityImportInProgress++;
     _importInProcess = true;
     setAttribute(Qt::WA_DeleteOnClose);
+    setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
     autoImportMode = false;
     autoImportStealth = false;
     init(files, context);
@@ -83,7 +86,10 @@ RideImportWizard::RideImportWizard(QList<QString> files, Context *context, QWidg
 
 RideImportWizard::RideImportWizard(RideAutoImportConfig *dirs, Context *context, QWidget *parent) : QDialog(parent), context(context), importConfig(dirs)
 {
+    context->activityImportInProgress++;
     _importInProcess = true;
+    setAttribute(Qt::WA_DeleteOnClose);
+    setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
     autoImportMode = true;
     autoImportStealth = true;
 
@@ -1226,6 +1232,8 @@ RideImportWizard::done(int rc)
 RideImportWizard::~RideImportWizard()
 {
     foreach(QString name, deleteMe) QFile(name).remove();
+
+    if (context->activityImportInProgress > 0) context->activityImportInProgress--;
 }
 
 

--- a/src/Gui/RideImportWizard.h
+++ b/src/Gui/RideImportWizard.h
@@ -56,7 +56,6 @@ public:
 
     int getNumberOfFiles();  // get the number of files selected for processing
     int process();
-    bool importInProcess() { return _importInProcess; }
     bool isAutoImport() { return autoImportMode;}
 
 private slots:

--- a/src/Gui/SaveDialogs.cpp
+++ b/src/Gui/SaveDialogs.cpp
@@ -294,7 +294,7 @@ SaveOnExitDialogWidget::SaveOnExitDialogWidget(MainWindow *mainWindow, Context *
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
 
     // Warning text
-    warnText = new QLabel(tr("WARNING\n\nYou have made changes to some rides which\nhave not been saved. They are listed below."));
+    warnText = new QLabel(tr("WARNING for athlete %1\n\nYou have made changes to some rides which\nhave not been saved. They are listed below.").arg(context->athlete->cyclist));
     mainLayout->addWidget(warnText);
 
     // File List

--- a/src/Gui/SearchBox.h
+++ b/src/Gui/SearchBox.h
@@ -42,7 +42,7 @@ public:
     enum searchboxmode { Search, Filter };
     typedef enum searchboxmode SearchBoxMode;
 
-    SearchBox(Context *context, QWidget *parent = 0, bool nochooser=true);
+    SearchBox(QWidget *parent, Context *context, bool nochooser=true);
 
     // either search box or filter box
     void setMode(SearchBoxMode mode);
@@ -50,7 +50,7 @@ public:
     void setText(QString);
     SearchBoxMode getMode() { return mode; }
     bool isFiltered() const { return filtered; }
-    void setContext(Context *c) { context = c; }
+    void setContext(Context *con);
 
 protected:
     void resizeEvent(QResizeEvent *);
@@ -109,10 +109,10 @@ signals:
     void lostFocus();
 
 private:
-    Context *context;
     QWidget *parent;
-    bool filtered;
+    Context *context;
     bool nochooser;
+    bool filtered;
     QToolButton *clearButton, *searchButton, *toolButton;
     QMenu *dropMenu;
     SearchBoxMode mode;

--- a/src/Gui/SearchFilterBox.cpp
+++ b/src/Gui/SearchFilterBox.cpp
@@ -34,7 +34,7 @@ SearchFilterBox::SearchFilterBox(QWidget *parent, Context *context, bool nochoos
     contents->setContentsMargins(0,0,0,0);
 
     // no column chooser if my parent widget is a modal widget
-    searchbox = new SearchBox(context, this, nochooser);
+    searchbox = new SearchBox(this, context, nochooser);
     searchbox->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed));
     contents->addWidget(searchbox);
 
@@ -55,6 +55,16 @@ SearchFilterBox::SearchFilterBox(QWidget *parent, Context *context, bool nochoos
     // syntax check
     connect(datafilter, SIGNAL(parseGood()), searchbox, SLOT(setGood()));
     connect(datafilter, SIGNAL(parseBad(QStringList)), searchbox, SLOT(setBad(QStringList)));
+}
+
+void
+SearchFilterBox::setContext(Context *con)
+{
+    if (context != con) {
+        context = con;
+        searchbox->setContext(con);
+        datafilter->setContext(con);
+    }
 }
 
 // static utility function to get list of files that match a filter

--- a/src/Gui/SearchFilterBox.h
+++ b/src/Gui/SearchFilterBox.h
@@ -42,7 +42,7 @@ public:
     QString text() const { return searchbox->text(); }
     void setText(QString t) { searchbox->setText(t); }
 
-    void setContext(Context *c) { context = c; searchbox->setContext(c); }
+    void setContext(Context *con);
 
     SearchBox *searchbox;
 

--- a/src/Metrics/Estimator.cpp
+++ b/src/Metrics/Estimator.cpp
@@ -201,12 +201,12 @@ Estimator::run()
     }
 
     // set up the models we support
-    CP2Model p2model(context);
-    CP3Model p3model(context);
-    ExtendedModel extmodel(context);
+    CP2Model p2model;
+    CP3Model p3model;
+    ExtendedModel extmodel;
 #if 0 // disable until model fitting errors are fixed (!!!)
-    WSModel wsmodel(context);
-    MultiModel multimodel(context);
+    WSModel wsmodel;
+    MultiModel multimodel;
 #endif
 
     QList <PDModel *> models;

--- a/src/Metrics/PDModel.cpp
+++ b/src/Metrics/PDModel.cpp
@@ -22,11 +22,10 @@
 
 //extern ztable PD_ZTABLE;
 // base class for all models
-PDModel::PDModel(Context *context) :
+PDModel::PDModel() :
     QwtSyntheticPointData(PDMODEL_MAXT),
     fit(Envelope),
     inverseTime(false),
-    context(context),
     sanI1(0), sanI2(0), anI1(0), anI2(0), aeI1(0), aeI2(0), laeI1(0), laeI2(0),
     cp(0), tau(0), t0(0), minutes(false)
 {
@@ -483,8 +482,7 @@ PDModel::calcSummary()
 // Classic 2 Parameter Model
 //
 
-CP2Model::CP2Model(Context *context) :
-    PDModel(context)
+CP2Model::CP2Model()
 {
     // set default intervals to search CP 2-3 mins and 10-20 mins
     anI1=120;
@@ -545,8 +543,7 @@ void CP2Model::onIntervalsChanged()
 //
 // Morton 3 Parameter Model
 //
-CP3Model::CP3Model(Context *context) :
-    PDModel(context)
+CP3Model::CP3Model()
 {
     // set default intervals to search CP 2-3 mins and 12-20mins
     anI1=120;
@@ -631,7 +628,7 @@ void CP3Model::onIntervalsChanged()
 //
 // Ward Smith Model
 //
-WSModel::WSModel(Context *context) : PDModel(context)
+WSModel::WSModel()
 {
     // set default intervals to search CP 30-60
     anI1=1800;
@@ -746,8 +743,7 @@ void WSModel::onIntervalsChanged()
 //
 // Currently deciding which of the three formulations to use
 // as the base for GoldenCheetah (we have enough models already !)
-MultiModel::MultiModel(Context *context) :
-    PDModel(context),
+MultiModel::MultiModel() :
     variant(0), w1(0), p1(0), p2(0), tau1(0), tau2(0), alpha(0), beta(0)
 {
     // set default intervals to search CP 30-60
@@ -891,8 +887,7 @@ void MultiModel::onIntervalsChanged()
 //
 // Extended CP Model
 //
-ExtendedModel::ExtendedModel(Context *context) :
-    PDModel(context),
+ExtendedModel::ExtendedModel() :
     paa(0), paa_dec(0), ecp(0), etau(0), ecp_del(0), tau_del(0), ecp_dec(0),
     ecp_dec_del(0)
 {

--- a/src/Metrics/PDModel.h
+++ b/src/Metrics/PDModel.h
@@ -70,7 +70,7 @@ class PDModel : public QObject, public QwtSyntheticPointData
                        LinearRegression=2         // using slope and intercept of linear regression
                      } fit;
 
-        PDModel(Context *context);
+        PDModel();
 
         // set which variant of the model to use (if the model
         // supports such a thing it needs to reimplement)
@@ -156,7 +156,6 @@ class PDModel : public QObject, public QwtSyntheticPointData
 
     protected:
 
-        Context *context;
         int model;
 
         // intervals to search for best points
@@ -210,7 +209,7 @@ class CP2Model : public PDModel
     Q_OBJECT
 
     public:
-        CP2Model(Context *context);
+        CP2Model();
 
         // synthetic data for a curve
         virtual double y(double t) const;
@@ -255,7 +254,7 @@ class CP3Model : public PDModel
     Q_OBJECT
 
     public:
-        CP3Model(Context *context);
+        CP3Model();
 
         bool modelDecay;    // should we apply CP + W' decay constants?
 
@@ -306,7 +305,7 @@ class WSModel : public PDModel // ward-smith
     Q_OBJECT
 
     public:
-        WSModel(Context *context);
+        WSModel();
 
         // synthetic data for a curve
         virtual double y(double t) const;
@@ -340,7 +339,7 @@ class MultiModel : public PDModel
     Q_OBJECT
 
     public:
-        MultiModel(Context *context);
+        MultiModel();
         void setVariant(int); // which variant to use
 
         // synthetic data for a curve
@@ -380,7 +379,7 @@ class ExtendedModel : public PDModel
     Q_OBJECT
 
     public:
-        ExtendedModel(Context *context);
+        ExtendedModel();
 
         // synthetic data for a curve
         virtual double y(double t) const;

--- a/src/Train/Library.cpp
+++ b/src/Train/Library.cpp
@@ -52,17 +52,14 @@ Library::findLibrary(QString name)
 }
 
 void
-Library::initialise(QDir home)
+Library::initialise(QDir gcRoot)
 {
     // Search paths from library.xml
     if (libraries.count() == 0) {
 
-        // it sits above all cyclist directories
-        home.cdUp();
-
         // lets read library.xml, if not there then add workout config
         // if thats not set then add home
-        QFile libraryXML(home.canonicalPath() + "/library.xml");
+        QFile libraryXML(gcRoot.canonicalPath() + "/library.xml");
         if (libraryXML.exists() == true) {
 
             // parse it!
@@ -82,7 +79,7 @@ Library::initialise(QDir home)
             Library *one = new Library;
             one->name = "Media Library";
             QString spath = appsettings->value(NULL, GC_WORKOUTDIR).toString();
-            if (spath == "") spath = home.absolutePath();
+            if (spath == "") spath = gcRoot.absolutePath();
             one->paths.append(spath);
             libraries.append(one);
         }

--- a/src/Train/Library.h
+++ b/src/Train/Library.h
@@ -48,7 +48,7 @@ class Library : QObject
         QList<QString> paths;   // array of search paths for files in this library
         QList<QString> refs;    // array of drag-n-dropped files referenced not copied
 
-        static void initialise(QDir); // init
+        static void initialise(QDir gcRoot); // init
         static Library *findLibrary(QString);
         static void importFiles(Context *context, QStringList files, LibraryBatchImportConfirmation dialog=LibraryBatchImportConfirmation::optionalDialog);
         void removeRef(Context *context, QString ref);

--- a/src/Train/WorkoutFilterBox.cpp
+++ b/src/Train/WorkoutFilterBox.cpp
@@ -45,18 +45,23 @@ WorkoutFilterBox::WorkoutFilterBox(QWidget *parent, Context *context) : FilterEd
     this->setFilterCommands(workoutFilterCommands());
     this->setMenuProvider(new WorkoutMenuProvider(this, QDir(gcroot).canonicalPath() + "/workoutfilters.xml"));
     connect(this, &FilterEditor::returnPressed, this, &WorkoutFilterBox::processInput);
-    if (context != nullptr) {
-        connect(context, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));
+    if (context) connect(context, &Context::configChanged, this, &WorkoutFilterBox::configChanged);
 
-        // set appearance
-        configChanged(CONFIG_APPEARANCE);
-    }
+    // set appearance
+    configChanged(CONFIG_APPEARANCE);
 }
 
 WorkoutFilterBox::~WorkoutFilterBox()
 {
 }
 
+void
+WorkoutFilterBox::setContext(Context *ctx)
+{
+    if (context) disconnect(context, &Context::configChanged, this, &WorkoutFilterBox::configChanged);
+    context = ctx;
+    if (context) connect(context, &Context::configChanged, this, &WorkoutFilterBox::configChanged);
+}
 
 void
 WorkoutFilterBox::clear

--- a/src/Train/WorkoutFilterBox.h
+++ b/src/Train/WorkoutFilterBox.h
@@ -33,7 +33,7 @@ class WorkoutFilterBox : public FilterEditor
 public:
     WorkoutFilterBox(QWidget *parent=nullptr, Context *context=nullptr);
     virtual ~WorkoutFilterBox();
-    void setContext(Context *ctx) { context = ctx; }
+    void setContext(Context *ctx);
 
 public slots:
     void clear();


### PR DESCRIPTION
The following PR builds upon (and includes PR https://github.com/GoldenCheetah/GoldenCheetah/pull/4815) to remove the specific code for the initial bootstrap athlete loaded at start-up. This PR changes the start-up sequence to load the initial athlete in the same way as any other subsequently loaded athlete. 