### PR TITLE
Update to calendar month view: Visual consistency

### DIFF
--- a/src/Gui/CalendarItemDelegates.cpp
+++ b/src/Gui/CalendarItemDelegates.cpp
@@ -40,7 +40,7 @@ static int paintMetric(QPainter *painter, const QRect &rect, const QFont::Weight
 
 
 //////////////////////////////////////////////////////////////////////////////
-// TimeScaleData
+// HitTester
 
 HitTester::HitTester
 ()
@@ -347,6 +347,8 @@ CalendarDetailedDayDelegate::paint
     QStyleOptionViewItem opt = option;
     initStyleOption(&opt, index);
 
+    const bool darkMode = GCColor::isPaletteDark(option.palette);
+
     bool ok;
     int pressedEntryIdx = index.data(PressedEntryRole).toInt(&ok);
     if (! ok) {
@@ -424,18 +426,14 @@ CalendarDetailedDayDelegate::paint
             entryFrame = entryBG;
         } else if (related) {
             QColor relColor = opt.palette.highlight().color();
-            relColor.setAlpha(40);
+            relColor.setAlphaF(0.16);
             relColor = GCColor::blendedColor(relColor, bgColor);
             entryBG = relColor;
             entryFrame = relColor;
         } else if (entry.type == ENTRY_TYPE_ACTUAL_ACTIVITY) {
             QColor overlayBG = entry.color;
             overlayBG = entry.color;
-            if (GCColor::isPaletteDark(option.palette)) {
-                overlayBG.setAlpha(150);
-            } else {
-                overlayBG.setAlpha(60);
-            }
+            overlayBG.setAlphaF(darkMode ? 0.6 : 0.2);
             entryBG = GCColor::blendedColor(overlayBG, entryBG);
             entryFrame = entryBG;
         }
@@ -738,7 +736,7 @@ CalendarTimeScaleDelegate::paint
         QRect rect = option.rect;
         rect.setHeight(blockY);
         QColor blockColor = option.palette.color(QPalette::Disabled, QPalette::Base);
-        blockColor.setAlpha(180);
+        blockColor.setAlphaF(0.7);
         painter->fillRect(rect, blockColor);
     }
     int currentY = scaleIndex.data(CurrentYRole).toInt();
@@ -808,6 +806,8 @@ CalendarCompactDayDelegate::paint
     QColor selColor = opt.palette.highlight().color();
     QColor entryColor;
 
+    const bool darkMode = GCColor::isPaletteDark(option.palette);
+
     bool ok;
     int pressedEntryIdx = index.data(PressedEntryRole).toInt(&ok);
     if (! ok) {
@@ -817,8 +817,9 @@ CalendarCompactDayDelegate::paint
     if (! ok) {
         relatedEntryIdx = -2;
     }
+    const bool cellSelected = opt.state & QStyle::State_Selected && pressedEntryIdx < 0;
 
-    if (pressedEntryIdx < 0 && opt.state & QStyle::State_Selected) {
+    if (cellSelected) {
         bgColor = opt.palette.color(calendarDay.isDimmed == DayDimLevel::Full ? QPalette::Disabled : QPalette::Active, QPalette::Highlight);
     } else if (calendarDay.isDimmed == DayDimLevel::Full) {
         bgColor = opt.palette.color(QPalette::Disabled, QPalette::Base);
@@ -827,7 +828,7 @@ CalendarCompactDayDelegate::paint
     }
     entryColor = GCColor::invertColor(bgColor);
     QColor relColor = opt.palette.highlight().color();
-    relColor.setAlpha(40);
+    relColor.setAlphaF(0.16);
     relColor = GCColor::blendedColor(relColor, bgColor);
 
     painter->fillRect(opt.rect, bgColor);
@@ -885,12 +886,25 @@ CalendarCompactDayDelegate::paint
             painter->setPen(relColor);
             painter->drawRoundedRect(entryRect, radius, radius);
             painter->setPen(GCColor::invertColor(relColor));
+        } else if (! cellSelected && calEntry.type == ENTRY_TYPE_ACTUAL_ACTIVITY) {
+            QColor activityColor = calEntry.color;
+            activityColor.setAlphaF(darkMode ? 0.6 : 0.2);
+            activityColor = GCColor::blendedColor(activityColor, bgColor);
+            painter->setBrush(activityColor);
+            painter->setPen(activityColor);
+            painter->drawRoundedRect(entryRect, radius, radius);
+            painter->setPen(GCColor::invertColor(activityColor));
+        } else if (! cellSelected && calEntry.type == ENTRY_TYPE_PLANNED_ACTIVITY) {
+            QColor activityColor = calEntry.color;
+            activityColor.setAlphaF(0.6);
+            activityColor = GCColor::blendedColor(activityColor, bgColor);
+            painter->setPen(activityColor);
+            painter->drawRoundedRect(entryRect, radius, radius);
+            painter->setPen(entryColor);
         }
         QPixmap pixmap;
         QColor pixmapColor(calEntry.color);
-        if (   i == pressedEntryIdx
-            || (   opt.state & QStyle::State_Selected
-                && pressedEntryIdx < 0)) {
+        if (i == pressedEntryIdx || cellSelected) {
             pixmapColor = GCColor::invertColor(selColor);
         } else if (i == relatedEntryIdx) {
             pixmapColor = GCColor::invertColor(relColor);
@@ -954,7 +968,7 @@ CalendarCompactDayDelegate::paint
                                    overflowWidth,
                                    lineHeight);
         QColor overflowBg(bgColor);
-        overflowBg.setAlpha(185);
+        overflowBg.setAlphaF(0.73);
         painter->save();
         painter->setPen(overflowBg);
         painter->setBrush(overflowBg);


### PR DESCRIPTION
Add colored backgrounds to calendar month view, to establish visual consistency to day and week view as well as the RideNavigator Implementing proposal 2b from https://groups.google.com/g/golden-cheetah-users/c/RVUs2FbTdPI/m/3f-a42IoAAAJ