### PR TITLE
Fix disappearing userchart content when changing the type

### DIFF
--- a/src/Charts/GenericChart.h
+++ b/src/Charts/GenericChart.h
@@ -83,43 +83,6 @@ class GenericSeriesInfo {
             color("red"), opacity(100.0), opengl(true), legend(true), datalabels(false), fill(false)
         {}
 
-        GenericSeriesInfo(const GenericSeriesInfo &other) {
-            *this = other;
-        }
-
-        GenericSeriesInfo &operator=(const GenericSeriesInfo &other) {
-            if (this == &other) return *this;
-
-            name = other.name;
-            group = other.group;
-            xseries = other.xseries;
-            yseries = other.yseries;
-            fseries = other.fseries;
-            xname = other.xname;
-            yname = other.yname;
-            labels = other.labels;
-            colors = other.colors;
-            line = other.line;
-            symbol = other.symbol;
-            size = other.size;
-            color = other.color;
-            opacity = other.opacity;
-            opengl = other.opengl;
-            legend = other.legend;
-            datalabels = other.datalabels;
-            fill = other.fill;
-            aggregateby = other.aggregateby;
-            annotations = other.annotations;
-            string1 = other.string1;
-            string2 = other.string2;
-            string3 = other.string3;
-            string4 = other.string4;
-
-            user1 = user2 = user3 = user4 = nullptr;
-
-            return *this;
-        }
-
         // available for use (e.g. UserChartSettings)
         void *user1, *user2, *user3, *user4;
         QString string1, string2, string3, string4;

--- a/src/Charts/UserChart.cpp
+++ b/src/Charts/UserChart.cpp
@@ -1089,6 +1089,7 @@ UserChartSettings::duplicateSeries()
             }
         }
     } while (duplicate);
+    seriesInfo.user1 = seriesInfo.user2 = seriesInfo.user3 = seriesInfo.user4 = nullptr;
     seriesinfo.append(seriesInfo);
     refreshSeriesTab();
     emit chartConfigChanged();


### PR DESCRIPTION
See https://groups.google.com/g/golden-cheetah-users/c/_ljv8-9VnbY/m/XAYLlGJJAwAJ

Removing the explicit copy-constructor and operator= from GenericSeriesInfo. Instead setting user1-4 explicitly to nullptr when duplicating a series.