### PR TITLE
Added some telemetry figures to RealtimeData:value(), ::seriesName() …

### DIFF
--- a/src/Train/RealtimeData.cpp
+++ b/src/Train/RealtimeData.cpp
@@ -443,6 +443,9 @@ double RealtimeData::value(DataSeries series) const
     case Watts: return watts;
         break;
 
+    case Wbal: return wbal;
+        break;
+
     case Speed: return speed;
         break;
 
@@ -823,6 +826,11 @@ QString RealtimeData::seriesName(DataSeries series)
         break;
     case HeatLoad: return tr("Estimated Heat Load");
         break;
+
+    case RightPCO: return tr("Right PCO");
+        break;
+    case LeftPCO: return tr("Left PCO");
+        break;
     }
 }
 
@@ -1021,6 +1029,11 @@ QString RealtimeData::seriesSymbol(DataSeries series)
     case HeatStrain: return QString("Heat Strain");
         break;
     case HeatLoad: return QString("Estimated Heat Load");
+        break;
+
+    case RightPCO: return QString("Right PCO");
+        break;
+    case LeftPCO: return QString("Left PCO");
         break;
     }
 }


### PR DESCRIPTION
…and ::seriesSymbol()

For training HTML charts to use those data

This is a continuation of [RealTimeData - Add seriesSymbol method](https://github.com/GoldenCheetah/GoldenCheetah/commit/590993826c7f8f02dc38af926552c03c85d3b6b3) to deliver Wbal, LeftPCO and RightPCO to HTML charts or, in general, to be compatible with other telemetry data.

There are a lot of other data not integrated in RealtimeData:value() or RealtimeData:seriesName() or RealtimeData:symbolName(), mostly because they are derived data (not telemetry themselves. We will think about how to deliver them for HTML charts in training