### PR TITLE
Combine view indexes and view relevance definitions

### DIFF
--- a/src/Charts/BlankState.cpp
+++ b/src/Charts/BlankState.cpp
@@ -21,6 +21,7 @@
 #include "Context.h"
 #include "Colors.h"
 #include "Athlete.h"
+#include "Views.h"
 
 //
 // Replace home window when no ride
@@ -181,7 +182,7 @@ BlankStateAnalysisPage::BlankStateAnalysisPage(Context *context) : BlankStatePag
 BlankStateHomePage::BlankStateHomePage(Context *context) : BlankStatePage(context)
 {
     dontShow->setChecked(appsettings->cvalue(context->athlete->cyclist, GC_BLANK_HOME, false).toBool());
-    welcomeTitle->setText(tr("Trends"));
+    welcomeTitle->setText(tr(TrendsView::userName));
     welcomeText->setText(tr("No ride ?\nLet's start with some data."));
 
     img->setIcon(QPixmap(":images/home.png"));
@@ -210,7 +211,7 @@ BlankStateHomePage::BlankStateHomePage(Context *context) : BlankStatePage(contex
 BlankStatePlanPage::BlankStatePlanPage(Context *context) : BlankStatePage(context)
 {
     dontShow->setChecked(appsettings->cvalue(context->athlete->cyclist, GC_BLANK_PLAN, false).toBool());
-    welcomeTitle->setText(tr("Plan"));
+    welcomeTitle->setText(tr(PlanView::userName) );
     welcomeText->setText(tr("No ride ?\nLet's start with some data."));
 
     img->setIcon(QPixmap(":images/plan.png"));
@@ -239,7 +240,7 @@ BlankStatePlanPage::BlankStatePlanPage(Context *context) : BlankStatePage(contex
 BlankStateTrainPage::BlankStateTrainPage(Context *context) : BlankStatePage(context)
 {
     dontShow->setChecked(appsettings->cvalue(context->athlete->cyclist, GC_BLANK_TRAIN, false).toBool());
-    welcomeTitle->setText(tr("Train"));
+    welcomeTitle->setText(tr(TrainView::userName));
     welcomeText->setText(tr("No devices or workouts ?\nLet's get you setup."));
 
     img->setIcon(QPixmap(":images/train.png"));

--- a/src/Charts/Overview.cpp
+++ b/src/Charts/Overview.cpp
@@ -23,6 +23,7 @@
 #include "AddTileWizard.h"
 #include "Utils.h"
 #include "HelpWhatsThis.h"
+#include "Views.h"
 
 OverviewWindow::OverviewWindow(Context *context, OverviewScope scope, bool blank) : GcChartWindow(context), context(context), configured(false), scope(scope), blank(blank)
 {
@@ -738,9 +739,9 @@ OverviewConfigDialog::exportChart()
     int chartId = GcWindowTypes::None;
 
     switch (item->parent->scope) {
-    case OverviewScope::ANALYSIS: chartId = GcWindowTypes::UserAnalysis; viewName = "analysis"; break;
-    case OverviewScope::TRENDS: chartId = GcWindowTypes::UserTrends; viewName = "home"; break;
-    case OverviewScope::PLAN: chartId = GcWindowTypes::UserPlan; viewName = "plan"; break;
+    case OverviewScope::ANALYSIS: chartId = GcWindowTypes::UserAnalysis; viewName = AnalysisView::internalName; break;
+    case OverviewScope::TRENDS: chartId = GcWindowTypes::UserTrends; viewName = TrendsView::internalName; break;
+    case OverviewScope::PLAN: chartId = GcWindowTypes::UserPlan; viewName = PlanView::internalName; break;
     default: break;
     }
 

--- a/src/Cloud/CloudDBChart.cpp
+++ b/src/Cloud/CloudDBChart.cpp
@@ -711,10 +711,10 @@ CloudDBChartListDialog::updateCurrentPresets(int index, int count) {
     QString view = tr("unknown");
     if (g_role == CloudDBCommon::UserImport ) {
         switch(g_chartViewType) {
-        case GcViewType::VIEW_TRENDS : view = tr("Trends"); break;
-        case GcViewType::VIEW_ANALYSIS : view = tr("Activities"); break;
-        case GcViewType::VIEW_PLAN : view = tr("Plan"); break;
-        case GcViewType::VIEW_TRAIN : view = tr("Train"); break;
+        case GcViewType::VIEW_TRENDS : view = tr(TrendsView::userName); break;
+        case GcViewType::VIEW_ANALYSIS : view = tr(AnalysisView::userName); break;
+        case GcViewType::VIEW_PLAN : view = tr(PlanView::userName) ; break;
+        case GcViewType::VIEW_TRAIN : view = tr(TrainView::userName); break;
         default: qDebug() << "Unhandled view type: " << static_cast<std::underlying_type_t<GcViewType>>(g_chartViewType); break;
         }
     } else

--- a/src/Cloud/CloudDBChart.h
+++ b/src/Cloud/CloudDBChart.h
@@ -120,7 +120,7 @@ public:
     CloudDBChartListDialog();
     ~CloudDBChartListDialog();
 
-    bool prepareData(QString athlete, CloudDBCommon::UserRole role, int chartView = 0);
+    bool prepareData(QString athlete, CloudDBCommon::UserRole role, GcViewType chartViewType = GcViewType::VIEW_TRENDS);
     QList<QString> getSelectedSettings() {return g_selected; }
 
     // re-implemented
@@ -190,7 +190,7 @@ private:
 
     // UserRole - UserEdit
     QPushButton *deleteUserEditButton, *editUserEditButton, *closeUserEditButton;
-    int g_chartView;
+    GcViewType g_chartViewType;
 
     // UserRole - Curator Edit
     QPushButton *curateCuratorEditButton, *editCuratorEditButton, *deleteCuratorEditButton, *closeCuratorButton;

--- a/src/Core/Context.cpp
+++ b/src/Core/Context.cpp
@@ -148,6 +148,7 @@ Context::Context(MainWindow *mainWindow): mainWindow(mainWindow)
     isfiltered = ishomefiltered = false;
     isCompareIntervals = isCompareDateRanges = false;
     isRunning = isPaused = false;
+    viewType = GcViewType::NO_VIEW_SET;
 
     connect(this, SIGNAL(loadProgress(QString, double)), mainWindow, SLOT(loadProgress(QString, double)));
 

--- a/src/Core/Context.h
+++ b/src/Core/Context.h
@@ -128,7 +128,7 @@ class Context : public QObject
 
         // mainwindow state
         NavigationModel *nav;
-        int viewIndex;
+        GcViewType viewType;
         bool showSidebar, showLowbar, showToolbar, showTabbar;
         int style;
         QString searchText;
@@ -213,7 +213,7 @@ class Context : public QObject
         void notifyUserMetricsChanged() { emit userMetricsChanged(); }
 
         // view changed
-        void setIndex(int i) { viewIndex = i; emit viewChanged(i); }
+        void setViewType(GcViewType v) { viewType = v; emit viewChanged(v); }
 
         // realtime signals
         void notifyTelemetryUpdate(const RealtimeData &rtData) { telemetryUpdate(rtData); }
@@ -319,7 +319,7 @@ class Context : public QObject
         void userMetricsChanged();
 
         // view changed
-        void viewChanged(int);
+        void viewChanged(GcViewType);
 
         // refreshing stats
         void refreshStart();

--- a/src/Core/RideCacheModel.cpp
+++ b/src/Core/RideCacheModel.cpp
@@ -132,7 +132,7 @@ RideCacheModel::itemChanged(RideItem *item)
         emit dataChanged(createIndex(row,0), createIndex(row,columns_-1));
     }
     //XXX hack to get the navigator to redraw
-    context->tab->view(1)->sidebar()->update();
+    context->tab->view(GcViewType::VIEW_ANALYSIS)->sidebar()->update();
 }
 
 void RideCacheModel::beginReset() { beginResetModel(); }

--- a/src/Gui/AbstractView.cpp
+++ b/src/Gui/AbstractView.cpp
@@ -35,8 +35,8 @@
 
 const int SIDEBAR_DEFAULT_WIDTH=200;
 
-AbstractView::AbstractView(Context *context, int type, const QString& view, const QString& heading) :
-    QWidget(context->tab), context(context), type(type), view(view),
+AbstractView::AbstractView(Context *context, GcViewType viewType, const QString& viewName, const QString& heading) :
+    QWidget(context->tab), context(context), _viewType(viewType), _viewName(viewName),
     _sidebar(true), _tiled(false), _selected(false), lastHeight(130*dpiYFactor), sidewidth(0),
     active(false), bottomRequested(false), bottomHideOnIdle(false), perspectiveactive(false),
     stack(NULL), splitter(NULL), mainSplitter(NULL), 
@@ -113,7 +113,7 @@ AbstractView::splitterMoved(int pos,int)
     sidewidth = splitter->sizes()[0];
 
     // we now have splitter settings for each view
-    QString setting = QString("%1/%2").arg(GC_SETTINGS_SPLITTER_SIZES).arg(type);
+    QString setting = QString("%1/%2").arg(GC_SETTINGS_SPLITTER_SIZES).arg(static_cast<std::underlying_type_t<GcViewType>>(_viewType));
     appsettings->setCValue(context->athlete->cyclist, setting, splitter->saveState());
 
     notifyViewSplitterMoved();
@@ -294,7 +294,7 @@ AbstractView::saveState()
     // we do not save all the other Qt properties since
     // we're not interested in them
     // NOTE: currently we support QString, int, double and bool types - beware custom types!!
-    QString filename = viewCfgPath + "/" + view + "-perspectives.xml";
+    QString filename = viewCfgPath + "/" + _viewName + "-perspectives.xml";
 
     QFile file(filename);
     if (!file.open(QFile::WriteOnly)) {
@@ -325,7 +325,7 @@ void
 AbstractView::restoreState(bool useDefault)
 {
     // restore window state
-    QString filename = viewCfgPath + "/" + view + "-perspectives.xml";
+    QString filename = viewCfgPath + "/" + _viewName + "-perspectives.xml";
 
     QFileInfo finfo(filename);
 
@@ -344,7 +344,7 @@ AbstractView::restoreState(bool useDefault)
         // fetch from the goldencheetah.org website
         QString request = QString("%1/%2-perspectives.xml")
                              .arg(VERSION_CONFIG_PREFIX)
-                             .arg(view);
+                             .arg(_viewName);
 
         QNetworkReply *reply = nam.get(QNetworkRequest(QUrl(request)));
 
@@ -379,7 +379,7 @@ AbstractView::restoreState(bool useDefault)
         // renamed as "Legacy" and prepended to default perspectives,
         // except when useDefault is requested
         if (!finfo.exists() && !useDefault) {
-            filename = context->athlete->home->config().canonicalPath() + "/" + view + "-layout.xml";
+            filename = context->athlete->home->config().canonicalPath() + "/" + _viewName + "-layout.xml";
 
             QFile file(filename);
             if (file.open(QIODevice::ReadOnly)) {
@@ -397,7 +397,7 @@ AbstractView::restoreState(bool useDefault)
                 QXmlInputSource source;
                 source.setData(content);
                 QXmlSimpleReader xmlReader;
-                ViewParser handler(context, type, useDefault);
+                ViewParser handler(context, _viewType, useDefault);
                 xmlReader.setContentHandler(&handler);
                 xmlReader.setErrorHandler(&handler);
 
@@ -411,7 +411,7 @@ AbstractView::restoreState(bool useDefault)
 
         // drop back to what is baked in
         if (!finfo.exists()) {
-            filename = QString(":xml/%1-perspectives.xml").arg(view);
+            filename = QString(":xml/%1-perspectives.xml").arg(_viewName);
             useDefault = true;
         }
         QFile file(filename);
@@ -432,7 +432,7 @@ AbstractView::restoreState(bool useDefault)
         QXmlInputSource source;
         source.setData(content);
         QXmlSimpleReader xmlReader;
-        ViewParser handler(context, type, useDefault);
+        ViewParser handler(context, _viewType, useDefault);
         xmlReader.setContentHandler(&handler);
         xmlReader.setErrorHandler(&handler);
 
@@ -448,7 +448,7 @@ AbstractView::restoreState(bool useDefault)
         if (legacy) restored[0]->title_ = "Legacy";
 
     } else { // MUST have at least one perspective
-        restored << new Perspective(context, "Empty", type);
+        restored << new Perspective(context, "Empty", _viewType);
     }
 
     // initialise them
@@ -472,7 +472,7 @@ AbstractView::appendPerspective(Perspective *page)
 bool
 AbstractView::importPerspective(QString filename)
 {
-    Perspective *newone = Perspective::fromFile(context, filename, type);
+    Perspective *newone = Perspective::fromFile(context, filename, _viewType);
     if (newone) {
         appendPerspective(newone);
         return true;
@@ -490,7 +490,7 @@ AbstractView::exportPerspective(Perspective *p, QString filename)
 Perspective *
 AbstractView::addPerspective(QString name)
 {
-    Perspective *page = new Perspective(context, name, type);
+    Perspective *page = new Perspective(context, name, _viewType);
 
     notifyViewPerspectiveAdded(page);
 
@@ -582,7 +582,7 @@ AbstractView::setPages(QStackedWidget *pages)
     splitter->setCollapsible(index, false);
 
     // restore sizes
-    QString setting = QString("%1/%2").arg(GC_SETTINGS_SPLITTER_SIZES).arg(type);
+    QString setting = QString("%1/%2").arg(GC_SETTINGS_SPLITTER_SIZES).arg(static_cast<std::underlying_type_t<GcViewType>>(_viewType));
     QVariant splitterSizes = appsettings->cvalue(context->athlete->cyclist, setting); 
 
     // new (3.1) mechanism 
@@ -701,7 +701,7 @@ AbstractView::sidebarChanged()
         sidebar_->show();
 
         // Restore sizes
-        QString setting = QString("%1/%2").arg(GC_SETTINGS_SPLITTER_SIZES).arg(type);
+        QString setting = QString("%1/%2").arg(GC_SETTINGS_SPLITTER_SIZES).arg(static_cast<std::underlying_type_t<GcViewType>>(_viewType));
         QVariant splitterSizes = appsettings->cvalue(context->athlete->cyclist, setting);
         if (splitterSizes.toByteArray().size() > 1 ) {
             splitter->restoreState(splitterSizes.toByteArray());
@@ -968,7 +968,7 @@ bool ViewParser::startElement( const QString&, const QString&, const QString &na
     if (name == "layout") {
 
         QString name="General";
-        int typetouse=type;
+        GcViewType typetouse=GcViewType::NO_VIEW_SET;
         int trainswitch=0;
         QString expression;
         for(int i=0; i<attrs.count(); i++) {
@@ -982,7 +982,7 @@ bool ViewParser::startElement( const QString&, const QString&, const QString &na
                 expression = Utils::unprotect(attrs.value(i));
             }
             if (attrs.qName(i) == "type") {
-                typetouse = Utils::unprotect(attrs.value(i)).toInt();
+                typetouse = static_cast<GcViewType>(Utils::unprotect(attrs.value(i)).toInt());
             }
             if (attrs.qName(i) == "trainswitch") {
                 trainswitch = attrs.value(i).toInt();

--- a/src/Gui/AbstractView.cpp
+++ b/src/Gui/AbstractView.cpp
@@ -35,8 +35,8 @@
 
 const int SIDEBAR_DEFAULT_WIDTH=200;
 
-AbstractView::AbstractView(Context *context, GcViewType viewType, const QString& viewName, const QString& heading) :
-    QWidget(context->tab), context(context), _viewType(viewType), _viewName(viewName),
+AbstractView::AbstractView(Context *context, GcViewType viewType, const QString& viewsInternalName, const QString& heading) :
+    QWidget(context->tab), context(context), _viewType(viewType), _internalViewName(viewsInternalName),
     _sidebar(true), _tiled(false), _selected(false), lastHeight(130*dpiYFactor), sidewidth(0),
     active(false), bottomRequested(false), bottomHideOnIdle(false), perspectiveactive(false),
     stack(NULL), splitter(NULL), mainSplitter(NULL), 
@@ -294,7 +294,7 @@ AbstractView::saveState()
     // we do not save all the other Qt properties since
     // we're not interested in them
     // NOTE: currently we support QString, int, double and bool types - beware custom types!!
-    QString filename = viewCfgPath + "/" + _viewName + "-perspectives.xml";
+    QString filename = viewCfgPath + "/" + _internalViewName + "-perspectives.xml";
 
     QFile file(filename);
     if (!file.open(QFile::WriteOnly)) {
@@ -325,7 +325,7 @@ void
 AbstractView::restoreState(bool useDefault)
 {
     // restore window state
-    QString filename = viewCfgPath + "/" + _viewName + "-perspectives.xml";
+    QString filename = viewCfgPath + "/" + _internalViewName + "-perspectives.xml";
 
     QFileInfo finfo(filename);
 
@@ -344,7 +344,7 @@ AbstractView::restoreState(bool useDefault)
         // fetch from the goldencheetah.org website
         QString request = QString("%1/%2-perspectives.xml")
                              .arg(VERSION_CONFIG_PREFIX)
-                             .arg(_viewName);
+                             .arg(_internalViewName);
 
         QNetworkReply *reply = nam.get(QNetworkRequest(QUrl(request)));
 
@@ -379,7 +379,7 @@ AbstractView::restoreState(bool useDefault)
         // renamed as "Legacy" and prepended to default perspectives,
         // except when useDefault is requested
         if (!finfo.exists() && !useDefault) {
-            filename = context->athlete->home->config().canonicalPath() + "/" + _viewName + "-layout.xml";
+            filename = context->athlete->home->config().canonicalPath() + "/" + _internalViewName + "-layout.xml";
 
             QFile file(filename);
             if (file.open(QIODevice::ReadOnly)) {
@@ -411,7 +411,7 @@ AbstractView::restoreState(bool useDefault)
 
         // drop back to what is baked in
         if (!finfo.exists()) {
-            filename = QString(":xml/%1-perspectives.xml").arg(_viewName);
+            filename = QString(":xml/%1-perspectives.xml").arg(_internalViewName);
             useDefault = true;
         }
         QFile file(filename);

--- a/src/Gui/AbstractView.h
+++ b/src/Gui/AbstractView.h
@@ -100,7 +100,8 @@ class AbstractView : public QWidget
         bool isSelected() const { return _selected; }
 
         GcViewType viewType() const { return _viewType; }
-        virtual QString viewTypeDesc() const = 0;
+        virtual QString viewsUserName() const = 0; // user name for the view
+        virtual QString viewsInternalName() const = 0; // internal name for the view
 
         void importChart(QMap<QString,QString>properties, bool select) { perspective_->importChart(properties, select); }
 
@@ -143,13 +144,13 @@ class AbstractView : public QWidget
     protected:
 
         // Hide constructor to create an Abstract class
-        AbstractView(Context *context, GcViewType viewType, const QString& view, const QString& heading);
+        AbstractView(Context *context, GcViewType viewType, const QString& viewsInternalName, const QString& heading);
 
         Context *context;
         const GcViewType _viewType; // used by windowregistry; e.g VIEW_TRAIN VIEW_ANALYSIS VIEW_PLAN VIEW_TRENDS
                         // we don't care what values are pass through to the GcWindowRegistry to decide
                         // what charts are relevant for this view.
-        const QString _viewName; // type of view:  "train", "analysis", "plan", "home"
+        const QString _internalViewName; // Cannot use the view's internalViewName() function as this is required in the destructor
         QString viewCfgPath; // directory path to the view's configuration
 
         // properties

--- a/src/Gui/AnalysisSidebar.cpp
+++ b/src/Gui/AnalysisSidebar.cpp
@@ -45,6 +45,8 @@
 // Filter for similar activities
 #include "FilterSimilarDialog.h"
 
+#include "Views.h"
+
 AnalysisSidebar::AnalysisSidebar(Context *context) : QWidget(context->mainWindow), context(context)
 {
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
@@ -166,7 +168,7 @@ AnalysisSidebar::AnalysisSidebar(Context *context) : QWidget(context->mainWindow
     splitterBanner->insertWidget(2, activityFilter);
     splitterBanner->insertStretch(2);
 
-    splitter->prepare(context->athlete->cyclist, "analysis");
+    splitter->prepare(context->athlete->cyclist, AnalysisView::internalName);
 
     // GC signal
     connect(context, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));

--- a/src/Gui/AthleteTab.cpp
+++ b/src/Gui/AthleteTab.cpp
@@ -133,17 +133,17 @@ AthleteTab::close()
  * MainWindow integration with Tab / TabView (mostly pass through)
  *****************************************************************************/
 
-bool AthleteTab::hasBottom() { return view(currentView())->hasBottom(); }
-bool AthleteTab::isBottomRequested() { return view(currentView())->isBottomRequested(); }
-void AthleteTab::setBottomRequested(bool x) { view(currentView())->setBottomRequested(x); }
-void AthleteTab::setSidebarEnabled(bool x) { view(currentView())->setSidebarEnabled(x); }
-bool AthleteTab::isSidebarEnabled() { return view(currentView())->sidebarEnabled(); }
-void AthleteTab::toggleSidebar() { view(currentView())->setSidebarEnabled(!view(currentView())->sidebarEnabled()); }
-void AthleteTab::setTiled(bool x) { view(currentView())->setTiled(x); }
-bool AthleteTab::isTiled() { return view(currentView())->isTiled(); }
-void AthleteTab::toggleTile() { view(currentView())->setTiled(!view(currentView())->isTiled()); }
-void AthleteTab::resetLayout(QComboBox *perspectiveSelector) { view(currentView())->resetLayout(perspectiveSelector); }
-void AthleteTab::addChart(GcWinID i) { view(currentView())->addChart(i); }
+bool AthleteTab::hasBottom() { return currentView()->hasBottom(); }
+bool AthleteTab::isBottomRequested() { return currentView()->isBottomRequested(); }
+void AthleteTab::setBottomRequested(bool x) { currentView()->setBottomRequested(x); }
+void AthleteTab::setSidebarEnabled(bool x) { currentView()->setSidebarEnabled(x); }
+bool AthleteTab::isSidebarEnabled() { return currentView()->sidebarEnabled(); }
+void AthleteTab::toggleSidebar() { currentView()->setSidebarEnabled(!currentView()->sidebarEnabled()); }
+void AthleteTab::setTiled(bool x) { currentView()->setTiled(x); }
+bool AthleteTab::isTiled() { return currentView()->isTiled(); }
+void AthleteTab::toggleTile() { currentView()->setTiled(!currentView()->isTiled()); }
+void AthleteTab::resetLayout(QComboBox *perspectiveSelector) { currentView()->resetLayout(perspectiveSelector); }
+void AthleteTab::addChart(GcWinID i) { currentView()->addChart(i); }
 void AthleteTab::addIntervals() { analysisView->addIntervals(); }
 
 void AthleteTab::setRide(RideItem*ride)
@@ -155,39 +155,87 @@ void AthleteTab::setRide(RideItem*ride)
 }
 
 AbstractView *
-AthleteTab::view(int index)
+AthleteTab::view(GcViewType viewType) const
 {
-    switch(index) {
-        case 0 : return homeView;
-        default:
-        case 1 : return analysisView;
-        case 2 : return planView;
-        case 3 : return trainView;
+    switch(viewType) {
+        case GcViewType::VIEW_TRENDS : return homeView;
+        case GcViewType::VIEW_ANALYSIS : return analysisView;
+        case GcViewType::VIEW_PLAN : return planView;
+        case GcViewType::VIEW_TRAIN : return trainView;
+        default: {
+            qCritical() << "Unhandled view type in AthleteTab, returning analysisView !";
+            return analysisView;
+        } break;
+    }
+}
+
+AbstractView *
+AthleteTab::currentView() const
+{
+    return view(currentViewType());
+}
+
+GcViewType
+AthleteTab::currentViewType() const
+{
+    // map from AthleteTab's internal qt stack index to view type
+    return indexToViewType(views->currentIndex());
+}
+
+GcViewType
+AthleteTab::indexToViewType(int index) const
+{
+    // map from AthleteTab's internal qt stack index to GcViewType
+    switch (index) {
+        case 0: return GcViewType::VIEW_TRENDS;
+        case 1: return GcViewType::VIEW_ANALYSIS;
+        case 2: return GcViewType::VIEW_PLAN;
+        case 3: return GcViewType::VIEW_TRAIN;
+        default: {
+            qCritical() << "Unhandled view index in AthleteTab, returning VIEW_ANALYSIS !";
+            return GcViewType::VIEW_ANALYSIS;
+        } break;
+    }
+}
+
+int
+AthleteTab::viewTypeToIndex(GcViewType viewType) const
+{
+    // map from GcViewType to AthleteTab's internal qt stack index
+    switch (viewType) {
+        case GcViewType::VIEW_TRENDS: return 0;
+        case GcViewType::VIEW_ANALYSIS: return 1;
+        case GcViewType::VIEW_PLAN: return 2;
+        case GcViewType::VIEW_TRAIN: return 3;
+        default: {
+            qCritical() << "Unhandled view type in AthleteTab, returning index 1 (aka Analysis view)!";
+            return 1;
+        } break;
     }
 }
 
 void
-AthleteTab::selectView(int index)
+AthleteTab::selectView(GcViewType viewType)
 {
     // ensure an initial viewChanged() event occurs for the navigation model, otherwise if the
     // startup view is trends (value zero) the guard rejects the selection as views->currentIndex() is zero
-    if (startupViewChangeSent && views->currentIndex() == index) return; // not changing
+    if (startupViewChangeSent && views->currentIndex() == viewTypeToIndex(viewType)) return; // not changing
 
     // suspend screen updates while the view is changed.
     views->setUpdatesEnabled(false);
 
-    emit viewChanged(index);
+    emit viewChanged(viewType);
 
-    // first we deselect the current
-    view(views->currentIndex())->setSelected(false);
+    // deselect the current view, but only after the initial selectView() call.
+    if (startupViewChangeSent) currentView()->setSelected(false);
     startupViewChangeSent = true;
 
     // now select the real one
-    views->setCurrentIndex(index);
-    view(index)->setSelected(true);
-    masterControls->setCurrentIndex(index);
-    context->setIndex(index);
-    context->mainWindow->resetPerspective(index); // set perspective for this view
+    views->setCurrentIndex(viewTypeToIndex(viewType));
+    view(viewType)->setSelected(true);
+    masterControls->setCurrentIndex(viewTypeToIndex(viewType));
+    context->setViewType(viewType);
+    context->mainWindow->resetPerspective(viewType); // set perspective for this view
 
     // enable screen updates to render the view without flickering
     views->setUpdatesEnabled(true);
@@ -213,7 +261,7 @@ AthleteTab::rideSelected(RideItem*)
         // when the view is selected by the user and no earlier
         if (analysisView->page() != NULL) {
             context->mainWindow->newSidebar()->setItemSelected(GcSideBarBtnId::ACTIVITIES_BTN, true);
-            selectView(1);
+            selectView(GcViewType::VIEW_ANALYSIS);
         }
     }
 

--- a/src/Gui/AthleteTab.h
+++ b/src/Gui/AthleteTab.h
@@ -42,8 +42,9 @@ class AthleteTab: public QWidget
         void close();
 
         ChartSettings *chartsettings() { return chartSettings; } // by HomeWindow
-        int currentView() { return views->currentIndex(); }
-        AbstractView *view(int index);
+        GcViewType currentViewType() const;
+        AbstractView *currentView() const;
+        AbstractView *view(GcViewType viewType) const;
 
         NavigationModel *nav; // back/forward for this tab
 
@@ -56,7 +57,7 @@ class AthleteTab: public QWidget
 
     signals:
 
-        void viewChanged(int);
+        void viewChanged(GcViewType);
         void rideItemSelected(RideItem*);
         void dateRangeSelected(DateRange);
 
@@ -88,12 +89,17 @@ class AthleteTab: public QWidget
         void addChart(GcWinID);
 
         // switch views
-        void selectView(int);
+        void selectView(GcViewType);
 
         // specific to analysis view
         void addIntervals();
 
     private:
+
+        // map between the view stack index and the GcViewType,
+        // the view stack and this mapping is hidden with athlete tab.
+        int viewTypeToIndex(GcViewType viewType) const;
+        GcViewType indexToViewType(int index) const;
 
         // constructor finished and navigation
         // model isn't undo/redo ride selection

--- a/src/Gui/GcWindowRegistry.cpp
+++ b/src/Gui/GcWindowRegistry.cpp
@@ -112,7 +112,7 @@ GcWindowRegistry::initialize()
     { GcViewType::VIEW_TRAIN, tr("Elevation Chart"),GcWindowTypes::ElevationChart },
     { GcViewType::VIEW_ANALYSIS|GcViewType::VIEW_TRENDS|GcViewType::VIEW_TRAIN, tr("Web page"),GcWindowTypes::WebPageWindow },
     { GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN, tr("Calendar"),GcWindowTypes::Calendar },
-    { GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN, tr("Agenda"),GcWindowTypes::Agenda },
+    { GcViewType::VIEW_PLAN, tr("Agenda"),GcWindowTypes::Agenda },
     { GcViewType::VIEW_PLAN, tr("Plan Adherence"),GcWindowTypes::PlanAdherence },
     { GcViewType::NO_VIEW_SET, "", GcWindowTypes::None }};
   // initialize the global registry

--- a/src/Gui/GcWindowRegistry.cpp
+++ b/src/Gui/GcWindowRegistry.cpp
@@ -66,65 +66,66 @@ GcWindowRegistry::initialize()
 {
   static GcWindowRegistry GcWindowsInit[] = {
     // name                     GcWinID
-    { VIEW_TRENDS, tr("Season Overview"),GcWindowTypes::OverviewTrends },
-    { VIEW_TRENDS, tr("Blank Overview "),GcWindowTypes::OverviewTrendsBlank },
-    { VIEW_PLAN, tr("Plan Overview"),GcWindowTypes::OverviewPlan },
-    { VIEW_PLAN, tr("Blank Overview "),GcWindowTypes::OverviewPlanBlank },
-    { VIEW_TRENDS, tr("User Chart"),GcWindowTypes::UserTrends },
-    { VIEW_PLAN, tr("User Chart"),GcWindowTypes::UserPlan },
-    { VIEW_TRENDS|VIEW_PLAN, tr("Trends"),GcWindowTypes::LTM },
-    { VIEW_TRENDS|VIEW_PLAN, tr("TreeMap"),GcWindowTypes::TreeMap },
-    //{ VIEW_TRENDS, tr("Weekly Summary"),GcWindowTypes::WeeklySummary },// DEPRECATED
-    { VIEW_TRENDS|VIEW_PLAN,  tr("Power Duration "),GcWindowTypes::CriticalPowerSummary },
-    //{ VIEW_TRENDS,  tr("Training Plan"),GcWindowTypes::SeasonPlan },
-    //{ VIEW_TRENDS|VIEW_DIARY,  tr("Performance Manager"),GcWindowTypes::PerformanceManager },
-    { VIEW_ANALYSIS, tr("Activity Overview"),GcWindowTypes::Overview },
-    { VIEW_ANALYSIS, tr("Blank Overview"),GcWindowTypes::OverviewAnalysisBlank },
-    { VIEW_ANALYSIS, tr("User Chart "),GcWindowTypes::UserAnalysis },
-    //{ VIEW_ANALYSIS, tr("Summary"),GcWindowTypes::RideSummary }, // DEPRECATED IN V3.6
-    { VIEW_ANALYSIS, tr("Data"),GcWindowTypes::MetadataWindow },
-    //{ VIEW_ANALYSIS, tr("Summary and Details"),GcWindowTypes::Summary },
-    //{ VIEW_ANALYSIS, tr("Editor"),GcWindowTypes::RideEditor },
-    { VIEW_ANALYSIS, tr("Performance"),GcWindowTypes::AllPlot },
-    { VIEW_ANALYSIS, tr("Power Duration"),GcWindowTypes::CriticalPower },
-    { VIEW_ANALYSIS, tr("Histogram"),GcWindowTypes::Histogram },
-    { VIEW_TRENDS|VIEW_PLAN, tr("Distribution"),GcWindowTypes::Distribution },
-    { VIEW_ANALYSIS, tr("Pedal Force vs Velocity"),GcWindowTypes::PfPv },
-    { VIEW_ANALYSIS, tr("Heartrate vs Power"),GcWindowTypes::HrPw },
-    { VIEW_ANALYSIS, tr("Map"),GcWindowTypes::RideMapWindow },
-    { VIEW_ANALYSIS, tr("R Chart"),GcWindowTypes::RConsole },
-    { VIEW_TRENDS|VIEW_PLAN, tr("R Chart "),GcWindowTypes::RConsoleSeason },
-    { VIEW_ANALYSIS, tr("Python Chart"),GcWindowTypes::Python },
-    { VIEW_TRENDS|VIEW_PLAN, tr("Python Chart "),GcWindowTypes::PythonSeason },
-    //{ VIEW_ANALYSIS, tr("Bing Map"),GcWindowTypes::BingMap },
-    { VIEW_ANALYSIS, tr("Scatter"),GcWindowTypes::Scatter },
-    { VIEW_ANALYSIS, tr("Aerolab"),GcWindowTypes::Aerolab },
-    //{ VIEW_TRENDS|VIEW_DIARY, tr("Calendar"),GcWindowTypes::Diary },
-    { VIEW_TRENDS|VIEW_PLAN, tr("Navigator"), GcWindowTypes::ActivityNavigator },
-    //{ VIEW_DIARY|VIEW_TRENDS, tr("Summary "), GcWindowTypes::DateRangeSummary }, // DEPRECATED IN V3.6
-    { VIEW_TRAIN, tr("Telemetry"),GcWindowTypes::DialWindow },
-    { VIEW_TRAIN, tr("Workout"),GcWindowTypes::WorkoutPlot },
-    { VIEW_TRAIN, tr("Realtime"),GcWindowTypes::RealtimePlot },
-    { VIEW_TRAIN, tr("Pedal Stroke"),GcWindowTypes::SpinScanPlot },
-    { VIEW_TRAIN, tr("Video Player"),GcWindowTypes::VideoPlayer },
-    { VIEW_TRAIN, tr("Workout Editor"),GcWindowTypes::WorkoutWindow },
-    { VIEW_TRAIN, tr("Live Map"),GcWindowTypes::LiveMapWebPageWindow },
-    { VIEW_TRAIN, tr("Elevation Chart"),GcWindowTypes::ElevationChart },
-    { VIEW_ANALYSIS|VIEW_TRENDS|VIEW_TRAIN, tr("Web page"),GcWindowTypes::WebPageWindow },
-    { VIEW_TRENDS|VIEW_PLAN, tr("Calendar"),GcWindowTypes::Calendar },
-    { VIEW_PLAN, tr("Agenda"),GcWindowTypes::Agenda },
-    { VIEW_PLAN, tr("Plan Adherence"),GcWindowTypes::PlanAdherence },
-    { 0, "", GcWindowTypes::None }};
+    { GcViewType::VIEW_TRENDS, tr("Season Overview"),GcWindowTypes::OverviewTrends },
+    { GcViewType::VIEW_TRENDS, tr("Blank Overview "),GcWindowTypes::OverviewTrendsBlank },
+    { GcViewType::VIEW_PLAN, tr("Plan Overview"),GcWindowTypes::OverviewPlan },
+    { GcViewType::VIEW_PLAN, tr("Blank Overview "),GcWindowTypes::OverviewPlanBlank },
+    { GcViewType::VIEW_TRENDS, tr("User Chart"),GcWindowTypes::UserTrends },
+    { GcViewType::VIEW_PLAN, tr("User Chart"),GcWindowTypes::UserPlan },
+    { GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN, tr("Trends"),GcWindowTypes::LTM },
+    { GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN, tr("TreeMap"),GcWindowTypes::TreeMap },
+    //{ GcViewType::VIEW_TRENDS, tr("Weekly Summary"),GcWindowTypes::WeeklySummary },// DEPRECATED
+    { GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN,  tr("Power Duration "),GcWindowTypes::CriticalPowerSummary },
+    //{ GcViewType::VIEW_TRENDS,  tr("Training Plan"),GcWindowTypes::SeasonPlan },
+    //{ GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN,  tr("Performance Manager"),GcWindowTypes::PerformanceManager },
+    { GcViewType::VIEW_ANALYSIS, tr("Activity Overview"),GcWindowTypes::Overview },
+    { GcViewType::VIEW_ANALYSIS, tr("Blank Overview"),GcWindowTypes::OverviewAnalysisBlank },
+    { GcViewType::VIEW_ANALYSIS, tr("User Chart "),GcWindowTypes::UserAnalysis },
+    //{ GcViewType::VIEW_ANALYSIS, tr("Summary"),GcWindowTypes::RideSummary }, // DEPRECATED IN V3.6
+    { GcViewType::VIEW_ANALYSIS, tr("Data"),GcWindowTypes::MetadataWindow },
+    //{ GcViewType::VIEW_ANALYSIS, tr("Summary and Details"),GcWindowTypes::Summary },
+    //{ GcViewType::VIEW_ANALYSIS, tr("Editor"),GcWindowTypes::RideEditor },
+    { GcViewType::VIEW_ANALYSIS, tr("Performance"),GcWindowTypes::AllPlot },
+    { GcViewType::VIEW_ANALYSIS, tr("Power Duration"),GcWindowTypes::CriticalPower },
+    { GcViewType::VIEW_ANALYSIS, tr("Histogram"),GcWindowTypes::Histogram },
+    { GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN, tr("Distribution"),GcWindowTypes::Distribution },
+    { GcViewType::VIEW_ANALYSIS, tr("Pedal Force vs Velocity"),GcWindowTypes::PfPv },
+    { GcViewType::VIEW_ANALYSIS, tr("Heartrate vs Power"),GcWindowTypes::HrPw },
+    { GcViewType::VIEW_ANALYSIS, tr("Map"),GcWindowTypes::RideMapWindow },
+    { GcViewType::VIEW_ANALYSIS, tr("R Chart"),GcWindowTypes::RConsole },
+    { GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN, tr("R Chart "),GcWindowTypes::RConsoleSeason },
+    { GcViewType::VIEW_ANALYSIS, tr("Python Chart"),GcWindowTypes::Python },
+    { GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN, tr("Python Chart "),GcWindowTypes::PythonSeason },
+    //{ GcViewType::VIEW_ANALYSIS, tr("Bing Map"),GcWindowTypes::BingMap },
+    { GcViewType::VIEW_ANALYSIS, tr("Scatter"),GcWindowTypes::Scatter },
+    { GcViewType::VIEW_ANALYSIS, tr("Aerolab"),GcWindowTypes::Aerolab },
+    //{ GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN, tr("Calendar"),GcWindowTypes::Diary },
+    { GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN, tr("Navigator"), GcWindowTypes::ActivityNavigator },
+    //{ GcViewType::VIEW_PLAN|GcViewType::VIEW_TRENDS, tr("Summary "), GcWindowTypes::DateRangeSummary }, // DEPRECATED IN V3.6
+    { GcViewType::VIEW_TRAIN, tr("Telemetry"),GcWindowTypes::DialWindow },
+    { GcViewType::VIEW_TRAIN, tr("Workout"),GcWindowTypes::WorkoutPlot },
+    { GcViewType::VIEW_TRAIN, tr("Realtime"),GcWindowTypes::RealtimePlot },
+    { GcViewType::VIEW_TRAIN, tr("Pedal Stroke"),GcWindowTypes::SpinScanPlot },
+    { GcViewType::VIEW_TRAIN, tr("Video Player"),GcWindowTypes::VideoPlayer },
+    { GcViewType::VIEW_TRAIN, tr("Workout Editor"),GcWindowTypes::WorkoutWindow },
+    { GcViewType::VIEW_TRAIN, tr("Live Map"),GcWindowTypes::LiveMapWebPageWindow },
+    { GcViewType::VIEW_TRAIN, tr("Elevation Chart"),GcWindowTypes::ElevationChart },
+    { GcViewType::VIEW_ANALYSIS|GcViewType::VIEW_TRENDS|GcViewType::VIEW_TRAIN, tr("Web page"),GcWindowTypes::WebPageWindow },
+    { GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN, tr("Calendar"),GcWindowTypes::Calendar },
+    { GcViewType::VIEW_TRENDS|GcViewType::VIEW_PLAN, tr("Agenda"),GcWindowTypes::Agenda },
+    { GcViewType::VIEW_PLAN, tr("Plan Adherence"),GcWindowTypes::PlanAdherence },
+    { GcViewType::NO_VIEW_SET, "", GcWindowTypes::None }};
   // initialize the global registry
   GcWindows = GcWindowsInit;
 }
 
-QStringList windowsForType(int type)
+QStringList
+GcWindowRegistry::windowsForType(GcViewType type)
 {
     QStringList returning;
 
-    for(int i=0; GcWindows[i].relevance; i++) {
-        if (GcWindows[i].relevance & type) 
+    for(int i=0; GcWindows[i].relevance != GcViewType::NO_VIEW_SET; i++) {
+        if (GcWindows[i].relevance & type)
             returning << GcWindows[i].name;
     }
     return returning;
@@ -133,18 +134,19 @@ QStringList windowsForType(int type)
 QString
 GcWindowRegistry::title(GcWinID id)
 {
-    for(int i=0; GcWindows[i].relevance; i++) {
-        if (GcWindows[i].relevance && GcWindows[i].id == id)
+    for(int i=0; GcWindows[i].relevance != GcViewType::NO_VIEW_SET; i++) {
+        if (GcWindows[i].id == id)
             return GcWindows[i].name;
     }
     return QString("unknown");
 }
 
-QList<GcWinID> idsForType(int type)
+QList<GcWinID>
+GcWindowRegistry::idsForType(GcViewType type)
 {
     QList<GcWinID> returning;
 
-    for(int i=0; GcWindows[i].relevance; i++) {
+    for(int i=0; GcWindows[i].relevance != GcViewType::NO_VIEW_SET; i++) {
         if (GcWindows[i].relevance & type) 
             returning << GcWindows[i].id;
     }

--- a/src/Gui/GcWindowRegistry.h
+++ b/src/Gui/GcWindowRegistry.h
@@ -89,25 +89,37 @@ enum gcwinid {
 typedef enum GcWindowTypes::gcwinid GcWinID;
 Q_DECLARE_METATYPE(GcWinID)
 
-// when declaring a window, what view is it relevant for?
-#define VIEW_TRAIN    0x01
-#define VIEW_ANALYSIS 0x02
-#define VIEW_PLAN 0x04
-#define VIEW_TRENDS   0x08
+// the GcViewType represents both the view type in GC code and due its unique
+// bit values it can be used as for defining a window's view relevance mask.
+enum class GcViewType : unsigned int {
+    NO_VIEW_SET =    0x00,
+    VIEW_TRAIN =     0x01,
+    VIEW_ANALYSIS =  0x02,
+    VIEW_PLAN =      0x04,
+    VIEW_TRENDS =    0x08
+};
+
+// support bitwise "|" and "&" operators for the GcViewType class
+inline constexpr GcViewType operator|(GcViewType Lhs, GcViewType Rhs) {
+    return static_cast<GcViewType>( static_cast<std::underlying_type_t<GcViewType>>(Lhs) | static_cast<std::underlying_type_t<GcViewType>>(Rhs) );
+}
+inline constexpr bool operator&(GcViewType Lhs, GcViewType Rhs) {
+    return static_cast<std::underlying_type_t<GcViewType>>(Lhs) & static_cast<std::underlying_type_t<GcViewType>>(Rhs);
+}
 
 class GcChartWindow;
 class GcWindowRegistry {
     Q_DECLARE_TR_FUNCTIONS(GcWindowRegistry)
     public:
 
-    unsigned int relevance;
+    GcViewType relevance;
     QString name;
     GcWinID id;
 
     static void initialize(); // initialize global registry
     static GcChartWindow *newGcWindow(GcWinID id, Context *context);
-    static QStringList windowsForType(int type);
-    static QList<GcWinID> idsForType(int type);
+    static QStringList windowsForType(GcViewType type);
+    static QList<GcWinID> idsForType(GcViewType type);
     static QString title(GcWinID id);
 };
 

--- a/src/Gui/LTMSidebar.cpp
+++ b/src/Gui/LTMSidebar.cpp
@@ -264,9 +264,9 @@ LTMSidebar::chartVisibilityChanged()
 }
 
 void
-LTMSidebar::updatePresetChartsOnShow(int viewType)
+LTMSidebar::updatePresetChartsOnShow(GcViewType viewType)
 {
-    bool trendsView(viewType == VIEW_TRENDS);
+    bool trendsView(viewType == GcViewType::VIEW_TRENDS);
 
     // show/hide the splitter toolbar icon
     chartsWidget->controlAction->setVisible(trendsView);

--- a/src/Gui/LTMSidebar.h
+++ b/src/Gui/LTMSidebar.h
@@ -50,7 +50,7 @@ class LTMSidebar : public QWidget
         int newSeason(QString, QDate, QDate, int);
         void updateSeason(int, QString, QDate, QDate, int);
 
-        void updatePresetChartsOnShow(int viewType);
+        void updatePresetChartsOnShow(GcViewType viewType);
 
     signals:
         void dateRangeChanged(DateRange);

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -726,13 +726,20 @@ MainWindow::MainWindow(const QDir &home)
 
     saveGCState(currentAthleteTab->context); // set to whatever we started with
 
-    // switch to the startup view, default is analysis.
-    switch (appsettings->value(NULL, GC_STARTUP_VIEW, "1").toInt()) {
+    // switch to the startup view based on the configured value,
+    // the default is analysis when no config exists or the configuration value is not recognised.
+    // note: the gcStartupView values must align with the startViewIdx entries in Pages.cpp
+    int gcStartupView = appsettings->value(NULL, GC_STARTUP_VIEW, -1).toInt();
+    switch (gcStartupView) {
         case 0: selectTrends(); break;
         case 1: selectAnalysis(); break;
         case 2: selectPlan(); break;
         case 3: selectTrain(); break;
-        default: selectAnalysis(); qDebug() << "Unknown startup view"; break;
+        default: {
+            qDebug() << "Startup view not specified or unknown value, defaulting to analysis view";
+            appsettings->setValue(GC_STARTUP_VIEW, 1);
+            selectAnalysis();
+        } break;
     }
 
     //grab focus
@@ -867,22 +874,15 @@ MainWindow::setSubChartMenu()
 void
 MainWindow::setChartMenu(QMenu *menu)
 {
-    unsigned int mask=0;
     // called when chart menu about to be shown
-    // setup to only show charts that are relevant
+    // setup only show charts that are relevant
     // to this view
-    switch(currentAthleteTab->currentView()) {
-        case 0 : mask = VIEW_TRENDS; break;
-        default:
-        case 1 : mask = VIEW_ANALYSIS; break;
-        case 2 : mask = VIEW_PLAN; break;
-        case 3 : mask = VIEW_TRAIN; break;
-    }
+    GcViewType mask = currentAthleteTab->currentViewType();
 
     menu->clear();
-    if (!mask) return;
+    if (mask == GcViewType::NO_VIEW_SET) return;
 
-    for(int i=0; GcWindows[i].relevance; i++) {
+    for(int i=0; GcWindows[i].relevance != GcViewType::NO_VIEW_SET; i++) {
         if (GcWindows[i].relevance & mask)
             menu->addAction(GcWindows[i].name);
     }
@@ -894,7 +894,7 @@ MainWindow::addChart(QAction*action)
     // & removed to avoid issues with kde AutoCheckAccelerators
     QString actionText = QString(action->text()).replace("&", "");
     GcWinID id = GcWindowTypes::None;
-    for (int i=0; GcWindows[i].relevance; i++) {
+    for (int i=0; GcWindows[i].relevance != GcViewType::NO_VIEW_SET; i++) {
         if (GcWindows[i].name == actionText) {
             id = GcWindows[i].id;
             break;
@@ -917,22 +917,12 @@ MainWindow::importChart()
 void
 MainWindow::exportPerspective()
 {
-    int view = currentAthleteTab->currentView();
-    AbstractView *current = NULL;
-
-    QString typedesc;
-
-    switch (view) {
-    case 0:  current = currentAthleteTab->homeView; typedesc = "Trends"; break;
-    case 1:  current = currentAthleteTab->analysisView; typedesc = "Analysis"; break;
-    case 2:  current = currentAthleteTab->planView; typedesc = "Plan"; break;
-    case 3:  current = currentAthleteTab->trainView; typedesc = "Train"; break;
-    }
+    AbstractView * current = currentAthleteTab->currentView();
 
     // export the current perspective to a file
     QString suffix;
     QString fileName = QFileDialog::getSaveFileName(this, tr("Export Persepctive"),
-                       QDir::homePath()+"/"+ typedesc + " " + current->perspective_->title() + ".gchartset",
+                       QDir::homePath()+"/"+ current->viewTypeDesc() + " " + current->perspective_->title() + ".gchartset",
                        ("*.gchartset;;"), &suffix, QFileDialog::DontUseNativeDialog); // native dialog hangs when threads in use (!)
 
     if (fileName.isEmpty()) {
@@ -945,16 +935,6 @@ MainWindow::exportPerspective()
 void
 MainWindow::importPerspective()
 {
-    int view = currentAthleteTab->currentView();
-    AbstractView *current = NULL;
-
-    switch (view) {
-    case 0:  current = currentAthleteTab->homeView; break;
-    case 1:  current = currentAthleteTab->analysisView; break;
-    case 2:  current = currentAthleteTab->planView; break;
-    case 3:  current = currentAthleteTab->trainView; break;
-    }
-
     // import a new perspective from a file
     QString fileName = QFileDialog::getOpenFileName(this, tr("Select Perspective file to import"), "", tr("GoldenCheetah Perspective Files (*.gchartset)"));
     if (fileName.isEmpty()) {
@@ -963,10 +943,11 @@ MainWindow::importPerspective()
 
         // import and select it
         pactive = true;
+        AbstractView* current = currentAthleteTab->currentView();
         if (current->importPerspective(fileName)) {
 
             // on success we select the new one forcefully, as the view hasn't changed.
-            resetPerspective(view, true);
+            resetPerspective(current->viewType(), true);
             //current->setPerspectives(perspectiveSelector);
 
             // and select remember pactive is true, so we do the heavy lifting here
@@ -988,7 +969,7 @@ MainWindow::exportChartToCloudDB()
 {
     // upload the current chart selected to the chart db
     // called from the sidebar menu
-    Perspective *page=currentAthleteTab->view(currentAthleteTab->currentView())->page();
+    Perspective *page=currentAthleteTab->currentView()->page();
     if (page->currentStyle == 0 && page->currentChart())
         page->currentChart()->exportChartToCloudDB();
 }
@@ -1008,7 +989,7 @@ MainWindow::addChartFromCloudDB()
         currentAthleteTab->context->cdbChartListDialog = new CloudDBChartListDialog();
     }
 
-    if (currentAthleteTab->context->cdbChartListDialog->prepareData(currentAthleteTab->context->athlete->cyclist, CloudDBCommon::UserImport, currentAthleteTab->currentView())) {
+    if (currentAthleteTab->context->cdbChartListDialog->prepareData(currentAthleteTab->context->athlete->cyclist, CloudDBCommon::UserImport, currentAthleteTab->currentViewType())) {
         if (currentAthleteTab->context->cdbChartListDialog->exec() == QDialog::Accepted) {
 
             // get selected chartDef
@@ -1018,7 +999,7 @@ MainWindow::addChartFromCloudDB()
             foreach (QString chartDef, chartDefs) {
                 QList<QMap<QString,QString> > properties = GcChartWindow::chartPropertiesFromString(chartDef);
                 for (int i = 0; i< properties.size(); i++) {
-                    currentAthleteTab->context->mainWindow->athleteTab()->view(currentAthleteTab->currentView())->importChart(properties.at(i), false);
+                    currentAthleteTab->currentView()->importChart(properties.at(i), false);
                 }
             }
         }
@@ -1304,10 +1285,10 @@ MainWindow::selectAthlete()
 void
 MainWindow::selectAnalysis()
 {
-    resetPerspective(1);
+    resetPerspective(GcViewType::VIEW_ANALYSIS);
     viewStack->setCurrentIndex(GcViewStackIdx::ATHLETE_TAB_STACK);
     sidebar->setItemSelected(GcSideBarBtnId::ACTIVITIES_BTN, true);
-    currentAthleteTab->selectView(1);
+    currentAthleteTab->selectView(GcViewType::VIEW_ANALYSIS);
     back->show();
     forward->show();
     perspectiveSelector->show();
@@ -1321,10 +1302,10 @@ MainWindow::selectAnalysis()
 void
 MainWindow::selectTrain()
 {
-    resetPerspective(3);
+    resetPerspective(GcViewType::VIEW_TRAIN);
     viewStack->setCurrentIndex(GcViewStackIdx::ATHLETE_TAB_STACK);
     sidebar->setItemSelected(GcSideBarBtnId::TRAIN_BTN, true);
-    currentAthleteTab->selectView(3);
+    currentAthleteTab->selectView(GcViewType::VIEW_TRAIN);
     back->show();
     forward->show();
     perspectiveSelector->show();
@@ -1338,10 +1319,10 @@ MainWindow::selectTrain()
 void
 MainWindow::selectPlan()
 {
-    resetPerspective(2);
+    resetPerspective(GcViewType::VIEW_PLAN);
     viewStack->setCurrentIndex(GcViewStackIdx::ATHLETE_TAB_STACK);
     sidebar->setItemSelected(GcSideBarBtnId::PLAN_BTN, true);
-    currentAthleteTab->selectView(2);
+    currentAthleteTab->selectView(GcViewType::VIEW_PLAN);
     back->show();
     forward->show();
     perspectiveSelector->show();
@@ -1354,10 +1335,10 @@ MainWindow::selectPlan()
 void
 MainWindow::selectTrends()
 {
-    resetPerspective(0);
+    resetPerspective(GcViewType::VIEW_TRENDS);
     viewStack->setCurrentIndex(GcViewStackIdx::ATHLETE_TAB_STACK);
     sidebar->setItemSelected(GcSideBarBtnId::TRENDS_BTN, true);
-    currentAthleteTab->selectView(0);
+    currentAthleteTab->selectView(GcViewType::VIEW_TRENDS);
     back->show();
     forward->show();
     perspectiveSelector->show();
@@ -1427,26 +1408,19 @@ MainWindow::switchPerspective(int index)
 }
 
 void
-MainWindow::resetPerspective(int view, bool force)
+MainWindow::resetPerspective(GcViewType viewType, bool force)
 {
     static AthleteTab *lastathlete=NULL;
-    static int lastview=-1;
+    static GcViewType lastViewType = GcViewType::NO_VIEW_SET;
 
-    if (!force && lastview == view && lastathlete == currentAthleteTab) return;
+    if (!force && lastViewType == viewType && lastathlete == currentAthleteTab) return;
 
     // remember who last updated it.
     lastathlete = currentAthleteTab;
-    lastview = view;
+    lastViewType = viewType;
 
     // don't argue just reset the perspective for this view
-    AbstractView *current = NULL;
-    switch (view) {
-
-    case 0:  current = currentAthleteTab->homeView; break;
-    case 1:  current = currentAthleteTab->analysisView; break;
-    case 2:  current = currentAthleteTab->planView; break;
-    case 3:  current = currentAthleteTab->trainView; break;
-    }
+    AbstractView *current = currentAthleteTab->view(viewType);
 
     // set the perspective
     pactive=true;
@@ -1461,14 +1435,7 @@ MainWindow::perspectiveSelected(int index)
     if (pactive) return;
 
     // set the perspective for the current view
-    int view = currentAthleteTab->currentView();
-    AbstractView *current = NULL;
-    switch (view) {
-    case 0:  current = currentAthleteTab->homeView; break;
-    case 1:  current = currentAthleteTab->analysisView; break;
-    case 2:  current = currentAthleteTab->planView; break;
-    case 3:  current = currentAthleteTab->trainView; break;
-    }
+    AbstractView *current = currentAthleteTab->currentView();
 
     // which perspective is currently being shown?
     int prior = current->perspectives_.indexOf(current->perspective_);
@@ -1476,12 +1443,7 @@ MainWindow::perspectiveSelected(int index)
     if (index < current->perspectives_.count()) {
 
         // a perspectives was selected
-        switch (view) {
-        case 0:  current->perspectiveSelected(index); break;
-        case 1:  current->perspectiveSelected(index); break;
-        case 2:  current->perspectiveSelected(index); break;
-        case 3:  current->perspectiveSelected(index); break;
-        }
+        current->perspectiveSelected(index);
 
     } else {
 
@@ -1498,7 +1460,7 @@ MainWindow::perspectiveSelected(int index)
                 QString name;
                 QString expression;
                 Perspective::switchenum trainswitch=Perspective::None;
-                AddPerspectiveDialog *dialog= new AddPerspectiveDialog(this, currentAthleteTab->context, name, expression, current->type, trainswitch);
+                AddPerspectiveDialog *dialog= new AddPerspectiveDialog(this, currentAthleteTab->context, name, expression, current->viewType(), trainswitch);
                 int ret= dialog->exec();
                 delete dialog;
                 if (ret == QDialog::Accepted && name != "") {
@@ -1530,15 +1492,7 @@ MainWindow::perspectiveSelected(int index)
 void
 MainWindow::perspectivesChanged()
 {
-    int view = currentAthleteTab->currentView();
-    AbstractView *current = NULL;
-
-    switch (view) {
-    case 0:  current = currentAthleteTab->homeView; break;
-    case 1:  current = currentAthleteTab->analysisView; break;
-    case 2:  current = currentAthleteTab->planView; break;
-    case 3:  current = currentAthleteTab->trainView; break;
-    }
+    AbstractView *current = currentAthleteTab->currentView();
 
     // which perspective is currently being selected (before we go setting the combobox)
     Perspective *prior = current->perspective_;
@@ -1546,7 +1500,7 @@ MainWindow::perspectivesChanged()
     // ok, so reset the combobox and force, since whilst it may have already
     // been set for this athlete+view combination the config was just changed
     // so it needs to be redone.
-    resetPerspective(view, true);
+    resetPerspective(current->viewType(), true);
     //current->setPerspectives(perspectiveSelector);
 
     // is the old selected perspective still available?
@@ -1631,7 +1585,7 @@ MainWindow::dropEvent(QDropEvent *event)
             images << filename;
 
         // Look for Workout files only in Train view
-        } else if (currentAthleteTab->currentView() == 3 && ErgFile::isWorkout(filename)) {
+        } else if (currentAthleteTab->currentViewType() == GcViewType::VIEW_TRAIN && ErgFile::isWorkout(filename)) {
             workouts << filename;
         } else {
             filenames.append(filename);
@@ -1681,7 +1635,7 @@ MainWindow::importImages(QStringList list)
 {
     // we need to be on activities view and with a current
     // ride otherwise we just ignore the list
-    if (currentAthleteTab->currentView() != 1 || currentAthleteTab->context->ride == NULL) {
+    if (currentAthleteTab->currentViewType() != GcViewType::VIEW_ANALYSIS || currentAthleteTab->context->ride == NULL) {
         QMessageBox::critical(this, tr("Import Images Failed"), tr("You can only import images on the activities view with an activity selected."));
         return;
     }
@@ -2333,15 +2287,16 @@ MainWindow::restoreGCState(Context *context)
     if (viewStack->currentIndex() != GcViewStackIdx::SELECT_ATHLETE_VIEW) {
 
         // not on athlete view...
-        resetPerspective(currentAthleteTab->currentView()); // will lazy load, hence doing it first
+        GcViewType viewType = currentAthleteTab->currentViewType();
+        resetPerspective(viewType); // will lazy load, hence doing it first
 
         // restore window state from the supplied context
-            switch(currentAthleteTab->currentView()) {
-            case 0: sidebar->setItemSelected(GcSideBarBtnId::TRENDS_BTN,true); break;
-            case 1: sidebar->setItemSelected(GcSideBarBtnId::ACTIVITIES_BTN,true); break;
-            case 2: sidebar->setItemSelected(GcSideBarBtnId::PLAN_BTN,true); break;
-            case 3: sidebar->setItemSelected(GcSideBarBtnId::TRAIN_BTN, true); break;
-            default: sidebar->setItemSelected(GcSideBarBtnId::SELECT_ATHLETE_BTN, true); break;
+        switch(viewType) {
+        case GcViewType::VIEW_TRENDS: sidebar->setItemSelected(GcSideBarBtnId::TRENDS_BTN,true); break;
+        case GcViewType::VIEW_ANALYSIS: sidebar->setItemSelected(GcSideBarBtnId::ACTIVITIES_BTN,true); break;
+        case GcViewType::VIEW_PLAN: sidebar->setItemSelected(GcSideBarBtnId::PLAN_BTN,true); break;
+        case GcViewType::VIEW_TRAIN: sidebar->setItemSelected(GcSideBarBtnId::TRAIN_BTN, true); break;
+        default: sidebar->setItemSelected(GcSideBarBtnId::SELECT_ATHLETE_BTN, true); break;
         }
     }
 

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -225,16 +225,16 @@ MainWindow::MainWindow(const QDir &home)
     // The ids of the sidebar buttons below are defined in NewSideBar.h
     sidebar->addItem(QImage(":sidebar/athlete.png"), tr("athletes"), GcSideBarBtnId::SELECT_ATHLETE_BTN, helpNewSideBar->getWhatsThisText(HelpWhatsThis::ScopeBar_Athletes));
 
-    sidebar->addItem(QImage(":sidebar/plan.png"), tr("plan"), GcSideBarBtnId::PLAN_BTN, helpNewSideBar->getWhatsThisText(HelpWhatsThis::ScopeBar_Plan));
+    sidebar->addItem(QImage(":sidebar/plan.png"), tr(PlanView::userName).toLower(), GcSideBarBtnId::PLAN_BTN, helpNewSideBar->getWhatsThisText(HelpWhatsThis::ScopeBar_Plan));
 
-    sidebar->addItem(QImage(":sidebar/trends.png"), tr("trends"), GcSideBarBtnId::TRENDS_BTN, helpNewSideBar->getWhatsThisText(HelpWhatsThis::ScopeBar_Trends));
+    sidebar->addItem(QImage(":sidebar/trends.png"), tr(TrendsView::userName).toLower(), GcSideBarBtnId::TRENDS_BTN, helpNewSideBar->getWhatsThisText(HelpWhatsThis::ScopeBar_Trends));
 
-    sidebar->addItem(QImage(":sidebar/assess.png"), tr("activities"), GcSideBarBtnId::ACTIVITIES_BTN, helpNewSideBar->getWhatsThisText(HelpWhatsThis::ScopeBar_Rides));
+    sidebar->addItem(QImage(":sidebar/assess.png"), tr(AnalysisView::userName).toLower(), GcSideBarBtnId::ACTIVITIES_BTN, helpNewSideBar->getWhatsThisText(HelpWhatsThis::ScopeBar_Rides));
 
     sidebar->addItem(QImage(":sidebar/reflect.png"), tr("reflect"), GcSideBarBtnId::REFLECT_BTN, tr("Feature not implemented yet"));
     sidebar->setItemEnabled(GcSideBarBtnId::REFLECT_BTN, false);
 
-    sidebar->addItem(QImage(":sidebar/train.png"), tr("train"), GcSideBarBtnId::TRAIN_BTN, helpNewSideBar->getWhatsThisText(HelpWhatsThis::ScopeBar_Train));
+    sidebar->addItem(QImage(":sidebar/train.png"), tr(TrainView::userName).toLower(), GcSideBarBtnId::TRAIN_BTN, helpNewSideBar->getWhatsThisText(HelpWhatsThis::ScopeBar_Train));
 
     sidebar->addStretch();
     sidebar->addItem(QImage(":sidebar/apps.png"), tr("apps"), GcSideBarBtnId::APPS_BTN, tr("Feature not implemented yet"));
@@ -676,10 +676,10 @@ MainWindow::MainWindow(const QDir &home)
     showhideTabbar->setChecked(true);
 
     viewMenu->addSeparator();
-    viewMenu->addAction(tr("Plan"), this, SLOT(selectPlan()));
-    viewMenu->addAction(tr("Trends"), this, SLOT(selectTrends()));
-    viewMenu->addAction(tr("Activities"), this, SLOT(selectAnalysis()));
-    viewMenu->addAction(tr("Train"), this, SLOT(selectTrain()));
+    viewMenu->addAction(tr(PlanView::userName) , this, SLOT(selectPlan()));
+    viewMenu->addAction(tr(TrendsView::userName), this, SLOT(selectTrends()));
+    viewMenu->addAction(tr(AnalysisView::userName), this, SLOT(selectAnalysis()));
+    viewMenu->addAction(tr(TrainView::userName), this, SLOT(selectTrain()));
     viewMenu->addSeparator();
     viewMenu->addAction(tr("Import Perspective..."), this, SLOT(importPerspective()));
     viewMenu->addAction(tr("Export Perspective..."), this, SLOT(exportPerspective()));
@@ -922,7 +922,7 @@ MainWindow::exportPerspective()
     // export the current perspective to a file
     QString suffix;
     QString fileName = QFileDialog::getSaveFileName(this, tr("Export Persepctive"),
-                       QDir::homePath()+"/"+ current->viewTypeDesc() + " " + current->perspective_->title() + ".gchartset",
+                       QDir::homePath()+"/"+ current->viewsUserName() + " " + current->perspective_->title() + ".gchartset",
                        ("*.gchartset;;"), &suffix, QFileDialog::DontUseNativeDialog); // native dialog hangs when threads in use (!)
 
     if (fileName.isEmpty()) {

--- a/src/Gui/MainWindow.h
+++ b/src/Gui/MainWindow.h
@@ -155,7 +155,7 @@ class MainWindow : public QMainWindow
         // perspective selected
         void perspectiveSelected(int index);
         void perspectivesChanged(); // when the list of perspectives is updated in PerspectivesDialog
-        void resetPerspective(int view, bool force=false); // reset when view changes
+        void resetPerspective(GcViewType viewType, bool force=false); // reset when view changes
 
         // import and export perspectives
         void exportPerspective();

--- a/src/Gui/NavigationModel.cpp
+++ b/src/Gui/NavigationModel.cpp
@@ -27,7 +27,7 @@
 
 NavigationModel::NavigationModel(AthleteTab *tab) : tab(tab), block(false), viewinit(false), drinit(false), iteminit(false)
 {
-    connect(tab, SIGNAL(viewChanged(int)), this, SLOT(viewChanged(int)));
+    connect(tab, SIGNAL(viewChanged(GcViewType)), this, SLOT(viewChanged(GcViewType)));
     connect(tab, SIGNAL(rideItemSelected(RideItem*)), this, SLOT(rideChanged(RideItem*)));
     connect(tab->context, SIGNAL(dateRangeSelected(DateRange)), this, SLOT(dateChanged(DateRange)));
     connect(tab->context->mainWindow, SIGNAL(backClicked()), this, SLOT(back()));
@@ -115,7 +115,7 @@ NavigationModel::dateChanged(DateRange x)
 }
 
 void
-NavigationModel::viewChanged(int x)
+NavigationModel::viewChanged(GcViewType x)
 {
     if (block) return;
 
@@ -150,13 +150,13 @@ NavigationModel::action(bool redo, NavigationEvent event)
     switch(event.type) {
     case NavigationEvent::VIEW:
     {
-        view = redo ? event.after.toInt() : event.before.toInt();
+        view = static_cast<GcViewType>(redo ? event.after.toInt() : event.before.toInt());
 
         switch (view) {
-        case 0:  tab->context->mainWindow->selectTrends(); break;
-        case 1:  tab->context->mainWindow->selectAnalysis(); break;
-        case 2:  tab->context->mainWindow->selectPlan(); break;
-        case 3:  tab->context->mainWindow->selectTrain(); break;
+        case GcViewType::VIEW_TRENDS:  tab->context->mainWindow->selectTrends(); break;
+        case GcViewType::VIEW_ANALYSIS:  tab->context->mainWindow->selectAnalysis(); break;
+        case GcViewType::VIEW_PLAN:  tab->context->mainWindow->selectPlan(); break;
+        case GcViewType::VIEW_TRAIN:  tab->context->mainWindow->selectTrain(); break;
         }
     }
     break;

--- a/src/Gui/NavigationModel.h
+++ b/src/Gui/NavigationModel.h
@@ -35,7 +35,7 @@ public:
     // about changing views, dates and ride selections
     enum NavigationEventType { VIEW=0, RIDE, DATERANGE } type;
 
-    NavigationEvent(NavigationEventType t, int v) : type(t) { after.setValue(v); }
+    NavigationEvent(NavigationEventType t, GcViewType v) : type(t) { after.setValue(v); }
     NavigationEvent(NavigationEventType t, DateRange v) : type(t) { after.setValue(v); }
     NavigationEvent(NavigationEventType t, RideItem* v) : type(t) { after.setValue(v); }
     NavigationEvent(NavigationEventType t, QString v) : type(t) { after.setValue(v); }
@@ -64,7 +64,7 @@ public:
 
 public slots:
 
-    void viewChanged(int);
+    void viewChanged(GcViewType);
     void rideChanged(RideItem*);
     void dateChanged(DateRange dr);
 
@@ -80,7 +80,7 @@ private:
     bool block;
 
     // current state, before an event arrives
-    int view; // which view is selected
+    GcViewType view; // which view is selected
     DateRange dr;
     RideItem *item;
 

--- a/src/Gui/Pages.cpp
+++ b/src/Gui/Pages.cpp
@@ -266,10 +266,10 @@ GeneralPage::GeneralPage(Context *context) : context(context)
     // the order of the ComboBox entries below must align with the
     // gcStartupView functionality in MainWindow's constructor
     startupView = new QComboBox();
-    startupView->addItem(tr("Trends"));   // startViewIdx = 0
-    startupView->addItem(tr("Activities")); // startViewIdx = 1
-    startupView->addItem(tr("Plan"));     // startViewIdx = 2
-    startupView->addItem(tr("Train"));    // startViewIdx = 3
+    startupView->addItem(tr(TrendsView::userName));
+    startupView->addItem(tr(AnalysisView::userName)); 
+    startupView->addItem(tr(PlanView::userName));
+    startupView->addItem(tr(TrainView::userName));
 
     // get the configured startup view configuration which matches with
     // the startViewIdx values defined by the comboBox order above.

--- a/src/Gui/Pages.cpp
+++ b/src/Gui/Pages.cpp
@@ -263,15 +263,25 @@ GeneralPage::GeneralPage(Context *context) : context(context)
 
     connect(athleteBrowseButton, SIGNAL(clicked()), this, SLOT(browseAthleteDir()));
 
+    // the order of the ComboBox entries below must align with the
+    // gcStartupView functionality in MainWindow's constructor
     startupView = new QComboBox();
-    startupView->addItem(tr("Trends"));
-    startupView->addItem(tr("Activities"));
-    startupView->addItem(tr("Plan"));
-    startupView->addItem(tr("Train"));
+    startupView->addItem(tr("Trends"));   // startViewIdx = 0
+    startupView->addItem(tr("Activities")); // startViewIdx = 1
+    startupView->addItem(tr("Plan"));     // startViewIdx = 2
+    startupView->addItem(tr("Train"));    // startViewIdx = 3
 
-    // map view indexes to combo box values
-    int startView = appsettings->value(NULL, GC_STARTUP_VIEW, "1").toInt();
-    startupView->setCurrentIndex(startView);
+    // get the configured startup view configuration which matches with
+    // the startViewIdx values defined by the comboBox order above.
+    int startViewIdx = appsettings->value(NULL, GC_STARTUP_VIEW, -1).toInt();
+
+    // the configuration values are retained and the startupView Combobox uses the same values
+    // the default is analysis when no config exists or the configuration value is not recognised.
+    if (startViewIdx < 0 && startViewIdx > 3) {
+        startViewIdx = 1;
+        appsettings->setValue(GC_STARTUP_VIEW, startViewIdx);
+    }
+    startupView->setCurrentIndex(startViewIdx);
 
     QFormLayout *form = newQFormLayout();
     form->addRow(new QLabel(HLO + tr("Localization") + HLC));
@@ -336,9 +346,8 @@ GeneralPage::saveClicked()
     };
     appsettings->setValue(GC_LANG, langs[langCombo->currentIndex()]);
 
-    // map combo box values to view indexes
-    int startView = startupView->currentIndex();
-    appsettings->setValue(GC_STARTUP_VIEW, startView);
+    // save the startup view
+    appsettings->setValue(GC_STARTUP_VIEW, startupView->currentIndex());
 
     // Garmin and cranks
     appsettings->setValue(GC_GARMIN_HWMARK, garminHWMarkedit->value());

--- a/src/Gui/Perspective.cpp
+++ b/src/Gui/Perspective.cpp
@@ -74,9 +74,9 @@
 static const int tileMargin = 20;
 static const int tileSpacing = 10;
 
-Perspective::Perspective(Context *context, QString title, int type) :
+Perspective::Perspective(Context *context, QString title, GcViewType viewType) :
     GcWindow(context), context(context), active(false),  resizing(false), clicked(NULL), dropPending(false),
-    type_(type), title_(title), chartCursor(-2), df(NULL), expression_(""), trainswitch(None)
+    viewType_(viewType), title_(title), chartCursor(-2), df(NULL), expression_(""), trainswitch(None)
 {
     SSS;
     // setup control area
@@ -103,12 +103,6 @@ Perspective::Perspective(Context *context, QString title, int type) :
     cl->addWidget(controlStack);
     setControls(cw);
 
-    switch(this->type_) {
-    case VIEW_ANALYSIS: view="analysis"; break;
-    case VIEW_PLAN: view="plan"; break;
-    case VIEW_TRENDS: view="home"; break;
-    case VIEW_TRAIN: view="train"; break;
-    }
     setProperty("isManager", true);
     nomenu=true;
     setAcceptDrops(true);
@@ -123,7 +117,7 @@ Perspective::Perspective(Context *context, QString title, int type) :
 
     QPalette palette;
     //palette.setBrush(backgroundRole(), QColor("#B3B4B6"));
-    palette.setBrush(backgroundRole(), type == VIEW_TRAIN ? GColor(CTRAINPLOTBACKGROUND) : GColor(CPLOTBACKGROUND));
+    palette.setBrush(backgroundRole(), viewType_ == GcViewType::VIEW_TRAIN ? GColor(CTRAINPLOTBACKGROUND) : GColor(CPLOTBACKGROUND));
     setAutoFillBackground(false);
 
     // each style has its own container widget
@@ -201,10 +195,10 @@ Perspective::Perspective(Context *context, QString title, int type) :
     connect(titleEdit, SIGNAL(textChanged(const QString&)), SLOT(titleChanged()));
 
     // trends view we should select a library chart when a chart is selected.
-    if (type == VIEW_TRENDS) connect(context, SIGNAL(presetSelected(int)), this, SLOT(presetSelected(int)));
+    if (viewType_ == GcViewType::VIEW_TRENDS) connect(context, SIGNAL(presetSelected(int)), this, SLOT(presetSelected(int)));
 
     // Allow realtime controllers to scroll train view with steering movements
-    if (type == VIEW_TRAIN) connect(context, SIGNAL(steerScroll(int)), this, SLOT(steerScroll(int)));
+    if (viewType_ == GcViewType::VIEW_TRAIN) connect(context, SIGNAL(steerScroll(int)), this, SLOT(steerScroll(int)));
 
     installEventFilter(this);
     qApp->installEventFilter(this);
@@ -230,7 +224,7 @@ Perspective::addChartFromMenu(QAction*action)
     // & removed to avoid issues with kde AutoCheckAccelerators
     QString actionText = QString(action->text()).replace("&", "");
     GcWinID id = GcWindowTypes::None;
-    for (int i=0; GcWindows[i].relevance; i++) {
+    for (int i=0; GcWindows[i].relevance != GcViewType::NO_VIEW_SET; i++) {
         if (GcWindows[i].name == actionText) {
             id = GcWindows[i].id;
             break;
@@ -273,7 +267,7 @@ Perspective::importChart(QMap<QString,QString>properties, bool select)
     const QMetaObject *m = chart->metaObject();
 
     // set all the properties
-    chart->setProperty("view", view);
+    chart->setProperty("view", static_cast<std::underlying_type_t<GcViewType>>(viewType_));
     chart->setProperty("perspective", QVariant::fromValue<Perspective*>(this));
 
     // each of the user properties
@@ -328,7 +322,7 @@ Perspective::configChanged(qint32)
     tileArea->verticalScrollBar()->setStyleSheet(AbstractView::ourStyleSheet());
 //#endif
     QPalette palette;
-    palette.setBrush(backgroundRole(), type() == VIEW_TRAIN ? GColor(CTRAINPLOTBACKGROUND) : GColor(CPLOTBACKGROUND));
+    palette.setBrush(backgroundRole(), viewType_ == GcViewType::VIEW_TRAIN ? GColor(CTRAINPLOTBACKGROUND) : GColor(CPLOTBACKGROUND));
     setPalette(palette);
     tileWidget->setPalette(palette);
     tileArea->setPalette(palette);
@@ -341,7 +335,7 @@ Perspective::configChanged(qint32)
             if (charts[i]->type() == GcWindowTypes::Overview || charts[i]->type() == GcWindowTypes::OverviewTrends) chartbar->setColor(i, GColor(COVERVIEWBACKGROUND));
             else if (charts[i]->type() == GcWindowTypes::UserAnalysis || charts[i]->type() == GcWindowTypes::UserTrends) chartbar->setColor(i, RGBColor(QColor(charts[i]->property("color").toString())));
             else {
-                if (type() == VIEW_TRAIN)chartbar->setColor(i, GColor(CTRAINPLOTBACKGROUND));
+                if (viewType_ == GcViewType::VIEW_TRAIN) chartbar->setColor(i, GColor(CTRAINPLOTBACKGROUND));
                 else chartbar->setColor(i, GColor(CPLOTBACKGROUND));
             }
         }
@@ -726,7 +720,7 @@ Perspective::addChart(GcChartWindow* newone)
         newone->installEventFilter(this);
 
         RideItem *notconst = (RideItem*)context->currentRideItem();
-        newone->setProperty("view", view);
+        newone->setProperty("view", static_cast<std::underlying_type_t<GcViewType>>(viewType_));
         newone->setProperty("ride", QVariant::fromValue<RideItem*>(notconst));
         newone->setProperty("dateRange", property("dateRange"));
         newone->setProperty("style", currentStyle);
@@ -745,7 +739,7 @@ Perspective::addChart(GcChartWindow* newone)
             // tab colors
             if (newone->type() == GcWindowTypes::Overview || newone->type() == GcWindowTypes::OverviewTrends) chartbar->setColor(chartnum, GColor(COVERVIEWBACKGROUND));
             else {
-                if (type() == VIEW_TRAIN)chartbar->setColor(chartnum, GColor(CTRAINPLOTBACKGROUND));
+                if (viewType_ == GcViewType::VIEW_TRAIN) chartbar->setColor(chartnum, GColor(CTRAINPLOTBACKGROUND));
                 else chartbar->setColor(chartnum, GColor(CPLOTBACKGROUND));
             }
 
@@ -1329,7 +1323,7 @@ GcWindowDialog::GcWindowDialog(GcWinID type, Context *context, GcChartWindow **h
     // the chart uses it to decide something - apologies for the convoluted
     // method to determine the perspective, but its rare to use this outside
     // the context of a chart or a view
-    win->setProperty("perspective", QVariant::fromValue<Perspective*>(context->mainWindow->athleteTab()->view(context->mainWindow->athleteTab()->currentView())->page()));
+    win->setProperty("perspective", QVariant::fromValue<Perspective*>(context->mainWindow->athleteTab()->currentView()->page()));
     chartLayout->addWidget(win);
     //win->setFrameStyle(QFrame::Box);
 
@@ -1538,7 +1532,7 @@ Perspective::presetSelected(int n)
 /*--------------------------------------------------------------------------------
  *  Import and Export the Perspective to xml
  * -----------------------------------------------------------------------------*/
-Perspective *Perspective::fromFile(Context *context, QString filename, int type)
+Perspective *Perspective::fromFile(Context *context, QString filename, GcViewType viewType)
 {
     SSS;
     Perspective *returning = NULL;
@@ -1559,7 +1553,7 @@ Perspective *Perspective::fromFile(Context *context, QString filename, int type)
     QXmlInputSource source;
     source.setData(content);
     QXmlSimpleReader xmlReader;
-    ViewParser handler(context, type, false);
+    ViewParser handler(context, viewType, false);
     xmlReader.setContentHandler(&handler);
     xmlReader.setErrorHandler(&handler);
 
@@ -1571,7 +1565,7 @@ Perspective *Perspective::fromFile(Context *context, QString filename, int type)
 
     // return the first one with the right type (if there are multiple)
     for(int i=0; i<handler.perspectives.count(); i++)
-        if (returning == NULL && handler.perspectives[i]->type_ == type)
+        if (returning == NULL && handler.perspectives[i]->viewType_ == viewType)
             returning = handler.perspectives[i];
 
     // delete any further perspectives
@@ -1609,7 +1603,7 @@ Perspective::toXml(QTextStream &out)
     SSS;
     out<<"<layout name=\""<< title_
        <<"\" style=\"" << currentStyle
-       <<"\" type=\"" << type_
+       <<"\" type=\"" << static_cast<unsigned int>(viewType_)
        <<"\" expression=\"" << Utils::xmlprotect(expression_)
        <<"\" trainswitch=\"" << (int)trainswitch
        << "\">\n";
@@ -1681,7 +1675,7 @@ Perspective::setExpression(QString expr)
 
     // notify charts that the filter changed
     // but only for trends views where it matters
-    if (type_ == VIEW_TRENDS)
+    if (viewType_ == GcViewType::VIEW_TRENDS)
         foreach(GcWindow *chart, charts)
             chart->notifyPerspectiveFilterChanged(expression_);
 }
@@ -1690,7 +1684,7 @@ bool
 Perspective::relevant(RideItem *item)
 {
     SSS;
-    if (type_ != VIEW_ANALYSIS) return true;
+    if (viewType_ != GcViewType::VIEW_ANALYSIS) return true;
     else if (df == NULL) return false;
     else if (df == NULL || item == NULL) return false;
 
@@ -1851,14 +1845,18 @@ ImportChartDialog::importClicked()
                 view = table->item(i,1)->text();
             }
 
-            int x=0;
-            if (view == tr("Trends"))      { x=0; context->mainWindow->selectTrends(); }
-            if (view == tr("Activities"))  { x=1; context->mainWindow->selectAnalysis(); }
-            if (view == tr("Plan"))        { x=2; context->mainWindow->selectPlan(); }
-            if (view == tr("Train"))       { x=3; context->mainWindow->selectTrain(); }
+            GcViewType viewType = GcViewType::NO_VIEW_SET;
+            if (view == tr("Trends"))      { viewType=GcViewType::VIEW_TRENDS; context->mainWindow->selectTrends(); }
+            if (view == tr("Activities"))  { viewType=GcViewType::VIEW_ANALYSIS; context->mainWindow->selectAnalysis(); }
+            if (view == tr("Plan"))        { viewType=GcViewType::VIEW_PLAN; context->mainWindow->selectPlan(); }
+            if (view == tr("Train"))       { viewType=GcViewType::VIEW_TRAIN; context->mainWindow->selectTrain(); }
 
             // add to the currently selected tab and select if only adding one chart
-            context->mainWindow->athleteTab()->view(x)->importChart(list[i], (list.count()==1));
+            if (viewType != GcViewType::NO_VIEW_SET) {
+                context->mainWindow->athleteTab()->view(viewType)->importChart(list[i], (list.count()==1));
+            } else {
+                qDebug() << "Unhandled view type in ImportChartDialog:" << view;
+            }
         }
     }
     accept();
@@ -1871,8 +1869,8 @@ ImportChartDialog::cancelClicked()
     accept();
 }
 
-AddPerspectiveDialog::AddPerspectiveDialog(QWidget *parent, Context *context, QString &name, QString &expression, int type, Perspective::switchenum &trainswitch, bool edit) :
-    QDialog(parent), context(context), name(name), expression(expression), trainswitch(trainswitch), type(type)
+AddPerspectiveDialog::AddPerspectiveDialog(QWidget *parent, Context *context, QString &name, QString &expression, GcViewType viewType, Perspective::switchenum &trainswitch, bool edit) :
+    QDialog(parent), context(context), name(name), expression(expression), trainswitch(trainswitch), viewType(viewType)
 {
     SSS;
     setWindowFlags(windowFlags());
@@ -1889,16 +1887,16 @@ AddPerspectiveDialog::AddPerspectiveDialog(QWidget *parent, Context *context, QS
     form->addRow(new QLabel(tr("Perspective Name")), nameEdit);
     layout->addLayout(form);
 
-    if (type == VIEW_ANALYSIS || type == VIEW_TRENDS) {
+    if (viewType == GcViewType::VIEW_ANALYSIS || viewType == GcViewType::VIEW_TRENDS) {
         filterEdit = new SearchBox(context, this);
         filterEdit->setFixedMode(true);
         filterEdit->setMode(SearchBox::Filter);
         filterEdit->setText(expression);
-        if (type == VIEW_ANALYSIS) form->addRow(new QLabel(tr("Switch expression")), filterEdit);
-        if (type == VIEW_TRENDS) form->addRow(new QLabel(tr("Activities filter")), filterEdit);
+        if (viewType == GcViewType::VIEW_ANALYSIS) form->addRow(new QLabel(tr("Switch expression")), filterEdit);
+        if (viewType == GcViewType::VIEW_TRENDS) form->addRow(new QLabel(tr("Activities filter")), filterEdit);
     }
 
-    if (type == VIEW_TRAIN) {
+    if (viewType == GcViewType::VIEW_TRAIN) {
         trainSwitch = new QComboBox(this);
         trainSwitch->addItem(tr("Don't switch"), Perspective::None);
         trainSwitch->addItem(tr("Erg Workout"), Perspective::Erg);
@@ -1927,8 +1925,8 @@ AddPerspectiveDialog::addClicked()
 {
     SSS;
     name = nameEdit->text();
-    if (type == VIEW_ANALYSIS || type == VIEW_TRENDS) expression = filterEdit->text();
-    if (type == VIEW_TRAIN) trainswitch=(Perspective::switchenum)trainSwitch->itemData(trainSwitch->currentIndex(), Qt::UserRole).toInt();
+    if (viewType == GcViewType::VIEW_ANALYSIS || viewType == GcViewType::VIEW_TRENDS) expression = filterEdit->text();
+    if (viewType == GcViewType::VIEW_TRAIN) trainswitch=(Perspective::switchenum)trainSwitch->itemData(trainSwitch->currentIndex(), Qt::UserRole).toInt();
     accept();
 }
 

--- a/src/Gui/Perspective.cpp
+++ b/src/Gui/Perspective.cpp
@@ -267,7 +267,7 @@ Perspective::importChart(QMap<QString,QString>properties, bool select)
     const QMetaObject *m = chart->metaObject();
 
     // set all the properties
-    chart->setProperty("view", static_cast<std::underlying_type_t<GcViewType>>(viewType_));
+    chart->setProperty("view", context->tab->view(viewType_)->viewsInternalName());
     chart->setProperty("perspective", QVariant::fromValue<Perspective*>(this));
 
     // each of the user properties
@@ -720,7 +720,7 @@ Perspective::addChart(GcChartWindow* newone)
         newone->installEventFilter(this);
 
         RideItem *notconst = (RideItem*)context->currentRideItem();
-        newone->setProperty("view", static_cast<std::underlying_type_t<GcViewType>>(viewType_));
+        newone->setProperty("view", context->tab->view(viewType_)->viewsInternalName());
         newone->setProperty("ride", QVariant::fromValue<RideItem*>(notconst));
         newone->setProperty("dateRange", property("dateRange"));
         newone->setProperty("style", currentStyle);
@@ -1763,10 +1763,11 @@ ImportChartDialog::ImportChartDialog(Context *context, QList<QMap<QString,QStrin
         // convert to user name for view from here, since
         // they won't recognise the names used internally
         // as they need to be translated too
-        if (view == "plan") view = tr("Plan");
-        if (view == "home") view = tr("Trends");
-        if (view == "analysis") view = tr("Activities");
-        if (view == "train") view = tr("Train");
+        if (view == PlanView::internalName) view = tr(PlanView::userName);
+        else if (view == TrendsView::internalName) view = tr(TrendsView::userName);
+        else if (view == AnalysisView::internalName) view = tr(AnalysisView::userName);
+        else if (view == TrainView::internalName) view = tr(TrainView::userName);
+        else qDebug() << "Unhandled view type in ImportChartDialog:" << view;
 
         QTableWidgetItem *t;
 #ifndef GC_HAVE_ICAL
@@ -1778,13 +1779,13 @@ ImportChartDialog::ImportChartDialog(Context *context, QList<QMap<QString,QStrin
 
 #else
         // we should be able to select trend/plan
-        if (view == tr("Plan") || view == tr("Trends")) {
+        if (view == tr(PlanView::userName)  || view == tr(TrendsView::userName)) {
 
             QComboBox *com = new QComboBox(this);
-            com->addItem(tr("Plan"));
-            com->addItem(tr("Trends"));
+            com->addItem(tr(PlanView::userName));
+            com->addItem(tr(TrendsView::userName));
             table->setCellWidget(i,1,com);
-            if (view == tr("Plan")) com->setCurrentIndex(0);
+            if (view == tr(PlanView::userName) ) com->setCurrentIndex(0);
             else com->setCurrentIndex(1);
 
         } else {
@@ -1836,20 +1837,20 @@ ImportChartDialog::importClicked()
             if (com) {
                 switch(com->currentIndex()) {
 
-                    case 0 : view = tr("Plan"); break;
+                    case 0 : view = tr(PlanView::userName) ; break;
 
                     default:
-                    case 1 : view = tr("Trends"); break;
+                    case 1 : view = tr(TrendsView::userName); break;
                 }
             } else {
                 view = table->item(i,1)->text();
             }
 
             GcViewType viewType = GcViewType::NO_VIEW_SET;
-            if (view == tr("Trends"))      { viewType=GcViewType::VIEW_TRENDS; context->mainWindow->selectTrends(); }
-            if (view == tr("Activities"))  { viewType=GcViewType::VIEW_ANALYSIS; context->mainWindow->selectAnalysis(); }
-            if (view == tr("Plan"))        { viewType=GcViewType::VIEW_PLAN; context->mainWindow->selectPlan(); }
-            if (view == tr("Train"))       { viewType=GcViewType::VIEW_TRAIN; context->mainWindow->selectTrain(); }
+            if (view == tr(TrendsView::userName))    { viewType=GcViewType::VIEW_TRENDS; context->mainWindow->selectTrends(); }
+            if (view == tr(AnalysisView::userName))  { viewType=GcViewType::VIEW_ANALYSIS; context->mainWindow->selectAnalysis(); }
+            if (view == tr(PlanView::userName))      { viewType=GcViewType::VIEW_PLAN; context->mainWindow->selectPlan(); }
+            if (view == tr(TrainView::userName))     { viewType=GcViewType::VIEW_TRAIN; context->mainWindow->selectTrain(); }
 
             // add to the currently selected tab and select if only adding one chart
             if (viewType != GcViewType::NO_VIEW_SET) {

--- a/src/Gui/Perspective.h
+++ b/src/Gui/Perspective.h
@@ -61,14 +61,14 @@ class Perspective : public GcWindow
 
     public:
 
-        Perspective(Context *, QString title, int type);
+        Perspective(Context *, QString title, GcViewType viewType);
         ~Perspective();
 
         // am I relevant? (for switching when ride selected)
         bool relevant(RideItem*);
 
         // the items I'd choose (for filtering on trends view, optionally refined by chart filter)
-        bool isFiltered() const override { return (type_ == VIEW_TRENDS && df != NULL); }
+        bool isFiltered() const override { return (viewType_ == GcViewType::VIEW_TRENDS && df != NULL); }
         QStringList filterlist(DateRange dr, bool isfiltered=false, QStringList files=QStringList());
 
         // get/set the expression (will compile df)
@@ -81,11 +81,11 @@ class Perspective : public GcWindow
         void setTrainSwitch(int x) { trainswitch = (switchenum)x; }
 
         // import and export
-        static Perspective *fromFile(Context *context, QString filename, int type);
+        static Perspective *fromFile(Context *context, QString filename, GcViewType viewType);
         bool toFile(QString filename);
         void toXml(QTextStream &out);
 
-        int type() const { return type_; }
+        GcViewType viewType() const { return viewType_; }
         QString title() const { return title_; }
 
         void resetLayout();
@@ -159,8 +159,7 @@ class Perspective : public GcWindow
         bool dropPending;
 
         // what are we?
-        int type_;
-        QString view;
+        GcViewType viewType_;
 
         // top bar
         QString title_;
@@ -255,7 +254,7 @@ class AddPerspectiveDialog : public QDialog
     Q_OBJECT
 
     public:
-        AddPerspectiveDialog(QWidget *parent, Context *context, QString &name, QString &expression, int type, Perspective::switchenum &trainswitch, bool edit=false);
+        AddPerspectiveDialog(QWidget *parent, Context *context, QString &name, QString &expression, GcViewType viewType, Perspective::switchenum &trainswitch, bool edit=false);
 
     protected:
         QLineEdit *nameEdit;
@@ -272,6 +271,6 @@ class AddPerspectiveDialog : public QDialog
         QString &name;
         QString &expression;
         Perspective::switchenum &trainswitch;
-        int type;
+        GcViewType viewType;
 };
 #endif // _GC_HomeWindow_h

--- a/src/Gui/PerspectiveDialog.cpp
+++ b/src/Gui/PerspectiveDialog.cpp
@@ -294,7 +294,7 @@ PerspectiveDialog::exportPerspectiveClicked()
     // export the current perspective to a file
     QString suffix;
     QString fileName = QFileDialog::getSaveFileName(this, tr("Export Perspective"),
-                       QDir::homePath()+"/"+ tabView->viewTypeDesc() + " " + current->title() + ".gchartset",
+                       QDir::homePath()+"/"+ tabView->viewsUserName() + " " + current->title() + ".gchartset",
                        ("*.gchartset;;"), &suffix, QFileDialog::DontUseNativeDialog); // native dialog hangs when threads in use (!)
 
     if (fileName.isEmpty()) {

--- a/src/Gui/Views.cpp
+++ b/src/Gui/Views.cpp
@@ -31,8 +31,8 @@
 
 QMap<Context*, LTMSidebar*> LTMSidebarView::LTMSidebars_;
 
-LTMSidebarView::LTMSidebarView(Context *context, int type, const QString& view, const QString& heading) :
-    AbstractView(context, type, view, heading)
+LTMSidebarView::LTMSidebarView(Context *context, GcViewType viewType, const QString& view, const QString& heading) :
+    AbstractView(context, viewType, view, heading)
 {
     // get or create the LTMSidebar shared between the views
     getLTMSidebar(context);
@@ -66,7 +66,7 @@ void LTMSidebarView::showEvent(QShowEvent*)
     setSidebar(LTMSidebars_[context]);
 
     // update the sidebar's preset chart visibility
-    LTMSidebars_[context]->updatePresetChartsOnShow(type);
+    LTMSidebars_[context]->updatePresetChartsOnShow(_viewType);
 
     // update sidebar for the new view
     sidebarChanged();
@@ -112,7 +112,7 @@ LTMSidebarView::dateRangeChanged(DateRange dr)
 }
 
 AnalysisView::AnalysisView(Context *context, QStackedWidget *controls) :
-        AbstractView(context, VIEW_ANALYSIS, "analysis", tr("Compare Activities and Intervals"))
+        AbstractView(context, GcViewType::VIEW_ANALYSIS, "analysis", tr("Compare Activities and Intervals"))
 {
     analSidebar = new AnalysisSidebar(context);
     BlankStateAnalysisPage *b = new BlankStateAnalysisPage(context);
@@ -158,7 +158,7 @@ AnalysisView::setRide(RideItem *ride)
 
     // if we are the current view and the current perspective is no longer relevant
     // then lets go find one to switch to..
-    if (context->mainWindow->athleteTab()->currentView() == 1 && page()->relevant(ride) != true) {
+    if (context->mainWindow->athleteTab()->currentViewType() == GcViewType::VIEW_ANALYSIS && page()->relevant(ride) != true) {
 
         // lets find a perspective to switch to
         int ridePerspectiveIdx = findRidesPerspective(ride);
@@ -247,7 +247,7 @@ AnalysisView::notifyViewSplitterMoved() {
 }
 
 PlanView::PlanView(Context *context, QStackedWidget *controls) :
-        LTMSidebarView(context, VIEW_PLAN, "plan", tr("Plan future activities"))
+        LTMSidebarView(context, GcViewType::VIEW_PLAN, "plan", tr("Plan future activities"))
 {
     BlankStatePlanPage *b = new BlankStatePlanPage(context);
 
@@ -276,7 +276,7 @@ PlanView::isBlank()
 }
 
 TrendsView::TrendsView(Context *context, QStackedWidget *controls) :
-        LTMSidebarView(context, VIEW_TRENDS, "home", tr("Compare Date Ranges"))
+        LTMSidebarView(context, GcViewType::VIEW_TRENDS, "home", tr("Compare Date Ranges"))
 {
     BlankStateHomePage *b = new BlankStateHomePage(context);
 
@@ -342,7 +342,7 @@ TrendsView::isBlank()
 }
 
 TrainView::TrainView(Context *context, QStackedWidget *controls) :
-        AbstractView(context, VIEW_TRAIN, "train", tr("Intensity Adjustments and Workout Control"))
+        AbstractView(context, GcViewType::VIEW_TRAIN, "train", tr("Intensity Adjustments and Workout Control"))
 {
     trainTool = new TrainSidebar(context);
     trainTool->setTrainView(this);

--- a/src/Gui/Views.cpp
+++ b/src/Gui/Views.cpp
@@ -112,7 +112,7 @@ LTMSidebarView::dateRangeChanged(DateRange dr)
 }
 
 AnalysisView::AnalysisView(Context *context, QStackedWidget *controls) :
-        AbstractView(context, GcViewType::VIEW_ANALYSIS, "analysis", tr("Compare Activities and Intervals"))
+        AbstractView(context, GcViewType::VIEW_ANALYSIS, internalName, tr("Compare Activities and Intervals"))
 {
     analSidebar = new AnalysisSidebar(context);
     BlankStateAnalysisPage *b = new BlankStateAnalysisPage(context);
@@ -131,7 +131,8 @@ AnalysisView::AnalysisView(Context *context, QStackedWidget *controls) :
     setBlank(b);
     setBottom(new ComparePane(context, this, ComparePane::interval));
 
-    setSidebarEnabled(appsettings->value(this, GC_SETTINGS_MAIN_SIDEBAR "analysis", defaultAppearance.sideanalysis).toBool());
+    QString path = QString(GC_SETTINGS_MAIN_SIDEBAR) + internalName;
+    setSidebarEnabled(appsettings->value(this, path, defaultAppearance.sideanalysis).toBool());
 
     connect(bottomSplitter(), SIGNAL(compareChanged(bool)), this, SLOT(compareChanged(bool)));
     connect(bottomSplitter(), SIGNAL(compareClear()), bottom(), SLOT(clear()));
@@ -144,7 +145,8 @@ RideNavigator *AnalysisView::rideNavigator()
 
 AnalysisView::~AnalysisView()
 {
-    appsettings->setValue(GC_SETTINGS_MAIN_SIDEBAR "analysis", _sidebar);
+    QString path = QString(GC_SETTINGS_MAIN_SIDEBAR) + internalName;
+    appsettings->setValue(path, _sidebar);
     delete analSidebar;
 }
 
@@ -247,7 +249,7 @@ AnalysisView::notifyViewSplitterMoved() {
 }
 
 PlanView::PlanView(Context *context, QStackedWidget *controls) :
-        LTMSidebarView(context, GcViewType::VIEW_PLAN, "plan", tr("Plan future activities"))
+        LTMSidebarView(context, GcViewType::VIEW_PLAN, internalName, tr("Plan future activities"))
 {
     BlankStatePlanPage *b = new BlankStatePlanPage(context);
 
@@ -256,7 +258,8 @@ PlanView::PlanView(Context *context, QStackedWidget *controls) :
     controls->addWidget(cstack);
     controls->setCurrentIndex(0);
 
-    setSidebarEnabled(appsettings->value(this,  GC_SETTINGS_MAIN_SIDEBAR "plan", defaultAppearance.sideplan).toBool());
+    QString path = QString(GC_SETTINGS_MAIN_SIDEBAR) + internalName;
+    setSidebarEnabled(appsettings->value(this, path, defaultAppearance.sideplan).toBool());
 
     pstack = new QStackedWidget(this);
     setPages(pstack);
@@ -265,7 +268,8 @@ PlanView::PlanView(Context *context, QStackedWidget *controls) :
 
 PlanView::~PlanView()
 {
-    appsettings->setValue(GC_SETTINGS_MAIN_SIDEBAR "plan", _sidebar);
+    QString path = QString(GC_SETTINGS_MAIN_SIDEBAR) + internalName;
+    appsettings->setValue(path, _sidebar);
 }
 
 bool
@@ -276,7 +280,7 @@ PlanView::isBlank()
 }
 
 TrendsView::TrendsView(Context *context, QStackedWidget *controls) :
-        LTMSidebarView(context, GcViewType::VIEW_TRENDS, "home", tr("Compare Date Ranges"))
+        LTMSidebarView(context, GcViewType::VIEW_TRENDS, internalName, tr("Compare Date Ranges"))
 {
     BlankStateHomePage *b = new BlankStateHomePage(context);
 
@@ -285,6 +289,7 @@ TrendsView::TrendsView(Context *context, QStackedWidget *controls) :
     controls->addWidget(cstack);
     controls->setCurrentIndex(0);
 
+    // note: "trend" differs from the normal internalName usage for sidebar settings
     setSidebarEnabled(appsettings->value(this,  GC_SETTINGS_MAIN_SIDEBAR "trend", defaultAppearance.sidetrend).toBool());
 
     pstack = new QStackedWidget(this);
@@ -298,6 +303,7 @@ TrendsView::TrendsView(Context *context, QStackedWidget *controls) :
 
 TrendsView::~TrendsView()
 {
+    // note: "trend" differs from the normal internalName usage for sidebar settings
     appsettings->setValue(GC_SETTINGS_MAIN_SIDEBAR "trend", _sidebar);
 }
 
@@ -342,7 +348,7 @@ TrendsView::isBlank()
 }
 
 TrainView::TrainView(Context *context, QStackedWidget *controls) :
-        AbstractView(context, GcViewType::VIEW_TRAIN, "train", tr("Intensity Adjustments and Workout Control"))
+        AbstractView(context, GcViewType::VIEW_TRAIN, internalName, tr("Intensity Adjustments and Workout Control"))
 {
     trainTool = new TrainSidebar(context);
     trainTool->setTrainView(this);
@@ -364,7 +370,8 @@ TrainView::TrainView(Context *context, QStackedWidget *controls) :
     setBottom(trainBottom);
     setHideBottomOnIdle(false);
 
-    setSidebarEnabled(appsettings->value(NULL,  GC_SETTINGS_MAIN_SIDEBAR "train", defaultAppearance.sidetrain).toBool());
+    QString path = QString(GC_SETTINGS_MAIN_SIDEBAR) + internalName;
+    setSidebarEnabled(appsettings->value(NULL, path, defaultAppearance.sidetrain).toBool());
     connect(this, SIGNAL(onSelectionChanged()), this, SLOT(onSelectionChanged()));
     connect(trainBottom, SIGNAL(autoHideChanged(bool)), this, SLOT(onAutoHideChanged(bool)));
 }
@@ -376,7 +383,8 @@ void TrainView::onAutoHideChanged(bool enabled)
 
 TrainView::~TrainView()
 {
-    appsettings->setValue(GC_SETTINGS_MAIN_SIDEBAR "train", _sidebar);
+    QString path = QString(GC_SETTINGS_MAIN_SIDEBAR) + internalName;
+    appsettings->setValue(path, _sidebar);
     delete trainTool;
 }
 

--- a/src/Gui/Views.h
+++ b/src/Gui/Views.h
@@ -51,7 +51,7 @@ class LTMSidebarView : public AbstractView
 
     protected:
 
-        LTMSidebarView(Context *context, int type, const QString& view, const QString& heading);
+        LTMSidebarView(Context *context, GcViewType viewType, const QString& view, const QString& heading);
         virtual ~LTMSidebarView();
 
         void showEvent(QShowEvent*) override;
@@ -77,6 +77,8 @@ class AnalysisView : public AbstractView
         void close() override;
         void setRide(RideItem*ride) override;
         void addIntervals();
+
+        QString viewTypeDesc() const override { return "Analysis"; }
 
         RideNavigator *rideNavigator();
         AnalysisSidebar *analSidebar;
@@ -106,6 +108,8 @@ class PlanView : public LTMSidebarView
         PlanView(Context *context, QStackedWidget *controls);
         virtual ~PlanView();
 
+        QString viewTypeDesc() const override { return "Diary"; }
+
     public slots:
 
         bool isBlank() override;
@@ -120,6 +124,8 @@ class TrainView : public AbstractView
         TrainView(Context *context, QStackedWidget *controls);
         virtual ~TrainView();
         void close() override;
+
+        QString viewTypeDesc() const override { return "Train"; }
 
     public slots:
 
@@ -147,6 +153,8 @@ class TrendsView : public LTMSidebarView
 
         TrendsView(Context *context, QStackedWidget *controls);
         virtual ~TrendsView();
+
+        QString viewTypeDesc() const override { return "Trends"; }
 
         int countActivities(Perspective *, DateRange dr);
 

--- a/src/Gui/Views.h
+++ b/src/Gui/Views.h
@@ -78,7 +78,12 @@ class AnalysisView : public AbstractView
         void setRide(RideItem*ride) override;
         void addIntervals();
 
-        QString viewTypeDesc() const override { return "Analysis"; }
+        // the view's user name must be translated for display
+        static constexpr const char* userName = "Activities";
+        QString viewsUserName() const override { return userName; }
+
+        static constexpr const char* internalName = "analysis";
+        QString viewsInternalName() const override { return internalName; }
 
         RideNavigator *rideNavigator();
         AnalysisSidebar *analSidebar;
@@ -108,7 +113,12 @@ class PlanView : public LTMSidebarView
         PlanView(Context *context, QStackedWidget *controls);
         virtual ~PlanView();
 
-        QString viewTypeDesc() const override { return "Diary"; }
+        // the view's user name must be translated for display
+        static constexpr const char* userName = "Plan";
+        QString viewsUserName() const override { return userName; }
+
+        static constexpr const char* internalName = "plan";
+        QString viewsInternalName() const override { return internalName; }
 
     public slots:
 
@@ -125,7 +135,12 @@ class TrainView : public AbstractView
         virtual ~TrainView();
         void close() override;
 
-        QString viewTypeDesc() const override { return "Train"; }
+        // the view's user name must be translated for display
+        static constexpr const char* userName = "Train";
+        QString viewsUserName() const override { return userName; }
+
+        static constexpr const char* internalName = "train";
+        QString viewsInternalName() const override { return internalName; }
 
     public slots:
 
@@ -154,7 +169,12 @@ class TrendsView : public LTMSidebarView
         TrendsView(Context *context, QStackedWidget *controls);
         virtual ~TrendsView();
 
-        QString viewTypeDesc() const override { return "Trends"; }
+        // the view's user name must be translated for display
+        static constexpr const char* userName = "Trends";
+        QString viewsUserName() const override { return userName; }
+
+        static constexpr const char* internalName = "home";
+        QString viewsInternalName() const override { return internalName; }
 
         int countActivities(Perspective *, DateRange dr);
 

--- a/src/R/RTool.cpp
+++ b/src/R/RTool.cpp
@@ -2567,7 +2567,7 @@ RTool::dfForDateRangeMeanmax(bool all, DateRange range, SEXP filter)
     UNPROTECT(1);
 
     // apply perspective filter if trends view and filtered
-    if (rtool->perspective && rtool->perspective->type() == VIEW_TRENDS && rtool->perspective->isFiltered()) {
+    if (rtool->perspective && rtool->perspective->viewType() == GcViewType::VIEW_TRENDS && rtool->perspective->isFiltered()) {
         filt = true;
         filelist << rtool->perspective->filterlist(DateRange(range));
     }

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -241,7 +241,7 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
 #endif
 
     connect(context, SIGNAL(newLap()), this, SLOT(resetLapTimer()));
-    connect(context, SIGNAL(viewChanged(int)), this, SLOT(viewChanged(int)));
+    connect(context, SIGNAL(viewChanged(GcViewType)), this, SLOT(viewChanged(GcViewType)));
 
     // workout filters
     connect(context, SIGNAL(workoutFiltersChanged(QList<ModelFilter*>&)), this, SLOT(workoutFiltersChanged(QList<ModelFilter*>&)));
@@ -1739,8 +1739,7 @@ void TrainSidebar::Connect()
     //qDebug() << "current tab:" << context->tab->currentView();
 
     // only try and connect if we are in train view..
-    // fixme: these values are hard-coded throughout
-    if (!(context->tab->currentView() == 3)) return;
+    if (context->tab->currentViewType() != GcViewType::VIEW_TRAIN) return;
 
     if (status&RT_CONNECTED) return; // already connected
 
@@ -3456,17 +3455,16 @@ void TrainSidebar::vo2Data(double rf, double rmv, double vo2, double vco2, doubl
 
 // connect/disconnect automatically when view changes
 void
-TrainSidebar::viewChanged(int index)
+TrainSidebar::viewChanged(GcViewType viewType)
 {
-    //qDebug() << "view has changed to:" << index;
+    //qDebug() << "view has changed to:" << static_cast<int>(viewType);
 
     // ensure buttons reflect current state
     setStatusFlags(0);
 
     if (!autoConnect) return;
 
-    // fixme: value hard-coded throughout
-    if (index == 3) {
+    if (viewType == GcViewType::VIEW_TRAIN) {
         //train view
         if ((status&RT_CONNECTED) == 0) {
             Connect();

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -326,7 +326,7 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
     trainSplitter->addWidget(videosyncItem);
 #endif //USE_RLV
 #endif //GC_VIDEO_NONE
-    trainSplitter->prepare(context->athlete->cyclist, "train");
+    trainSplitter->prepare(context->athlete->cyclist, TrainView::internalName);
 
 #ifdef Q_OS_MAC
     // get rid of annoying focus rectangle for sidebar components

--- a/src/Train/TrainSidebar.h
+++ b/src/Train/TrainSidebar.h
@@ -164,7 +164,7 @@ class TrainSidebar : public GcWindow
         void removeInvalidVideoSync();
         void removeInvalidWorkout();
 
-        void viewChanged(int index);
+        void viewChanged(GcViewType index);
 
         int  getCalibrationIndex(void);
 


### PR DESCRIPTION
Please find a fixed version of the combined view indexes and view relevance definitions

I can only apologise for the chart export/import error (https://groups.google.com/g/golden-cheetah-developers/c/kqK_RuzhOuQ/m/By8_kO0dBgAJ), as I was away for three weeks it was very frustrating not having the opportunity to fix this issue, and understand why it was reverted.

I have updated the PR (second commit) to avoid confusion over internal and external view names (they are now defined for each view in Views.h), please take a look, as I'd rather this work wasn't wasted. 

