### PR TITLE
Using QObject as baseclass for ICalendar

### DIFF
--- a/src/Core/ICalendar.cpp
+++ b/src/Core/ICalendar.cpp
@@ -164,7 +164,7 @@ static QDateTime propertyToDate(icalproperty *p)
     }
 }
 
-ICalendar::ICalendar(Context *context) : QWidget(context->mainWindow), context(context)
+ICalendar::ICalendar(Context *context) : QObject(context->mainWindow), context(context)
 {
     // get from local and remote calendar
 

--- a/src/Core/ICalendar.h
+++ b/src/Core/ICalendar.h
@@ -20,12 +20,12 @@
 #define _GC_ICalendar_h 1
 #include "GoldenCheetah.h"
 
-#include <QtGui>
+#include <QObject>
 #include "Context.h"
 #include "RideMetric.h"
 #include <libical/ical.h>
 
-class ICalendar : public QWidget
+class ICalendar : public QObject
 {
     Q_OBJECT
     G_OBJECT


### PR DESCRIPTION
As ICalendar is not a real UI class and is never added to any layout, it overlays the menubar, preventing opening the first two entries. Using QObject instead of QWidget as superclass fixes this issue