### PR TITLE
Fix wrong icons in RideNavigator

### DIFF
--- a/src/Core/RideCacheModel.cpp
+++ b/src/Core/RideCacheModel.cpp
@@ -166,12 +166,21 @@ RideCacheModel::endRemove(int)
 bool 
 RideCacheModel::setHeaderData (int section, Qt::Orientation orientation, const QVariant &value, int role)
 {
-    if (orientation == Qt::Horizontal && role == Qt::EditRole) {
-        headings_[section] = value.toString();
-        emit headerDataChanged (Qt::Horizontal, section, section);
-        return true;
+    if (orientation != Qt::Horizontal) {
+        return false;
     }
-    return false;
+    bool changed = false;
+    if (role == Qt::EditRole) {
+        headings_[section] = value.toString();
+        changed = true;
+    } else if (role == Qt::UserRole + 1) {
+        headingsTechnical_[section] = value.toString();
+        changed = true;
+    }
+    if (changed) {
+        emit headerDataChanged(Qt::Horizontal, section, section);
+    }
+    return changed;
 }
 
 QVariant 
@@ -179,6 +188,8 @@ RideCacheModel::headerData(int section, Qt::Orientation orientation, int role) c
 {
     if (orientation == Qt::Horizontal && role == Qt::DisplayRole) {
         return headings_[section];
+    } else if (orientation == Qt::Horizontal && role == Qt::UserRole + 1) {
+        return headingsTechnical_[section];
     }
 
     // nought (importanty including 0 for Qt::SizeHintRole)
@@ -238,6 +249,7 @@ RideCacheModel::configChanged(qint32)
             break;
         }
     }
+    headingsTechnical_ = headings_;
 
     headerDataChanged (Qt::Horizontal, 0, columns_-1);
 

--- a/src/Core/RideCacheModel.h
+++ b/src/Core/RideCacheModel.h
@@ -77,6 +77,7 @@ class RideCacheModel : public QAbstractTableModel
 
         int columns_; // column count, based upon metric + meta config
         QStringList headings_;
+        QStringList headingsTechnical_;
 
         // the fields as defined
         QList<FieldDefinition> metadata;

--- a/src/Gui/RideNavigator.cpp
+++ b/src/Gui/RideNavigator.cpp
@@ -512,6 +512,7 @@ RideNavigator::resetView()
 
         if ((friendly = nameMap.value(techname, "unknown")) != "unknown") {
             sortModel->setHeaderData(i, Qt::Horizontal, friendly);
+            sortModel->setHeaderData(i, Qt::Horizontal, techname, Qt::UserRole + 1);
             logicalHeadings << friendly;
         } else
             logicalHeadings << techname;

--- a/src/Gui/RideNavigatorProxy.h
+++ b/src/Gui/RideNavigatorProxy.h
@@ -167,10 +167,10 @@ public:
             if (model->headerData(i, Qt::Horizontal, Qt::DisplayRole).toString() == "ride_date") {
                 dateColumn = i;
             }
-            if (model->headerData(i, Qt::Horizontal, Qt::DisplayRole).toString() == "Sport") {
+            if (model->headerData(i, Qt::Horizontal, Qt::UserRole + 1).toString() == "Sport") {
                 sportIndex = i;
             }
-            if (model->headerData(i, Qt::Horizontal, Qt::DisplayRole).toString() == "SubSport") {
+            if (model->headerData(i, Qt::Horizontal, Qt::UserRole + 1).toString() == "SubSport") {
                 subSportIndex = i;
             }
             starttimeHeader = "ride_time"; //initialisation with techname


### PR DESCRIPTION
See https://groups.google.com/g/golden-cheetah-users/c/RVUs2FbTdPI/m/FAhSjqzGAQAJ
Source of the issue: Sport and SubSport are read from RideCacheModel
(via GroupByModel). To find the correct column in those models, the
metric name is used - but the model can have either translated or
original name as column title (this is the rootcause of the sometimes it
works, sometimes not).
RideNavigatorProxy doesn't have the translations of the column names
available, therefore using an empty string instead of SubSport. Sport
can have the same issue if translated.
    
This PR adds the untranslated, technical names (e.g. time_in_zone_L1)
using the role Qt::UserRole + 1 to the headerData and uses these values
for the icon lookup
