### PR TITLE
LTM Sidebar filtering

### DIFF
--- a/src/Charts/CalendarWindow.cpp
+++ b/src/Charts/CalendarWindow.cpp
@@ -1044,10 +1044,28 @@ CalendarWindow::getSummaries
     int numTimeBuckets = firstDay.daysTo(lastDay) / timeBucketSize + 1;
     bool useMetricUnits = GlobalContext::context()->useMetricUnits;
 
-    const RideMetricFactory &factory = RideMetricFactory::instance();
-    FilterSet filterSet(context->isfiltered, context->filters);
     Specification spec;
-    spec.setFilterSet(filterSet);
+    const RideMetricFactory &factory = RideMetricFactory::instance();
+    if (context->isfiltered && context->ishomefiltered) {
+
+        // take the intersection of the two filter sets
+        auto mergedSet =
+                QSet<QString>(
+                        context->filters.begin(),
+                        context->filters.end()).intersect(
+                QSet<QString>(
+                        context->homeFilters.begin(),
+                        context->homeFilters.end()
+                        )
+                );
+        spec.setFilterSet(FilterSet(true, QStringList(mergedSet.begin(), mergedSet.end())));
+
+    } else if (context->isfiltered) {
+        spec.setFilterSet(FilterSet(true, context->filters));
+    } else if (context->ishomefiltered) {
+        spec.setFilterSet(FilterSet(true, context->homeFilters));
+    }
+
     for (int timeBucket = 0; timeBucket < numTimeBuckets; ++timeBucket) {
         QDate firstDayOfTimeBucket = firstDay.addDays(timeBucket * timeBucketSize);
         QDate lastDayOfTimeBucket = firstDayOfTimeBucket.addDays(timeBucketSize - 1);

--- a/src/Gui/GcSideBarItem.cpp
+++ b/src/Gui/GcSideBarItem.cpp
@@ -442,6 +442,7 @@ GcSplitterItem::GcSplitterItem(QString title, QIcon icon, QWidget *parent) : QWi
     layout->setContentsMargins(0,0,0,0);
     layout->setSpacing(0);
     content = NULL;
+    splitterHandle = NULL;
     //titleBar = new GcSideBarTitle(title, this);
     //layout->addWidget(titleBar);
 }

--- a/src/Gui/LTMSidebar.h
+++ b/src/Gui/LTMSidebar.h
@@ -108,6 +108,7 @@ class LTMSidebar : public QWidget
     protected slots:
 
         void chartVisibilityChanged();
+        void filterVisibilityChanged();
 
     private:
 


### PR DESCRIPTION
Using the planning view with the new calendar I noticed and have fixed the following minor issues:

1) The LTMS sidebar filter, once selected cannot be unselected, so I have changed its selection model from ExtendedSelection to MultiSelection, which supports selecting numerous filters by toggling each on/off with a mouse click, allowing the removal of all filters.

2) The Calendar wasn't combining the LTM sidebar and global filter (filter & home filter), I have updated the code so both can be applied, and the result is the intersection of the filters.

3) When the filter splitter is hidden, the filters remain applied, which I think is confusing, given that if the auto filters are hidden then any auto filter selections are removed, I think the same should apply to the main filter splitter, and I have implemented this.

Please let me know if you have comments/feedback & testing, happy to modify as required.