### PR TITLE
PlanAdherence: Prefer icon from completed activity

### DIFF
--- a/src/Charts/PlanAdherenceWindow.cpp
+++ b/src/Charts/PlanAdherenceWindow.cpp
@@ -413,6 +413,7 @@ PlanAdherenceWindow::updateActivities
             linkedItem = context->athlete->rideCache->getRide(rideItem->getLinkedFileName());
         }
         if (entry.isPlanned && linkedItem != nullptr) {
+            entry.iconFile = IconManager::instance().getFilepath(linkedItem);
             if (linkedItem->color.alpha() < 255) {
                 entry.color = GCColor::invertColor(GColor(CPLOTBACKGROUND));
             } else {


### PR DESCRIPTION
Use the icon from the completed activity instead of the planned one (if both are available)