### PR TITLE
Revert "Combine view indexes and view relevance definitions into single enumerated type (#4795)"

### DIFF
--- a/src/Cloud/CloudDBChart.cpp
+++ b/src/Cloud/CloudDBChart.cpp
@@ -436,8 +436,7 @@ CloudDBChartClient::unmarshallAPIv1Object(QJsonObject* object, ChartAPIv1* chart
 static const int chartImageWidth = 320;
 static const int chartImageHeight = 240;
 
-CloudDBChartListDialog::CloudDBChartListDialog() :
-    const_stepSize(5), g_chartViewType(GcViewType::VIEW_TRENDS)
+CloudDBChartListDialog::CloudDBChartListDialog() : const_stepSize(5)
 {
    g_client = new CloudDBChartClient();
    g_currentHeaderList = new QList<CommonAPIHeaderV1>;
@@ -616,10 +615,10 @@ CloudDBChartListDialog::closeEvent(QCloseEvent* event) {
 }
 
 bool
-CloudDBChartListDialog::prepareData(QString athlete, CloudDBCommon::UserRole role, GcViewType chartViewType) {
+CloudDBChartListDialog::prepareData(QString athlete, CloudDBCommon::UserRole role, int chartView) {
 
     g_role = role;
-    g_chartViewType = chartViewType;
+    g_chartView = chartView;
     // and now initialize the dialog
     setVisibleButtonsForRole();
 
@@ -710,12 +709,11 @@ CloudDBChartListDialog::updateCurrentPresets(int index, int count) {
 
     QString view = tr("unknown");
     if (g_role == CloudDBCommon::UserImport ) {
-        switch(g_chartViewType) {
-        case GcViewType::VIEW_TRENDS : view = tr("Trends"); break;
-        case GcViewType::VIEW_ANALYSIS : view = tr("Activities"); break;
-        case GcViewType::VIEW_PLAN : view = tr("Plan"); break;
-        case GcViewType::VIEW_TRAIN : view = tr("Train"); break;
-        default: qDebug() << "Unhandled view type: " << static_cast<std::underlying_type_t<GcViewType>>(g_chartViewType); break;
+        switch(g_chartView) {
+        case 0 : view = tr("Trends"); break;
+        case 1 : view = tr("Activities"); break;
+        case 2 : view = tr("Plan"); break;
+        case 3 : view = tr("Train"); break;
         }
     } else
     {
@@ -1065,7 +1063,16 @@ CloudDBChartListDialog::languageFilterChanged(int) {
 void
 CloudDBChartListDialog::applyAllFilters() {
 
+
     // setup to only show charts that are relevant to the current view
+    unsigned int mask=0;
+    switch(g_chartView) {
+        case 0 : mask = VIEW_TRENDS; break;
+        default:
+        case 1 : mask = VIEW_ANALYSIS; break;
+        case 2 : mask = VIEW_PLAN; break;
+        case 3 : mask = VIEW_TRAIN; break;
+    }
 
     QStringList searchList;
     g_currentHeaderList->clear();
@@ -1077,13 +1084,13 @@ CloudDBChartListDialog::applyAllFilters() {
 
         // list does not contain any deleted chart id's
 
+
         // first filter based on the current view (Home, Analysis, Plan) - but only on Imp
-        // note: g_chartViewType is both the view type and the view relevance mask.
         bool chartOkForView = false;
         if (g_role == CloudDBCommon::UserImport) {
             int winId = chart.ChartType.toInt();
-            for (int i = 0; GcWindows[i].relevance != GcViewType::NO_VIEW_SET; i++) {
-                if (GcWindows[i].id == winId && (GcWindows[i].relevance & g_chartViewType)) {
+            for (int i = 0; GcWindows[i].relevance; i++) {
+                if (GcWindows[i].id == winId && (GcWindows[i].relevance & mask)) {
                     chartOkForView = true;
                     break;
                 }

--- a/src/Cloud/CloudDBChart.h
+++ b/src/Cloud/CloudDBChart.h
@@ -120,7 +120,7 @@ public:
     CloudDBChartListDialog();
     ~CloudDBChartListDialog();
 
-    bool prepareData(QString athlete, CloudDBCommon::UserRole role, GcViewType chartViewType = GcViewType::VIEW_TRENDS);
+    bool prepareData(QString athlete, CloudDBCommon::UserRole role, int chartView = 0);
     QList<QString> getSelectedSettings() {return g_selected; }
 
     // re-implemented
@@ -190,7 +190,7 @@ private:
 
     // UserRole - UserEdit
     QPushButton *deleteUserEditButton, *editUserEditButton, *closeUserEditButton;
-    GcViewType g_chartViewType;
+    int g_chartView;
 
     // UserRole - Curator Edit
     QPushButton *curateCuratorEditButton, *editCuratorEditButton, *deleteCuratorEditButton, *closeCuratorButton;

--- a/src/Core/Context.cpp
+++ b/src/Core/Context.cpp
@@ -148,7 +148,6 @@ Context::Context(MainWindow *mainWindow): mainWindow(mainWindow)
     isfiltered = ishomefiltered = false;
     isCompareIntervals = isCompareDateRanges = false;
     isRunning = isPaused = false;
-    viewType = GcViewType::NO_VIEW_SET;
 
     connect(this, SIGNAL(loadProgress(QString, double)), mainWindow, SLOT(loadProgress(QString, double)));
 

--- a/src/Core/Context.h
+++ b/src/Core/Context.h
@@ -121,7 +121,7 @@ class Context : public QObject
 
         // mainwindow state
         NavigationModel *nav;
-        GcViewType viewType;
+        int viewIndex;
         bool showSidebar, showLowbar, showToolbar, showTabbar;
         int style;
         QString searchText;
@@ -206,7 +206,7 @@ class Context : public QObject
         void notifyUserMetricsChanged() { emit userMetricsChanged(); }
 
         // view changed
-        void setViewType(GcViewType v) { viewType = v; emit viewChanged(v); }
+        void setIndex(int i) { viewIndex = i; emit viewChanged(i); }
 
         // realtime signals
         void notifyTelemetryUpdate(const RealtimeData &rtData) { telemetryUpdate(rtData); }
@@ -312,7 +312,7 @@ class Context : public QObject
         void userMetricsChanged();
 
         // view changed
-        void viewChanged(GcViewType);
+        void viewChanged(int);
 
         // refreshing stats
         void refreshStart();

--- a/src/Core/RideCacheModel.cpp
+++ b/src/Core/RideCacheModel.cpp
@@ -132,7 +132,7 @@ RideCacheModel::itemChanged(RideItem *item)
         emit dataChanged(createIndex(row,0), createIndex(row,columns_-1));
     }
     //XXX hack to get the navigator to redraw
-    context->tab->view(GcViewType::VIEW_ANALYSIS)->sidebar()->update();
+    context->tab->view(1)->sidebar()->update();
 }
 
 void RideCacheModel::beginReset() { beginResetModel(); }

--- a/src/Gui/AbstractView.cpp
+++ b/src/Gui/AbstractView.cpp
@@ -35,8 +35,8 @@
 
 const int SIDEBAR_DEFAULT_WIDTH=200;
 
-AbstractView::AbstractView(Context *context, GcViewType viewType, const QString& viewName, const QString& heading) :
-    QWidget(context->tab), context(context), _viewType(viewType), _viewName(viewName),
+AbstractView::AbstractView(Context *context, int type, const QString& view, const QString& heading) :
+    QWidget(context->tab), context(context), type(type), view(view),
     _sidebar(true), _tiled(false), _selected(false), lastHeight(130*dpiYFactor), sidewidth(0),
     active(false), bottomRequested(false), bottomHideOnIdle(false), perspectiveactive(false),
     stack(NULL), splitter(NULL), mainSplitter(NULL), 
@@ -113,7 +113,7 @@ AbstractView::splitterMoved(int pos,int)
     sidewidth = splitter->sizes()[0];
 
     // we now have splitter settings for each view
-    QString setting = QString("%1/%2").arg(GC_SETTINGS_SPLITTER_SIZES).arg(static_cast<std::underlying_type_t<GcViewType>>(_viewType));
+    QString setting = QString("%1/%2").arg(GC_SETTINGS_SPLITTER_SIZES).arg(type);
     appsettings->setCValue(context->athlete->cyclist, setting, splitter->saveState());
 
     notifyViewSplitterMoved();
@@ -294,7 +294,7 @@ AbstractView::saveState()
     // we do not save all the other Qt properties since
     // we're not interested in them
     // NOTE: currently we support QString, int, double and bool types - beware custom types!!
-    QString filename = viewCfgPath + "/" + _viewName + "-perspectives.xml";
+    QString filename = viewCfgPath + "/" + view + "-perspectives.xml";
 
     QFile file(filename);
     if (!file.open(QFile::WriteOnly)) {
@@ -325,7 +325,7 @@ void
 AbstractView::restoreState(bool useDefault)
 {
     // restore window state
-    QString filename = viewCfgPath + "/" + _viewName + "-perspectives.xml";
+    QString filename = viewCfgPath + "/" + view + "-perspectives.xml";
 
     QFileInfo finfo(filename);
 
@@ -344,7 +344,7 @@ AbstractView::restoreState(bool useDefault)
         // fetch from the goldencheetah.org website
         QString request = QString("%1/%2-perspectives.xml")
                              .arg(VERSION_CONFIG_PREFIX)
-                             .arg(_viewName);
+                             .arg(view);
 
         QNetworkReply *reply = nam.get(QNetworkRequest(QUrl(request)));
 
@@ -379,7 +379,7 @@ AbstractView::restoreState(bool useDefault)
         // renamed as "Legacy" and prepended to default perspectives,
         // except when useDefault is requested
         if (!finfo.exists() && !useDefault) {
-            filename = context->athlete->home->config().canonicalPath() + "/" + _viewName + "-layout.xml";
+            filename = context->athlete->home->config().canonicalPath() + "/" + view + "-layout.xml";
 
             QFile file(filename);
             if (file.open(QIODevice::ReadOnly)) {
@@ -397,7 +397,7 @@ AbstractView::restoreState(bool useDefault)
                 QXmlInputSource source;
                 source.setData(content);
                 QXmlSimpleReader xmlReader;
-                ViewParser handler(context, _viewType, useDefault);
+                ViewParser handler(context, type, useDefault);
                 xmlReader.setContentHandler(&handler);
                 xmlReader.setErrorHandler(&handler);
 
@@ -411,7 +411,7 @@ AbstractView::restoreState(bool useDefault)
 
         // drop back to what is baked in
         if (!finfo.exists()) {
-            filename = QString(":xml/%1-perspectives.xml").arg(_viewName);
+            filename = QString(":xml/%1-perspectives.xml").arg(view);
             useDefault = true;
         }
         QFile file(filename);
@@ -432,7 +432,7 @@ AbstractView::restoreState(bool useDefault)
         QXmlInputSource source;
         source.setData(content);
         QXmlSimpleReader xmlReader;
-        ViewParser handler(context, _viewType, useDefault);
+        ViewParser handler(context, type, useDefault);
         xmlReader.setContentHandler(&handler);
         xmlReader.setErrorHandler(&handler);
 
@@ -448,7 +448,7 @@ AbstractView::restoreState(bool useDefault)
         if (legacy) restored[0]->title_ = "Legacy";
 
     } else { // MUST have at least one perspective
-        restored << new Perspective(context, "Empty", _viewType);
+        restored << new Perspective(context, "Empty", type);
     }
 
     // initialise them
@@ -472,7 +472,7 @@ AbstractView::appendPerspective(Perspective *page)
 bool
 AbstractView::importPerspective(QString filename)
 {
-    Perspective *newone = Perspective::fromFile(context, filename, _viewType);
+    Perspective *newone = Perspective::fromFile(context, filename, type);
     if (newone) {
         appendPerspective(newone);
         return true;
@@ -493,7 +493,7 @@ AbstractView::exportPerspective(Perspective *p, QString filename)
 Perspective *
 AbstractView::addPerspective(QString name)
 {
-    Perspective *page = new Perspective(context, name, _viewType);
+    Perspective *page = new Perspective(context, name, type);
 
     notifyViewPerspectiveAdded(page);
 
@@ -585,7 +585,7 @@ AbstractView::setPages(QStackedWidget *pages)
     splitter->setCollapsible(index, false);
 
     // restore sizes
-    QString setting = QString("%1/%2").arg(GC_SETTINGS_SPLITTER_SIZES).arg(static_cast<std::underlying_type_t<GcViewType>>(_viewType));
+    QString setting = QString("%1/%2").arg(GC_SETTINGS_SPLITTER_SIZES).arg(type);
     QVariant splitterSizes = appsettings->cvalue(context->athlete->cyclist, setting); 
 
     // new (3.1) mechanism 
@@ -704,7 +704,7 @@ AbstractView::sidebarChanged()
         sidebar_->show();
 
         // Restore sizes
-        QString setting = QString("%1/%2").arg(GC_SETTINGS_SPLITTER_SIZES).arg(static_cast<std::underlying_type_t<GcViewType>>(_viewType));
+        QString setting = QString("%1/%2").arg(GC_SETTINGS_SPLITTER_SIZES).arg(type);
         QVariant splitterSizes = appsettings->cvalue(context->athlete->cyclist, setting);
         if (splitterSizes.toByteArray().size() > 1 ) {
             splitter->restoreState(splitterSizes.toByteArray());
@@ -971,7 +971,7 @@ bool ViewParser::startElement( const QString&, const QString&, const QString &na
     if (name == "layout") {
 
         QString name="General";
-        GcViewType typetouse=GcViewType::NO_VIEW_SET;
+        int typetouse=type;
         int trainswitch=0;
         QString expression;
         for(int i=0; i<attrs.count(); i++) {
@@ -985,7 +985,7 @@ bool ViewParser::startElement( const QString&, const QString&, const QString &na
                 expression = Utils::unprotect(attrs.value(i));
             }
             if (attrs.qName(i) == "type") {
-                typetouse = static_cast<GcViewType>(Utils::unprotect(attrs.value(i)).toInt());
+                typetouse = Utils::unprotect(attrs.value(i)).toInt();
             }
             if (attrs.qName(i) == "trainswitch") {
                 trainswitch = attrs.value(i).toInt();

--- a/src/Gui/AbstractView.h
+++ b/src/Gui/AbstractView.h
@@ -54,6 +54,7 @@ class AbstractView : public QWidget
 
     public:
 
+        AbstractView(Context *context, int type, const QString& view, const QString& heading);
         virtual ~AbstractView();
         virtual void close() {};
 
@@ -99,8 +100,7 @@ class AbstractView : public QWidget
         void setSelected(bool x) { _selected=x; selectionChanged(); }
         bool isSelected() const { return _selected; }
 
-        GcViewType viewType() const { return _viewType; }
-        virtual QString viewTypeDesc() const = 0;
+        int viewType() { return type; }
 
         void importChart(QMap<QString,QString>properties, bool select) { perspective_->importChart(properties, select); }
 
@@ -142,14 +142,11 @@ class AbstractView : public QWidget
 
     protected:
 
-        // Hide constructor to create an Abstract class
-        AbstractView(Context *context, GcViewType viewType, const QString& view, const QString& heading);
-
         Context *context;
-        const GcViewType _viewType; // used by windowregistry; e.g VIEW_TRAIN VIEW_ANALYSIS VIEW_PLAN VIEW_TRENDS
+        const int type; // used by windowregistry; e.g VIEW_TRAIN VIEW_ANALYSIS VIEW_PLAN VIEW_TRENDS
                         // we don't care what values are pass through to the GcWindowRegistry to decide
                         // what charts are relevant for this view.
-        const QString _viewName; // type of view:  "train", "analysis", "plan", "home"
+        const QString view; // type of view:  "train", "analysis", "plan", "home"
         QString viewCfgPath; // directory path to the view's configuration
 
         // properties
@@ -206,7 +203,7 @@ class ViewParser : public QXmlDefaultHandler
 {
 
 public:
-    ViewParser(Context *context, GcViewType viewType, bool useDefault) : style(2), context(context), viewType(viewType), useDefault(useDefault) {}
+    ViewParser(Context *context, int type, bool useDefault) : style(2), context(context), type(type), useDefault(useDefault) {}
 
     // the results!
     QList<Perspective*> perspectives;
@@ -223,7 +220,7 @@ protected:
     Context *context;
     GcChartWindow *chart;
     Perspective *page; // current
-    GcViewType viewType; // what type of view is this VIEW_{TRENDS,ANALYSIS,PLAN,TRAIN}
+    int type; // what type of view is this VIEW_{HOME,ANALYSIS,PLAN,TRAIN}
     bool useDefault; // force a reset by using the default layouts
 
 };
@@ -246,7 +243,7 @@ protected:
     QSplitterHandle *createHandle() override {
         if (this->tabView)
         {
-            if (this->tabView->viewType() == GcViewType::VIEW_TRAIN)
+            if (this->tabView->viewType() == VIEW_TRAIN)
             {
                 return new GcSplitterHandle(name, orientation, NULL, NULL, NULL, this);
             }

--- a/src/Gui/AthleteTab.cpp
+++ b/src/Gui/AthleteTab.cpp
@@ -133,17 +133,17 @@ AthleteTab::close()
  * MainWindow integration with Tab / TabView (mostly pass through)
  *****************************************************************************/
 
-bool AthleteTab::hasBottom() { return currentView()->hasBottom(); }
-bool AthleteTab::isBottomRequested() { return currentView()->isBottomRequested(); }
-void AthleteTab::setBottomRequested(bool x) { currentView()->setBottomRequested(x); }
-void AthleteTab::setSidebarEnabled(bool x) { currentView()->setSidebarEnabled(x); }
-bool AthleteTab::isSidebarEnabled() { return currentView()->sidebarEnabled(); }
-void AthleteTab::toggleSidebar() { currentView()->setSidebarEnabled(!currentView()->sidebarEnabled()); }
-void AthleteTab::setTiled(bool x) { currentView()->setTiled(x); }
-bool AthleteTab::isTiled() { return currentView()->isTiled(); }
-void AthleteTab::toggleTile() { currentView()->setTiled(!currentView()->isTiled()); }
-void AthleteTab::resetLayout(QComboBox *perspectiveSelector) { currentView()->resetLayout(perspectiveSelector); }
-void AthleteTab::addChart(GcWinID i) { currentView()->addChart(i); }
+bool AthleteTab::hasBottom() { return view(currentView())->hasBottom(); }
+bool AthleteTab::isBottomRequested() { return view(currentView())->isBottomRequested(); }
+void AthleteTab::setBottomRequested(bool x) { view(currentView())->setBottomRequested(x); }
+void AthleteTab::setSidebarEnabled(bool x) { view(currentView())->setSidebarEnabled(x); }
+bool AthleteTab::isSidebarEnabled() { return view(currentView())->sidebarEnabled(); }
+void AthleteTab::toggleSidebar() { view(currentView())->setSidebarEnabled(!view(currentView())->sidebarEnabled()); }
+void AthleteTab::setTiled(bool x) { view(currentView())->setTiled(x); }
+bool AthleteTab::isTiled() { return view(currentView())->isTiled(); }
+void AthleteTab::toggleTile() { view(currentView())->setTiled(!view(currentView())->isTiled()); }
+void AthleteTab::resetLayout(QComboBox *perspectiveSelector) { view(currentView())->resetLayout(perspectiveSelector); }
+void AthleteTab::addChart(GcWinID i) { view(currentView())->addChart(i); }
 void AthleteTab::addIntervals() { analysisView->addIntervals(); }
 
 void AthleteTab::setRide(RideItem*ride)
@@ -155,87 +155,39 @@ void AthleteTab::setRide(RideItem*ride)
 }
 
 AbstractView *
-AthleteTab::view(GcViewType viewType) const
+AthleteTab::view(int index)
 {
-    switch(viewType) {
-        case GcViewType::VIEW_TRENDS : return homeView;
-        case GcViewType::VIEW_ANALYSIS : return analysisView;
-        case GcViewType::VIEW_PLAN : return planView;
-        case GcViewType::VIEW_TRAIN : return trainView;
-        default: {
-            qCritical() << "Unhandled view type in AthleteTab, returning analysisView !";
-            return analysisView;
-        } break;
-    }
-}
-
-AbstractView *
-AthleteTab::currentView() const
-{
-    return view(currentViewType());
-}
-
-GcViewType
-AthleteTab::currentViewType() const
-{
-    // map from AthleteTab's internal qt stack index to view type
-    return indexToViewType(views->currentIndex());
-}
-
-GcViewType
-AthleteTab::indexToViewType(int index) const
-{
-    // map from AthleteTab's internal qt stack index to GcViewType
-    switch (index) {
-        case 0: return GcViewType::VIEW_TRENDS;
-        case 1: return GcViewType::VIEW_ANALYSIS;
-        case 2: return GcViewType::VIEW_PLAN;
-        case 3: return GcViewType::VIEW_TRAIN;
-        default: {
-            qCritical() << "Unhandled view index in AthleteTab, returning VIEW_ANALYSIS !";
-            return GcViewType::VIEW_ANALYSIS;
-        } break;
-    }
-}
-
-int
-AthleteTab::viewTypeToIndex(GcViewType viewType) const
-{
-    // map from GcViewType to AthleteTab's internal qt stack index
-    switch (viewType) {
-        case GcViewType::VIEW_TRENDS: return 0;
-        case GcViewType::VIEW_ANALYSIS: return 1;
-        case GcViewType::VIEW_PLAN: return 2;
-        case GcViewType::VIEW_TRAIN: return 3;
-        default: {
-            qCritical() << "Unhandled view type in AthleteTab, returning index 1 (aka Analysis view)!";
-            return 1;
-        } break;
+    switch(index) {
+        case 0 : return homeView;
+        default:
+        case 1 : return analysisView;
+        case 2 : return planView;
+        case 3 : return trainView;
     }
 }
 
 void
-AthleteTab::selectView(GcViewType viewType)
+AthleteTab::selectView(int index)
 {
     // ensure an initial viewChanged() event occurs for the navigation model, otherwise if the
     // startup view is trends (value zero) the guard rejects the selection as views->currentIndex() is zero
-    if (startupViewChangeSent && views->currentIndex() == viewTypeToIndex(viewType)) return; // not changing
+    if (startupViewChangeSent && views->currentIndex() == index) return; // not changing
 
     // suspend screen updates while the view is changed.
     views->setUpdatesEnabled(false);
 
-    emit viewChanged(viewType);
+    emit viewChanged(index);
 
-    // deselect the current view, but only after the initial selectView() call.
-    if (startupViewChangeSent) currentView()->setSelected(false);
+    // first we deselect the current
+    view(views->currentIndex())->setSelected(false);
     startupViewChangeSent = true;
 
     // now select the real one
-    views->setCurrentIndex(viewTypeToIndex(viewType));
-    view(viewType)->setSelected(true);
-    masterControls->setCurrentIndex(viewTypeToIndex(viewType));
-    context->setViewType(viewType);
-    context->mainWindow->resetPerspective(viewType); // set perspective for this view
+    views->setCurrentIndex(index);
+    view(index)->setSelected(true);
+    masterControls->setCurrentIndex(index);
+    context->setIndex(index);
+    context->mainWindow->resetPerspective(index); // set perspective for this view
 
     // enable screen updates to render the view without flickering
     views->setUpdatesEnabled(true);
@@ -261,7 +213,7 @@ AthleteTab::rideSelected(RideItem*)
         // when the view is selected by the user and no earlier
         if (analysisView->page() != NULL) {
             context->mainWindow->newSidebar()->setItemSelected(GcSideBarBtnId::ACTIVITIES_BTN, true);
-            selectView(GcViewType::VIEW_ANALYSIS);
+            selectView(1);
         }
     }
 

--- a/src/Gui/AthleteTab.h
+++ b/src/Gui/AthleteTab.h
@@ -42,9 +42,8 @@ class AthleteTab: public QWidget
         void close();
 
         ChartSettings *chartsettings() { return chartSettings; } // by HomeWindow
-        GcViewType currentViewType() const;
-        AbstractView *currentView() const;
-        AbstractView *view(GcViewType viewType) const;
+        int currentView() { return views->currentIndex(); }
+        AbstractView *view(int index);
 
         NavigationModel *nav; // back/forward for this tab
 
@@ -57,7 +56,7 @@ class AthleteTab: public QWidget
 
     signals:
 
-        void viewChanged(GcViewType);
+        void viewChanged(int);
         void rideItemSelected(RideItem*);
         void dateRangeSelected(DateRange);
 
@@ -89,17 +88,12 @@ class AthleteTab: public QWidget
         void addChart(GcWinID);
 
         // switch views
-        void selectView(GcViewType);
+        void selectView(int);
 
         // specific to analysis view
         void addIntervals();
 
     private:
-
-        // map between the view stack index and the GcViewType,
-        // the view stack and this mapping is hidden with athlete tab.
-        int viewTypeToIndex(GcViewType viewType) const;
-        GcViewType indexToViewType(int index) const;
 
         // constructor finished and navigation
         // model isn't undo/redo ride selection

--- a/src/Gui/GcWindowRegistry.cpp
+++ b/src/Gui/GcWindowRegistry.cpp
@@ -68,66 +68,65 @@ GcWindowRegistry::initialize()
 {
   static GcWindowRegistry GcWindowsInit[] = {
     // name                     GcWinID
-    { GcViewType::VIEW_TRENDS, tr("Season Overview"),GcWindowTypes::OverviewTrends },
-    { GcViewType::VIEW_TRENDS, tr("Blank Overview "),GcWindowTypes::OverviewTrendsBlank },
-    { GcViewType::VIEW_PLAN, tr("Plan Overview"),GcWindowTypes::OverviewPlan },
-    { GcViewType::VIEW_PLAN, tr("Blank Overview "),GcWindowTypes::OverviewPlanBlank },
-    { GcViewType::VIEW_TRENDS, tr("User Chart"),GcWindowTypes::UserTrends },
-    { GcViewType::VIEW_PLAN, tr("User Chart"),GcWindowTypes::UserPlan },
-    { GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN, tr("Trends"),GcWindowTypes::LTM },
-    { GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN, tr("TreeMap"),GcWindowTypes::TreeMap },
-    //{ GcViewType::VIEW_TRENDS, tr("Weekly Summary"),GcWindowTypes::WeeklySummary },// DEPRECATED
-    { GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN,  tr("Power Duration "),GcWindowTypes::CriticalPowerSummary },
-    //{ GcViewType::VIEW_TRENDS,  tr("Training Plan"),GcWindowTypes::SeasonPlan },
-    //{ GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN,  tr("Performance Manager"),GcWindowTypes::PerformanceManager },
-    { GcViewType::VIEW_ANALYSIS, tr("Activity Overview"),GcWindowTypes::Overview },
-    { GcViewType::VIEW_ANALYSIS, tr("Blank Overview"),GcWindowTypes::OverviewAnalysisBlank },
-    { GcViewType::VIEW_ANALYSIS, tr("User Chart "),GcWindowTypes::UserAnalysis },
-    //{ GcViewType::VIEW_ANALYSIS, tr("Summary"),GcWindowTypes::RideSummary }, // DEPRECATED IN V3.6
-    { GcViewType::VIEW_ANALYSIS, tr("Data"),GcWindowTypes::MetadataWindow },
-    //{ GcViewType::VIEW_ANALYSIS, tr("Summary and Details"),GcWindowTypes::Summary },
-    //{ GcViewType::VIEW_ANALYSIS, tr("Editor"),GcWindowTypes::RideEditor },
-    { GcViewType::VIEW_ANALYSIS, tr("Performance"),GcWindowTypes::AllPlot },
-    { GcViewType::VIEW_ANALYSIS, tr("Power Duration"),GcWindowTypes::CriticalPower },
-    { GcViewType::VIEW_ANALYSIS, tr("Histogram"),GcWindowTypes::Histogram },
-    { GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN, tr("Distribution"),GcWindowTypes::Distribution },
-    { GcViewType::VIEW_ANALYSIS, tr("Pedal Force vs Velocity"),GcWindowTypes::PfPv },
-    { GcViewType::VIEW_ANALYSIS, tr("Heartrate vs Power"),GcWindowTypes::HrPw },
-    { GcViewType::VIEW_ANALYSIS, tr("Map"),GcWindowTypes::RideMapWindow },
-    { GcViewType::VIEW_ANALYSIS, tr("R Chart"),GcWindowTypes::RConsole },
-    { GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN, tr("R Chart "),GcWindowTypes::RConsoleSeason },
-    { GcViewType::VIEW_ANALYSIS, tr("Python Chart"),GcWindowTypes::Python },
-    { GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN, tr("Python Chart "),GcWindowTypes::PythonSeason },
-    //{ GcViewType::VIEW_ANALYSIS, tr("Bing Map"),GcWindowTypes::BingMap },
-    { GcViewType::VIEW_ANALYSIS, tr("Scatter"),GcWindowTypes::Scatter },
-    { GcViewType::VIEW_ANALYSIS, tr("Aerolab"),GcWindowTypes::Aerolab },
-    //{ GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN, tr("Calendar"),GcWindowTypes::Diary },
-    { GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN, tr("Navigator"), GcWindowTypes::ActivityNavigator },
-    //{ GcViewType::VIEW_PLAN|GcViewType::VIEW_TRENDS, tr("Summary "), GcWindowTypes::DateRangeSummary }, // DEPRECATED IN V3.6
-    { GcViewType::VIEW_TRAIN, tr("Telemetry"),GcWindowTypes::DialWindow },
-    { GcViewType::VIEW_TRAIN, tr("Workout"),GcWindowTypes::WorkoutPlot },
-    { GcViewType::VIEW_TRAIN, tr("Realtime"),GcWindowTypes::RealtimePlot },
-    { GcViewType::VIEW_TRAIN, tr("Pedal Stroke"),GcWindowTypes::SpinScanPlot },
-    { GcViewType::VIEW_TRAIN, tr("Video Player"),GcWindowTypes::VideoPlayer },
-    { GcViewType::VIEW_TRAIN, tr("Workout Editor"),GcWindowTypes::WorkoutWindow },
-    { GcViewType::VIEW_TRAIN, tr("Live Map"),GcWindowTypes::LiveMapWebPageWindow },
-    { GcViewType::VIEW_TRAIN, tr("Elevation Chart"),GcWindowTypes::ElevationChart },
-    { GcViewType::VIEW_ANALYSIS|GcViewType::VIEW_TRENDS|GcViewType::VIEW_TRAIN, tr("Web page"),GcWindowTypes::WebPageWindow },
-    { GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN, tr("Calendar"),GcWindowTypes::Calendar },
-    { GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN, tr("Agenda"),GcWindowTypes::Agenda },
-    { GcViewType::VIEW_PLAN, tr("Plan Adherence"),GcWindowTypes::PlanAdherence },
-    { GcViewType::NO_VIEW_SET, "", GcWindowTypes::None }};
+    { VIEW_TRENDS, tr("Season Overview"),GcWindowTypes::OverviewTrends },
+    { VIEW_TRENDS, tr("Blank Overview "),GcWindowTypes::OverviewTrendsBlank },
+    { VIEW_PLAN, tr("Plan Overview"),GcWindowTypes::OverviewPlan },
+    { VIEW_PLAN, tr("Blank Overview "),GcWindowTypes::OverviewPlanBlank },
+    { VIEW_TRENDS, tr("User Chart"),GcWindowTypes::UserTrends },
+    { VIEW_PLAN, tr("User Chart"),GcWindowTypes::UserPlan },
+    { VIEW_TRENDS|VIEW_PLAN, tr("Trends"),GcWindowTypes::LTM },
+    { VIEW_TRENDS|VIEW_PLAN, tr("TreeMap"),GcWindowTypes::TreeMap },
+    //{ VIEW_TRENDS, tr("Weekly Summary"),GcWindowTypes::WeeklySummary },// DEPRECATED
+    { VIEW_TRENDS|VIEW_PLAN,  tr("Power Duration "),GcWindowTypes::CriticalPowerSummary },
+    //{ VIEW_TRENDS,  tr("Training Plan"),GcWindowTypes::SeasonPlan },
+    //{ VIEW_TRENDS|VIEW_DIARY,  tr("Performance Manager"),GcWindowTypes::PerformanceManager },
+    { VIEW_ANALYSIS, tr("Activity Overview"),GcWindowTypes::Overview },
+    { VIEW_ANALYSIS, tr("Blank Overview"),GcWindowTypes::OverviewAnalysisBlank },
+    { VIEW_ANALYSIS, tr("User Chart "),GcWindowTypes::UserAnalysis },
+    //{ VIEW_ANALYSIS, tr("Summary"),GcWindowTypes::RideSummary }, // DEPRECATED IN V3.6
+    { VIEW_ANALYSIS, tr("Data"),GcWindowTypes::MetadataWindow },
+    //{ VIEW_ANALYSIS, tr("Summary and Details"),GcWindowTypes::Summary },
+    //{ VIEW_ANALYSIS, tr("Editor"),GcWindowTypes::RideEditor },
+    { VIEW_ANALYSIS, tr("Performance"),GcWindowTypes::AllPlot },
+    { VIEW_ANALYSIS, tr("Power Duration"),GcWindowTypes::CriticalPower },
+    { VIEW_ANALYSIS, tr("Histogram"),GcWindowTypes::Histogram },
+    { VIEW_TRENDS|VIEW_PLAN, tr("Distribution"),GcWindowTypes::Distribution },
+    { VIEW_ANALYSIS, tr("Pedal Force vs Velocity"),GcWindowTypes::PfPv },
+    { VIEW_ANALYSIS, tr("Heartrate vs Power"),GcWindowTypes::HrPw },
+    { VIEW_ANALYSIS, tr("Map"),GcWindowTypes::RideMapWindow },
+    { VIEW_ANALYSIS, tr("R Chart"),GcWindowTypes::RConsole },
+    { VIEW_TRENDS|VIEW_PLAN, tr("R Chart "),GcWindowTypes::RConsoleSeason },
+    { VIEW_ANALYSIS, tr("Python Chart"),GcWindowTypes::Python },
+    { VIEW_TRENDS|VIEW_PLAN, tr("Python Chart "),GcWindowTypes::PythonSeason },
+    //{ VIEW_ANALYSIS, tr("Bing Map"),GcWindowTypes::BingMap },
+    { VIEW_ANALYSIS, tr("Scatter"),GcWindowTypes::Scatter },
+    { VIEW_ANALYSIS, tr("Aerolab"),GcWindowTypes::Aerolab },
+    //{ VIEW_TRENDS|VIEW_DIARY, tr("Calendar"),GcWindowTypes::Diary },
+    { VIEW_TRENDS|VIEW_PLAN, tr("Navigator"), GcWindowTypes::ActivityNavigator },
+    //{ VIEW_DIARY|VIEW_TRENDS, tr("Summary "), GcWindowTypes::DateRangeSummary }, // DEPRECATED IN V3.6
+    { VIEW_TRAIN, tr("Telemetry"),GcWindowTypes::DialWindow },
+    { VIEW_TRAIN, tr("Workout"),GcWindowTypes::WorkoutPlot },
+    { VIEW_TRAIN, tr("Realtime"),GcWindowTypes::RealtimePlot },
+    { VIEW_TRAIN, tr("Pedal Stroke"),GcWindowTypes::SpinScanPlot },
+    { VIEW_TRAIN, tr("Video Player"),GcWindowTypes::VideoPlayer },
+    { VIEW_TRAIN, tr("Workout Editor"),GcWindowTypes::WorkoutWindow },
+    { VIEW_TRAIN, tr("Live Map"),GcWindowTypes::LiveMapWebPageWindow },
+    { VIEW_TRAIN, tr("Elevation Chart"),GcWindowTypes::ElevationChart },
+    { VIEW_ANALYSIS|VIEW_TRENDS|VIEW_TRAIN, tr("Web page"),GcWindowTypes::WebPageWindow },
+    { VIEW_TRENDS|VIEW_PLAN, tr("Calendar"),GcWindowTypes::Calendar },
+    { VIEW_PLAN, tr("Agenda"),GcWindowTypes::Agenda },
+    { VIEW_PLAN, tr("Plan Adherence"),GcWindowTypes::PlanAdherence },
+    { 0, "", GcWindowTypes::None }};
   // initialize the global registry
   GcWindows = GcWindowsInit;
 }
 
-QStringList
-GcWindowRegistry::windowsForType(GcViewType type)
+QStringList windowsForType(int type)
 {
     QStringList returning;
 
-    for(int i=0; GcWindows[i].relevance != GcViewType::NO_VIEW_SET; i++) {
-        if (GcWindows[i].relevance & type)
+    for(int i=0; GcWindows[i].relevance; i++) {
+        if (GcWindows[i].relevance & type) 
             returning << GcWindows[i].name;
     }
     return returning;
@@ -136,19 +135,18 @@ GcWindowRegistry::windowsForType(GcViewType type)
 QString
 GcWindowRegistry::title(GcWinID id)
 {
-    for(int i=0; GcWindows[i].relevance != GcViewType::NO_VIEW_SET; i++) {
-        if (GcWindows[i].id == id)
+    for(int i=0; GcWindows[i].relevance; i++) {
+        if (GcWindows[i].relevance && GcWindows[i].id == id)
             return GcWindows[i].name;
     }
     return QString("unknown");
 }
 
-QList<GcWinID>
-GcWindowRegistry::idsForType(GcViewType type)
+QList<GcWinID> idsForType(int type)
 {
     QList<GcWinID> returning;
 
-    for(int i=0; GcWindows[i].relevance != GcViewType::NO_VIEW_SET; i++) {
+    for(int i=0; GcWindows[i].relevance; i++) {
         if (GcWindows[i].relevance & type) 
             returning << GcWindows[i].id;
     }

--- a/src/Gui/GcWindowRegistry.h
+++ b/src/Gui/GcWindowRegistry.h
@@ -89,37 +89,25 @@ enum gcwinid {
 typedef enum GcWindowTypes::gcwinid GcWinID;
 Q_DECLARE_METATYPE(GcWinID)
 
-// the GcViewType represents both the view type in GC code and due its unique
-// bit values it can be used as for defining a window's view relevance mask.
-enum class GcViewType : unsigned int {
-    NO_VIEW_SET =    0x00,
-    VIEW_TRAIN =     0x01,
-    VIEW_ANALYSIS =  0x02,
-    VIEW_PLAN =      0x04,
-    VIEW_TRENDS =    0x08
-};
-
-// support bitwise "|" and "&" operators for the GcViewType class
-inline constexpr GcViewType operator|(GcViewType Lhs, GcViewType Rhs) {
-    return static_cast<GcViewType>( static_cast<std::underlying_type_t<GcViewType>>(Lhs) | static_cast<std::underlying_type_t<GcViewType>>(Rhs) );
-}
-inline constexpr bool operator&(GcViewType Lhs, GcViewType Rhs) {
-    return static_cast<std::underlying_type_t<GcViewType>>(Lhs) & static_cast<std::underlying_type_t<GcViewType>>(Rhs);
-}
+// when declaring a window, what view is it relevant for?
+#define VIEW_TRAIN    0x01
+#define VIEW_ANALYSIS 0x02
+#define VIEW_PLAN 0x04
+#define VIEW_TRENDS   0x08
 
 class GcChartWindow;
 class GcWindowRegistry {
     Q_DECLARE_TR_FUNCTIONS(GcWindowRegistry)
     public:
 
-    GcViewType relevance;
+    unsigned int relevance;
     QString name;
     GcWinID id;
 
     static void initialize(); // initialize global registry
     static GcChartWindow *newGcWindow(GcWinID id, Context *context);
-    static QStringList windowsForType(GcViewType type);
-    static QList<GcWinID> idsForType(GcViewType type);
+    static QStringList windowsForType(int type);
+    static QList<GcWinID> idsForType(int type);
     static QString title(GcWinID id);
 };
 

--- a/src/Gui/LTMSidebar.cpp
+++ b/src/Gui/LTMSidebar.cpp
@@ -264,9 +264,9 @@ LTMSidebar::chartVisibilityChanged()
 }
 
 void
-LTMSidebar::updatePresetChartsOnShow(GcViewType viewType)
+LTMSidebar::updatePresetChartsOnShow(int viewType)
 {
-    bool trendsView(viewType == GcViewType::VIEW_TRENDS);
+    bool trendsView(viewType == VIEW_TRENDS);
 
     // show/hide the splitter toolbar icon
     chartsWidget->controlAction->setVisible(trendsView);

--- a/src/Gui/LTMSidebar.h
+++ b/src/Gui/LTMSidebar.h
@@ -50,7 +50,7 @@ class LTMSidebar : public QWidget
         int newSeason(QString, QDate, QDate, int);
         void updateSeason(int, QString, QDate, QDate, int);
 
-        void updatePresetChartsOnShow(GcViewType viewType);
+        void updatePresetChartsOnShow(int viewType);
 
     signals:
         void dateRangeChanged(DateRange);

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -709,20 +709,13 @@ MainWindow::MainWindow(const QDir &home)
 
     saveGCState(currentAthleteTab->context); // set to whatever we started with
 
-    // switch to the startup view based on the configured value,
-    // the default is analysis when no config exists or the configuration value is not recognised.
-    // note: the gcStartupView values must align with the startViewIdx entries in Pages.cpp
-    int gcStartupView = appsettings->value(NULL, GC_STARTUP_VIEW, -1).toInt();
-    switch (gcStartupView) {
+    // switch to the startup view, default is analysis.
+    switch (appsettings->value(NULL, GC_STARTUP_VIEW, "1").toInt()) {
         case 0: selectTrends(); break;
         case 1: selectAnalysis(); break;
         case 2: selectPlan(); break;
         case 3: selectTrain(); break;
-        default: {
-            qDebug() << "Startup view not specified or unknown value, defaulting to analysis view";
-            appsettings->setValue(GC_STARTUP_VIEW, 1);
-            selectAnalysis();
-        } break;
+        default: selectAnalysis(); qDebug() << "Unknown startup view"; break;
     }
 
     //grab focus
@@ -857,15 +850,22 @@ MainWindow::setSubChartMenu()
 void
 MainWindow::setChartMenu(QMenu *menu)
 {
+    unsigned int mask=0;
     // called when chart menu about to be shown
-    // setup only show charts that are relevant
+    // setup to only show charts that are relevant
     // to this view
-    GcViewType mask = currentAthleteTab->currentViewType();
+    switch(currentAthleteTab->currentView()) {
+        case 0 : mask = VIEW_TRENDS; break;
+        default:
+        case 1 : mask = VIEW_ANALYSIS; break;
+        case 2 : mask = VIEW_PLAN; break;
+        case 3 : mask = VIEW_TRAIN; break;
+    }
 
     menu->clear();
-    if (mask == GcViewType::NO_VIEW_SET) return;
+    if (!mask) return;
 
-    for(int i=0; GcWindows[i].relevance != GcViewType::NO_VIEW_SET; i++) {
+    for(int i=0; GcWindows[i].relevance; i++) {
         if (GcWindows[i].relevance & mask)
             menu->addAction(GcWindows[i].name);
     }
@@ -877,7 +877,7 @@ MainWindow::addChart(QAction*action)
     // & removed to avoid issues with kde AutoCheckAccelerators
     QString actionText = QString(action->text()).replace("&", "");
     GcWinID id = GcWindowTypes::None;
-    for (int i=0; GcWindows[i].relevance != GcViewType::NO_VIEW_SET; i++) {
+    for (int i=0; GcWindows[i].relevance; i++) {
         if (GcWindows[i].name == actionText) {
             id = GcWindows[i].id;
             break;
@@ -900,12 +900,22 @@ MainWindow::importChart()
 void
 MainWindow::exportPerspective()
 {
-    AbstractView * current = currentAthleteTab->currentView();
+    int view = currentAthleteTab->currentView();
+    AbstractView *current = NULL;
+
+    QString typedesc;
+
+    switch (view) {
+    case 0:  current = currentAthleteTab->homeView; typedesc = "Trends"; break;
+    case 1:  current = currentAthleteTab->analysisView; typedesc = "Analysis"; break;
+    case 2:  current = currentAthleteTab->planView; typedesc = "Plan"; break;
+    case 3:  current = currentAthleteTab->trainView; typedesc = "Train"; break;
+    }
 
     // export the current perspective to a file
     QString suffix;
     QString fileName = QFileDialog::getSaveFileName(this, tr("Export Persepctive"),
-                       QDir::homePath()+"/"+ current->viewTypeDesc() + " " + current->perspective_->title() + ".gchartset",
+                       QDir::homePath()+"/"+ typedesc + " " + current->perspective_->title() + ".gchartset",
                        ("*.gchartset;;"), &suffix, QFileDialog::DontUseNativeDialog); // native dialog hangs when threads in use (!)
 
     if (fileName.isEmpty()) {
@@ -918,6 +928,16 @@ MainWindow::exportPerspective()
 void
 MainWindow::importPerspective()
 {
+    int view = currentAthleteTab->currentView();
+    AbstractView *current = NULL;
+
+    switch (view) {
+    case 0:  current = currentAthleteTab->homeView; break;
+    case 1:  current = currentAthleteTab->analysisView; break;
+    case 2:  current = currentAthleteTab->planView; break;
+    case 3:  current = currentAthleteTab->trainView; break;
+    }
+
     // import a new perspective from a file
     QString fileName = QFileDialog::getOpenFileName(this, tr("Select Perspective file to import"), "", tr("GoldenCheetah Perspective Files (*.gchartset)"));
     if (fileName.isEmpty()) {
@@ -926,11 +946,10 @@ MainWindow::importPerspective()
 
         // import and select it
         pactive = true;
-        AbstractView* current = currentAthleteTab->currentView();
         if (current->importPerspective(fileName)) {
 
             // on success we select the new one
-            resetPerspective(current->viewType());
+            resetPerspective(view);
             //current->setPerspectives(perspectiveSelector);
 
             // and select remember pactive is true, so we do the heavy lifting here
@@ -949,7 +968,7 @@ MainWindow::exportChartToCloudDB()
 {
     // upload the current chart selected to the chart db
     // called from the sidebar menu
-    Perspective *page=currentAthleteTab->currentView()->page();
+    Perspective *page=currentAthleteTab->view(currentAthleteTab->currentView())->page();
     if (page->currentStyle == 0 && page->currentChart())
         page->currentChart()->exportChartToCloudDB();
 }
@@ -969,7 +988,7 @@ MainWindow::addChartFromCloudDB()
         currentAthleteTab->context->cdbChartListDialog = new CloudDBChartListDialog();
     }
 
-    if (currentAthleteTab->context->cdbChartListDialog->prepareData(currentAthleteTab->context->athlete->cyclist, CloudDBCommon::UserImport, currentAthleteTab->currentViewType())) {
+    if (currentAthleteTab->context->cdbChartListDialog->prepareData(currentAthleteTab->context->athlete->cyclist, CloudDBCommon::UserImport, currentAthleteTab->currentView())) {
         if (currentAthleteTab->context->cdbChartListDialog->exec() == QDialog::Accepted) {
 
             // get selected chartDef
@@ -979,7 +998,7 @@ MainWindow::addChartFromCloudDB()
             foreach (QString chartDef, chartDefs) {
                 QList<QMap<QString,QString> > properties = GcChartWindow::chartPropertiesFromString(chartDef);
                 for (int i = 0; i< properties.size(); i++) {
-                    currentAthleteTab->currentView()->importChart(properties.at(i), false);
+                    currentAthleteTab->context->mainWindow->athleteTab()->view(currentAthleteTab->currentView())->importChart(properties.at(i), false);
                 }
             }
         }
@@ -1263,10 +1282,10 @@ MainWindow::selectAthlete()
 void
 MainWindow::selectAnalysis()
 {
-    resetPerspective(GcViewType::VIEW_ANALYSIS);
+    resetPerspective(1);
     viewStack->setCurrentIndex(GcViewStackIdx::ATHLETE_TAB_STACK);
     sidebar->setItemSelected(GcSideBarBtnId::ACTIVITIES_BTN, true);
-    currentAthleteTab->selectView(GcViewType::VIEW_ANALYSIS);
+    currentAthleteTab->selectView(1);
     back->show();
     forward->show();
     perspectiveSelector->show();
@@ -1280,10 +1299,10 @@ MainWindow::selectAnalysis()
 void
 MainWindow::selectTrain()
 {
-    resetPerspective(GcViewType::VIEW_TRAIN);
+    resetPerspective(3);
     viewStack->setCurrentIndex(GcViewStackIdx::ATHLETE_TAB_STACK);
     sidebar->setItemSelected(GcSideBarBtnId::TRAIN_BTN, true);
-    currentAthleteTab->selectView(GcViewType::VIEW_TRAIN);
+    currentAthleteTab->selectView(3);
     back->show();
     forward->show();
     perspectiveSelector->show();
@@ -1297,10 +1316,10 @@ MainWindow::selectTrain()
 void
 MainWindow::selectPlan()
 {
-    resetPerspective(GcViewType::VIEW_PLAN);
+    resetPerspective(2);
     viewStack->setCurrentIndex(GcViewStackIdx::ATHLETE_TAB_STACK);
     sidebar->setItemSelected(GcSideBarBtnId::PLAN_BTN, true);
-    currentAthleteTab->selectView(GcViewType::VIEW_PLAN);
+    currentAthleteTab->selectView(2);
     back->show();
     forward->show();
     perspectiveSelector->show();
@@ -1313,10 +1332,10 @@ MainWindow::selectPlan()
 void
 MainWindow::selectTrends()
 {
-    resetPerspective(GcViewType::VIEW_TRENDS);
+    resetPerspective(0);
     viewStack->setCurrentIndex(GcViewStackIdx::ATHLETE_TAB_STACK);
     sidebar->setItemSelected(GcSideBarBtnId::TRENDS_BTN, true);
-    currentAthleteTab->selectView(GcViewType::VIEW_TRENDS);
+    currentAthleteTab->selectView(0);
     back->show();
     forward->show();
     perspectiveSelector->show();
@@ -1386,19 +1405,26 @@ MainWindow::switchPerspective(int index)
 }
 
 void
-MainWindow::resetPerspective(GcViewType viewType, bool force)
+MainWindow::resetPerspective(int view, bool force)
 {
     static AthleteTab *lastathlete=NULL;
-    static GcViewType lastViewType = GcViewType::NO_VIEW_SET;
+    static int lastview=-1;
 
-    if (!force && lastViewType == viewType && lastathlete == currentAthleteTab) return;
+    if (!force && lastview == view && lastathlete == currentAthleteTab) return;
 
     // remember who last updated it.
     lastathlete = currentAthleteTab;
-    lastViewType = viewType;
+    lastview = view;
 
     // don't argue just reset the perspective for this view
-    AbstractView *current = currentAthleteTab->view(viewType);
+    AbstractView *current = NULL;
+    switch (view) {
+
+    case 0:  current = currentAthleteTab->homeView; break;
+    case 1:  current = currentAthleteTab->analysisView; break;
+    case 2:  current = currentAthleteTab->planView; break;
+    case 3:  current = currentAthleteTab->trainView; break;
+    }
 
     // set the perspective
     pactive=true;
@@ -1413,7 +1439,14 @@ MainWindow::perspectiveSelected(int index)
     if (pactive) return;
 
     // set the perspective for the current view
-    AbstractView *current = currentAthleteTab->currentView();
+    int view = currentAthleteTab->currentView();
+    AbstractView *current = NULL;
+    switch (view) {
+    case 0:  current = currentAthleteTab->homeView; break;
+    case 1:  current = currentAthleteTab->analysisView; break;
+    case 2:  current = currentAthleteTab->planView; break;
+    case 3:  current = currentAthleteTab->trainView; break;
+    }
 
     // which perspective is currently being shown?
     int prior = current->perspectives_.indexOf(current->perspective_);
@@ -1421,7 +1454,12 @@ MainWindow::perspectiveSelected(int index)
     if (index < current->perspectives_.count()) {
 
         // a perspectives was selected
-        current->perspectiveSelected(index);
+        switch (view) {
+        case 0:  current->perspectiveSelected(index); break;
+        case 1:  current->perspectiveSelected(index); break;
+        case 2:  current->perspectiveSelected(index); break;
+        case 3:  current->perspectiveSelected(index); break;
+        }
 
     } else {
 
@@ -1438,7 +1476,7 @@ MainWindow::perspectiveSelected(int index)
                 QString name;
                 QString expression;
                 Perspective::switchenum trainswitch=Perspective::None;
-                AddPerspectiveDialog *dialog= new AddPerspectiveDialog(this, currentAthleteTab->context, name, expression, current->viewType(), trainswitch);
+                AddPerspectiveDialog *dialog= new AddPerspectiveDialog(this, currentAthleteTab->context, name, expression, current->type, trainswitch);
                 int ret= dialog->exec();
                 delete dialog;
                 if (ret == QDialog::Accepted && name != "") {
@@ -1470,7 +1508,15 @@ MainWindow::perspectiveSelected(int index)
 void
 MainWindow::perspectivesChanged()
 {
-    AbstractView *current = currentAthleteTab->currentView();
+    int view = currentAthleteTab->currentView();
+    AbstractView *current = NULL;
+
+    switch (view) {
+    case 0:  current = currentAthleteTab->homeView; break;
+    case 1:  current = currentAthleteTab->analysisView; break;
+    case 2:  current = currentAthleteTab->planView; break;
+    case 3:  current = currentAthleteTab->trainView; break;
+    }
 
     // which perspective is currently being selected (before we go setting the combobox)
     Perspective *prior = current->perspective_;
@@ -1478,7 +1524,7 @@ MainWindow::perspectivesChanged()
     // ok, so reset the combobox and force, since whilst it may have already
     // been set for this athlete+view combination the config was just changed
     // so it needs to be redone.
-    resetPerspective(current->viewType(), true);
+    resetPerspective(view, true);
     //current->setPerspectives(perspectiveSelector);
 
     // is the old selected perspective still available?
@@ -1563,7 +1609,7 @@ MainWindow::dropEvent(QDropEvent *event)
             images << filename;
 
         // Look for Workout files only in Train view
-        } else if (currentAthleteTab->currentViewType() == GcViewType::VIEW_TRAIN && ErgFile::isWorkout(filename)) {
+        } else if (currentAthleteTab->currentView() == 3 && ErgFile::isWorkout(filename)) {
             workouts << filename;
         } else {
             filenames.append(filename);
@@ -1613,7 +1659,7 @@ MainWindow::importImages(QStringList list)
 {
     // we need to be on activities view and with a current
     // ride otherwise we just ignore the list
-    if (currentAthleteTab->currentViewType() != GcViewType::VIEW_ANALYSIS || currentAthleteTab->context->ride == NULL) {
+    if (currentAthleteTab->currentView() != 1 || currentAthleteTab->context->ride == NULL) {
         QMessageBox::critical(this, tr("Import Images Failed"), tr("You can only import images on the activities view with an activity selected."));
         return;
     }
@@ -2275,16 +2321,15 @@ MainWindow::restoreGCState(Context *context)
     if (viewStack->currentIndex() != GcViewStackIdx::SELECT_ATHLETE_VIEW) {
 
         // not on athlete view...
-        GcViewType viewType = currentAthleteTab->currentViewType();
-        resetPerspective(viewType); // will lazy load, hence doing it first
+        resetPerspective(currentAthleteTab->currentView()); // will lazy load, hence doing it first
 
         // restore window state from the supplied context
-        switch(viewType) {
-        case GcViewType::VIEW_TRENDS: sidebar->setItemSelected(GcSideBarBtnId::TRENDS_BTN,true); break;
-        case GcViewType::VIEW_ANALYSIS: sidebar->setItemSelected(GcSideBarBtnId::ACTIVITIES_BTN,true); break;
-        case GcViewType::VIEW_PLAN: sidebar->setItemSelected(GcSideBarBtnId::PLAN_BTN,true); break;
-        case GcViewType::VIEW_TRAIN: sidebar->setItemSelected(GcSideBarBtnId::TRAIN_BTN, true); break;
-        default: sidebar->setItemSelected(GcSideBarBtnId::SELECT_ATHLETE_BTN, true); break;
+            switch(currentAthleteTab->currentView()) {
+            case 0: sidebar->setItemSelected(GcSideBarBtnId::TRENDS_BTN,true); break;
+            case 1: sidebar->setItemSelected(GcSideBarBtnId::ACTIVITIES_BTN,true); break;
+            case 2: sidebar->setItemSelected(GcSideBarBtnId::PLAN_BTN,true); break;
+            case 3: sidebar->setItemSelected(GcSideBarBtnId::TRAIN_BTN, true); break;
+            default: sidebar->setItemSelected(GcSideBarBtnId::SELECT_ATHLETE_BTN, true); break;
         }
     }
 

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -153,7 +153,7 @@ class MainWindow : public QMainWindow
         // perspective selected
         void perspectiveSelected(int index);
         void perspectivesChanged(); // when the list of perspectives is updated in PerspectivesDialog
-        void resetPerspective(GcViewType viewType, bool force=false); // reset when view changes
+        void resetPerspective(int view, bool force=false); // reset when view changes
 
         // import and export perspectives
         void exportPerspective();

--- a/src/Gui/NavigationModel.cpp
+++ b/src/Gui/NavigationModel.cpp
@@ -27,7 +27,7 @@
 
 NavigationModel::NavigationModel(AthleteTab *tab) : tab(tab), block(false), viewinit(false), drinit(false), iteminit(false)
 {
-    connect(tab, SIGNAL(viewChanged(GcViewType)), this, SLOT(viewChanged(GcViewType)));
+    connect(tab, SIGNAL(viewChanged(int)), this, SLOT(viewChanged(int)));
     connect(tab, SIGNAL(rideItemSelected(RideItem*)), this, SLOT(rideChanged(RideItem*)));
     connect(tab->context, SIGNAL(dateRangeSelected(DateRange)), this, SLOT(dateChanged(DateRange)));
     connect(tab->context->mainWindow, SIGNAL(backClicked()), this, SLOT(back()));
@@ -115,7 +115,7 @@ NavigationModel::dateChanged(DateRange x)
 }
 
 void
-NavigationModel::viewChanged(GcViewType x)
+NavigationModel::viewChanged(int x)
 {
     if (block) return;
 
@@ -150,13 +150,13 @@ NavigationModel::action(bool redo, NavigationEvent event)
     switch(event.type) {
     case NavigationEvent::VIEW:
     {
-        view = static_cast<GcViewType>(redo ? event.after.toInt() : event.before.toInt());
+        view = redo ? event.after.toInt() : event.before.toInt();
 
         switch (view) {
-        case GcViewType::VIEW_TRENDS:  tab->context->mainWindow->selectTrends(); break;
-        case GcViewType::VIEW_ANALYSIS:  tab->context->mainWindow->selectAnalysis(); break;
-        case GcViewType::VIEW_PLAN:  tab->context->mainWindow->selectPlan(); break;
-        case GcViewType::VIEW_TRAIN:  tab->context->mainWindow->selectTrain(); break;
+        case 0:  tab->context->mainWindow->selectTrends(); break;
+        case 1:  tab->context->mainWindow->selectAnalysis(); break;
+        case 2:  tab->context->mainWindow->selectPlan(); break;
+        case 3:  tab->context->mainWindow->selectTrain(); break;
         }
     }
     break;

--- a/src/Gui/NavigationModel.h
+++ b/src/Gui/NavigationModel.h
@@ -35,7 +35,7 @@ public:
     // about changing views, dates and ride selections
     enum NavigationEventType { VIEW=0, RIDE, DATERANGE } type;
 
-    NavigationEvent(NavigationEventType t, GcViewType v) : type(t) { after.setValue(v); }
+    NavigationEvent(NavigationEventType t, int v) : type(t) { after.setValue(v); }
     NavigationEvent(NavigationEventType t, DateRange v) : type(t) { after.setValue(v); }
     NavigationEvent(NavigationEventType t, RideItem* v) : type(t) { after.setValue(v); }
     NavigationEvent(NavigationEventType t, QString v) : type(t) { after.setValue(v); }
@@ -64,7 +64,7 @@ public:
 
 public slots:
 
-    void viewChanged(GcViewType);
+    void viewChanged(int);
     void rideChanged(RideItem*);
     void dateChanged(DateRange dr);
 
@@ -80,7 +80,7 @@ private:
     bool block;
 
     // current state, before an event arrives
-    GcViewType view; // which view is selected
+    int view; // which view is selected
     DateRange dr;
     RideItem *item;
 

--- a/src/Gui/Pages.cpp
+++ b/src/Gui/Pages.cpp
@@ -263,25 +263,15 @@ GeneralPage::GeneralPage(Context *context) : context(context)
 
     connect(athleteBrowseButton, SIGNAL(clicked()), this, SLOT(browseAthleteDir()));
 
-    // the order of the ComboBox entries below must align with the
-    // gcStartupView functionality in MainWindow's constructor
     startupView = new QComboBox();
-    startupView->addItem(tr("Trends"));   // startViewIdx = 0
-    startupView->addItem(tr("Analysis")); // startViewIdx = 1
-    startupView->addItem(tr("Plan"));     // startViewIdx = 2
-    startupView->addItem(tr("Train"));    // startViewIdx = 3
+    startupView->addItem(tr("Trends"));
+    startupView->addItem(tr("Analysis"));
+    startupView->addItem(tr("Plan"));
+    startupView->addItem(tr("Train"));
 
-    // get the configured startup view configuration which matches with
-    // the startViewIdx values defined by the comboBox order above.
-    int startViewIdx = appsettings->value(NULL, GC_STARTUP_VIEW, -1).toInt();
-
-    // the configuration values are retained and the startupView Combobox uses the same values
-    // the default is analysis when no config exists or the configuration value is not recognised.
-    if (startViewIdx < 0 && startViewIdx > 3) {
-        startViewIdx = 1;
-        appsettings->setValue(GC_STARTUP_VIEW, startViewIdx);
-    }
-    startupView->setCurrentIndex(startViewIdx);
+    // map view indexes to combo box values
+    int startView = appsettings->value(NULL, GC_STARTUP_VIEW, "1").toInt();
+    startupView->setCurrentIndex(startView);
 
     QFormLayout *form = newQFormLayout();
     form->addRow(new QLabel(HLO + tr("Localization") + HLC));
@@ -346,8 +336,9 @@ GeneralPage::saveClicked()
     };
     appsettings->setValue(GC_LANG, langs[langCombo->currentIndex()]);
 
-    // save the startup view
-    appsettings->setValue(GC_STARTUP_VIEW, startupView->currentIndex());
+    // map combo box values to view indexes
+    int startView = startupView->currentIndex();
+    appsettings->setValue(GC_STARTUP_VIEW, startView);
 
     // Garmin and cranks
     appsettings->setValue(GC_GARMIN_HWMARK, garminHWMarkedit->value());

--- a/src/Gui/Perspective.cpp
+++ b/src/Gui/Perspective.cpp
@@ -74,9 +74,9 @@
 static const int tileMargin = 20;
 static const int tileSpacing = 10;
 
-Perspective::Perspective(Context *context, QString title, GcViewType viewType) :
+Perspective::Perspective(Context *context, QString title, int type) :
     GcWindow(context), context(context), active(false),  resizing(false), clicked(NULL), dropPending(false),
-    viewType_(viewType), title_(title), chartCursor(-2), df(NULL), expression_(""), trainswitch(None)
+    type_(type), title_(title), chartCursor(-2), df(NULL), expression_(""), trainswitch(None)
 {
     SSS;
     // setup control area
@@ -103,6 +103,12 @@ Perspective::Perspective(Context *context, QString title, GcViewType viewType) :
     cl->addWidget(controlStack);
     setControls(cw);
 
+    switch(this->type_) {
+    case VIEW_ANALYSIS: view="analysis"; break;
+    case VIEW_PLAN: view="plan"; break;
+    case VIEW_TRENDS: view="home"; break;
+    case VIEW_TRAIN: view="train"; break;
+    }
     setProperty("isManager", true);
     nomenu=true;
     setAcceptDrops(true);
@@ -117,7 +123,7 @@ Perspective::Perspective(Context *context, QString title, GcViewType viewType) :
 
     QPalette palette;
     //palette.setBrush(backgroundRole(), QColor("#B3B4B6"));
-    palette.setBrush(backgroundRole(), viewType_ == GcViewType::VIEW_TRAIN ? GColor(CTRAINPLOTBACKGROUND) : GColor(CPLOTBACKGROUND));
+    palette.setBrush(backgroundRole(), type == VIEW_TRAIN ? GColor(CTRAINPLOTBACKGROUND) : GColor(CPLOTBACKGROUND));
     setAutoFillBackground(false);
 
     // each style has its own container widget
@@ -195,10 +201,10 @@ Perspective::Perspective(Context *context, QString title, GcViewType viewType) :
     connect(titleEdit, SIGNAL(textChanged(const QString&)), SLOT(titleChanged()));
 
     // trends view we should select a library chart when a chart is selected.
-    if (viewType_ == GcViewType::VIEW_TRENDS) connect(context, SIGNAL(presetSelected(int)), this, SLOT(presetSelected(int)));
+    if (type == VIEW_TRENDS) connect(context, SIGNAL(presetSelected(int)), this, SLOT(presetSelected(int)));
 
     // Allow realtime controllers to scroll train view with steering movements
-    if (viewType_ == GcViewType::VIEW_TRAIN) connect(context, SIGNAL(steerScroll(int)), this, SLOT(steerScroll(int)));
+    if (type == VIEW_TRAIN) connect(context, SIGNAL(steerScroll(int)), this, SLOT(steerScroll(int)));
 
     installEventFilter(this);
     qApp->installEventFilter(this);
@@ -224,7 +230,7 @@ Perspective::addChartFromMenu(QAction*action)
     // & removed to avoid issues with kde AutoCheckAccelerators
     QString actionText = QString(action->text()).replace("&", "");
     GcWinID id = GcWindowTypes::None;
-    for (int i=0; GcWindows[i].relevance != GcViewType::NO_VIEW_SET; i++) {
+    for (int i=0; GcWindows[i].relevance; i++) {
         if (GcWindows[i].name == actionText) {
             id = GcWindows[i].id;
             break;
@@ -267,7 +273,7 @@ Perspective::importChart(QMap<QString,QString>properties, bool select)
     const QMetaObject *m = chart->metaObject();
 
     // set all the properties
-    chart->setProperty("view", static_cast<std::underlying_type_t<GcViewType>>(viewType_));
+    chart->setProperty("view", view);
     chart->setProperty("perspective", QVariant::fromValue<Perspective*>(this));
 
     // each of the user properties
@@ -322,7 +328,7 @@ Perspective::configChanged(qint32)
     tileArea->verticalScrollBar()->setStyleSheet(AbstractView::ourStyleSheet());
 //#endif
     QPalette palette;
-    palette.setBrush(backgroundRole(), viewType_ == GcViewType::VIEW_TRAIN ? GColor(CTRAINPLOTBACKGROUND) : GColor(CPLOTBACKGROUND));
+    palette.setBrush(backgroundRole(), type() == VIEW_TRAIN ? GColor(CTRAINPLOTBACKGROUND) : GColor(CPLOTBACKGROUND));
     setPalette(palette);
     tileWidget->setPalette(palette);
     tileArea->setPalette(palette);
@@ -335,7 +341,7 @@ Perspective::configChanged(qint32)
             if (charts[i]->type() == GcWindowTypes::Overview || charts[i]->type() == GcWindowTypes::OverviewTrends) chartbar->setColor(i, GColor(COVERVIEWBACKGROUND));
             else if (charts[i]->type() == GcWindowTypes::UserAnalysis || charts[i]->type() == GcWindowTypes::UserTrends) chartbar->setColor(i, RGBColor(QColor(charts[i]->property("color").toString())));
             else {
-                if (viewType_ == GcViewType::VIEW_TRAIN) chartbar->setColor(i, GColor(CTRAINPLOTBACKGROUND));
+                if (type() == VIEW_TRAIN)chartbar->setColor(i, GColor(CTRAINPLOTBACKGROUND));
                 else chartbar->setColor(i, GColor(CPLOTBACKGROUND));
             }
         }
@@ -720,7 +726,7 @@ Perspective::addChart(GcChartWindow* newone)
         newone->installEventFilter(this);
 
         RideItem *notconst = (RideItem*)context->currentRideItem();
-        newone->setProperty("view", static_cast<std::underlying_type_t<GcViewType>>(viewType_));
+        newone->setProperty("view", view);
         newone->setProperty("ride", QVariant::fromValue<RideItem*>(notconst));
         newone->setProperty("dateRange", property("dateRange"));
         newone->setProperty("style", currentStyle);
@@ -739,7 +745,7 @@ Perspective::addChart(GcChartWindow* newone)
             // tab colors
             if (newone->type() == GcWindowTypes::Overview || newone->type() == GcWindowTypes::OverviewTrends) chartbar->setColor(chartnum, GColor(COVERVIEWBACKGROUND));
             else {
-                if (viewType_ == GcViewType::VIEW_TRAIN) chartbar->setColor(chartnum, GColor(CTRAINPLOTBACKGROUND));
+                if (type() == VIEW_TRAIN)chartbar->setColor(chartnum, GColor(CTRAINPLOTBACKGROUND));
                 else chartbar->setColor(chartnum, GColor(CPLOTBACKGROUND));
             }
 
@@ -1323,7 +1329,7 @@ GcWindowDialog::GcWindowDialog(GcWinID type, Context *context, GcChartWindow **h
     // the chart uses it to decide something - apologies for the convoluted
     // method to determine the perspective, but its rare to use this outside
     // the context of a chart or a view
-    win->setProperty("perspective", QVariant::fromValue<Perspective*>(context->mainWindow->athleteTab()->currentView()->page()));
+    win->setProperty("perspective", QVariant::fromValue<Perspective*>(context->mainWindow->athleteTab()->view(context->mainWindow->athleteTab()->currentView())->page()));
     chartLayout->addWidget(win);
     //win->setFrameStyle(QFrame::Box);
 
@@ -1532,7 +1538,7 @@ Perspective::presetSelected(int n)
 /*--------------------------------------------------------------------------------
  *  Import and Export the Perspective to xml
  * -----------------------------------------------------------------------------*/
-Perspective *Perspective::fromFile(Context *context, QString filename, GcViewType viewType)
+Perspective *Perspective::fromFile(Context *context, QString filename, int type)
 {
     SSS;
     Perspective *returning = NULL;
@@ -1553,7 +1559,7 @@ Perspective *Perspective::fromFile(Context *context, QString filename, GcViewTyp
     QXmlInputSource source;
     source.setData(content);
     QXmlSimpleReader xmlReader;
-    ViewParser handler(context, viewType, false);
+    ViewParser handler(context, type, false);
     xmlReader.setContentHandler(&handler);
     xmlReader.setErrorHandler(&handler);
 
@@ -1565,7 +1571,7 @@ Perspective *Perspective::fromFile(Context *context, QString filename, GcViewTyp
 
     // return the first one with the right type (if there are multiple)
     for(int i=0; i<handler.perspectives.count(); i++)
-        if (returning == NULL && handler.perspectives[i]->viewType_ == viewType)
+        if (returning == NULL && handler.perspectives[i]->type_ == type)
             returning = handler.perspectives[i];
 
     // delete any further perspectives
@@ -1603,7 +1609,7 @@ Perspective::toXml(QTextStream &out)
     SSS;
     out<<"<layout name=\""<< title_
        <<"\" style=\"" << currentStyle
-       <<"\" type=\"" << static_cast<unsigned int>(viewType_)
+       <<"\" type=\"" << type_
        <<"\" expression=\"" << Utils::xmlprotect(expression_)
        <<"\" trainswitch=\"" << (int)trainswitch
        << "\">\n";
@@ -1675,7 +1681,7 @@ Perspective::setExpression(QString expr)
 
     // notify charts that the filter changed
     // but only for trends views where it matters
-    if (viewType_ == GcViewType::VIEW_TRENDS)
+    if (type_ == VIEW_TRENDS)
         foreach(GcWindow *chart, charts)
             chart->notifyPerspectiveFilterChanged(expression_);
 }
@@ -1684,7 +1690,7 @@ bool
 Perspective::relevant(RideItem *item)
 {
     SSS;
-    if (viewType_ != GcViewType::VIEW_ANALYSIS) return true;
+    if (type_ != VIEW_ANALYSIS) return true;
     else if (df == NULL) return false;
     else if (df == NULL || item == NULL) return false;
 
@@ -1845,18 +1851,14 @@ ImportChartDialog::importClicked()
                 view = table->item(i,1)->text();
             }
 
-            GcViewType viewType = GcViewType::NO_VIEW_SET;
-            if (view == tr("Trends"))      { viewType=GcViewType::VIEW_TRENDS; context->mainWindow->selectTrends(); }
-            if (view == tr("Activities"))  { viewType=GcViewType::VIEW_ANALYSIS; context->mainWindow->selectAnalysis(); }
-            if (view == tr("Plan"))        { viewType=GcViewType::VIEW_PLAN; context->mainWindow->selectPlan(); }
-            if (view == tr("Train"))       { viewType=GcViewType::VIEW_TRAIN; context->mainWindow->selectTrain(); }
+            int x=0;
+            if (view == tr("Trends"))      { x=0; context->mainWindow->selectTrends(); }
+            if (view == tr("Activities"))  { x=1; context->mainWindow->selectAnalysis(); }
+            if (view == tr("Plan"))        { x=2; context->mainWindow->selectPlan(); }
+            if (view == tr("Train"))       { x=3; context->mainWindow->selectTrain(); }
 
             // add to the currently selected tab and select if only adding one chart
-            if (viewType != GcViewType::NO_VIEW_SET) {
-                context->mainWindow->athleteTab()->view(viewType)->importChart(list[i], (list.count()==1));
-            } else {
-                qDebug() << "Unhandled view type in ImportChartDialog:" << view;
-            }
+            context->mainWindow->athleteTab()->view(x)->importChart(list[i], (list.count()==1));
         }
     }
     accept();
@@ -1869,8 +1871,8 @@ ImportChartDialog::cancelClicked()
     accept();
 }
 
-AddPerspectiveDialog::AddPerspectiveDialog(QWidget *parent, Context *context, QString &name, QString &expression, GcViewType viewType, Perspective::switchenum &trainswitch, bool edit) :
-    QDialog(parent), context(context), name(name), expression(expression), trainswitch(trainswitch), viewType(viewType)
+AddPerspectiveDialog::AddPerspectiveDialog(QWidget *parent, Context *context, QString &name, QString &expression, int type, Perspective::switchenum &trainswitch, bool edit) :
+    QDialog(parent), context(context), name(name), expression(expression), trainswitch(trainswitch), type(type)
 {
     SSS;
     setWindowFlags(windowFlags());
@@ -1887,16 +1889,16 @@ AddPerspectiveDialog::AddPerspectiveDialog(QWidget *parent, Context *context, QS
     form->addRow(new QLabel(tr("Perspective Name")), nameEdit);
     layout->addLayout(form);
 
-    if (viewType == GcViewType::VIEW_ANALYSIS || viewType == GcViewType::VIEW_TRENDS) {
+    if (type == VIEW_ANALYSIS || type == VIEW_TRENDS) {
         filterEdit = new SearchBox(context, this);
         filterEdit->setFixedMode(true);
         filterEdit->setMode(SearchBox::Filter);
         filterEdit->setText(expression);
-        if (viewType == GcViewType::VIEW_ANALYSIS) form->addRow(new QLabel(tr("Switch expression")), filterEdit);
-        if (viewType == GcViewType::VIEW_TRENDS) form->addRow(new QLabel(tr("Activities filter")), filterEdit);
+        if (type == VIEW_ANALYSIS) form->addRow(new QLabel(tr("Switch expression")), filterEdit);
+        if (type == VIEW_TRENDS) form->addRow(new QLabel(tr("Activities filter")), filterEdit);
     }
 
-    if (viewType == GcViewType::VIEW_TRAIN) {
+    if (type == VIEW_TRAIN) {
         trainSwitch = new QComboBox(this);
         trainSwitch->addItem(tr("Don't switch"), Perspective::None);
         trainSwitch->addItem(tr("Erg Workout"), Perspective::Erg);
@@ -1925,8 +1927,8 @@ AddPerspectiveDialog::addClicked()
 {
     SSS;
     name = nameEdit->text();
-    if (viewType == GcViewType::VIEW_ANALYSIS || viewType == GcViewType::VIEW_TRENDS) expression = filterEdit->text();
-    if (viewType == GcViewType::VIEW_TRAIN) trainswitch=(Perspective::switchenum)trainSwitch->itemData(trainSwitch->currentIndex(), Qt::UserRole).toInt();
+    if (type == VIEW_ANALYSIS || type == VIEW_TRENDS) expression = filterEdit->text();
+    if (type == VIEW_TRAIN) trainswitch=(Perspective::switchenum)trainSwitch->itemData(trainSwitch->currentIndex(), Qt::UserRole).toInt();
     accept();
 }
 

--- a/src/Gui/Perspective.h
+++ b/src/Gui/Perspective.h
@@ -61,14 +61,14 @@ class Perspective : public GcWindow
 
     public:
 
-        Perspective(Context *, QString title, GcViewType viewType);
+        Perspective(Context *, QString title, int type);
         ~Perspective();
 
         // am I relevant? (for switching when ride selected)
         bool relevant(RideItem*);
 
         // the items I'd choose (for filtering on trends view, optionally refined by chart filter)
-        bool isFiltered() const override { return (viewType_ == GcViewType::VIEW_TRENDS && df != NULL); }
+        bool isFiltered() const override { return (type_ == VIEW_TRENDS && df != NULL); }
         QStringList filterlist(DateRange dr, bool isfiltered=false, QStringList files=QStringList());
 
         // get/set the expression (will compile df)
@@ -81,11 +81,11 @@ class Perspective : public GcWindow
         void setTrainSwitch(int x) { trainswitch = (switchenum)x; }
 
         // import and export
-        static Perspective *fromFile(Context *context, QString filename, GcViewType viewType);
+        static Perspective *fromFile(Context *context, QString filename, int type);
         bool toFile(QString filename);
         void toXml(QTextStream &out);
 
-        GcViewType viewType() const { return viewType_; }
+        int type() const { return type_; }
         QString title() const { return title_; }
 
         void resetLayout();
@@ -159,7 +159,8 @@ class Perspective : public GcWindow
         bool dropPending;
 
         // what are we?
-        GcViewType viewType_;
+        int type_;
+        QString view;
 
         // top bar
         QString title_;
@@ -254,7 +255,7 @@ class AddPerspectiveDialog : public QDialog
     Q_OBJECT
 
     public:
-        AddPerspectiveDialog(QWidget *parent, Context *context, QString &name, QString &expression, GcViewType viewType, Perspective::switchenum &trainswitch, bool edit=false);
+        AddPerspectiveDialog(QWidget *parent, Context *context, QString &name, QString &expression, int type, Perspective::switchenum &trainswitch, bool edit=false);
 
     protected:
         QLineEdit *nameEdit;
@@ -271,6 +272,6 @@ class AddPerspectiveDialog : public QDialog
         QString &name;
         QString &expression;
         Perspective::switchenum &trainswitch;
-        GcViewType viewType;
+        int type;
 };
 #endif // _GC_HomeWindow_h

--- a/src/Gui/PerspectiveDialog.cpp
+++ b/src/Gui/PerspectiveDialog.cpp
@@ -48,12 +48,12 @@ PerspectiveDialog::PerspectiveDialog(QWidget *parent, AbstractView *tabView) : Q
 #endif
 
     QString typedesc;
-    switch (tabView->viewType()) {
-    case GcViewType::VIEW_PLAN:
-    case GcViewType::VIEW_TRENDS: typedesc=tr("Activities filter"); break;
-    case GcViewType::VIEW_ANALYSIS: typedesc=tr("Switch expression"); break;
-    case GcViewType::VIEW_TRAIN: typedesc=tr("Switch for"); break;
-    default: qDebug() << "Unhandled view type in PerspectiveDialog:" << static_cast<unsigned int>(tabView->viewType()); break;
+    switch (tabView->type) {
+    case VIEW_PLAN:
+    case VIEW_TRENDS: typedesc=tr("Activities filter"); break;
+    case VIEW_ANALYSIS: typedesc=tr("Switch expression"); break;
+    case VIEW_TRAIN: typedesc=tr("Switch for"); break;
+    default: qDebug() << "Unknown view type in PerspectiveDialog:" << tabView->type; break;
     }
 
     perspectiveTable->setColumnCount(2);
@@ -151,11 +151,11 @@ void PerspectiveDialog::setTables()
         perspectiveTable->setItem(perspectiverow, 0, add);
 
         QString description;
-        switch (tabView->viewType()) {
-        case GcViewType::VIEW_TRENDS:
-        case GcViewType::VIEW_ANALYSIS:
-        case GcViewType::VIEW_PLAN: description = perspective->expression(); break;
-        case GcViewType::VIEW_TRAIN: {
+        switch (tabView->type) {
+        case VIEW_TRENDS:
+        case VIEW_ANALYSIS:
+        case VIEW_PLAN: description = perspective->expression(); break;
+        case VIEW_TRAIN: {
             switch (perspective->trainswitch) {
             case Perspective::None: description=tr("Don't switch"); break;
             case Perspective::Erg: description=tr("Erg Workout"); break;
@@ -164,7 +164,7 @@ void PerspectiveDialog::setTables()
             case Perspective::Map: description=tr("Map Workout"); break;
             default: qDebug() << "Unknown train switch value in PerspectiveDialog:" << perspective->trainswitch; break;
         } break;
-        default: qDebug() << "Unhandled view type in PerspectiveDialog:" << static_cast<unsigned int>(tabView->viewType()); break;
+        default: qDebug() << "Unknown view type in PerspectiveDialog:" << tabView->type; break;
         }
         }
 
@@ -244,7 +244,7 @@ PerspectiveDialog::editPerspectiveClicked()
 
         Perspective *editing = tabView->perspectives_[index];
         QString expression=editing->expression();
-        AddPerspectiveDialog *dialog= new AddPerspectiveDialog(this, tabView->context, editing->title_, expression, tabView->viewType(), editing->trainswitch, true);
+        AddPerspectiveDialog *dialog= new AddPerspectiveDialog(this, tabView->context, editing->title_, expression, tabView->type, editing->trainswitch, true);
         int ret= dialog->exec();
         delete dialog;
         if (ret == QDialog::Accepted) {
@@ -261,7 +261,7 @@ PerspectiveDialog::addPerspectiveClicked()
     QString name;
     QString expression;
     Perspective::switchenum trainswitch = Perspective::None;
-    AddPerspectiveDialog *dialog= new AddPerspectiveDialog(this, tabView->context, name, expression, tabView->viewType(), trainswitch);
+    AddPerspectiveDialog *dialog= new AddPerspectiveDialog(this, tabView->context, name, expression, tabView->type, trainswitch);
     int ret= dialog->exec();
     delete dialog;
     if (ret == QDialog::Accepted && name != "") {
@@ -269,12 +269,12 @@ PerspectiveDialog::addPerspectiveClicked()
          // add...
         Perspective *newone =tabView->addPerspective(name);
 
-        switch (tabView->viewType()) {
-        case GcViewType::VIEW_TRENDS:
-        case GcViewType::VIEW_ANALYSIS:
-        case GcViewType::VIEW_PLAN: newone->setExpression(expression); break;
-        case GcViewType::VIEW_TRAIN: newone->setTrainSwitch(trainswitch); break;
-        default: qDebug() << "Unhandled view type in PerspectiveDialog:" << static_cast<std::underlying_type_t<GcViewType>>(tabView->viewType()); break;
+        switch (tabView->type) {
+        case VIEW_TRENDS:
+        case VIEW_ANALYSIS:
+        case VIEW_PLAN: newone->setExpression(expression); break;
+        case VIEW_TRAIN: newone->setTrainSwitch(trainswitch); break;
+        default: qDebug() << "Unknown view type in PerspectiveDialog:" << tabView->type; break;
         }
 
     emit perspectivesChanged();
@@ -291,10 +291,19 @@ PerspectiveDialog::exportPerspectiveClicked()
     // wipe it - tabView will worry about bounds and switching if we delete the currently selected one
     Perspective *current = tabView->perspectives_[index];
 
+    QString typedesc;
+    switch (tabView->type) {
+    case VIEW_TRENDS: typedesc="Trends"; break;
+    case VIEW_ANALYSIS: typedesc="Analysis"; break;
+    case VIEW_PLAN: typedesc="Plan"; break;
+    case VIEW_TRAIN: typedesc="Train"; break;
+    default: qDebug() << "Unknown view type in PerspectiveDialog:" << tabView->type; break;
+    }
+
     // export the current perspective to a file
     QString suffix;
     QString fileName = QFileDialog::getSaveFileName(this, tr("Export Perspective"),
-                       QDir::homePath()+"/"+ tabView->viewTypeDesc() + " " + current->title() + ".gchartset",
+                       QDir::homePath()+"/"+ typedesc + " " + current->title() + ".gchartset",
                        ("*.gchartset;;"), &suffix, QFileDialog::DontUseNativeDialog); // native dialog hangs when threads in use (!)
 
     if (fileName.isEmpty()) {

--- a/src/Gui/Views.cpp
+++ b/src/Gui/Views.cpp
@@ -31,8 +31,8 @@
 
 QMap<Context*, LTMSidebar*> LTMSidebarView::LTMSidebars_;
 
-LTMSidebarView::LTMSidebarView(Context *context, GcViewType viewType, const QString& view, const QString& heading) :
-    AbstractView(context, viewType, view, heading)
+LTMSidebarView::LTMSidebarView(Context *context, int type, const QString& view, const QString& heading) :
+    AbstractView(context, type, view, heading)
 {
     // get or create the LTMSidebar shared between the views
     getLTMSidebar(context);
@@ -66,7 +66,7 @@ void LTMSidebarView::showEvent(QShowEvent*)
     setSidebar(LTMSidebars_[context]);
 
     // update the sidebar's preset chart visibility
-    LTMSidebars_[context]->updatePresetChartsOnShow(_viewType);
+    LTMSidebars_[context]->updatePresetChartsOnShow(type);
 
     // update sidebar for the new view
     sidebarChanged();
@@ -112,7 +112,7 @@ LTMSidebarView::dateRangeChanged(DateRange dr)
 }
 
 AnalysisView::AnalysisView(Context *context, QStackedWidget *controls) :
-        AbstractView(context, GcViewType::VIEW_ANALYSIS, "analysis", tr("Compare Activities and Intervals"))
+        AbstractView(context, VIEW_ANALYSIS, "analysis", tr("Compare Activities and Intervals"))
 {
     analSidebar = new AnalysisSidebar(context);
     BlankStateAnalysisPage *b = new BlankStateAnalysisPage(context);
@@ -158,7 +158,7 @@ AnalysisView::setRide(RideItem *ride)
 
     // if we are the current view and the current perspective is no longer relevant
     // then lets go find one to switch to..
-    if (context->mainWindow->athleteTab()->currentViewType() == GcViewType::VIEW_ANALYSIS && page()->relevant(ride) != true) {
+    if (context->mainWindow->athleteTab()->currentView() == 1 && page()->relevant(ride) != true) {
 
         // lets find a perspective to switch to
         int ridePerspectiveIdx = findRidesPerspective(ride);
@@ -247,7 +247,7 @@ AnalysisView::notifyViewSplitterMoved() {
 }
 
 PlanView::PlanView(Context *context, QStackedWidget *controls) :
-        LTMSidebarView(context, GcViewType::VIEW_PLAN, "plan", tr("Plan future activities"))
+        LTMSidebarView(context, VIEW_PLAN, "plan", tr("Plan future activities"))
 {
     BlankStatePlanPage *b = new BlankStatePlanPage(context);
 
@@ -276,7 +276,7 @@ PlanView::isBlank()
 }
 
 TrendsView::TrendsView(Context *context, QStackedWidget *controls) :
-        LTMSidebarView(context, GcViewType::VIEW_TRENDS, "home", tr("Compare Date Ranges"))
+        LTMSidebarView(context, VIEW_TRENDS, "home", tr("Compare Date Ranges"))
 {
     BlankStateHomePage *b = new BlankStateHomePage(context);
 
@@ -342,7 +342,7 @@ TrendsView::isBlank()
 }
 
 TrainView::TrainView(Context *context, QStackedWidget *controls) :
-        AbstractView(context, GcViewType::VIEW_TRAIN, "train", tr("Intensity Adjustments and Workout Control"))
+        AbstractView(context, VIEW_TRAIN, "train", tr("Intensity Adjustments and Workout Control"))
 {
     trainTool = new TrainSidebar(context);
     trainTool->setTrainView(this);

--- a/src/Gui/Views.h
+++ b/src/Gui/Views.h
@@ -51,7 +51,7 @@ class LTMSidebarView : public AbstractView
 
     protected:
 
-        LTMSidebarView(Context *context, GcViewType viewType, const QString& view, const QString& heading);
+        LTMSidebarView(Context *context, int type, const QString& view, const QString& heading);
         virtual ~LTMSidebarView();
 
         void showEvent(QShowEvent*) override;
@@ -77,8 +77,6 @@ class AnalysisView : public AbstractView
         void close() override;
         void setRide(RideItem*ride) override;
         void addIntervals();
-
-        QString viewTypeDesc() const override { return "Analysis"; }
 
         RideNavigator *rideNavigator();
         AnalysisSidebar *analSidebar;
@@ -108,8 +106,6 @@ class PlanView : public LTMSidebarView
         PlanView(Context *context, QStackedWidget *controls);
         virtual ~PlanView();
 
-        QString viewTypeDesc() const override { return "Diary"; }
-
     public slots:
 
         bool isBlank() override;
@@ -124,8 +120,6 @@ class TrainView : public AbstractView
         TrainView(Context *context, QStackedWidget *controls);
         virtual ~TrainView();
         void close() override;
-
-        QString viewTypeDesc() const override { return "Train"; }
 
     public slots:
 
@@ -153,8 +147,6 @@ class TrendsView : public LTMSidebarView
 
         TrendsView(Context *context, QStackedWidget *controls);
         virtual ~TrendsView();
-
-        QString viewTypeDesc() const override { return "Trends"; }
 
         int countActivities(Perspective *, DateRange dr);
 

--- a/src/R/RTool.cpp
+++ b/src/R/RTool.cpp
@@ -2567,7 +2567,7 @@ RTool::dfForDateRangeMeanmax(bool all, DateRange range, SEXP filter)
     UNPROTECT(1);
 
     // apply perspective filter if trends view and filtered
-    if (rtool->perspective && rtool->perspective->viewType() == GcViewType::VIEW_TRENDS && rtool->perspective->isFiltered()) {
+    if (rtool->perspective && rtool->perspective->type() == VIEW_TRENDS && rtool->perspective->isFiltered()) {
         filt = true;
         filelist << rtool->perspective->filterlist(DateRange(range));
     }

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -241,7 +241,7 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
 #endif
 
     connect(context, SIGNAL(newLap()), this, SLOT(resetLapTimer()));
-    connect(context, SIGNAL(viewChanged(GcViewType)), this, SLOT(viewChanged(GcViewType)));
+    connect(context, SIGNAL(viewChanged(int)), this, SLOT(viewChanged(int)));
 
     // workout filters
     connect(context, SIGNAL(workoutFiltersChanged(QList<ModelFilter*>&)), this, SLOT(workoutFiltersChanged(QList<ModelFilter*>&)));
@@ -1739,7 +1739,8 @@ void TrainSidebar::Connect()
     //qDebug() << "current tab:" << context->tab->currentView();
 
     // only try and connect if we are in train view..
-    if (context->tab->currentViewType() != GcViewType::VIEW_TRAIN) return;
+    // fixme: these values are hard-coded throughout
+    if (!(context->tab->currentView() == 3)) return;
 
     if (status&RT_CONNECTED) return; // already connected
 
@@ -3455,16 +3456,17 @@ void TrainSidebar::vo2Data(double rf, double rmv, double vo2, double vco2, doubl
 
 // connect/disconnect automatically when view changes
 void
-TrainSidebar::viewChanged(GcViewType viewType)
+TrainSidebar::viewChanged(int index)
 {
-    //qDebug() << "view has changed to:" << static_cast<int>(viewType);
+    //qDebug() << "view has changed to:" << index;
 
     // ensure buttons reflect current state
     setStatusFlags(0);
 
     if (!autoConnect) return;
 
-    if (viewType == GcViewType::VIEW_TRAIN) {
+    // fixme: value hard-coded throughout
+    if (index == 3) {
         //train view
         if ((status&RT_CONNECTED) == 0) {
             Connect();

--- a/src/Train/TrainSidebar.h
+++ b/src/Train/TrainSidebar.h
@@ -164,7 +164,7 @@ class TrainSidebar : public GcWindow
         void removeInvalidVideoSync();
         void removeInvalidWorkout();
 
-        void viewChanged(GcViewType index);
+        void viewChanged(int index);
 
         int  getCalibrationIndex(void);
 


### PR DESCRIPTION
This reverts commits https://github.com/GoldenCheetah/GoldenCheetah/commit/b716c547cddcb0ee6970439a776577c181b47c34 and https://github.com/GoldenCheetah/GoldenCheetah/commit/9087c0df9923c9231831fb6979371c1b800bdde2.
It is a problematic non-functional refactoring which doesn't account
 for the impact on external representation of the changed
 index, the first problem detected was fixed in the complementary
 commit,  but [it also breaks chart import/export]( https://groups.google.com/g/golden-cheetah-users/c/8yN1VpGny_k)  and likely other
 functionality without a clear Benefit.
 I should not have merged it, sorry for the inconvenience.