### PR TITLE
Calendar: Set the minimum number of visible minutes per activity

### DIFF
--- a/src/Charts/CalendarWindow.cpp
+++ b/src/Charts/CalendarWindow.cpp
@@ -296,6 +296,7 @@ CalendarWindow::CalendarWindow(Context *context)
 
     setStartHour(8);
     setEndHour(21);
+    setMinVisibleMins(0);
     setShowSecondaryLabel(true);
     setSummaryIncludePlanned(0);
 
@@ -541,6 +542,25 @@ CalendarWindow::setEndHour
     startHourSpin->setMaximum(hour - 1);
     if (calendar != nullptr) {
         calendar->setEndHour(hour);
+        updateActivities();
+    }
+}
+
+
+int
+CalendarWindow::getMinVisibleMins
+() const
+{
+    return minVisibleMinsSpin->value();
+}
+
+
+void
+CalendarWindow::setMinVisibleMins
+(int mins)
+{
+    minVisibleMinsSpin->setValue(mins);
+    if (calendar != nullptr) {
         updateActivities();
     }
 }
@@ -830,6 +850,10 @@ CalendarWindow::mkControls
     endHourSpin = new QSpinBox();
     endHourSpin->setSuffix(":00");
     endHourSpin->setMaximum(24);
+    minVisibleMinsSpin = new QSpinBox();
+    minVisibleMinsSpin->setRange(0, 120);
+    minVisibleMinsSpin->setSingleStep(15);
+    minVisibleMinsSpin->setSuffix(" " + tr("mins"));
     includePlannedCombo = new QComboBox();
     includePlannedCombo->addItem(tr("Always"), QVariant::fromValue(PlanFilterType::IncludeAll));
     includePlannedCombo->addItem(tr("If upcoming or missed"), QVariant::fromValue(PlanFilterType::IncludeIfUpcomingOrMissed));
@@ -866,6 +890,7 @@ CalendarWindow::mkControls
     generalForm->addRow(new QLabel(HLO + tr("Calendar Basics") + HLC));
     generalForm->addRow(tr("Startup View"), defaultViewCombo);
     generalForm->addRow(tr("First Day of Week"), firstDayOfWeekCombo);
+    generalForm->addRow(tr("Minimum Display Duration"), minVisibleMinsSpin);
     generalForm->addItem(new QSpacerItem(0, 20 * dpiYFactor));
     generalForm->addRow(new QLabel(HLO + tr("Default Times") + HLC));
     generalForm->addRow(tr("Default Start Time"), startHourSpin);
@@ -897,6 +922,7 @@ CalendarWindow::mkControls
 
     connect(startHourSpin, &QSpinBox::valueChanged, this, &CalendarWindow::setStartHour);
     connect(endHourSpin, &QSpinBox::valueChanged, this, &CalendarWindow::setEndHour);
+    connect(minVisibleMinsSpin, &QSpinBox::valueChanged, this, &CalendarWindow::setMinVisibleMins);
     connect(defaultViewCombo, &QComboBox::currentIndexChanged, this, &CalendarWindow::setDefaultView);
     connect(firstDayOfWeekCombo, &QComboBox::currentIndexChanged, this, [this](int idx) { setFirstDayOfWeek(idx + 1); });
     connect(primaryMainCombo, &QComboBox::currentIndexChanged, this, &CalendarWindow::updateActivities);
@@ -1058,6 +1084,7 @@ CalendarWindow::getActivities
         activity.reference = rideItem->fileName;
         activity.start = rideItem->dateTime.time();
         activity.durationSecs = rideItem->getForSymbol("workout_time", GlobalContext::context()->useMetricUnits);
+        activity.visibleSecs = std::min(std::max(activity.durationSecs, getMinVisibleMins() * 60), activity.start.secsTo(QTime(23, 59, 59)));
         activity.type = rideItem->planned ? ENTRY_TYPE_PLANNED_ACTIVITY : ENTRY_TYPE_ACTUAL_ACTIVITY;
         activity.isRelocatable = rideItem->planned;
         activity.hasTrainMode = rideItem->planned && sport == "Bike" && ! buildWorkoutFilter(rideItem).isEmpty();

--- a/src/Charts/CalendarWindow.cpp
+++ b/src/Charts/CalendarWindow.cpp
@@ -1084,7 +1084,11 @@ CalendarWindow::getActivities
         activity.reference = rideItem->fileName;
         activity.start = rideItem->dateTime.time();
         activity.durationSecs = rideItem->getForSymbol("workout_time", GlobalContext::context()->useMetricUnits);
