### PR TITLE
Excluding planned future but linked activities from expected load

### DIFF
--- a/src/Metrics/PMCData.cpp
+++ b/src/Metrics/PMCData.cpp
@@ -291,7 +291,7 @@ void PMCData::refresh()
                         todayActualStress += value;
                     }
                 } else if (start_.addDays(offset).daysTo(QDate::currentDate()) < 0) {
-                    if (item->planned) {
+                    if (item->planned && ! item->hasLinkedActivity()) {
                         expected_stress_[offset] += value;
                     }
                 } else {


### PR DESCRIPTION
Status Quo: When executing a planned activity early, its load is counted twice: Once from the planned activity (future), once from the actual activity (past)
This fix excludes such planned activities from calculation (while keeping unlinked ones)