### PR TITLE
Fix crash when updating power zones

### DIFF
--- a/src/Core/RideCache.cpp
+++ b/src/Core/RideCache.cpp
@@ -534,14 +534,35 @@ RideCache::nextRefresh()
     return(returning);
 }
 
+
+RideCacheRefreshThread::RideCacheRefreshThread(RideCache *cache)
+: cache(cache)
+{
+    QPointer<RideCacheRefreshThread> weakSelf(this);
+    connect(this, &QThread::finished, cache, [weakSelf, c = QPointer<RideCache>(cache)]() {
+        if (weakSelf && c) {
+            c->cleanupThread(weakSelf.data());
+        }
+    }, Qt::QueuedConnection);
+}
+
+void
+RideCache::cleanupThread(RideCacheRefreshThread *thread)
+{
+    thread->wait();
+    delete thread;
+}
+
 void
 RideCache::threadCompleted(RideCacheRefreshThread*thread)
 {
     updateMutex.lock();
     refreshThreads.removeOne(thread);
+    bool isLast = refreshThreads.isEmpty();
+    bool cancelled = isCancelled;
     updateMutex.unlock();
 
-    if (refreshThreads.count() == 0) {
+    if (isLast && ! cancelled) {
         //fprintf(stderr,"refresh ended\n"); fflush(stderr);
         context->notifyRefreshEnd();
         garbageCollect();
@@ -567,16 +588,24 @@ void
 RideCache::cancel()
 {
     updateMutex.lock();
-    QVector<RideCacheRefreshThread*>current = refreshThreads;
-    updates=-1;
+    QVector<RideCacheRefreshThread*> current = refreshThreads;
+    updates = -1;
+    isCancelled = true;
     updateMutex.unlock();
 
     // wait till threads are empty, but use our copy as the master
     // is going to be changing as threads terminate and we need to be
     // sure all our threads have stopped before returning.
-    foreach(RideCacheRefreshThread *thread, current) {
+    for (RideCacheRefreshThread *thread : current) {
+        thread->requestInterruption();
+        disconnect(thread, &QThread::finished, nullptr, nullptr);
         thread->wait();
+        delete thread;
     }
+
+    updateMutex.lock();
+    isCancelled = false;
+    updateMutex.unlock();
 }
 
 // check if we need to refresh the metrics then start the thread if needed
@@ -1813,24 +1842,28 @@ bool
 RideCache::updateFromWorkoutAfter
 (const QDate &when, bool autoSave)
 {
+    cancel();
+
     QList<RideItem*> changedItems;
-    for (RideItem *item : context->athlete->rideCache->rides()) {
-        if (item->planned && item->dateTime.date() >= when) {
-            if (context->athlete->rideCache->updateFromWorkout(item, false)) {
+    for (RideItem *item : rides()) {
+        if (   item
+            && item->planned
+            && item->dateTime.date() >= when) {
+            if (updateFromWorkout(item, false)) {
                 changedItems << item;
             }
         }
     }
-    if (changedItems.count() > 0) {
+
+    if (! changedItems.isEmpty()) {
         if (autoSave) {
             QString error;
             saveActivities(changedItems, error);
         }
-        cancel();
         refresh();
         estimator->refresh();
     }
-    return changedItems.count() > 0;
+    return ! changedItems.isEmpty();
 }
 
 
@@ -1909,26 +1942,35 @@ RideCache::copyPlannedRideFile
 // refresh metrics
 void RideCacheRefreshThread::run()
 {
-    //fprintf(stderr, "worker thread starts!\n"); fflush(stderr);
-    while (1) {
-
+    while (! isInterruptionRequested()) {
         int n = cache->nextRefresh();
         //fprintf(stderr, "refreshing %d of %d\n", n+1, cache->reverse_.count()); fflush(stderr);
-        if (n<0) {
+        if (n < 0) {
             //fprintf(stderr, "worker thread exits!\n"); fflush(stderr);
             goto exitthread;
         }
 
-        // we have one to do
-        RideItem *item = cache->reverse_[n];
-        if(item->isstale) {
+        if (isInterruptionRequested()) {
+            goto exitthread;
+        }
+
+        RideItem *item = nullptr;
+        {
+            QMutexLocker locker(&cache->updateMutex);
+            if (n < cache->reverse_.count()) {
+                item = cache->reverse_[n];
+            }
+        }
+
+        if (item && item->isstale) {
             item->refresh();
-            if (item == item->context->currentRideItem())
+            if (item == item->context->currentRideItem()) {
                 item->context->notifyRideChanged(item);
+            }
         }
     }
-
 exitthread:
-    cache->threadCompleted(this);
-    return;
+    if (cache) {
+        cache->threadCompleted(this);
+    }
 }

--- a/src/Core/RideCache.h
+++ b/src/Core/RideCache.h
@@ -27,6 +27,7 @@
 
 #include <QVector>
 #include <QThread>
+#include <QPointer>
 
 #include <QFuture>
 #include <QFutureWatcher>
@@ -160,6 +161,9 @@ class RideCache : public QObject
         void postLoad();
         void save(bool opendata=false, QString filename="");
 
+        // clean up refresh threads
+        void cleanupThread(RideCacheRefreshThread *thread);
+
         // find entry quickly
         int find(RideItem *);
 
@@ -221,6 +225,8 @@ class RideCache : public QObject
         bool renameRideFiles(const QString& oldFileName, const QString& newFileName, bool isPlanned, QString &error);
         bool isValidLink(RideItem *item1, RideItem *item2, QString &error);
         RideItem* copyPlannedRideFile(RideItem *sourceItem, const QDate &newDate, const QTime &newTime, QString &error);
+
+        bool isCancelled = false;
 };
 
 class AthleteBest
@@ -237,7 +243,7 @@ class AthleteBest
 class RideCacheRefreshThread : public QThread
 {
     public:
-        RideCacheRefreshThread(RideCache *cache) : cache(cache) {}
+        RideCacheRefreshThread(RideCache *cache);
 
     protected:
 
@@ -245,7 +251,7 @@ class RideCacheRefreshThread : public QThread
         virtual void run() override;
 
     private:
-        RideCache *cache;
+        QPointer<RideCache> cache;
 };
 
 #endif // _GC_RideCache_h

--- a/src/Metrics/RideMetadata.h
+++ b/src/Metrics/RideMetadata.h
@@ -22,6 +22,7 @@
 
 #include "Context.h"
 
+#include <QPointer>
 #include <QWidget>
 #include <QLabel>
 #include <QCheckBox>
@@ -180,7 +181,8 @@ class RideMetadata : public QWidget
     Q_OBJECT
     G_OBJECT
     Q_PROPERTY(RideItem *ride READ rideItem WRITE setRideItem)
-    RideItem *_ride, *_connected;
+    QPointer<RideItem> _ride;
+    QPointer<RideItem> _connected;
 
     public:
         RideMetadata(Context *, bool singlecolumn = false);


### PR DESCRIPTION
* Deleting RideCacheRefreshThreads after they finish
* Added option to cancel / interrupt RideCacheRefreshThreads
* Introduced QPointers to prevent use after free
* Canceling all RideCacheRefreshThreads before updating activities from Workout

```
#0  0x000055656d54dbf0 in RideCache::updateFromWorkoutAfter(QDate const&, bool) ()
[Current thread is 1 (Thread 0x7f6c0c0a62c0 (LWP 113812))]
(gdb) backtrace 
#0  0x000055656d54dbf0 in RideCache::updateFromWorkoutAfter(QDate const&, bool) ()
#1  0x000055656d765908 in LTMSidebar::configChanged(int) ()
#2  0x00007f6c12a04d99 in ??? () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#3  0x000055656db757c5 in Context::configChanged(int) ()
#4  0x000055656d4daa2c in Context::notifyConfigChanged(int) ()
#5  0x000055656d83dc2d in AthleteConfigDialog::saveClicked() ()
#6  0x00007f6c12a04ea1 in ??? () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#7  0x00007f6c209cac88 in ??? () at /usr/lib/x86_64-linux-gnu/libQt6Widgets.so.6
#8  0x00007f6c12a04ea1 in ??? () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#9  0x00007f6c208f482b in QAbstractButton::clicked(bool) () at /usr/lib/x86_64-linux-gnu/libQt6Widgets.so.6
```