### PR TITLE
Remove the specific bootstrap athlete code

### DIFF
--- a/src/Charts/CPPlot.cpp
+++ b/src/Charts/CPPlot.cpp
@@ -355,21 +355,21 @@ CPPlot::initModel()
         pdModel = NULL;
         break;
     case 1 : // 2 param
-        pdModel = new CP2Model(context);
+        pdModel = new CP2Model();
         break;
     case 2 : // 3 param
-        pdModel = new CP3Model(context);
+        pdModel = new CP3Model();
         static_cast<CP3Model*>(pdModel)->modelDecay = modelDecay;
         break;
     case 3 : // extended model
-        pdModel = new ExtendedModel(context);
+        pdModel = new ExtendedModel();
         break;
     case 4 : // multimodel
-        pdModel = new MultiModel(context);
+        pdModel = new MultiModel();
         pdModel->setVariant(modelVariant);
         break;
     case 5 : // ward smith
-        pdModel = new WSModel(context);
+        pdModel = new WSModel();
         pdModel->setVariant(modelVariant);
         break;
     }
@@ -890,20 +890,20 @@ CPPlot::plotModel(QVector<double> vector, QColor plotColor, PDModel *baseline)
     switch (model) {
 
     case 1 : // 2 param
-        pdmodel = new CP2Model(context);
+        pdmodel = new CP2Model();
         break;
     case 2 : // 3 param
-        pdmodel = new CP3Model(context);
+        pdmodel = new CP3Model();
         break;
     case 3 : // extended model
-        pdmodel = new ExtendedModel(context);
+        pdmodel = new ExtendedModel();
         break;
     case 4 : // multimodel
-        pdmodel = new MultiModel(context);
+        pdmodel = new MultiModel();
         pdmodel->setVariant(modelVariant);
         break;
     case 5 : // ward smith model
-        pdmodel = new WSModel(context);
+        pdmodel = new WSModel();
         pdmodel->setVariant(modelVariant);
         break;
     }
@@ -2751,20 +2751,20 @@ CPPlot::calculateForDateRanges(QList<CompareDateRange> compareDateRanges)
             // get a model
             switch (model) {
             case 1 : // 2 param
-                baselineModel = new CP2Model(context);
+                baselineModel = new CP2Model();
                 break;
             case 2 : // 3 param
-                baselineModel = new CP3Model(context);
+                baselineModel = new CP3Model();
                 break;
             case 3 : // extended model
-                baselineModel = new ExtendedModel(context);
+                baselineModel = new ExtendedModel();
                 break;
             case 4 : // multimodel
-                baselineModel = new MultiModel(context);
+                baselineModel = new MultiModel();
                 baselineModel->setVariant(modelVariant);
                 break;
             case 5 : // ward smith
-                baselineModel = new WSModel(context);
+                baselineModel = new WSModel();
                 baselineModel->setVariant(modelVariant);
                 break;
             }

--- a/src/Charts/CPPlot.h
+++ b/src/Charts/CPPlot.h
@@ -25,7 +25,7 @@
 
 #include "CriticalPowerWindow.h"
 #include "RideFileCache.h"
-#include "PDModel.h"
+#include "PDModel.h" // for all the models
 #include "ExtendedCriticalPower.h"
 #include "CpPlotCurve.h"
 #include "PowerHist.h" // for penTooltip
@@ -49,8 +49,6 @@ class Context;
 class LTMCanvasPicker;
 class CriticalPowerWindow;
 class LogTimeScaleDraw;
