### PR TITLE
Fix crash in TreeMapPlot: Prevent div-by-zero

### DIFF
--- a/src/Charts/TreeMapPlot.cpp
+++ b/src/Charts/TreeMapPlot.cpp
@@ -86,8 +86,13 @@ TreeMapPlot::setData(TMSettings *settings)
 void
 TreeMapPlot::resizeEvent(QResizeEvent *)
 {
+    static constexpr int margin = 9;
     // layout the map
-    if (root) root->layout(QRect(9,9,geometry().width()-18, geometry().height()-18));
+    if (   root
+        && geometry().width() > 2 * margin
+        && geometry().height() > 2 * margin) {
+        root->layout(QRect(margin, margin, geometry().width() - 2 * margin, geometry().height() - 2 * margin));
+    }
 }
 
 

--- a/src/Charts/TreeMapPlot.h
+++ b/src/Charts/TreeMapPlot.h
@@ -137,6 +137,9 @@ class TreeMap
 
             double total=0;
             for(int i=start; i<=end; i++) total += items[i]->value;
+            if (! (total > 0.0)) {
+                return;
+            }
             int mid=start;
             double a=items[start]->value/total;
             double b=a;
@@ -195,6 +198,9 @@ class TreeMap
             // setup
             double total=0, accumulator=0; // total value of items and running total
             for(int i= start; i<= end && i<items.count(); i++) total += items[i]->value;
+            if (! (total > 0.0)) {
+                return;
+            }
             Qt::Orientation orientation = (bounds.width() > bounds.height()) ? Qt::Horizontal : Qt::Vertical;
 
             // slice em up!


### PR DESCRIPTION
Trace:
```
Thread 1 "GoldenCheetah" received signal SIGABRT, Aborted.
__pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:44
⚠ warning: 44  ./nptl/pthread_kill.c: Datei oder Verzeichnis nicht gefunden
(gdb) 
(gdb) backtrace 
#0  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at ./nptl/pthread_kill.c:44
#1  0x00007fffe90a4dbf in __pthread_kill_internal (threadid=<optimized out>, signo=6) at ./nptl/pthread_kill.c:89
#2  0x00007fffe904dd02 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#3  0x00007fffe90354b2 in __GI_abort () at ./stdlib/abort.c:77
#4  0x00007fffe8adf9e3 in ??? () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#5  0x00007fffe8ae0511 in QMessageLogger::fatal(char const*, ...) const () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#6  0x00007fffe8add4be in qt_assert_x(char const*, char const*, char const*, int) () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#7  0x000055555581fda4 in QtPrivate::QCheckedIntegers::AssertReportPolicy::check
    (ok=false, where=0x555556643660 "constexpr QtPrivate::QCheckedIntegers::QCheckedInt<int> QtPrivate::QCheckedIntegers::operator+(QCheckedInt<int>, QCheckedInt<int>)", description=0x555556643643 "Overflow in operator+") at /usr/include/x86_64-linux-gnu/qt6/QtCore/qcheckedint_impl.h:69
#8  0x0000555555820ad0 in QtPrivate::QCheckedIntegers::operator+ (lhs=..., rhs=...) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qcheckedint_impl.h:152
#9  0x0000555555820b79 in QtPrivate::QCheckedIntegers::operator+<int, true> (lhs=..., rhs=-2147483648) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qcheckedint_impl.h:159
#10 0x0000555555c15d3f in QRect::setHeight (this=0x555562c59790, h=-2147483648) at /usr/include/x86_64-linux-gnu/qt6/QtCore/qrect.h:410
#11 0x0000555555c16f2c in TreeMap::slicelayout (this=0x555562c6a6b0, items=..., start=0, end=0, bounds=...) at Charts/TreeMapPlot.h:209
#12 0x0000555555c1664b in TreeMap::layout (this=0x555562c6a6b0, items=..., start=0, end=0, bounds=...) at Charts/TreeMapPlot.h:127
#13 0x0000555555c164a0 in TreeMap::squarifyLayout (this=0x555562c6a6b0, items=..., bounds=...) at Charts/TreeMapPlot.h:115
#14 0x0000555555c16514 in TreeMap::squarifyLayout (this=0x555562b29bb0, items=..., bounds=...) at Charts/TreeMapPlot.h:117
#15 0x0000555555c1633c in TreeMap::layout (this=0x555562b29bb0, rect=...) at Charts/TreeMapPlot.h:102
#16 0x0000555555c14c36 in TreeMapPlot::resizeEvent (this=0x555562b29820) at Charts/TreeMapPlot.cpp:90
#17 0x0000555555c14acf in TreeMapPlot::setData (this=0x555562b29820, settings=0x55555ab15310) at Charts/TreeMapPlot.cpp:81
#18 0x0000555555c1bc03 in TreeMapWindow::refreshPlot (this=0x55555ab15110) at Charts/TreeMapWindow.cpp:187
#19 0x0000555555c1c7f3 in TreeMapWindow::refresh (this=0x55555ab15110) at Charts/TreeMapWindow.cpp:263
#20 0x0000555555c1caa4 in TreeMapWindow::dateRangeChanged (this=0x55555ab15110) at Charts/TreeMapWindow.cpp:277
#21 0x0000555555c1be86 in TreeMapWindow::useThruToday (this=0x55555ab15110) at Charts/TreeMapWindow.cpp:215
#22 0x0000555556522208 in TreeMapWindow::qt_static_metacall (_o=0x55555ab15110, _c=QMetaObject::InvokeMetaMethod, _id=9, _a=0x7fffffff8878) at .moc/moc_TreeMapWindow.cpp:151
#23 0x00007fffe8c04d99 in ??? () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
#24 0x000055555653b817 in DateSettingsEdit::useThruToday (this=0x555562cb22c0) at .moc/moc_TimeUtils.cpp:141
#25 0x0000555555dd6c48 in DateSettingsEdit::setDateSettings (this=0x555562cb22c0) at Core/TimeUtils.cpp:371
#26 0x000055555653b5b1 in DateSettingsEdit::qt_static_metacall (_o=0x555562cb22c0, _c=QMetaObject::InvokeMetaMethod, _id=3, _a=0x7fffffff8d30) at .moc/moc_TimeUtils.cpp:87
#27 0x00007fffe8c04d99 in ??? () at /usr/lib/x86_64-linux-gnu/libQt6Core.so.6
```