-        activity.visibleSecs = std::min(std::max(activity.durationSecs, getMinVisibleMins() * 60), activity.start.secsTo(QTime(23, 59, 59)));
+        if (calendar->currentView() == CalendarView::Day || calendar->currentView() == CalendarView::Week) {
+            activity.visibleSecs = std::min(std::max(activity.durationSecs, getMinVisibleMins() * 60), activity.start.secsTo(QTime(23, 59, 59)));
+        } else {
+            activity.visibleSecs = activity.durationSecs;
+        }
         activity.type = rideItem->planned ? ENTRY_TYPE_PLANNED_ACTIVITY : ENTRY_TYPE_ACTUAL_ACTIVITY;
         activity.isRelocatable = rideItem->planned;
         activity.hasTrainMode = rideItem->planned && sport == "Bike" && ! buildWorkoutFilter(rideItem).isEmpty();

--- a/src/Charts/CalendarWindow.h
+++ b/src/Charts/CalendarWindow.h
@@ -79,6 +79,7 @@ class CalendarWindow : public GcChartWindow
     Q_PROPERTY(int firstDayOfWeek READ getFirstDayOfWeek WRITE setFirstDayOfWeek USER true)
     Q_PROPERTY(int startHour READ getStartHour WRITE setStartHour USER true)
     Q_PROPERTY(int endHour READ getEndHour WRITE setEndHour USER true)
+    Q_PROPERTY(int minVisibleMins READ getMinVisibleMins WRITE setMinVisibleMins USER true)
     Q_PROPERTY(int summaryIncludePlanned READ getSummaryIncludePlanned WRITE setSummaryIncludePlanned USER true)
     Q_PROPERTY(bool summaryVisibleDay READ isSummaryVisibleDay WRITE setSummaryVisibleDay USER true)
     Q_PROPERTY(bool summaryVisibleWeek READ isSummaryVisibleWeek WRITE setSummaryVisibleWeek USER true)
@@ -97,6 +98,7 @@ class CalendarWindow : public GcChartWindow
         int getFirstDayOfWeek() const;
         int getStartHour() const;
         int getEndHour() const;
+        int getMinVisibleMins() const;
         int getSummaryIncludePlanned() const;
         bool isSummaryVisibleDay() const;
         bool isSummaryVisibleWeek() const;
@@ -117,6 +119,7 @@ class CalendarWindow : public GcChartWindow
         void setFirstDayOfWeek(int fdw);
         void setStartHour(int hour);
         void setEndHour(int hour);
+        void setMinVisibleMins(int mins);
         void setSummaryIncludePlanned(int type);
         void setSummaryVisibleDay(bool visible);
         void setSummaryVisibleWeek(bool visible);
@@ -142,6 +145,7 @@ class CalendarWindow : public GcChartWindow
         QComboBox *firstDayOfWeekCombo;
         QSpinBox *startHourSpin;
         QSpinBox *endHourSpin;
+        QSpinBox *minVisibleMinsSpin;
         QComboBox *includePlannedCombo;
         QCheckBox *summaryDayCheck;
         QCheckBox *summaryWeekCheck;

--- a/src/Gui/Calendar.cpp
+++ b/src/Gui/Calendar.cpp
@@ -147,7 +147,7 @@ CalendarOverview::drawEntries
 
 
 //////////////////////////////////////////////////////////////////////////////
-// CalendarDayTable
+// CalendarBaseTable
 
 CalendarBaseTable::CalendarBaseTable
 (QWidget *parent)

