### PR TITLE
Calendar summary was missing homeFilter

### DIFF
--- a/src/Charts/CalendarWindow.cpp
+++ b/src/Charts/CalendarWindow.cpp
@@ -1089,6 +1089,7 @@ CalendarWindow::getSummaries
 
     const RideMetricFactory &factory = RideMetricFactory::instance();
     FilterSet filterSet(context->isfiltered, context->filters);
+    filterSet.addFilter(context->ishomefiltered, context->homeFilters);
     Specification spec;
     spec.setFilterSet(filterSet);
     PlanFilterType planFilterType = PlanFilterType::IncludeAll;


### PR DESCRIPTION
Calendar summary only used filter, not homeFilter, thus showing wrong values. This fix adds support for both filters