-
-#include "PDModel.h" // for all the models
 
 class CPPlot : public QwtPlot
 {

--- a/src/Charts/LTMPlot.cpp
+++ b/src/Charts/LTMPlot.cpp
@@ -68,11 +68,11 @@ LTMPlot::LTMPlot(LTMWindow *parent, Context *context, int position) :
     setAutoFillBackground(true);
 
     // set up the models we support
-    models << new CP2Model(context);
-    models << new CP3Model(context);
-    models << new MultiModel(context);
-    models << new ExtendedModel(context);
-    models << new WSModel(context);
+    models << new CP2Model();
+    models << new CP3Model();
+    models << new MultiModel();
+    models << new ExtendedModel();
+    models << new WSModel();
 
     // setup my axes
     // for now we limit to 4 on left and 4 on right

--- a/src/Charts/LTMTool.cpp
+++ b/src/Charts/LTMTool.cpp
@@ -1741,10 +1741,10 @@ EditMetricDetailDialog::EditMetricDetailDialog(Context *context, LTMTool *ltmToo
     estimateSelect = new QComboBox(this);
 
     // working with estimates, local utility functions
-    models << new CP2Model(context);
-    models << new CP3Model(context);
+    models << new CP2Model();
+    models << new CP3Model();
     //models << new MultiModel(context); disabled in v3.6
-    models << new ExtendedModel(context);
+    models << new ExtendedModel();
     //models << new WSModel(context); disabled in v3.6
     foreach(PDModel *model, models) {
         modelSelect->addItem(model->name(), model->code());

--- a/src/Core/Athlete.cpp
+++ b/src/Core/Athlete.cpp
@@ -144,7 +144,6 @@ Athlete::Athlete(Context *context, const QDir &homeDir)
 
     // read athlete's autoimport configuration and initialize the autoimport process
     autoImportConfig = new RideAutoImportConfig(home->config());
-    autoImport = NULL;
 
     // Search / filter
     namedSearches = new NamedSearches(this); // must be before navigator
@@ -259,7 +258,6 @@ Athlete::~Athlete()
     foreach (HrZones* hrzones, hrzones_) delete hrzones;
     for (int i=0; i<2; i++) delete pacezones_[i];
     delete autoImportConfig;
-    delete autoImport;
 
 }
 
@@ -371,14 +369,14 @@ Athlete::configChanged(qint32 state)
 void
 Athlete::importFilesWhenOpeningAthlete() {
 
-    autoImport = NULL;
     // just do it if something is configured
     if (autoImportConfig->hasRules()) {
 
-        autoImport = new RideImportWizard(autoImportConfig, context);
+        // memory deleted on closure by Qt::WA_DeleteOnClose attribute
+        RideImportWizard* autoImport = new RideImportWizard(autoImportConfig, context);
 
         // only process the popup if we have any files available at all
-        if ( autoImport->getNumberOfFiles() > 0) {
+        if (autoImport->getNumberOfFiles() > 0) {
            autoImport->process();
         }
     }

--- a/src/Core/Athlete.h
+++ b/src/Core/Athlete.h
@@ -126,7 +126,6 @@ class Athlete : public QObject
 #endif
 
         // Athlete's autoimport handling
-        RideImportWizard *autoImport;
         RideAutoImportConfig *autoImportConfig;
 
         // preset charts

--- a/src/Core/Context.cpp
+++ b/src/Core/Context.cpp
@@ -140,16 +140,24 @@ GlobalContext::userMetricsConfigChanged()
 
 bool Context::isValid(Context *p) { return p != NULL &&_contexts.contains(p); }
 
-Context::Context(MainWindow *mainWindow): mainWindow(mainWindow)
+Context::Context(MainWindow *mainWindow)
+    : mainWindow(mainWindow), nav(nullptr), rideNavigator(nullptr), tab(nullptr),
+      athlete(nullptr), ride(nullptr), season(nullptr), workout(nullptr), videosync(nullptr),
+      now(0), importInProgress(0)
 {
-    ride = NULL;
-    workout = NULL;
-    videosync = NULL;
+    // mainwindow state
+    viewIndex = -1;
+    showToolbar = true;
+    scopehighlighted = false;
+
+    // search filter
     isfiltered = ishomefiltered = false;
-    isCompareIntervals = isCompareDateRanges = false;
+
+    // train mode state
     isRunning = isPaused = false;
 
-    connect(this, SIGNAL(loadProgress(QString, double)), mainWindow, SLOT(loadProgress(QString, double)));
+    // comparing things
+    isCompareIntervals = isCompareDateRanges = false;
 
 #ifdef GC_HAS_CLOUD_DB
     cdbChartListDialog = NULL;

--- a/src/Core/Context.h
+++ b/src/Core/Context.h
@@ -129,8 +129,7 @@ class Context : public QObject
         // mainwindow state
         NavigationModel *nav;
         int viewIndex;
-        bool showSidebar, showLowbar, showToolbar, showTabbar;
-        int style;
+        bool showToolbar;
         QString searchText;
         QString workoutFilterText;
         bool scopehighlighted;
@@ -148,11 +147,12 @@ class Context : public QObject
         Athlete *athlete;
         RideItem *ride;  // the currently selected ride
         DateRange dr_;
-        Season const *season = nullptr;
+        Season const *season;
         ErgFile *workout; // the currently selected workout file
         VideoSyncFile *videosync; // the currently selected videosync file
         QString videoFilename;
         long now; // point in time during train session
+        unsigned int importInProgress;
 
         // search filter
         bool isfiltered;

--- a/src/Core/DataFilter.h
+++ b/src/Core/DataFilter.h
@@ -221,6 +221,8 @@ class DataFilter : public QObject
         DataFilter(QObject *parent, Context *context, QString formula);
         ~DataFilter() { clearFilter(); }
 
+        void setContext(Context *con);
+
         // runtime passed by datafilter
         DataFilterRuntime rt;
         QObject *parent() { return parent_; }
@@ -248,7 +250,7 @@ class DataFilter : public QObject
         void colorSyntax(QTextDocument *content, int pos);
 
         static QStringList completerList(Context *, bool); // return list of names for auto-completers
-        static QStringList builtins(Context *); // return list of functions supported
+        static QStringList builtins(); // return list of functions supported
 
         int refcount; // used by user metrics
 

--- a/src/Core/NamedSearch.cpp
+++ b/src/Core/NamedSearch.cpp
@@ -201,7 +201,7 @@ NamedSearchParser::serialize(QString filename, QList<NamedSearch>NamedSearches)
         msgBox.setInformativeText(QObject::tr("File: %1 cannot be opened for 'Writing'. Please check file properties.").arg(filename));
         msgBox.exec();
         return false;
-    };
+    }
     file.resize(0);
     QTextStream out(&file);
 
@@ -259,7 +259,7 @@ EditNamedSearches::EditNamedSearches(QWidget *parent, Context *context) : QDialo
     layout->addLayout(row2);
     QLabel *filter = new QLabel(tr("Filter"), this);
     row2->addWidget(filter);
-    editSearch = new SearchBox(context, this, true);
+    editSearch = new SearchBox(this, context);
     row2->addWidget(editSearch);
 
     // add/update buttons

--- a/src/Core/RideCache.cpp
+++ b/src/Core/RideCache.cpp
@@ -485,7 +485,7 @@ RideCache::writeAsCSV(QString filename)
         msgBox.setInformativeText(tr("File: %1 cannot be opened for 'Writing'. Please check file properties.").arg(filename));
         msgBox.exec();
         return;
-    };
+    }
     file.resize(0);
     QTextStream out(&file);
 

--- a/src/Core/main.cpp
+++ b/src/Core/main.cpp
@@ -720,12 +720,12 @@ main(int argc, char *argv[])
                     appsettings->initializeQSettingsAthlete(homeDir, cyclist);
                     GcUpgrade v3;
                     if (v3.upgradeConfirmedByUser(home)) {
-                        MainWindow *mainWindow = new MainWindow(home);
-                        mainWindow->show();
-                        mainWindow->ridesAutoImport();
-                        gc_opened++;
+                        MainWindow *mainWindow = new MainWindow();
+                        if (mainWindow->openAthleteTab(cyclist)) {
+                            gc_opened++;
+                            anyOpened = true;
+                        }
                         home.cdUp();
-                        anyOpened = true;
                     } else {
                         delete trainDB;
                         terminate(0);
@@ -759,10 +759,8 @@ main(int argc, char *argv[])
             // .. and open a mainwindow
             GcUpgrade v3;
             if (v3.upgradeConfirmedByUser(home)) {
-                MainWindow *mainWindow = new MainWindow(home);
-                mainWindow->show();
-                mainWindow->ridesAutoImport();
-                gc_opened++;
+                MainWindow *mainWindow = new MainWindow();
+                if (mainWindow->openAthleteTab(home.dirName())) gc_opened++;
             } else {
                 delete trainDB;
                 terminate(0);

--- a/src/Gui/AbstractView.cpp
+++ b/src/Gui/AbstractView.cpp
@@ -304,7 +304,7 @@ AbstractView::saveState()
         msgBox.setInformativeText(tr("File: %1 cannot be opened for 'Writing'. Please check file properties.").arg(filename));
         msgBox.exec();
         return;
-    };
+    }
     file.resize(0);
     QTextStream out(&file);
 

--- a/src/Gui/AthleteTab.h
+++ b/src/Gui/AthleteTab.h
@@ -135,4 +135,4 @@ class ProgressLine : public QWidget
     private:
         Context *context;
 };
-#endif // _GC_TabView_h
+#endif // _GC_Tab_h

--- a/src/Gui/AthleteView.cpp
+++ b/src/Gui/AthleteView.cpp
@@ -41,20 +41,9 @@ static const int gl_progress_width = ROWHEIGHT/2;
 static const int gl_button_height = ROWHEIGHT*1.5;
 static const int gl_button_width = ROWHEIGHT*5;
 
-AthleteView::AthleteView(Context *context) : ChartSpace(context, OverviewScope::ATHLETES, NULL), mainWindow_(context->mainWindow)
+AthleteView::AthleteView(MainWindow *mainWindow)
+    : ChartSpace(mainWindow, OverviewScope::ATHLETES, nullptr), mainWindow_(mainWindow)
 {
-    // AthleteView most likely has a lifetime greater than the athlete's context, so ensure
-    // we do not register signals, events or hold this context pointer...
-
-    // remove the athlete context specific configChanged signal registration created by ChartSpace, and
-    // replace it with a global configChanged signal registration instead 
-    disconnect(context, &Context::configChanged, this, &ChartSpace::configChanged);
-    connect(GlobalContext::context(), &GlobalContext::configChanged, this, &ChartSpace::configChanged);
-
-    // the athlete's context provided to this constructor must not be used!
-    // it is set to null to ensure misuse is detected, and prevent unintended behaviour
-    this->context = context = nullptr;
-
     HelpWhatsThis *help = new HelpWhatsThis(this);
     this->setWhatsThis(help->getWhatsThisText(HelpWhatsThis::ScopeBar_Athletes));
 
@@ -156,6 +145,18 @@ AthleteView::closingAthlete(QString name, Context *context)
             static_cast<AthleteCard*>(item)->closingAthlete(name, context);
         }    
     }
+
+    if (openAthletes() == 1) {
+        // find the selected one, and update it
+        foreach(ChartSpaceItem* item, allItems()) {
+            if (!static_cast<AthleteCard*>(item)->isAthleteClosed()) {
+
+                // must be the selected item, so update it
+                static_cast<AthleteCard*>(item)->setCurrentAthlete(true);
+                break;
+            }
+        }
+    }
 }
 
 uint32_t
@@ -174,20 +175,6 @@ AthleteView::currentAthlete(QString name)
     foreach(ChartSpaceItem* item, allItems()) {
         static_cast<AthleteCard*>(item)->setCurrentAthlete(item->name == name);
     }
-}
-
-bool
-AthleteView::setBootStrapAthlete(Context *context)
-{
-    foreach(ChartSpaceItem* item, allItems()) {
-        if (item->name == context->athlete->cyclist) {
-            if (static_cast<AthleteCard*>(item)->setBootStrapAthlete(context)) {
-                currentAthlete(context->athlete->cyclist);
-                return true;
-            }
-        }
-    }
-    return false;
 }
 
 void
@@ -281,41 +268,6 @@ AthleteCard::AthleteCard(ChartSpace *parent, QString name) :
 
     refreshStats();
     update();