--- a/src/Gui/CalendarData.cpp
+++ b/src/Gui/CalendarData.cpp
@@ -52,7 +52,7 @@ CalendarEntryLayouter::groupOverlapping
     for (int i = 0; i < entries.size(); ++i) {
         const CalendarEntry &entry = entries[i];
         qint64 startSecs = entry.start.hour() * 3600 + entry.start.minute() * 60 + entry.start.second();
-        QTime endTime = entry.start.addSecs(entry.durationSecs);
+        QTime endTime = entry.start.addSecs(entry.visibleSecs);
         qint64 endSecs = endTime.hour() * 3600 + endTime.minute() * 60 + endTime.second();
         if (endTime < entry.start) {
             endSecs += 24 * 3600;
@@ -104,7 +104,7 @@ CalendarEntryLayouter::assignColumns
     for (int entryIdx : cluster) {
         const CalendarEntry &entry = entries[entryIdx];
         qint64 startSecs = entry.start.hour() * 3600 + entry.start.minute() * 60 + entry.start.second();
-        QTime endTime = entry.start.addSecs(entry.durationSecs);
+        QTime endTime = entry.start.addSecs(entry.visibleSecs);
         qint64 endSecs = endTime.hour() * 3600 + endTime.minute() * 60 + endTime.second();
         if (endTime < entry.start) {
             endSecs += 24 * 3600;

--- a/src/Gui/CalendarData.h
+++ b/src/Gui/CalendarData.h
@@ -64,6 +64,7 @@ struct CalendarEntry {
     QString reference;
     QTime start;
     int durationSecs = 0;
+    int visibleSecs = 0;
     int type = 0;
     bool isExcludedFromSummary = false;
     bool isRelocatable = false;

--- a/src/Gui/CalendarItemDelegates.cpp
+++ b/src/Gui/CalendarItemDelegates.cpp
@@ -401,7 +401,7 @@ CalendarDetailedDayDelegate::paint
         bool related = (l.entryIdx == relatedEntryIdx);
         const CalendarEntry &entry = calendarDay.entries[l.entryIdx];
         int startMinute = entry.start.hour() * 60 + entry.start.minute();
-        int endMinute = startMinute + entry.durationSecs / 60;
+        int endMinute = startMinute + entry.visibleSecs / 60;
         int columnWidth = (rectWidth - (l.columnCount - 1) * columnSpacing) / std::max(1, l.columnCount);
         int left = rectLeft + l.columnIndex * (columnWidth + columnSpacing);
         int top = timeScaleData->minuteToYInTable(startMinute, option.rect);

--- a/src/Gui/CalendarItemDelegates.cpp
+++ b/src/Gui/CalendarItemDelegates.cpp
@@ -1751,43 +1751,48 @@ toolTipDayEntry(const QPoint &pos, QAbstractItemView *view, const CalendarDay &d
         CalendarEntry calEntry = day.entries[idx];
         QString status;
         if (calEntry.type == ENTRY_TYPE_ACTUAL_ACTIVITY) {
-            status = QObject::tr("actual");
+            status = QObject::tr("actual").toHtmlEscaped();
         } else {
-            status = QObject::tr("planned");
+            status = QObject::tr("planned").toHtmlEscaped();
         }
         if (calEntry.dirty) {
-            status += " • " + QObject::tr("modified");
+            status += " • " + QObject::tr("modified").toHtmlEscaped();
         }
         if (calEntry.isExcludedFromSummary) {
-            status += " • " + QObject::tr("not in summary");
+            status += " • " + QObject::tr("not in summary").toHtmlEscaped();
+        }
+        if (calEntry.visibleSecs > calEntry.durationSecs) {
+            status += " • " + QObject::tr("enlarged for readability").toHtmlEscaped();
+        } else if (calEntry.visibleSecs < calEntry.durationSecs) {
+            status += " • " + QObject::tr("shortened at midnight").toHtmlEscaped();
         }
 
         QString tooltip = QString("<div style='padding: %1px;'>").arg(4 * dpiXFactor);
-        tooltip += QString("<div style='font-weight: bold; font-size: 110%; margin-bottom: %1px;'>%2</div>").arg(8 * dpiYFactor).arg(calEntry.primary);
-        tooltip += QString("<div style='font-style: italic; color: gray; margin-bottom: %1px;'>%2</div>").arg(6 * dpiYFactor).arg(status);
+        tooltip += QString("<div style='font-weight: bold; font-size: 110%; margin-bottom: %1px;'>%2</div>").arg(8 * dpiYFactor).arg(calEntry.primary.toHtmlEscaped());
+        tooltip += QString("<div style='font-style: italic; color: gray; margin-bottom: %1px;'>%2</div>").arg(6 * dpiYFactor).arg(status.toHtmlEscaped());
         tooltip += "<table>";
         if (! calEntry.secondary.isEmpty()) {
-            tooltip += QString("<tr><td><b>%1:</b></td><td>%2</td></tr>").arg(calEntry.secondaryMetric).arg(calEntry.secondary);
+            tooltip += QString("<tr><td><b>%1:</b></td><td>%2</td></tr>").arg(calEntry.secondaryMetric).arg(calEntry.secondary.toHtmlEscaped());
         }
         if (calEntry.start.isValid()) {
             QString time = calEntry.start.toString();
             if (calEntry.durationSecs > 0) {
                 time += " - " + calEntry.start.addSecs(calEntry.durationSecs).toString();
             }
-            tooltip += QString("<tr><td><b>%1:</b></td><td>%2</td></tr>").arg(QObject::tr("When")).arg(time);
+            tooltip += QString("<tr><td><b>%1:</b></td><td>%2</td></tr>").arg(QObject::tr("When").toHtmlEscaped()).arg(time.toHtmlEscaped());
         }
         if (calEntry.type == ENTRY_TYPE_PLANNED_ACTIVITY && ! calEntry.originalPlanLabel.isEmpty()) {
             tooltip += QString("<tr><td><b>%1:</b></td><td>%2</td></tr>")
-                              .arg(QObject::tr("Originally"))
-                              .arg(calEntry.originalPlanLabel);
+                              .arg(QObject::tr("Originally").toHtmlEscaped())
+                              .arg(calEntry.originalPlanLabel.toHtmlEscaped());
         }
         if (! calEntry.linkedReference.isEmpty()) {
             QString countertype;
             countertype = QObject::tr("Linked");
             tooltip += QString("<tr><td style='padding-top: %1px'><b>%2:</b></td><td style='padding-top: %1px'>%3</td></tr>")
                               .arg(6 * dpiYFactor)
-                              .arg(countertype)
-                              .arg(calEntry.linkedPrimary);
+                              .arg(countertype.toHtmlEscaped())
+                              .arg(calEntry.linkedPrimary.toHtmlEscaped());
             if (calEntry.linkedStartDT.isValid()) {
                 QString linkedWhen;
                 QLocale locale;
@@ -1796,11 +1801,11 @@ toolTipDayEntry(const QPoint &pos, QAbstractItemView *view, const CalendarDay &d
                 } else {
                     linkedWhen = locale.toString(calEntry.linkedStartDT, QLocale::NarrowFormat);
                 }
-                tooltip += QString("<tr><td><b>%1:</b></td><td>%2</td></tr>").arg(QObject::tr("On")).arg(linkedWhen);
+                tooltip += QString("<tr><td><b>%1:</b></td><td>%2</td></tr>").arg(QObject::tr("On").toHtmlEscaped()).arg(linkedWhen.toHtmlEscaped());
                 if (calEntry.type == ENTRY_TYPE_ACTUAL_ACTIVITY && ! calEntry.originalPlanLabel.isEmpty()) {
                     tooltip += QString("<tr><td><b>%1:</b></td><td>%2</td></tr>")
-                                      .arg(QObject::tr("Originally"))
-                                      .arg(calEntry.originalPlanLabel);
+                                      .arg(QObject::tr("Originally").toHtmlEscaped())
+                                      .arg(calEntry.originalPlanLabel.toHtmlEscaped());
                 }
             }
         }
@@ -1824,7 +1829,7 @@ toolTipMore
         entries << entry.primary;
     }
     if (! entries.isEmpty()) {
-        QString tooltip = entries.join("\n");
+        QString tooltip = entries.join("\n").toHtmlEscaped();
         QToolTip::showText(pos, tooltip, view);
         return true;
     }

--- a/unittests/Gui/calendarData/testCalendarData.cpp
+++ b/unittests/Gui/calendarData/testCalendarData.cpp
@@ -12,11 +12,11 @@ private slots:
     void layoutCalendarEntry() {
 
         QList<CalendarEntry> entries = {
-            { "", "", "", "", "", Qt::red, "", QTime(9, 0), 3600 },
-            { "", "", "", "", "", Qt::red, "", QTime(9, 30), 3600 },
-            { "", "", "", "", "", Qt::red, "", QTime(10, 30), 1800 },
-            { "", "", "", "", "", Qt::red, "", QTime(11, 0), 1800 },
-            { "", "", "", "", "", Qt::red, "", QTime(11, 15), 3600 },
+            { "", "", "", "", "", Qt::red, "", QTime(9, 0), 3600, 3600 },
+            { "", "", "", "", "", Qt::red, "", QTime(9, 30), 3600, 3600 },
+            { "", "", "", "", "", Qt::red, "", QTime(10, 30), 1800, 1800 },
+            { "", "", "", "", "", Qt::red, "", QTime(11, 0), 1800, 1800 },
+            { "", "", "", "", "", Qt::red, "", QTime(11, 15), 3600, 3600 },
         };
         CalendarEntryLayouter layouter;
         QList<CalendarEntryLayout> layout = layouter.layout(entries);


### PR DESCRIPTION
In day and week view, short activities might not show any data in their box. This change adds an option to define the minimum number of visible minutes per activity.