### PR TITLE
src/Python/PythonEmbed.cpp: fix loading of flexiblas symbols when locally compiled

### DIFF
--- a/src/Python/PythonEmbed.cpp
+++ b/src/Python/PythonEmbed.cpp
@@ -275,10 +275,6 @@ PythonEmbed::PythonEmbed(const bool verbose, const bool interactive) : verbose(v
             // our base code - traps stdout and loads goldencheetan module
             // mapping all the bindings to a GC object.
             std::string stdOutErr = ("import sys\n"
- #ifdef Q_OS_LINUX
-                                     "import os\n"
-                                     "sys.setdlopenflags(os.RTLD_NOW | os.RTLD_DEEPBIND)\n"
- #endif
                                      "class CatchOutErr:\n"
                                      "    def __init__(self):\n"
                                      "        self.value = ''\n"
@@ -299,6 +295,8 @@ PythonEmbed::PythonEmbed(const bool verbose, const bool interactive) : verbose(v
             // ensure site-packages is in path when using deployed Python on Linux
             if (PYTHONHOME == deployedPython) {
                 std::string ensureSitePackages = ("import sys\n"
+                                                  "import os\n"
+                                                  "sys.setdlopenflags(os.RTLD_NOW | os.RTLD_DEEPBIND)\n"
                                                   "sys.path.append(sys.prefix+'/lib/python3.'+str(sys.version_info.minor)+'/site-packages')\n");
                 PyRun_SimpleString(ensureSitePackages.c_str()); //invoke code
             }


### PR DESCRIPTION
RTLD_DEEPBIND prevents SciPy's Fortran extensions from resolving some symbols from FlexiBLAS when compiled locally with system python.

move "sys.setdlopenflags(os.RTLD_NOW | os.RTLD_DEEPBIND)" into the appimage specific "if (PYTHONHOME == deployedPython)" block.


fixes the issue mentioned in https://groups.google.com/g/golden-cheetah-users/c/EpPCEjlinvk:
```
Thread 59 "Thread (pooled)" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7faad1ffb6c0 (LWP 776189)]
0x0000000000000000 in ?? ()
(gdb) bt
#0  0x0000000000000000 in ??? ()
#1  0x00007faab5e3d8df in f2py_rout__flapack_dgelsd_lwork (capi_self=<optimized out>, capi_args=<optimized out>, capi_keywds=<optimized out>, f2py_func=0x0)
    at scipy/linalg/_flapackmodule.c:18697
#2  0x00007faab5f31263 in fortran_call (fp=fp@entry=0x7faab6324c60, arg=arg@entry=(1, 2, 10, <numpy.float64 at remote 0x7faac3d06050>), kw=kw@entry={})
    at ../../../../../../../usr/lib/python3.13/site-packages/numpy/f2py/src/fortranobject.c:542
#3  0x00007fabd54ade3b in _PyObject_Call
    (tstate=0x7faacc005fe0, callable=callable@entry=<fortran at remote 0x7faab6324c60>, args=args@entry=(1, 2, 10, <numpy.float64 at remote 0x7faac3d06050>), kwargs=kwargs@entry={}) at Objects/call.c:361
#4  0x00007fabd54adf34 in PyObject_Call
    (callable=callable@entry=<fortran at remote 0x7faab6324c60>, args=args@entry=(1, 2, 10, <numpy.float64 at remote 0x7faac3d06050>), kwargs=kwargs@entry={})
    at Objects/call.c:373
#5  0x00007fabd55e913c in _PyEval_EvalFrameDefault (tstate=0x7faacc005fe0, frame=0x7fabbc009498, throwflag=0) at Python/generated_cases.c.h:1362
#6  0x00007fabd55f8274 in _PyEval_EvalFrame (tstate=tstate@entry=0x7faacc005fe0, frame=<optimized out>, throwflag=throwflag@entry=0)
    at ./Include/internal/pycore_ceval.h:120
#7  0x00007fabd55f83cc in _PyEval_Vector
    (tstate=tstate@entry=0x7faacc005fe0, func=func@entry=0x7fabbca0de40, locals=locals@entry={'__name__': '__main__', '__doc__': None, '__package__': None, '__loader__': <type at remote 0x561667328210>, '__spec__': None, '__annotations__': {}, '__builtins__': <module at remote 0x7fabbcba18a0>, 'sys': <module at remote 0x7fabbcb97a60>, 'os': <module at remote 0x7fabbca22480>, 'CatchOutErr': <type at remote 0x56166722c160>, 'catchOutErr': <CatchOutErr(value='3.13.12 (main, Mar 16 2026, 19:18:49) [GCC 15.2.1 20260214]\n') at remote 0x7fabbcb3af90>, 'goldencheetah': <module at remote 0x7fabbcaa6750>, 'GC': <Bindings(activity=<function at remote 0x7fabbc11d440>, activityXdata=<function at remote 0x7fabbc11d3a0>, setChart=<function at remote 0x7fabbc11d4e0>, addCurve=<function at remote 0x7fabbc11d580>, setAxis=<function at remote 0x7fabbc11d620>, annotate=<function at remote 0x7fabbc11d6c0>, CHART_LINE=1, CHART_SCATTER=2, CHART_BAR=3, CHART_PIE=4, CHART_STACK=5, CHART_PERCENT=6, AXIS_CONTINUOUS=0, AXIS_DATE=1, AXIS_TIME=2, AXIS_CATEGORY=3, SERIES_SECS=0, SERIES_CAD=1, SERIES_CADD=2, SERIES_HR=3, SERIES_HR...(truncated), args=args@entry=0x0, argcount=argcount@entry=0, kwnames=kwnames@entry=0x0) at Python/ceval.c:1820
#8  0x00007fabd55f849f in PyEval_EvalCode
    (co=co@entry=<code at remote 0x7fabbcbb63a0>, globals=globals@entry={'__name__': '__main__', '__doc__': None, '__package__': None, '__loader__': <type at remote 0x561667328210>, '__spec__': None, '__annotations__': {}, '__builtins__': <module at remote 0x7fabbcba18a0>, 'sys': <module at remote 0x7fabbcb97a60>, 'os': <module at remote 0x7fabbca22480>, 'CatchOutErr': <type at remote 0x56166722c160>, 'catchOutErr': <CatchOutErr(value='3.13.12 (main, Mar 16 2026, 19:18:49) [GCC 15.2.1 20260214]\n') at remote 0x7fabbcb3af90>, 'goldencheetah': <module at remote 0x7fabbcaa6750>, 'GC': <Bindings(activity=<function at remote 0x7fabbc11d440>, activityXdata=<function at remote 0x7fabbc11d3a0>, setChart=<function at remote 0x7fabbc11d4e0>, addCurve=<function at remote 0x7fabbc11d580>, setAxis=<function at remote 0x7fabbc11d620>, annotate=<function at remote 0x7fabbc11d6c0>, CHART_LINE=1, CHART_SCATTER=2, CHART_BAR=3, CHART_PIE=4, CHART_STACK=5, CHART_PERCENT=6, AXIS_CONTINUOUS=0, AXIS_DATE=1, AXIS_TIME=2, AXIS_CATEGORY=3, SERIES_SECS=0, SERIES_CAD=1, SERIES_CADD=2, SERIES_HR=3, SERIES_HR...(truncated), locals=locals@entry={'__name__': '__main__', '__doc__': None, '__package__': None, '__loader__': <type at remote 0x561667328210>, '__spec__': None, '__annotations__': {}, '__builtins__': <module at remote 0x7fabbcba18a0>, 'sys': <module at remote 0x7fabbcb97a60>, 'os': <module at remote 0x7fabbca22480>, 'CatchOutErr': <type at remote 0x56166722c160>, 'catchOutErr': <CatchOutErr(value='3.13.12 (main, Mar 16 2026, 19:18:49) [GCC 15.2.1 20260214]\n') at remote 0x7fabbcb3af90>, 'goldencheetah': <module at remote 0x7fabbcaa6750--Type <RET> for more, q to quit, c to continue without paging--c
>, 'GC': <Bindings(activity=<function at remote 0x7fabbc11d440>, activityXdata=<function at remote 0x7fabbc11d3a0>, setChart=<function at remote 0x7fabbc11d4e0>, addCurve=<function at remote 0x7fabbc11d580>, setAxis=<function at remote 0x7fabbc11d620>, annotate=<function at remote 0x7fabbc11d6c0>, CHART_LINE=1, CHART_SCATTER=2, CHART_BAR=3, CHART_PIE=4, CHART_STACK=5, CHART_PERCENT=6, AXIS_CONTINUOUS=0, AXIS_DATE=1, AXIS_TIME=2, AXIS_CATEGORY=3, SERIES_SECS=0, SERIES_CAD=1, SERIES_CADD=2, SERIES_HR=3, SERIES_HR...(truncated)) at Python/ceval.c:604
#9  0x00007fabd5664f2e in run_eval_code_obj
    (tstate=tstate@entry=0x7faacc005fe0, co=co@entry=0x7fabbcbb63a0, globals=globals@entry={'__name__': '__main__', '__doc__': None, '__package__': None, '__loader__': <type at remote 0x561667328210>, '__spec__': None, '__annotations__': {}, '__builtins__': <module at remote 0x7fabbcba18a0>, 'sys': <module at remote 0x7fabbcb97a60>, 'os': <module at remote 0x7fabbca22480>, 'CatchOutErr': <type at remote 0x56166722c160>, 'catchOutErr': <CatchOutErr(value='3.13.12 (main, Mar 16 2026, 19:18:49) [GCC 15.2.1 20260214]\n') at remote 0x7fabbcb3af90>, 'goldencheetah': <module at remote 0x7fabbcaa6750>, 'GC': <Bindings(activity=<function at remote 0x7fabbc11d440>, activityXdata=<function at remote 0x7fabbc11d3a0>, setChart=<function at remote 0x7fabbc11d4e0>, addCurve=<function at remote 0x7fabbc11d580>, setAxis=<function at remote 0x7fabbc11d620>, annotate=<function at remote 0x7fabbc11d6c0>, CHART_LINE=1, CHART_SCATTER=2, CHART_BAR=3, CHART_PIE=4, CHART_STACK=5, CHART_PERCENT=6, AXIS_CONTINUOUS=0, AXIS_DATE=1, AXIS_TIME=2, AXIS_CATEGORY=3, SERIES_SECS=0, SERIES_CAD=1, SERIES_CADD=2, SERIES_HR=3, SERIES_HR...(truncated), locals=locals@entry={'__name__': '__main__', '__doc__': None, '__package__': None, '__loader__': <type at remote 0x561667328210>, '__spec__': None, '__annotations__': {}, '__builtins__': <module at remote 0x7fabbcba18a0>, 'sys': <module at remote 0x7fabbcb97a60>, 'os': <module at remote 0x7fabbca22480>, 'CatchOutErr': <type at remote 0x56166722c160>, 'catchOutErr': <CatchOutErr(value='3.13.12 (main, Mar 16 2026, 19:18:49) [GCC 15.2.1 20260214]\n') at remote 0x7fabbcb3af90>, 'goldencheetah': <module at remote 0x7fabbcaa6750>, 'GC': <Bindings(activity=<function at remote 0x7fabbc11d440>, activityXdata=<function at remote 0x7fabbc11d3a0>, setChart=<function at remote 0x7fabbc11d4e0>, addCurve=<function at remote 0x7fabbc11d580>, setAxis=<function at remote 0x7fabbc11d620>, annotate=<function at remote 0x7fabbc11d6c0>, CHART_LINE=1, CHART_SCATTER=2, CHART_BAR=3, CHART_PIE=4, CHART_STACK=5, CHART_PERCENT=6, AXIS_CONTINUOUS=0, AXIS_DATE=1, AXIS_TIME=2, AXIS_CATEGORY=3, SERIES_SECS=0, SERIES_CAD=1, SERIES_CADD=2, SERIES_HR=3, SERIES_HR...(truncated)) at Python/pythonrun.c:1381
#10 0x00007fabd566510c in run_mod
    (mod=mod@entry=0x7faacc010ad8, filename=filename@entry='<string>', globals=globals@entry={'__name__': '__main__', '__doc__': None, '__package__': None, '__loader__': <type at remote 0x561667328210>, '__spec__': None, '__annotations__': {}, '__builtins__': <module at remote 0x7fabbcba18a0>, 'sys': <module at remote 0x7fabbcb97a60>, 'os': <module at remote 0x7fabbca22480>, 'CatchOutErr': <type at remote 0x56166722c160>, 'catchOutErr': <CatchOutErr(value='3.13.12 (main, Mar 16 2026, 19:18:49) [GCC 15.2.1 20260214]\n') at remote 0x7fabbcb3af90>, 'goldencheetah': <module at remote 0x7fabbcaa6750>, 'GC': <Bindings(activity=<function at remote 0x7fabbc11d440>, activityXdata=<function at remote 0x7fabbc11d3a0>, setChart=<function at remote 0x7fabbc11d4e0>, addCurve=<function at remote 0x7fabbc11d580>, setAxis=<function at remote 0x7fabbc11d620>, annotate=<function at remote 0x7fabbc11d6c0>, CHART_LINE=1, CHART_SCATTER=2, CHART_BAR=3, CHART_PIE=4, CHART_STACK=5, CHART_PERCENT=6, AXIS_CONTINUOUS=0, AXIS_DATE=1, AXIS_TIME=2, AXIS_CATEGORY=3, SERIES_SECS=0, SERIES_CAD=1, SERIES_CADD=2, SERIES_HR=3, SERIES_HR...(truncated), locals=locals@entry={'__name__': '__main__', '__doc__': None, '__package__': None, '__loader__': <type at remote 0x561667328210>, '__spec__': None, '__annotations__': {}, '__builtins__': <module at remote 0x7fabbcba18a0>, 'sys': <module at remote 0x7fabbcb97a60>, 'os': <module at remote 0x7fabbca22480>, 'CatchOutErr': <type at remote 0x56166722c160>, 'catchOutErr': <CatchOutErr(value='3.13.12 (main, Mar 16 2026, 19:18:49) [GCC 15.2.1 20260214]\n') at remote 0x7fabbcb3af90>, 'goldencheetah': <module at remote 0x7fabbcaa6750>, 'GC': <Bindings(activity=<function at remote 0x7fabbc11d440>, activityXdata=<function at remote 0x7fabbc11d3a0>, setChart=<function at remote 0x7fabbc11d4e0>, addCurve=<function at remote 0x7fabbc11d580>, setAxis=<function at remote 0x7fabbc11d620>, annotate=<function at remote 0x7fabbc11d6c0>, CHART_LINE=1, CHART_SCATTER=2, CHART_BAR=3, CHART_PIE=4, CHART_STACK=5, CHART_PERCENT=6, AXIS_CONTINUOUS=0, AXIS_DATE=1, AXIS_TIME=2, AXIS_CATEGORY=3, SERIES_SECS=0, SERIES_CAD=1, SERIES_CADD=2, SERIES_HR=3, SERIES_HR...(truncated), flags=flags@entry=0x0, arena=arena@entry=0x7fabbcb1fc90, interactive_src=0x0, generate_new_source=0)
    at Python/pythonrun.c:1489
#11 0x00007fabd5665c1d in _PyRun_StringFlagsWithName
    (str=str@entry=0x7faacc003390 "import sys\nimport pandas as pd\nimport numpy as np\nfrom scipy import signal\n\nprint(sys.version)\n\ndf = pd.DataFrame(np.random.randn(10), columns=['X'])\ndf_detrended = pd.DataFrame(signal.detrend(df))\n\n#"..., name='<string>',
    name@entry=0x0, start=start@entry=257, globals=globals@entry={'__name__': '__main__', '__doc__': None, '__package__': None, '__loader__': <type at remote 0x561667328210>, '__spec__': None, '__annotations__': {}, '__builtins__': <module at remote 0x7fabbcba18a0>, 'sys': <module at remote 0x7fabbcb97a60>, 'os': <module at remote 0x7fabbca22480>, 'CatchOutErr': <type at remote 0x56166722c160>, 'catchOutErr': <CatchOutErr(value='3.13.12 (main, Mar 16 2026, 19:18:49) [GCC 15.2.1 20260214]\n') at remote 0x7fabbcb3af90>, 'goldencheetah': <module at remote 0x7fabbcaa6750>, 'GC': <Bindings(activity=<function at remote 0x7fabbc11d440>, activityXdata=<function at remote 0x7fabbc11d3a0>, setChart=<function at remote 0x7fabbc11d4e0>, addCurve=<function at remote 0x7fabbc11d580>, setAxis=<function at remote 0x7fabbc11d620>, annotate=<function at remote 0x7fabbc11d6c0>, CHART_LINE=1, CHART_SCATTER=2, CHART_BAR=3, CHART_PIE=4, CHART_STACK=5, CHART_PERCENT=6, AXIS_CONTINUOUS=0, AXIS_DATE=1, AXIS_TIME=2, AXIS_CATEGORY=3, SERIES_SECS=0, SERIES_CAD=1, SERIES_CADD=2, SERIES_HR=3, SERIES_HR...(truncated), locals=locals@entry={'__name__': '__main__', '__doc__': None, '__package__': None, '__loader__': <type at remote 0x561667328210>, '__spec__': None, '__annotations__': {}, '__builtins__': <module at remote 0x7fabbcba18a0>, 'sys': <module at remote 0x7fabbcb97a60>, 'os': <module at remote 0x7fabbca22480>, 'CatchOutErr': <type at remote 0x56166722c160>, 'catchOutErr': <CatchOutErr(value='3.13.12 (main, Mar 16 2026, 19:18:49) [GCC 15.2.1 20260214]\n') at remote 0x7fabbcb3af90>, 'goldencheetah': <module at remote 0x7fabbcaa6750>, 'GC': <Bindings(activity=<function at remote 0x7fabbc11d440>, activityXdata=<function at remote 0x7fabbc11d3a0>, setChart=<function at remote 0x7fabbc11d4e0>, addCurve=<function at remote 0x7fabbc11d580>, setAxis=<function at remote 0x7fabbc11d620>, annotate=<function at remote 0x7fabbc11d6c0>, CHART_LINE=1, CHART_SCATTER=2, CHART_BAR=3, CHART_PIE=4, CHART_STACK=5, CHART_PERCENT=6, AXIS_CONTINUOUS=0, AXIS_DATE=1, AXIS_TIME=2, AXIS_CATEGORY=3, SERIES_SECS=0, SERIES_CAD=1, SERIES_CADD=2, SERIES_HR=3, SERIES_HR...(truncated), flags=flags@entry=0x0, generate_new_source=0) at Python/pythonrun.c:1261
#12 0x00007fabd5667906 in PyRun_StringFlags
    (str=str@entry=0x7faacc003390 "import sys\nimport pandas as pd\nimport numpy as np\nfrom scipy import signal\n\nprint(sys.version)\n\ndf = pd.DataFrame(np.random.randn(10), columns=['X'])\ndf_detrended = pd.DataFrame(signal.detrend(df))\n\n#"..., start=start@entry=257, globals=globals@entry={'__name__': '__main__', '__doc__': None, '__package__': None, '__loader__': <type at remote 0x561667328210>, '__spec__': None, '__annotations__': {}, '__builtins__': <module at remote 0x7fabbcba18a0>, 'sys': <module at remote 0x7fabbcb97a60>, 'os': <module at remote 0x7fabbca22480>, 'CatchOutErr': <type at remote 0x56166722c160>, 'catchOutErr': <CatchOutErr(value='3.13.12 (main, Mar 16 2026, 19:18:49) [GCC 15.2.1 20260214]\n') at remote 0x7fabbcb3af90>, 'goldencheetah': <module at remote 0x7fabbcaa6750>, 'GC': <Bindings(activity=<function at remote 0x7fabbc11d440>, activityXdata=<function at remote 0x7fabbc11d3a0>, setChart=<function at remote 0x7fabbc11d4e0>, addCurve=<function at remote 0x7fabbc11d580>, setAxis=<function at remote 0x7fabbc11d620>, annotate=<function at remote 0x7fabbc11d6c0>, CHART_LINE=1, CHART_SCATTER=2, CHART_BAR=3, CHART_PIE=4, CHART_STACK=5, CHART_PERCENT=6, AXIS_CONTINUOUS=0, AXIS_DATE=1, AXIS_TIME=2, AXIS_CATEGORY=3, SERIES_SECS=0, SERIES_CAD=1, SERIES_CADD=2, SERIES_HR=3, SERIES_HR...(truncated), locals=locals@entry={'__name__': '__main__', '__doc__': None, '__package__': None, '__loader__': <type at remote 0x561667328210>, '__spec__': None, '__annotations__': {}, '__builtins__': <module at remote 0x7fabbcba18a0>, 'sys': <module at remote 0x7fabbcb97a60>, 'os': <module at remote 0x7fabbca22480>, 'CatchOutErr': <type at remote 0x56166722c160>, 'catchOutErr': <CatchOutErr(value='3.13.12 (main, Mar 16 2026, 19:18:49) [GCC 15.2.1 20260214]\n') at remote 0x7fabbcb3af90>, 'goldencheetah': <module at remote 0x7fabbcaa6750>, 'GC': <Bindings(activity=<function at remote 0x7fabbc11d440>, activityXdata=<function at remote 0x7fabbc11d3a0>, setChart=<function at remote 0x7fabbc11d4e0>, addCurve=<function at remote 0x7fabbc11d580>, setAxis=<function at remote 0x7fabbc11d620>, annotate=<function at remote 0x7fabbc11d6c0>, CHART_LINE=1, CHART_SCATTER=2, CHART_BAR=3, CHART_PIE=4, CHART_STACK=5, CHART_PERCENT=6, AXIS_CONTINUOUS=0, AXIS_DATE=1, AXIS_TIME=2, AXIS_CATEGORY=3, SERIES_SECS=0, SERIES_CAD=1, SERIES_CADD=2, SERIES_HR=3, SERIES_HR...(truncated), flags=flags@entry=0x0) at Python/pythonrun.c:1273
#13 0x00007fabd56679ef in _PyRun_SimpleStringFlagsWithName
    (command=0x7faacc003390 "import sys\nimport pandas as pd\nimport numpy as np\nfrom scipy import signal\n\nprint(sys.version)\n\ndf = pd.DataFrame(np.random.randn(10), columns=['X'])\ndf_detrended = pd.DataFrame(signal.detrend(df))\n\n#"..., name=name@entry=0x0, flags=0x0) at Python/pythonrun.c:567
#14 0x00007fabd5667a52 in PyRun_SimpleStringFlags (command=<optimized out>, flags=<optimized out>) at Python/pythonrun.c:590
#15 0x0000561656045619 in PythonEmbed::runline (this=this@entry=0x561666ecfd40, scriptContext=..., line=...)
    at /usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/basic_string.h:238
#16 0x000056165604d812 in PythonChart::execScript (chart=0x561674ca8b30) at Charts/PythonChart.cpp:585
#17 0x00005616560501da in std::__invoke_impl<void, void (*&)(PythonChart*), PythonChart*&> (__f=<synthetic pointer>: <optimized out>)
    at /usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:62
#18 std::__invoke<void (*&)(PythonChart*), PythonChart*&> (__fn=<synthetic pointer>: <optimized out>)
    at /usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:98
#19 std::invoke<void (*&)(PythonChart*), PythonChart*&> (__fn=<synthetic pointer>: <optimized out>)
    at /usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/functional:122
#20 QtConcurrent::StoredFunctionCall<void (*)(PythonChart*), PythonChart*>::runFunctor()::{lambda(void (*)(PythonChart*), PythonChart*)#1}::operator()(void (*)(PythonChart*), PythonChart*) const (__closure=<synthetic pointer>, function=<optimized out>, args#0=<optimized out>)
    at /usr/include/qt6/QtConcurrent/qtconcurrentstoredfunctioncall.h:117
#21 std::__invoke_impl<void, QtConcurrent::StoredFunctionCall<void (*)(PythonChart*), PythonChart*>::runFunctor()::{lambda(void (* const&)(PythonChart*), PythonChart*)#1}, void (*)(PythonChart*), PythonChart*>(std::__invoke_other, QtConcurrent::StoredFunctionCall<void (*)(PythonChart*), PythonChart*>::runFunctor()::{lambda(void (* const&)(PythonChart*), PythonChart*)#1}, void (*&&)(PythonChart*), PythonChart*&&) (__f=<synthetic pointer>...)
    at /usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:63
#22 std::__invoke<QtConcurrent::StoredFunctionCall<void (*)(PythonChart*), PythonChart*>::runFunctor()::{lambda(void (* const&)(PythonChart*), PythonChart*)#1}, void (*)(PythonChart*), PythonChart*>(QtConcurrent::StoredFunctionCall<void (*)(PythonChart*), PythonChart*>::runFunctor()::{lambda(void (* const&)(PythonChart*), PythonChart*)#1}, void (*&&)(PythonChart*), PythonChart*&&) (__fn=<synthetic pointer>...) at /usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/bits/invoke.h:98
#23 std::__apply_impl<QtConcurrent::StoredFunctionCall<void (*)(PythonChart*), PythonChart*>::runFunctor()::{lambda(void (* const&)(PythonChart*), PythonChart*)#1}, std::tuple<void (*)(PythonChart*), PythonChart*>, 0ul, 1ul>(QtConcurrent::StoredFunctionCall<void (*)(PythonChart*), PythonChart*>::runFunctor()::{lambda(void (* const&)(PythonChart*), PythonChart*)#1}, std::tuple<void (*)(PythonChart*), PythonChart*>&&, std::integer_sequence<unsigned long, 0ul, 1ul>)
    (__f=<synthetic pointer>..., __t=<optimized out>) at /usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/tuple:2920
#24 std::apply<QtConcurrent::StoredFunctionCall<void (*)(PythonChart*), PythonChart*>::runFunctor()::{lambda(void (* const&)(PythonChart*), PythonChart*)#1}, std::tuple<void (*)(PythonChart*), PythonChart*> >(QtConcurrent::StoredFunctionCall<void (*)(PythonChart*), PythonChart*>::runFunctor()::{lambda(void (* const&)(PythonChart*), PythonChart*)#1}, std::tuple<void (*)(PythonChart*), PythonChart*>&&) (__f=<synthetic pointer>..., __t=<optimized out>)
    at /usr/lib/gcc/x86_64-pc-linux-gnu/15/include/g++-v15/tuple:2935
#25 QtConcurrent::StoredFunctionCall<void (*)(PythonChart*), PythonChart*>::runFunctor (this=<optimized out>)
    at /usr/include/qt6/QtConcurrent/qtconcurrentstoredfunctioncall.h:121
#26 0x0000561656050cce in QtConcurrent::RunFunctionTaskBase<void>::run (this=0x56166ca89d00) at /usr/include/qt6/QtConcurrent/qtconcurrentrunbase.h:84
#27 0x00007fabc7e12497 in QThreadPoolThread::run (this=0x561672ca06d0)
    at /var/tmp/portage/dev-qt/qtbase-6.10.2/work/qtbase-everywhere-src-6.10.2/src/corelib/thread/qthreadpool.cpp:72
#28 0x00007fabc7da714f in operator() (__closure=__closure@entry=0x7faad1ff92c0)
    at /var/tmp/portage/dev-qt/qtbase-6.10.2/work/qtbase-everywhere-src-6.10.2/src/corelib/thread/qthread_unix.cpp:448
#29 0x00007fabc7da71b3 in (anonymous namespace)::terminate_on_exception<QThreadPrivate::start(void*)::<lambda()> >(struct {...} &&) (t=...)
    at /var/tmp/portage/dev-qt/qtbase-6.10.2/work/qtbase-everywhere-src-6.10.2/src/corelib/thread/qthread_unix.cpp:373
#30 0x00007fabc7da73dd in QThreadPrivate::start (arg=0x561672ca06d0)
    at /var/tmp/portage/dev-qt/qtbase-6.10.2/work/qtbase-everywhere-src-6.10.2/src/corelib/thread/qthread_unix.cpp:422
#31 0x00007fabc76b162e in start_thread (arg=<optimized out>) at pthread_create.c:448
#32 0x00007fabc772e01c in __GI___clone3 () at ../sysdeps/unix/sysv/linux/x86_64/clone3.S:78
```