-}
-
-bool
-AthleteCard::setBootStrapAthlete(Context *context)
-{
-    static bool onlyOnce{false};
-    if (onlyOnce == false) {
-        onlyOnce = true;
-
-        // register context and signals for the bootstrap (first) athlete
-        // note: opening() and loadDone() are not called for the bootstrap (first) athlete
-        context_ = context;
-        currentAthlete_ = true;
-
-        // the current athlete is loaded by default
-        loadProgress_=100;
-        deleteButton->hide();
-
-        // watch metric updates
-        connect(context_, &Context::refreshStart, this, &AthleteCard::refreshStart);
-        connect(context_, &Context::refreshEnd, this, &AthleteCard::refreshEnd);
-        connect(context_, &Context::refreshUpdate, this, &AthleteCard::refreshUpdate); // we might miss 1st one
-
-        // watch activity changes
-        registerRideEvents(true);
-
-        // config icon for loaded athletes
-        setShowConfig(true);
-
-        refreshStats();
-        update();
-
-        return true;
-    }
-    return false;
 }
 
 void

--- a/src/Gui/AthleteView.h
+++ b/src/Gui/AthleteView.h
@@ -30,12 +30,7 @@ class AthleteView : public ChartSpace
         friend AthleteCard;
 
 public:
-    // only mainWindow is used from the provided context in AthleteView & ChartSpace
-    AthleteView(Context *context);
-
-    // called once at startup for the bootstrap athlete and sets the 
-    // bootstrap as the current athlete, subsequent calls are ignored.
-    bool setBootStrapAthlete(Context *context);
+    AthleteView(MainWindow *mainWindow);
 
 protected:
 
@@ -89,7 +84,6 @@ class AthleteCard : public ChartSpaceItem
         bool clickWithinAthleteSwitchRegion(const QPointF& scenePos);
 
         // accessible via AthleteView equivalents
-        bool setBootStrapAthlete(Context *context);
         void setCurrentAthlete(bool status);
 
     protected slots:

--- a/src/Gui/ChartSpace.cpp
+++ b/src/Gui/ChartSpace.cpp
@@ -39,11 +39,29 @@ static QIcon grayEdit, whiteEdit, accentEdit;
 
 ChartSpaceItemRegistry *ChartSpaceItemRegistry::_instance;
 
-ChartSpace::ChartSpace(Context *context, OverviewScope scope, GcWindow *window) :
-    state(NONE), context(context), scope(scope), mincols(5), window(window), group(NULL), fixedZoom(0), _viewY(0),
-    yresizecursor(false), xresizecursor(false), block(false), scrolling(false),
-    setscrollbar(false), lasty(-1)
+ChartSpace::ChartSpace(Context *context, OverviewScope scope, GcWindow *window)
+    : context(context), scope(scope), window(window)
 {
+    initialise(context->mainWindow);
+}
+
+ChartSpace::ChartSpace(MainWindow *mainWindow, OverviewScope scope, GcWindow *window)
+    : context(nullptr), scope(scope), window(window)
+{
+    initialise(mainWindow);
+}
+
+void
+ChartSpace::initialise(MainWindow *mainWindow)
+{
+    state = NONE;
+    mincols = 5;
+    group = nullptr;
+    fixedZoom = 0;
+    _viewY = 0;
+    yresizecursor = xresizecursor = false;
+    block = scrolling = setscrollbar = false;
+    lasty = -1;
     setContentsMargins(0,0,0,0);
 
     QHBoxLayout *main = new QHBoxLayout;
@@ -52,7 +70,7 @@ ChartSpace::ChartSpace(Context *context, OverviewScope scope, GcWindow *window) 
 
     // add a view and scene and centre
     scene = new QGraphicsScene(this);
-    view = new GGraphicsView(context->mainWindow, this);
+    view = new GGraphicsView(mainWindow, this);
 
     view->viewport()->setAttribute(Qt::WA_AcceptTouchEvents, false); // stops it stealing focus on mouseover
     scrollbar = new QScrollBar(Qt::Vertical, this);
@@ -88,7 +106,12 @@ ChartSpace::ChartSpace(Context *context, OverviewScope scope, GcWindow *window) 
     scene->installEventFilter(this);
 
     // once all widgets created we can connect the signals
-    connect(context, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));
+    if (context) {
+        connect(context, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));
+    } else {
+        // as no context exists register a global configChanged signal instead 
+        connect(GlobalContext::context(), &GlobalContext::configChanged, this, &ChartSpace::configChanged);
+    }
     connect(scroller, SIGNAL(finished()), this, SLOT(scrollFinished()));
     connect(scrollbar, SIGNAL(valueChanged(int)), this, SLOT(scrollbarMoved(int)));
 

--- a/src/Gui/ChartSpace.h
+++ b/src/Gui/ChartSpace.h
@@ -231,7 +231,12 @@ class ChartSpace : public QWidget
 
     public:
 
+        // Constructor for athlete specific chart spaces
         ChartSpace(Context *context, OverviewScope scope, GcWindow *window);
+
+        // Constructor for non athlete chart spaces
+        ChartSpace(MainWindow *mainWindow, OverviewScope scope, GcWindow *window);
+
         QGraphicsScene *getScene() { return scene; }
 
         // current state for event processing
@@ -327,6 +332,8 @@ class ChartSpace : public QWidget
         virtual bool clickOverride(ChartSpaceItem*, QGraphicsSceneMouseEvent*) { return false; }
 
     private:
+
+        void initialise(MainWindow *mainWindow);
 
         // gui setup
         QGraphicsScene *scene;

--- a/src/Gui/LTMSidebar.cpp
+++ b/src/Gui/LTMSidebar.cpp
@@ -61,8 +61,9 @@
 #include "RideMetadata.h"
 #include "SpecialFields.h"
 
