### PR TITLE
Pyfix: dark / lightmode in syntax highlighting

### DIFF
--- a/src/FileIO/FixPyScriptsDialog.cpp
+++ b/src/FileIO/FixPyScriptsDialog.cpp
@@ -277,7 +277,7 @@ void EditFixPyScriptDialog::setScript(QString string)
 {
     if (python && script) {
         script->setText(string);
-        new PythonSyntax(script->document());
+        new PythonSyntax(script->document(), GCColor::isDark(GColor(CPLOTBACKGROUND)));
     }
 
     text = string;


### PR DESCRIPTION
PR #4869 updated the colors for Pythons Syntax Highlighting but missed checking for dark or light mode (default: dark) resulting in unreadable text in light mode