### PR TITLE
Fix crash in saveAllFilesSIlent

### DIFF
--- a/src/Gui/SaveDialogs.cpp
+++ b/src/Gui/SaveDialogs.cpp
@@ -214,7 +214,9 @@ MainWindow::saveSilent(Context *context, RideItem *rideItem)
 void
 MainWindow::saveAllFilesSilent(Context *context)
 {
-    for (RideItem *rideItem : context->athlete->rideCache->rides()) {
+    // iterate over snapshot of rides to prevent crash by iterator invalidation
+    const QList<RideItem*> snapshot = context->athlete->rideCache->rides().toList();
+    for (RideItem *rideItem : snapshot) {
         if (rideItem->isDirty()) {
             this->saveRideSingleDialog(context, rideItem);
         }


### PR DESCRIPTION
Iterate over snapshot of rides to prevent crash by iterator invalidation

Trace:
```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x000055b0ad8b62cc in MainWindow::saveAllFilesSilent(Context*) ()
[Current thread is 1 (Thread 0x7f9a3fc842c0 (LWP 755277))]
(gdb) backtrace 
#0  0x000055b0ad8b62cc in MainWindow::saveAllFilesSilent(Context*) ()
#1  0x00007f9a46604ea1 in ??? () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#2  0x00007f9a473a044b in QAction::triggered(bool) () at /usr/lib/x86_64-linux-gnu/libQt6Gui.so.6
#3  0x00007f9a473a7c90 in QAction::activate(QAction::ActionEvent) () at /usr/lib/x86_64-linux-gnu/libQt6Gui.so.6
#4  0x00007f9a545ae904 in ??? () at /usr/lib/x86_64-linux-gnu/libQt6Widgets.so.6
#5  0x00007f9a545b3a71 in ??? () at /usr/lib/x86_64-linux-gnu/libQt6Widgets.so.6
#6  0x00007f9a544120f7 in QWidget::event(QEvent*) () at /usr/lib/x86_64-linux-gnu/libQt6Widgets.so.6
#7  0x00007f9a543bd5f8 in QApplicationPrivate::notify_helper(QObject*, QEvent*) () at /usr/lib/x86_64-linux-gnu/libQt6Widgets.so.6
#8  0x00007f9a543c22a6 in QApplication::notify(QObject*, QEvent*) () at /usr/lib/x86_64-linux-gnu/libQt6Widgets.so.6
#9  0x00007f9a465abe08 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#10 0x00007f9a543b498b in QApplicationPrivate::sendMouseEvent(QWidget*, QMouseEvent*, QWidget*, QWidget*, QWidget**, QPointer<QWidget>&, bool, bool) ()
    at /usr/lib/x86_64-linux-gnu/libQt6Widgets.so.6
#11 0x00007f9a5442febd in ??? () at /usr/lib/x86_64-linux-gnu/libQt6Widgets.so.6
#12 0x00007f9a54432f70 in ??? () at /usr/lib/x86_64-linux-gnu/libQt6Widgets.so.6
#13 0x00007f9a543bd5f8 in QApplicationPrivate::notify_helper(QObject*, QEvent*) () at /usr/lib/x86_64-linux-gnu/libQt6Widgets.so.6
#14 0x00007f9a465abe08 in QCoreApplication::notifyInternal2(QObject*, QEvent*) () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#15 0x00007f9a46ffa87d in QGuiApplicationPrivate::processMouseEvent(QWindowSystemInterfacePrivate::MouseEvent*) () at /usr/lib/x86_64-linux-gnu/libQt6Gui.so.6
#16 0x00007f9a4705909b in QWindowSystemInterface::sendWindowSystemEvents(QFlags<QEventLoop::ProcessEventsFlag>) () at /usr/lib/x86_64-linux-gnu/libQt6Gui.so.6
#17 0x00007f9a3f1ec57e in ??? () at /usr/lib/x86_64-linux-gnu/libQt6XcbQpa.so.6
#18 0x00007f9a43c5f66e in ??? () at /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0
#19 0x00007f9a43c629ff in ??? () at /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0
#20 0x00007f9a43c63190 in g_main_context_iteration () at /usr/lib/x86_64-linux-gnu/libglib-2.0.so.0
#21 0x00007f9a46818cf8 in QEventDispatcherGlib::processEvents(QFlags<QEventLoop::ProcessEventsFlag>) () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#22 0x00007f9a465b4ada in QEventLoop::exec(QFlags<QEventLoop::ProcessEventsFlag>) () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#23 0x00007f9a465ae921 in QCoreApplication::exec() () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#24 0x000055b0ad1a5890 in main ()
```