-
-LTMSidebar::LTMSidebar(Context *context) : QWidget(context->mainWindow), context(context), active(false),
+// initially create LTMSidebar without a parent widget, the first display
+// of a view (trends, plan) will attach LTMSidebar's mainLayout to the view.
+LTMSidebar::LTMSidebar(Context *context) : QWidget(nullptr), context(context), active(false),
                                            isqueryfilter(false), isautofilter(false)
 {
     QVBoxLayout *mainLayout = new QVBoxLayout(this);

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -132,11 +132,9 @@ extern double gl_major; // 1.x 2.x 3.x - we insist on 2.x or higher to enable Op
 // constants for gui
 static int gl_toolheight=28;
 
-MainWindow::MainWindow(const QDir &home)
+MainWindow::MainWindow()
+    : currentAthleteTab(nullptr), blockTabbarUpdates(false) 
 {
-    /*----------------------------------------------------------------------
-     *  Bootstrap
-     *--------------------------------------------------------------------*/
     setAttribute(Qt::WA_DeleteOnClose);
     mainwindows.append(this);  // add us to the list of open windows
     pactive = init = false;
@@ -146,32 +144,11 @@ MainWindow::MainWindow(const QDir &home)
     splash = new SplashScreen();
 
 #if defined(_MSC_VER) && defined(_WIN64)
-    // set dbg/stacktrace directory for Windows to the athlete directory
-    // don't use the GC_HOMEDIR .ini value, since we want to have a proper path
-    // even if default athlete dirs are used.
-    QDir varHome = home;
-    varHome.cdUp();
-    setCrashFilePath(varHome.canonicalPath().toStdString());
-
+    // set dbg/stacktrace directory for Windows to GC root directory
+    setCrashFilePath(gcroot.toStdString());
 #endif
 
-    // create the context for the bootstrap (first) athlete loaded at startup, care must be taken
-    // with this bootstrap context as any global class instances may have a lifetime greater than
-    // the athlete, and the context is deleted when the athlete is closed !!
-    // If this context is stored (or signals/events registered) in any global class instances (e.g. searchBox)
-    // then the context in those instances must be updated when the current athlete is changed.
-
-    Context *context = new Context(this);
-    context->athlete = new Athlete(context, home);
-
-    QString temp = const_cast<AthleteDirectoryStructure*>(context->athlete->directoryStructure())->temp().absolutePath();
-    context->webEngineProfile->setCachePath(temp);
-    context->webEngineProfile->setPersistentStoragePath(temp);
-
-    currentAthleteTab = new AthleteTab(context);
-
     setWindowIcon(QIcon(":images/gc.png"));
-    setWindowTitle(context->athlete->home->root().dirName());
     setContentsMargins(0,0,0,0);
     setAcceptDrops(true);
 
@@ -209,9 +186,6 @@ MainWindow::MainWindow(const QDir &home)
          resize(defaults.windowsize.width(), defaults.windowsize.height());
 
      }
-
-     // store "last_openend" athlete for next time
-     appsettings->setValue(GC_SETTINGS_LAST, context->athlete->home->root().dirName());
 
     /*----------------------------------------------------------------------
      * ScopeBar as sidebar from v3.6
@@ -353,14 +327,14 @@ MainWindow::MainWindow(const QDir &home)
     perspectiveSelector->setWhatsThis(helpPerspectiveSelector->getWhatsThisText(HelpWhatsThis::ToolBar_PerspectiveSelector));
 
     // Search/Filter box
-    searchBox = new SearchFilterBox(this,context,false);
+    searchBox = new SearchFilterBox(this, nullptr, false);
 
     searchBox->setStyle(toolStyle);
     searchBox->setFixedWidth(400 * dpiXFactor);
     searchBox->setFixedHeight(gl_toolheight * dpiYFactor);
 
     // Workout Filter Box
-    workoutFilterBox = new WorkoutFilterBox(this, context);
+    workoutFilterBox = new WorkoutFilterBox(this);
 
     workoutFilterBox->setStyle(toolStyle);
     workoutFilterBox->setFixedWidth(400 * dpiXFactor);
@@ -424,17 +398,14 @@ MainWindow::MainWindow(const QDir &home)
      *--------------------------------------------------------------------*/
     splash->showMessage(tr("Setting up GUI: Central Widget..."));
 
-    blockTabbarUpdates = false;
     tabbar = new DragBar(this);
     tabbar->setTabsClosable(true);
 #ifdef Q_OS_MAC
     tabbar->setDocumentMode(true);
 #endif
 
-    // only mainWindow is used from the provided context in AthleteView & ChartSpace
-    athleteView = new AthleteView(context);
-    // the athlete's context is used in AthleteCard, as this represents the athlete
-    athleteView->setBootStrapAthlete(context);
+    // Create the athlete view
+    athleteView = new AthleteView(this);
 
     // Note: The order of the viewStack tabs below, must match the GcViewStackIdx definitions above.
     viewStack = new QStackedWidget(this);
@@ -443,18 +414,11 @@ MainWindow::MainWindow(const QDir &home)
     tabStack = new QStackedWidget(this);
     viewStack->addWidget(tabStack);
 
-    // first tab
-    athletetabs.insert(currentAthleteTab->context->athlete->home->root().dirName(), currentAthleteTab);
-
-    // stack, list and bar all share a common index
-    tabList.append(currentAthleteTab);
-    tabbar->addTab(currentAthleteTab->context->athlete->home->root().dirName());
-    tabStack->addWidget(currentAthleteTab);
-    tabStack->setCurrentIndex(0);
-
-    connect(tabbar, SIGNAL(dragTab(int)), this, SLOT(tabbarAthleteChange(int)));
-    connect(tabbar, SIGNAL(currentChanged(int)), this, SLOT(tabbarAthleteChange(int)));
-    connect(tabbar, &DragBar::tabCloseRequested, this, &MainWindow::closeTabClicked);
+    connect(tabbar, &DragBar::dragTab, this, &MainWindow::tabbarAthleteChange);
+    connect(tabbar, &DragBar::currentChanged, this, &MainWindow::tabbarAthleteChange);
+    connect(tabbar, &DragBar::tabCloseRequested, this, [this](int index) {
+        closeAthleteTab(tabList[index]->context->athlete->cyclist);
+    });
 
     /*----------------------------------------------------------------------
      * Central Widget
@@ -531,7 +495,7 @@ MainWindow::MainWindow(const QDir &home)
     fileMenu->addAction(tr("Settings..."), this, SLOT(athleteSettings()));
     fileMenu->addSeparator();
     fileMenu->addAction(tr("Save all modified activities"), this, [this] () {
-        saveAllUnsavedRides(this->currentAthleteTab->context);
+        if (this->currentAthleteTab) saveAllUnsavedRides(this->currentAthleteTab->context);
     });
 
     fileMenu->addSeparator();
@@ -540,7 +504,6 @@ MainWindow::MainWindow(const QDir &home)
     actionQuit->setShortcutContext(Qt::ApplicationShortcut);
     connect(actionQuit, SIGNAL(triggered()), this, SLOT(closeWindow()));
     fileMenu->addAction(actionQuit);
-    //fileMenu->addAction(tr("&Close Tab"), this, SLOT(closeTab())); use athlete view
 
     HelpWhatsThis *fileMenuHelp = new HelpWhatsThis(fileMenu);
     fileMenu->setWhatsThis(fileMenuHelp->getWhatsThisText(HelpWhatsThis::MenuBar_Athlete));
@@ -717,26 +680,7 @@ MainWindow::MainWindow(const QDir &home)
     HelpWhatsThis *helpMenuHelp = new HelpWhatsThis(helpMenu);
     helpMenu->setWhatsThis(helpMenuHelp->getWhatsThisText(HelpWhatsThis::MenuBar_Help));
 
-    /*----------------------------------------------------------------------
-     * Lets go, choose latest ride and get GUI up and running
-     *--------------------------------------------------------------------*/
-    splash->showMessage(tr("Selecting ride..."));
-
     showTabbar(appsettings->value(NULL, GC_TABBAR, "0").toBool());
-
-    saveGCState(currentAthleteTab->context); // set to whatever we started with
-
-    // switch to the startup view, default is analysis.
-    switch (appsettings->value(NULL, GC_STARTUP_VIEW, "1").toInt()) {
-        case 0: selectTrends(); break;
-        case 1: selectAnalysis(); break;
-        case 2: selectPlan(); break;
-        case 3: selectTrain(); break;
-        default: selectAnalysis(); qDebug() << "Unknown startup view"; break;
-    }
-
-    //grab focus
-    currentAthleteTab->setFocus();
 
     installEventFilter(this);
 
@@ -749,13 +693,6 @@ MainWindow::MainWindow(const QDir &home)
     /*----------------------------------------------------------------------
      * Lets ask for telemetry and check for updates
      *--------------------------------------------------------------------*/
-
-#if !defined(OPENDATA_DISABLE)
-    splash->showMessage(tr("Checking for udates..."));
-    OpenData::check(currentAthleteTab->context);
-#else
-    fprintf(stderr, "OpenData disabled, secret not defined.\n"); fflush(stderr);
-#endif
 
 #ifdef GC_HAS_CLOUD_DB
     splash->showMessage(tr("Asking for telemetry..."));
@@ -778,9 +715,6 @@ MainWindow::MainWindow(const QDir &home)
 
 #endif
 
-    // get rid of splash when currentTab is shown
-    delete splash;
-    splash = nullptr;
 }
 
 
