### PR TITLE
Queueing RideCache::save and executing in dedicated thread

### DIFF
--- a/src/Core/RideCache.cpp
+++ b/src/Core/RideCache.cpp
@@ -146,6 +146,11 @@ RideCache::RideCache(Context *context) : context(context)
     connect(rideCacheLoader, SIGNAL(finished()), this, SLOT(postLoad()));
     connect(rideCacheLoader, SIGNAL(finished()), this, SIGNAL(loadComplete()));
     rideCacheLoader->start();
+
+    saveThread_ = new QThread(this);
+    saveWorker_ = new QObject();
+    saveWorker_->moveToThread(saveThread_);
+    saveThread_->start();
 }
 
 void
@@ -197,6 +202,10 @@ RideCache::~RideCache()
 
     // cancel any refresh that may be running
     cancel();
+
+    saveThread_->quit();
+    saveThread_->wait();
+    delete saveWorker_;
 
     // save to store
     save();
@@ -566,7 +575,9 @@ RideCache::threadCompleted(RideCacheRefreshThread*thread)
         //fprintf(stderr,"refresh ended\n"); fflush(stderr);
         context->notifyRefreshEnd();
         garbageCollect();
-        save();
+        QMetaObject::invokeMethod(saveWorker_, [this]() {
+            save();
+        }, Qt::QueuedConnection);
     }
 }
 

--- a/src/Core/RideCache.h
+++ b/src/Core/RideCache.h
@@ -227,6 +227,8 @@ class RideCache : public QObject
         RideItem* copyPlannedRideFile(RideItem *sourceItem, const QDate &newDate, const QTime &newTime, QString &error);
 
         bool isCancelled = false;
+        QThread *saveThread_ = nullptr;
+        QObject *saveWorker_ = nullptr;
 };
 
 class AthleteBest


### PR DESCRIPTION
Followup to #4864, fixing a crash I experienced when deleting multiple planned activities.

```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007f820dca80a0 in QDateTime::Data::timeZone() const () from /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
[Current thread is 1 (Thread 0x7f81367fc6c0 (LWP 316095))]
(gdb) backtrace 
#0  0x00007f820dca80a0 in QDateTime::Data::timeZone() const () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#1  0x00007f820dca80cf in QDateTime::timeRepresentation() const () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#2  0x00007f820dcac7af in QDateTime::toTimeZone(QTimeZone const&) const () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#3  0x00007f820dcaca4e in QDateTime::toUTC() const () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#4  0x000055ecb1141bfe in RideCache::save(bool, QString) ()
#5  0x000055ecb0ab2c82 in RideCache::threadCompleted(RideCacheRefreshThread*) ()
#6  0x00007f820dd2e01b in ??? () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#7  0x00007f820e0a2da9 in start_thread (arg=<optimized out>) at ./nptl/pthread_create.c:448
#8  0x00007f820e121e08 in __GI___clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78
```