### PR TITLE
HrZones implements getZoneDescriptions() as Zones already does

### DIFF
--- a/src/Metrics/HrZones.cpp
+++ b/src/Metrics/HrZones.cpp
@@ -620,6 +620,22 @@ QList <QString> HrZones::getZoneNames(int rnum) const {
     return return_values;
 }
 
+// return the list of zone descriptions
+QList <QString> HrZones::getZoneDescriptions(int rnum) const
+{
+    if (rnum < 0 || rnum >= ranges.size()) return QList <QString>();
+
+    const HrZoneRange &range = ranges[rnum];
+    QList <QString> return_values;
+
+    for (int i = 0; i < range.zones.size(); i++) {
+        return_values.append(ranges[rnum].zones[i].desc);
+    }
+
+    return return_values;
+}
+
+
 // return the list of zone trimp coef
 QList <double> HrZones::getZoneTrimps(int rnum) const {
     if (rnum >= ranges.size())

--- a/src/Metrics/HrZones.h
+++ b/src/Metrics/HrZones.h
@@ -205,6 +205,7 @@ class HrZones : public QObject
         QList <int> getZoneHighs(int rnum) const;
         QList <double> getZoneTrimps(int rnum) const;
         QList <QString> getZoneNames(int rnum) const;
+        QList <QString> getZoneDescriptions(int rnum) const;
 
         // get/set range start and end date
         QDate getStartDate(int rnum) const;

--- a/src/Metrics/Zones.cpp
+++ b/src/Metrics/Zones.cpp
@@ -745,7 +745,7 @@ QList <QString> Zones::getZoneNames(int rnum) const
     return return_values;
 }
 
-// return the list of zone names
+// return the list of zone descriptions
 QList <QString> Zones::getZoneDescriptions(int rnum) const
 {
     if (rnum < 0 || rnum >= ranges.size()) return QList <QString>();


### PR DESCRIPTION
Needed by HTML chart, as well as for completeness.
It is a small change used by a next PR for HTML charts, but I think it is better to isolate it, as it does not belong to HTML but to old stable code. It keeps consistency with power Zones class, and avoids to repeat code if you are interested in these HR zones, as it is the case for HTML harts