@@ -1087,38 +1021,26 @@ void
 MainWindow::closeEvent(QCloseEvent* event)
 {
     QGuiApplication::setOverrideCursor(Qt::WaitCursor);
-    QList<AthleteTab*> closing = tabList;
-    bool needtosave = false;
-    bool importrunning = false;
+    bool importRunningOrUnsaved(false);
 
-    // close all the tabs .. if any refuse we need to ignore
-    //                       the close event
-    foreach(AthleteTab *tab, closing) {
+    // if the closure is due to main menu quit or the window decoration close X button, then there will be athlete's to
+    // close, so close them without changing their positions and without updating the last opened athlete,
+    // if any refuse we need to ignore the close event
+    for(int i=tabbar->count()-1; i > -1; i--) {
 
-        // check for if RideImport is is process and let it finalize / or be stopped by the user
-        if (tab->context->athlete->autoImport) {
-            if (tab->context->athlete->autoImport->importInProcess() ) {
-                importrunning = true;
-                QGuiApplication::restoreOverrideCursor();
-                QMessageBox::information(this, tr("Activity Import"),
-                        tr("INFO for athlete %1\n\nClosing of athlete window not possible while background activity import is in progress...")
-                            .arg(tab->context->athlete->cyclist));
-                QGuiApplication::setOverrideCursor(Qt::WaitCursor);
-            }
+        QGuiApplication::restoreOverrideCursor();
+
+        if (checkImportAndUnsaved(i)) {
+            removeAthleteTab(tabList[i], false); // don't update the last opened athlete
+        } else {
+            importRunningOrUnsaved = true;
         }
 
-        // only check for unsaved if autoimport is not running any more
-        if (!importrunning) {
-            // do we need to save?
-            if (tab->context->mainWindow->saveRideExitDialog(tab->context) == true)
-                removeAthleteTab(tab);
-            else
-                needtosave = true;
-        }
+        QGuiApplication::setOverrideCursor(Qt::WaitCursor);
     }
 
     // were any left hanging around? or autoimport in action on any windows, then don't close any
-    if (needtosave || importrunning) event->ignore();
+    if (importRunningOrUnsaved) event->ignore();
     else {
 
         // finish off the job and leave
@@ -1131,6 +1053,7 @@ MainWindow::closeEvent(QCloseEvent* event)
 
         // save global mainwindow settings
         appsettings->setValue(GC_TABBAR, showhideTabbar->isChecked());
+
         // wait for threads.. max of 10 seconds before just exiting anyway
         for (int i=0; i<10 && QThreadPool::globalInstance()->activeThreadCount(); i++) {
             QThread::sleep(1);
@@ -1373,6 +1296,44 @@ MainWindow::isStarting
     return splash != nullptr;
 }
 
+void
+MainWindow::displayMainWindow()
+{
+    splash->showMessage(tr("Opening Main Window..."));
+
+    // switch to the startup view based on the configured value,
+    // the default is analysis when no config exists or the configuration value is not recognised.
+    // note: the gcStartupView values must align with the startViewIdx entries in Pages.cpp
+    int gcStartupView = appsettings->value(NULL, GC_STARTUP_VIEW, -1).toInt();
+    switch (gcStartupView) {
+        case 0: selectTrends(); break;
+        case 1: selectAnalysis(); break;
+        case 2: selectPlan(); break;
+        case 3: selectTrain(); break;
+        default: {
+            qDebug() << "Startup view not specified or unknown value, defaulting to analysis view";
+            appsettings->setValue(GC_STARTUP_VIEW, 1);
+            selectAnalysis();
+        } break;
+    }
+
+    //grab focus
+    currentAthleteTab->setFocus();
+
+#if !defined(OPENDATA_DISABLE)
+    splash->showMessage(tr("Checking for udates..."));
+    OpenData::check(currentAthleteTab->context);
+#else
+    fprintf(stderr, "OpenData disabled, secret not defined.\n"); fflush(stderr);
+#endif
+
+    // get rid of splash once the first athlete is loaded
+    delete splash;
+    splash = nullptr;
+
+    // display GC main window
+    show();
+}
 
 bool
 MainWindow::filenameWillChange(RideItem *rideItem, QString *newName) const
@@ -2018,6 +1979,10 @@ MainWindow::closeWindow()
 bool
 MainWindow::openAthleteTab(QString name)
 {
+    blockTabbarUpdates = true;
+
+    if (splash) splash->showMessage(QString(tr("Loading Athlete %1...")).arg(name));
+
     QDir home(gcroot);
     appsettings->initializeQSettingsGlobal(gcroot);
     home.cd(name);
@@ -2028,12 +1993,13 @@ MainWindow::openAthleteTab(QString name)
     GcUpgrade v3;
     if (!v3.upgradeConfirmedByUser(home)) return false;
 
-    // save how we are
-    saveGCState(currentAthleteTab->context);
-
     Context *con= new Context(this);
 
-    con->athlete = NULL;
+    // splash is a proxy for first startup, so register load progress for the splash updates
+    if (splash) connect(con, &Context::loadProgress, this, [this, name] (QString,double progress) {
+        this->splash->showMessage(QString(tr("Loading activities for %1: %2\%")).arg(name).arg(static_cast<int>(progress)));
+    });
+
     emit openingAthlete(name, con);
 
     connect(con, SIGNAL(loadCompleted(QString,Context*)), this, SLOT(loadCompleted(QString, Context*)));
@@ -2047,84 +2013,100 @@ MainWindow::openAthleteTab(QString name)
 void
 MainWindow::loadCompleted(QString name, Context *context)
 {
-    // athlete loaded
-    currentAthleteTab = new AthleteTab(context);
+    if (splash) splash->showMessage(QString(tr("Loaded Athlete %1...")).arg(name));
 
-    // clear splash - progress whilst loading tab
-    //clearSplash();
-
-    // setup the WebEngine paths
+    // setup the athlete's WebEngine paths
     QString temp = const_cast<AthleteDirectoryStructure*>(context->athlete->directoryStructure())->temp().absolutePath();
     context->webEngineProfile->setCachePath(temp);
     context->webEngineProfile->setPersistentStoragePath(temp);
 
+    // new athlete loaded, so create an AthleteTab
+    AthleteTab* newAthleteTab = new AthleteTab(context);
+
     // first tab
-    athletetabs.insert(currentAthleteTab->context->athlete->home->root().dirName(), currentAthleteTab);
+    athletetabs.insert(name, newAthleteTab);
 
     // stack, list and bar all share a common index
-    tabList.append(currentAthleteTab);
-    tabbar->addTab(currentAthleteTab->context->athlete->home->root().dirName());
-    tabStack->addWidget(currentAthleteTab);
+    tabList.append(newAthleteTab);
+    tabbar->addTab(name);
+    tabStack->addWidget(newAthleteTab);
+    int newAthleteIndex = tabList.count()-1;
 
-    // switch to newly created athlete
-    tabbar->setCurrentIndex(tabList.count()-1);
+    // switch to newly created athlete (tabbar are events disabled during loading)
+    tabbar->setCurrentIndex(newAthleteIndex);
+
+    // switch to the new athlete, updates currentAthleteTab with the newAthleteTab
+    switchAthleteTab(newAthleteIndex);
 
     // show the tabbar if we're gonna open tabs -- but wait till the last second
     // to show it to avoid crappy paint artefacts
-    showTabbar(true);
+    if (tabList.count() > 1) showTabbar(true); // need it for more than one!
 
-    // clear the workout filter box text
-    workoutFilterBox->clear();
+    // splash is a proxy for first startup, so now display the main window
+    if (splash) displayMainWindow();
+
+    blockTabbarUpdates = false;
 
     // tell everyone
     currentAthleteTab->context->notifyLoadDone(name, context);
 
     // now do the automatic ride file import
-    context->athlete->importFilesWhenOpeningAthlete();
-}
-
-bool
-MainWindow::closeTabClicked(int index)
-{
-    AthleteTab *tab = tabList[index];
-
-    // check for autoimport and let it finalize
-    if (tab->context->athlete->autoImport) {
-        if (tab->context->athlete->autoImport->importInProcess() ) {
-            QMessageBox::information(this, tr("Activity Import"),
-                    tr("INFO for athlete %1\n\nClosing of athlete window not possible while background activity import is in progress...")
-                        .arg(tab->context->athlete->cyclist));
-            return false;
-        }
-    }
-
-    if (saveRideExitDialog(tab->context) == false) return false;
-
-    // lets wipe it
-    removeAthleteTab(tab);
-
-    return true;
+    currentAthleteTab->context->athlete->importFilesWhenOpeningAthlete();
 }
 
 bool
 MainWindow::closeAthleteTab(QString name)
 {
-    // if its the last athlete tab we close GoldenCheetah
-    if (tabbar->count() == 1) {
-        closeWindow();
-    } else {
-        for(int i=0; i<tabbar->count(); i++) {
-            if (name == tabbar->tabText(i)) {
-                return closeTabClicked(i);
-            }
+    int athleteCanBeClosed(-1);
+
+    for(int i=0; i<tabbar->count(); i++) {
+        if (name == tabbar->tabText(i)) {
+
+            if (checkImportAndUnsaved(i)) athleteCanBeClosed = i;
+            break;
         }
     }
+
+    if (athleteCanBeClosed != -1) {
+
+        // lets wipe it
+        removeAthleteTab(tabList[athleteCanBeClosed]);
+
+        // if its the last athlete tab we must close GoldenCheetah
+        if (tabList.count() == 0) closeWindow();
+
+        return true;
+    }
+
     return false;
+}
+
+bool
+MainWindow::checkImportAndUnsaved(int index)
+{
+    AthleteTab *tab = tabList[index];
+
+    // check for any ride import process in progress
+    if (tab->context->importInProgress > 0) {
+
+        QMessageBox msgBox;
+        msgBox.setWindowTitle("Information");
+        msgBox.setText(tr("INFO for athlete %1\n\nClosing the athlete window is not possible while file import is in progress...")
+                            .arg(tab->context->athlete->cyclist));
+        msgBox.setIcon(QMessageBox::Information);
+        msgBox.setWindowFlags(msgBox.windowFlags() | Qt::WindowStaysOnTopHint);
+        msgBox.exec();
+
+        return false;
+    }
+
+    // now check for unsaved activities
+    return saveRideExitDialog(tab->context);
 }
 
 // no questions asked just wipe away the current tab
 void
-MainWindow::removeAthleteTab(AthleteTab *tab)
+MainWindow::removeAthleteTab(AthleteTab *tab, bool updateLastOpenedAthlete /* = true */)
 {
     blockTabbarUpdates = true;
 
@@ -2141,29 +2123,34 @@ MainWindow::removeAthleteTab(AthleteTab *tab)
     // clear the clipboard if neccessary
     QApplication::clipboard()->setText("");
 
-    // Remember where we were
+    // Remember the athlete we are closing
     QString name = tab->context->athlete->cyclist;
 
     // switch to neighbour (currentTab will change)
     int index = tabList.indexOf(tab);
 
-    // if this is not the last athlete and we are removing the current 
-    // athlete tab then we need to select another athlete
-    if ((tabList.count() > 1) && (tab == currentAthleteTab)) {
-        switchAthleteTab((index == 0) ? index+1 : index-1);
+    if (tabList.count() == 1) { // last athlete so save the settings, don't switch
+
+        // save the previous athlete's settings
+        saveGCState(tab);
+
+    } else { // switching athlete
+
+        // if this is not the last athlete and we are removing the current 
+        // athlete tab then we need to select another athlete
+        if ((tabList.count() > 1) && (tab == currentAthleteTab)) {
+            switchAthleteTab((index == 0) ? index+1 : index-1, updateLastOpenedAthlete);
+        }
     }
-    
+ 
     // close the athlete's card
     emit closingAthlete(name, tab->context);
 
-    // refresh the athlete's card button labels, there might only be one open athlete now
-    emit currentAthlete(currentAthleteTab->context->athlete->cyclist);
-
-    // close gracefully
+    // close athlete gracefully
     tab->close();
     tab->context->athlete->close();
 
-    // remove from state
+    // remove athlete from state
     athletetabs.remove(name);
     tabList.removeAt(index);
     tabbar->removeTab(index);
@@ -2312,20 +2299,23 @@ MainWindow::deleteAthlete(QString name)
 }
 
 void
-MainWindow::saveGCState(Context *context)
+MainWindow::saveGCState(AthleteTab *athleteTab)
 {
-    // save all the current state to the supplied context
-    context->showSidebar = showhideSidebar->isChecked();
-    //context->showTabbar = showhideTabbar->isChecked();
-    context->showLowbar = showhideLowbar->isChecked();
-    context->showToolbar = showhideToolbar->isChecked();
-    context->searchText = searchBox->text();
-    context->workoutFilterText = workoutFilterBox->text();
-    context->style = styleAction->isChecked();
+    // save the view related state to the athleteTab's view
+    athleteTab->setSidebarEnabled(showhideSidebar->isChecked());
+    athleteTab->setBottomRequested(showhideLowbar->isChecked());
+    athleteTab->setTiled(styleAction->isChecked());
+
+    Context* tabContext(athleteTab->context);
+
+    // save the athlete related state to the athleteTab's context
+    tabContext->showToolbar = showhideToolbar->isChecked();
+    tabContext->searchText = searchBox->text();
+    tabContext->workoutFilterText = workoutFilterBox->text();
 }
 
 void
-MainWindow::restoreGCState(Context *context)
+MainWindow::restoreGCState(AthleteTab *athleteTab)
 {
     if (viewStack->currentIndex() != GcViewStackIdx::SELECT_ATHLETE_VIEW) {
 
@@ -2333,23 +2323,32 @@ MainWindow::restoreGCState(Context *context)
         resetPerspective(currentAthleteTab->currentView()); // will lazy load, hence doing it first
 
         // restore window state from the supplied context
-            switch(currentAthleteTab->currentView()) {
+        switch(currentAthleteTab->currentView()) {
             case 0: sidebar->setItemSelected(GcSideBarBtnId::TRENDS_BTN,true); break;
             case 1: sidebar->setItemSelected(GcSideBarBtnId::ACTIVITIES_BTN,true); break;
             case 2: sidebar->setItemSelected(GcSideBarBtnId::PLAN_BTN,true); break;
             case 3: sidebar->setItemSelected(GcSideBarBtnId::TRAIN_BTN, true); break;
             default: sidebar->setItemSelected(GcSideBarBtnId::SELECT_ATHLETE_BTN, true); break;
         }
+
+        // restore the view related state from the provided athleteTab's view
+        showSidebar(athleteTab->isSidebarEnabled());
+        showLowbar(athleteTab->hasBottom());
+
+        // there is no set style action, so...
+        styleAction->setChecked(athleteTab->isTiled());
+        setToolButtons();
     }
 
-    showSidebar(context->showSidebar);
-    showToolbar(context->showToolbar);
-    //showTabbar(context->showTabbar);
-    showLowbar(context->showLowbar);
-    searchBox->setContext(context);
-    searchBox->setText(context->searchText);
-    workoutFilterBox->setContext(context);
-    workoutFilterBox->setText(context->workoutFilterText);
+    Context* tabContext(athleteTab->context);
+
+    // restore the context related state from the athleteTab's context
+    showToolbar(tabContext->showToolbar);
+    searchBox->setContext(tabContext);
+    searchBox->setText(tabContext->searchText);
+    workoutFilterBox->setContext(tabContext);
+    workoutFilterBox->setText(tabContext->workoutFilterText);
+    setWindowTitle(tabContext->athlete->cyclist);
 }
 
 void
@@ -2377,7 +2376,7 @@ MainWindow::switchAthleteTab(QString name)
 }
 
 void
-MainWindow::switchAthleteTab(int index)
+MainWindow::switchAthleteTab(int index, bool updateLastOpenedAthlete /* = true */)
 {
     if (index < 0) return;
 
@@ -2394,17 +2393,22 @@ MainWindow::switchAthleteTab(int index)
 #endif
 
     // save the previous athlete's settings (there isn't one at startup)
-    if (currentAthleteTab) saveGCState(currentAthleteTab->context);
+    if (currentAthleteTab) saveGCState(currentAthleteTab);
 
+    // switch to the new athlete
     currentAthleteTab = tabList[index];
 
     tabStack->setCurrentIndex(index);
     tabbar->setCurrentIndex(index);
 
-    // restore back
-    restoreGCState(currentAthleteTab->context);
+    // restore new athlete's settings
+    restoreGCState(currentAthleteTab);
 
-    setWindowTitle(currentAthleteTab->context->athlete->cyclist);
+    // store the new athlete as the "last_openend" athlete for next time
+    if (updateLastOpenedAthlete) appsettings->setValue(GC_SETTINGS_LAST, currentAthleteTab->context->athlete->cyclist);
+
+    // refresh the athlete's card button labels
+    emit currentAthlete(currentAthleteTab->context->athlete->cyclist);
 
     setUpdatesEnabled(true);
 }
@@ -2677,27 +2681,9 @@ MainWindow::downloadMeasures(QAction *action)
 }
 
 void
-MainWindow::loadProgress
-(QString folder, double progress)
-{
-    Q_UNUSED(folder)
-    if (splash) {
-        splash->showMessage(QString(tr("Loading activities: %1\%")).arg(static_cast<int>(progress)));
-    }
-}
-
-
-void
 MainWindow::addIntervals()
 {
     currentAthleteTab->addIntervals();
-}
-
-void
-MainWindow::ridesAutoImport() {
-
-    currentAthleteTab->context->athlete->importFilesWhenOpeningAthlete();
-
 }
 
 void MainWindow::onEditMenuAboutToShow()

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -89,7 +89,7 @@ class MainWindow : public QMainWindow
 
     public:
 
-        MainWindow(const QDir &home);
+        MainWindow();
         ~MainWindow(); // temp to zap db - will move to tab //
 
         void byebye() { close(); } // go bye bye for a restart
@@ -149,9 +149,6 @@ class MainWindow : public QMainWindow
         void logBug();
         void support();
 
-        void loadProgress(QString folder, double progress);
-
-
         // perspective selected
         void perspectiveSelected(int index);
         void perspectivesChanged(); // when the list of perspectives is updated in PerspectivesDialog
@@ -174,7 +171,6 @@ class MainWindow : public QMainWindow
         void newCyclistTab();  // create a new Cyclist
         bool openAthleteTab(QString name);
         void loadCompleted(QString name, Context *context);
-        bool closeTabClicked(int index); // user clicked to close tab
         bool closeAthleteTab(QString name); // close named athlete
         void switchAthleteTab(QString name); // athlete switching for change
         void tabbarAthleteChange(int index); // blockable tabbar generated athlete switching
@@ -278,9 +274,6 @@ class MainWindow : public QMainWindow
         void revertRide();
         bool saveRideExitDialog(Context *);              // save dirty rides on exit dialog
 
-        // autoload rides from athlete specific directory (preferences)
-        void ridesAutoImport();
-
 #ifdef GC_HAS_CLOUD_DB
         // CloudDB actions
         void cloudDBuserEditChart();
@@ -292,16 +285,19 @@ class MainWindow : public QMainWindow
         void exportChartToCloudDB();
 #endif
         // save and restore state to context
-        void saveGCState(Context *);
-        void restoreGCState(Context *);
+        void saveGCState(AthleteTab *);
+        void restoreGCState(AthleteTab *);
 
         void configChanged(qint32);
         void onEditMenuAboutToShow();
 
     protected:
 
-        void switchAthleteTab(int index); // athlete switching for change & athlete closure
-        void removeAthleteTab(AthleteTab*);  // remove without question
+        void displayMainWindow();
+
+        void switchAthleteTab(int index, bool updateLastOpenedAthlete = true); // athlete switching for change & athlete closure
+        bool checkImportAndUnsaved(int index);
+        void removeAthleteTab(AthleteTab*, bool updateLastOpenedAthlete = true);  // remove without question
 
     private:
 

--- a/src/Gui/Perspective.cpp
+++ b/src/Gui/Perspective.cpp
@@ -1890,7 +1890,7 @@ AddPerspectiveDialog::AddPerspectiveDialog(QWidget *parent, Context *context, QS
     layout->addLayout(form);
 
     if (type == VIEW_ANALYSIS || type == VIEW_TRENDS) {
-        filterEdit = new SearchBox(context, this);
+        filterEdit = new SearchBox(this, context);
         filterEdit->setFixedMode(true);
         filterEdit->setMode(SearchBox::Filter);
         filterEdit->setText(expression);

--- a/src/Gui/RideImportWizard.cpp
+++ b/src/Gui/RideImportWizard.cpp
@@ -55,6 +55,7 @@ enum WizardTable {
 // drag and drop passes urls ... convert to a list of files and call main constructor
 RideImportWizard::RideImportWizard(QList<QUrl> *urls, Context *context, QWidget *parent) : QDialog(parent), context(context)
 {
+    context->importInProgress++;
     _importInProcess = true;
     setAttribute(Qt::WA_DeleteOnClose);
     setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
@@ -71,8 +72,10 @@ RideImportWizard::RideImportWizard(QList<QUrl> *urls, Context *context, QWidget 
 
 RideImportWizard::RideImportWizard(QList<QString> files, Context *context, QWidget *parent) : QDialog(parent), context(context)
 {
+    context->importInProgress++;
     _importInProcess = true;
     setAttribute(Qt::WA_DeleteOnClose);
+    setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
     autoImportMode = false;
     autoImportStealth = false;
     init(files, context);
@@ -83,7 +86,10 @@ RideImportWizard::RideImportWizard(QList<QString> files, Context *context, QWidg
 
 RideImportWizard::RideImportWizard(RideAutoImportConfig *dirs, Context *context, QWidget *parent) : QDialog(parent), context(context), importConfig(dirs)
 {
+    context->importInProgress++;
     _importInProcess = true;
+    setAttribute(Qt::WA_DeleteOnClose);
+    setWindowFlags(windowFlags() | Qt::WindowStaysOnTopHint);
     autoImportMode = true;
     autoImportStealth = true;
 
@@ -1226,6 +1232,12 @@ RideImportWizard::done(int rc)
 RideImportWizard::~RideImportWizard()
 {
     foreach(QString name, deleteMe) QFile(name).remove();
+
+    if (context->importInProgress > 0) {
+        context->importInProgress--;
+    } else {
+        qDebug() << "Error in RideImportWizard instance tracking";
+    }
 }
 
 

--- a/src/Gui/RideImportWizard.h
+++ b/src/Gui/RideImportWizard.h
@@ -56,7 +56,6 @@ public:
 
     int getNumberOfFiles();  // get the number of files selected for processing
     int process();
-    bool importInProcess() { return _importInProcess; }
     bool isAutoImport() { return autoImportMode;}
 
 private slots:

--- a/src/Gui/SearchBox.h
+++ b/src/Gui/SearchBox.h
@@ -42,7 +42,7 @@ public:
     enum searchboxmode { Search, Filter };
     typedef enum searchboxmode SearchBoxMode;
 
-    SearchBox(Context *context, QWidget *parent = 0, bool nochooser=true);
+    SearchBox(QWidget *parent, Context *context, bool nochooser=true);
 
     // either search box or filter box
     void setMode(SearchBoxMode mode);
@@ -50,7 +50,7 @@ public:
     void setText(QString);
     SearchBoxMode getMode() { return mode; }
     bool isFiltered() const { return filtered; }
-    void setContext(Context *c) { context = c; }
+    void setContext(Context *con);
 
 protected:
     void resizeEvent(QResizeEvent *);

--- a/src/Gui/SearchFilterBox.cpp
+++ b/src/Gui/SearchFilterBox.cpp
@@ -34,7 +34,7 @@ SearchFilterBox::SearchFilterBox(QWidget *parent, Context *context, bool nochoos
     contents->setContentsMargins(0,0,0,0);
 
     // no column chooser if my parent widget is a modal widget
-    searchbox = new SearchBox(context, this, nochooser);
+    searchbox = new SearchBox(this, context, nochooser);
     searchbox->setSizePolicy(QSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed));
     contents->addWidget(searchbox);
 
@@ -55,6 +55,16 @@ SearchFilterBox::SearchFilterBox(QWidget *parent, Context *context, bool nochoos
     // syntax check
     connect(datafilter, SIGNAL(parseGood()), searchbox, SLOT(setGood()));
     connect(datafilter, SIGNAL(parseBad(QStringList)), searchbox, SLOT(setBad(QStringList)));
+}
+
+void
+SearchFilterBox::setContext(Context *con)
+{
+    if (context != con) {
+        context = con;
+        searchbox->setContext(con);
+        datafilter->setContext(con);
+    }
 }
 
 // static utility function to get list of files that match a filter

--- a/src/Gui/SearchFilterBox.h
+++ b/src/Gui/SearchFilterBox.h
@@ -42,7 +42,7 @@ public:
     QString text() const { return searchbox->text(); }
     void setText(QString t) { searchbox->setText(t); }
 
-    void setContext(Context *c) { context = c; searchbox->setContext(c); }
+    void setContext(Context *con);
 
     SearchBox *searchbox;
 

--- a/src/Metrics/Estimator.cpp
+++ b/src/Metrics/Estimator.cpp
@@ -201,12 +201,12 @@ Estimator::run()
     }
 
     // set up the models we support
-    CP2Model p2model(context);
-    CP3Model p3model(context);
-    ExtendedModel extmodel(context);
+    CP2Model p2model;
+    CP3Model p3model;
+    ExtendedModel extmodel;
 #if 0 // disable until model fitting errors are fixed (!!!)
-    WSModel wsmodel(context);
-    MultiModel multimodel(context);
+    WSModel wsmodel;
+    MultiModel multimodel;
 #endif
 
     QList <PDModel *> models;

--- a/src/Metrics/PDModel.cpp
+++ b/src/Metrics/PDModel.cpp
@@ -22,11 +22,10 @@
 
 //extern ztable PD_ZTABLE;
 // base class for all models
-PDModel::PDModel(Context *context) :
+PDModel::PDModel() :
     QwtSyntheticPointData(PDMODEL_MAXT),
     fit(Envelope),
     inverseTime(false),
-    context(context),
     sanI1(0), sanI2(0), anI1(0), anI2(0), aeI1(0), aeI2(0), laeI1(0), laeI2(0),
     cp(0), tau(0), t0(0), minutes(false)
 {
@@ -483,8 +482,7 @@ PDModel::calcSummary()
 // Classic 2 Parameter Model
 //
 
-CP2Model::CP2Model(Context *context) :
-    PDModel(context)
+CP2Model::CP2Model()
 {
     // set default intervals to search CP 2-3 mins and 10-20 mins
     anI1=120;
@@ -545,8 +543,7 @@ void CP2Model::onIntervalsChanged()
 //
 // Morton 3 Parameter Model
 //
-CP3Model::CP3Model(Context *context) :
-    PDModel(context)
+CP3Model::CP3Model()
 {
     // set default intervals to search CP 2-3 mins and 12-20mins
     anI1=120;
@@ -631,7 +628,7 @@ void CP3Model::onIntervalsChanged()
 //
 // Ward Smith Model
 //
-WSModel::WSModel(Context *context) : PDModel(context)
+WSModel::WSModel()
 {
     // set default intervals to search CP 30-60
     anI1=1800;
@@ -746,8 +743,7 @@ void WSModel::onIntervalsChanged()
 //
 // Currently deciding which of the three formulations to use
 // as the base for GoldenCheetah (we have enough models already !)
-MultiModel::MultiModel(Context *context) :
-    PDModel(context),
+MultiModel::MultiModel() :
     variant(0), w1(0), p1(0), p2(0), tau1(0), tau2(0), alpha(0), beta(0)
 {
     // set default intervals to search CP 30-60
@@ -891,8 +887,7 @@ void MultiModel::onIntervalsChanged()
 //
 // Extended CP Model
 //
-ExtendedModel::ExtendedModel(Context *context) :
-    PDModel(context),
+ExtendedModel::ExtendedModel() :
     paa(0), paa_dec(0), ecp(0), etau(0), ecp_del(0), tau_del(0), ecp_dec(0),
     ecp_dec_del(0)
 {

--- a/src/Metrics/PDModel.h
+++ b/src/Metrics/PDModel.h
@@ -70,7 +70,7 @@ class PDModel : public QObject, public QwtSyntheticPointData
                        LinearRegression=2         // using slope and intercept of linear regression
                      } fit;
 
-        PDModel(Context *context);
+        PDModel();
 
         // set which variant of the model to use (if the model
         // supports such a thing it needs to reimplement)
@@ -156,7 +156,6 @@ class PDModel : public QObject, public QwtSyntheticPointData
 
     protected:
 
-        Context *context;
         int model;
 
         // intervals to search for best points
@@ -210,7 +209,7 @@ class CP2Model : public PDModel
     Q_OBJECT
 
     public:
-        CP2Model(Context *context);
+        CP2Model();
 
         // synthetic data for a curve
         virtual double y(double t) const;
@@ -255,7 +254,7 @@ class CP3Model : public PDModel
     Q_OBJECT
 
     public:
-        CP3Model(Context *context);
+        CP3Model();
 
         bool modelDecay;    // should we apply CP + W' decay constants?
 
@@ -306,7 +305,7 @@ class WSModel : public PDModel // ward-smith
     Q_OBJECT
 
     public:
-        WSModel(Context *context);
+        WSModel();
 
         // synthetic data for a curve
         virtual double y(double t) const;
@@ -340,7 +339,7 @@ class MultiModel : public PDModel
     Q_OBJECT
 
     public:
-        MultiModel(Context *context);
+        MultiModel();
         void setVariant(int); // which variant to use
 
         // synthetic data for a curve
@@ -380,7 +379,7 @@ class ExtendedModel : public PDModel
     Q_OBJECT
 
     public:
-        ExtendedModel(Context *context);
+        ExtendedModel();
 
         // synthetic data for a curve
         virtual double y(double t) const;

--- a/src/Train/WorkoutFilterBox.cpp
+++ b/src/Train/WorkoutFilterBox.cpp
@@ -45,18 +45,23 @@ WorkoutFilterBox::WorkoutFilterBox(QWidget *parent, Context *context) : FilterEd
     this->setFilterCommands(workoutFilterCommands());
     this->setMenuProvider(new WorkoutMenuProvider(this, QDir(gcroot).canonicalPath() + "/workoutfilters.xml"));
     connect(this, &FilterEditor::returnPressed, this, &WorkoutFilterBox::processInput);
-    if (context != nullptr) {
-        connect(context, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));
+    if (context) connect(context, &Context::configChanged, this, &WorkoutFilterBox::configChanged);
 
-        // set appearance
-        configChanged(CONFIG_APPEARANCE);
-    }
+    // set appearance
+    configChanged(CONFIG_APPEARANCE);
 }
 
 WorkoutFilterBox::~WorkoutFilterBox()
 {
 }
 
+void
+WorkoutFilterBox::setContext(Context *ctx)
+{
+    if (context) disconnect(context, &Context::configChanged, this, &WorkoutFilterBox::configChanged);
+    context = ctx;
+    if (context) connect(context, &Context::configChanged, this, &WorkoutFilterBox::configChanged);
+}
 
 void
 WorkoutFilterBox::clear

--- a/src/Train/WorkoutFilterBox.h
+++ b/src/Train/WorkoutFilterBox.h
@@ -33,7 +33,7 @@ class WorkoutFilterBox : public FilterEditor
 public:
     WorkoutFilterBox(QWidget *parent=nullptr, Context *context=nullptr);
     virtual ~WorkoutFilterBox();
-    void setContext(Context *ctx) { context = ctx; }
+    void setContext(Context *ctx);
 
 public slots:
     void clear();


### PR DESCRIPTION
The following PR removes the specific bootstrap athlete code from MainWindow's constructor, the first athlete is now loaded the same as any other athlete.