### PR TITLE
Start-up tiled view displays initially empty.

### DIFF
--- a/src/Gui/AbstractView.cpp
+++ b/src/Gui/AbstractView.cpp
@@ -1014,7 +1014,6 @@ bool ViewParser::startElement( const QString&, const QString&, const QString &na
         type = static_cast<GcWinID>(typeStr.toInt());
         chart = GcWindowRegistry::newGcWindow(type, context);
         if (chart != NULL) {
-            chart->hide();
             chart->setProperty("title", QVariant(title));
         }
     }

--- a/src/Gui/AthleteTab.cpp
+++ b/src/Gui/AthleteTab.cpp
@@ -220,15 +220,15 @@ AthleteTab::selectView(GcViewType viewType)
     // ensure an initial viewChanged() event occurs for the navigation model, otherwise if the
     // startup view is trends (value zero) the guard rejects the selection as views->currentIndex() is zero
     if (startupViewChangeSent && views->currentIndex() == viewTypeToIndex(viewType)) return; // not changing
-    startupViewChangeSent = true;
 
     // suspend screen updates while the view is changed.
     views->setUpdatesEnabled(false);
 
     emit viewChanged(viewType);
 
-    // first we deselect the current view
-    currentView()->setSelected(false);
+    // deselect the current view, but only after the initial selectView() call.
+    if (startupViewChangeSent) currentView()->setSelected(false);
+    startupViewChangeSent = true;
 
     // now select the real one
     views->setCurrentIndex(viewTypeToIndex(viewType));

--- a/src/Gui/Perspective.cpp
+++ b/src/Gui/Perspective.cpp
@@ -322,7 +322,7 @@ Perspective::configChanged(qint32)
     tileArea->verticalScrollBar()->setStyleSheet(AbstractView::ourStyleSheet());
 //#endif
     QPalette palette;
-    palette.setBrush(backgroundRole(), viewType() == GcViewType::VIEW_TRAIN ? GColor(CTRAINPLOTBACKGROUND) : GColor(CPLOTBACKGROUND));
+    palette.setBrush(backgroundRole(), viewType_ == GcViewType::VIEW_TRAIN ? GColor(CTRAINPLOTBACKGROUND) : GColor(CPLOTBACKGROUND));
     setPalette(palette);
     tileWidget->setPalette(palette);
     tileArea->setPalette(palette);
@@ -335,7 +335,7 @@ Perspective::configChanged(qint32)
             if (charts[i]->type() == GcWindowTypes::Overview || charts[i]->type() == GcWindowTypes::OverviewTrends) chartbar->setColor(i, GColor(COVERVIEWBACKGROUND));
             else if (charts[i]->type() == GcWindowTypes::UserAnalysis || charts[i]->type() == GcWindowTypes::UserTrends) chartbar->setColor(i, RGBColor(QColor(charts[i]->property("color").toString())));
             else {
-                if (viewType() == GcViewType::VIEW_TRAIN) chartbar->setColor(i, GColor(CTRAINPLOTBACKGROUND));
+                if (viewType_ == GcViewType::VIEW_TRAIN) chartbar->setColor(i, GColor(CTRAINPLOTBACKGROUND));
                 else chartbar->setColor(i, GColor(CPLOTBACKGROUND));
             }
         }
@@ -739,7 +739,7 @@ Perspective::addChart(GcChartWindow* newone)
             // tab colors
             if (newone->type() == GcWindowTypes::Overview || newone->type() == GcWindowTypes::OverviewTrends) chartbar->setColor(chartnum, GColor(COVERVIEWBACKGROUND));
             else {
-                if (viewType() == GcViewType::VIEW_TRAIN) chartbar->setColor(chartnum, GColor(CTRAINPLOTBACKGROUND));
+                if (viewType_ == GcViewType::VIEW_TRAIN) chartbar->setColor(chartnum, GColor(CTRAINPLOTBACKGROUND));
                 else chartbar->setColor(chartnum, GColor(CPLOTBACKGROUND));
             }
 
@@ -796,7 +796,6 @@ Perspective::addChart(GcChartWindow* newone)
         // add to the list
         if (currentStyle == 2 && chartCursor >= 0) charts.insert(chartCursor, newone);
         else charts.append(newone);
-        newone->hide();
 
         // watch for moves etc
         connect(newone, SIGNAL(resizing(GcWindow*)), this, SLOT(windowResizing(GcWindow*)));

--- a/src/Train/LiveMapWebPageWindow.h
+++ b/src/Train/LiveMapWebPageWindow.h
@@ -88,7 +88,6 @@ class LiveMapWebPageWindow : public GcChartWindow
 
         QWebEngineView *view;
         QWebEnginePage* webPage;
-        LiveMapWebPageWindow();  // default ctor
         // setting dialog
         QLabel* customUrlLabel;
         QLabel* customLonLabel;


### PR DESCRIPTION
Experimenting with the Start-up view configuration and the "Tabbed not Tiled" options, when the tiled mode was set, and GC restarted the main window contents would be empty until an event occurred that updated the charts, config change from metric to imperial, switching views, etc. This was most noticeable on Train View which is usually displayed in tiled mode, this PR fixes this issue.

Note: the initial start-up display of UserCharts in tiled mode are not displayed correctly, I have a fix for this, but will put in a separate PR.