### PR TITLE
Refactor RealtimeData derived series

### DIFF
--- a/src/Train/RealtimeData.cpp
+++ b/src/Train/RealtimeData.cpp
@@ -19,6 +19,7 @@
 
 #include "RealtimeData.h"
 #include "RideFile.h"
+#include "Context.h"
 
 #include <QtDebug>
 
@@ -1095,3 +1096,43 @@ double RealtimeData::getTemp() const { return temp; }
 double RealtimeData::getCoreTemp() const { return coreTemp; }
 double RealtimeData::getSkinTemp() const { return skinTemp; }
 double RealtimeData::getHeatStrain() const { return heatStrain; }
+
+//
+// RealtimeDataSession
+//
+void RealtimeDataSession::start()
+{
+    wbalr = 0;
+    wbal = WPRIME;
+}
+
+void RealtimeDataSession::stop()
+{
+    wbalr = 0;
+    wbal = WPRIME;
+}
+
+void RealtimeDataSession::newLap()
+{
+}
+
+void RealtimeDataSession::updateDerived()
+{
+    // W'bal on the fly
+    // using Dave Waterworth's reformulation
+
+    // any watts expended in last 200msec?
+    double joules = double(getWatts() - CP) / 5.00f;
+    if (joules < 0) joules = 0;
+
+    // running total of replenishment
+    wbalr += joules * exp((getMsecs()/1000.00f) / TAU);
+    wbal = WPRIME - (wbalr * exp((-getMsecs()/1000.00f) / TAU));
+
+    setWbal(wbal);
+
+    // VAMinator
+    double VAM = vaminator.Push(getAltitude(), getMsecs(), getRouteDistance());
+    if (!GlobalContext::context()->useMetricUnits) VAM *= (1. / 0.3048);
+    setVAM(VAM);
+}

--- a/src/Train/RealtimeData.h
+++ b/src/Train/RealtimeData.h
@@ -258,4 +258,67 @@ private:
     bool trainerBrakeFault;
 };
 
+// Class implements queue for tracking altitude across time for
+// past minute. This is used to derive a vertical meters per minute
+// value that is retuned by each push.
+// A route location change of more than 50 meters in a second is
+// considered a 'skip' and clears the vam queue.
+// New data is accepted only every second.
+
+#include <queue>
+
+class Vaminator {
+    std::deque<std::tuple<double, double, double>> q;
+
+public:
+    Vaminator() {}
+    double Push(double altitude, double sessionMS, double routeLocationKM) {
+
+        bool fDoPush = true;
+        if (!q.empty()) {
+            // a seek is more than 50 meters in a second
+            double routeDelta = routeLocationKM - std::get<2>(q.back());
+            if (fabs(routeDelta) > (50. / 1000.)) {
+                q.clear(); // make empty
+            } else {
+                // Pop elements more than 1 minute back
+                double startTimeMS = std::get<1>(q.front());
+                while ((sessionMS - startTimeMS) > (60. * 1000.)) {
+                    q.pop_front();
+                    if (q.empty())
+                        break;
+                    startTimeMS = std::get<1>(q.front());
+                }
+
+                fDoPush = q.empty() || sessionMS - 1000. >= std::get<1>(q.back());
+            }
+        }
+
+        // Push element if its > 1 second ahead of newest
+        if (fDoPush)
+            q.push_back(std::make_tuple( altitude, sessionMS, routeLocationKM ));
+
+        double vertDeltaM = std::get<0>(q.back()) - std::get<0>(q.front());
+        double timeDeltaHour = (std::get<1>(q.back()) - std::get<1>(q.front())) / (1000. * 60. * 60);
+
+        // Require 1 second of time data before posting non-zero value.
+        return (timeDeltaHour > (1./3600.)) ? vertDeltaM / timeDeltaHour : 0.;
+    }
+};
+
+class RealtimeDataSession : public RealtimeData
+{
+public:
+    RealtimeDataSession(double CP, double WPRIME, double TAU) : CP(CP), WPRIME(WPRIME), TAU(TAU) {}
+    void start();
+    void stop();
+    void newLap();
+    void updateDerived();
+
+private:
+    double CP, WPRIME, TAU;
+    Vaminator vaminator;
+    double wbalr, wbal;
+};
+
 #endif

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -394,11 +394,6 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
 
     displayTemp = 0;
     displayWorkoutLap = 0;
-    pwrcount = 0;
-    cadcount = 0;
-    hrcount = 0;
-    spdcount = 0;
-    lodcount = 0;
     load_msecs = total_msecs = lap_msecs = 0;
     displayWorkoutDistance = displayDistance = displayPower = displayHeartRate =
     displaySpeed = displayCadence = slope = load = 0;
@@ -1664,11 +1659,6 @@ void TrainSidebar::Stop(int deviceStatus)        // when stop button is pressed
 
     // Re-enable gui elements
     // reset counters etc
-    pwrcount = 0;
-    cadcount = 0;
-    hrcount = 0;
-    spdcount = 0;
-    lodcount = 0;
     displayTemp = 0;
     displayWorkoutLap = 0;
     session_elapsed_msec = 0;
@@ -2214,10 +2204,6 @@ void TrainSidebar::resetLapTimer()
     lap_time.restart();
     lap_elapsed_msec = 0;
     displayLapDistance = 0;
-    pwrcount  = 0;
-    cadcount  = 0;
-    hrcount   = 0;
-    spdcount  = 0;
     this->resetTextAudioEmitTracking();
     this->maintainLapDistanceState();
 }

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -80,7 +80,7 @@
 #endif
 
 TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(context),
-    bicycle(context)
+    bicycle(context), rtData(0, 0, 0)
 {
     // Athlete
     FTP=285; // default to 285 if zones are not set
@@ -91,6 +91,10 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
         FTP = context->athlete->zones("Bike")->getCP(range);
         WPRIME = context->athlete->zones("Bike")->getWprime(range);
     }
+
+    double TAU = appsettings->cvalue(context->athlete->cyclist, GC_WBALTAU, 300).toInt();
+
+    rtData = RealtimeDataSession(FTP, WPRIME, TAU);
 
     QWidget *c = new QWidget;
     //c->setContentsMargins(0,0,0,0); // bit of space is useful
@@ -395,7 +399,6 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
     hrcount = 0;
     spdcount = 0;
     lodcount = 0;
-    wbalr = wbal = 0;
     load_msecs = total_msecs = lap_msecs = 0;
     displayWorkoutDistance = displayDistance = displayPower = displayHeartRate =
     displaySpeed = displayCadence = slope = load = 0;
@@ -1416,8 +1419,7 @@ void TrainSidebar::Start()       // when start button is pressed
         session_elapsed_msec = 0;
         lap_time.start();
         lap_elapsed_msec = 0;
-        wbalr = 0;
-        wbal = WPRIME;
+        rtData.start();
         
         resetTextAudioEmitTracking();
 
@@ -1669,12 +1671,11 @@ void TrainSidebar::Stop(int deviceStatus)        // when stop button is pressed
     lodcount = 0;
     displayTemp = 0;
     displayWorkoutLap = 0;
-    wbalr = 0;
-    wbal = WPRIME;
     session_elapsed_msec = 0;
     session_time.restart();
     lap_elapsed_msec = 0;
     lap_time.restart();
+    rtData.stop();
     displayWorkoutDistance = displayDistance = 0;
     displayLapDistance = 0;
     displayLapDistanceRemaining = -1;
@@ -1808,7 +1809,6 @@ void TrainSidebar::Disconnect()
 
 void TrainSidebar::guiUpdate()           // refreshes the telemetry
 {
-    RealtimeData rtData;
     rtData.setLap(displayWorkoutLap);
     rtData.mode = mode;
 
@@ -2178,24 +2178,8 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
 
             rtData.setVirtualSpeed(vs);
 
-            // W'bal on the fly
-            // using Dave Waterworth's reformulation
-            double TAU = appsettings->cvalue(context->athlete->cyclist, GC_WBALTAU, 300).toInt();
-
-            // any watts expended in last 200msec?
-            double JOULES = double(rtData.getWatts() - FTP) / 5.00f;
-            if (JOULES < 0) JOULES = 0;
-
-            // running total of replenishment
-            wbalr += JOULES * exp((total_msecs/1000.00f) / TAU);
-            wbal = WPRIME - (wbalr * exp((-total_msecs/1000.00f) / TAU));
-
-            rtData.setWbal(wbal);
-
-            // VAMinator
-            displayVAM = vaminator.Push(displayAltitude, session_time.elapsed(), displayWorkoutDistance);
-            if (!GlobalContext::context()->useMetricUnits) displayVAM *= (1. / 0.3048);
-            rtData.setVAM(displayVAM);
+            // Update Derived data series
+            rtData.updateDerived();
 
             // go update the displays...
             context->notifyTelemetryUpdate(rtData); // signal everyone to update telemetry

--- a/src/Train/TrainSidebar.h
+++ b/src/Train/TrainSidebar.h
@@ -284,10 +284,7 @@ class TrainSidebar : public GcWindow
 
         RealtimeDataSession rtData;
 
-        // for non-zero average calcs
-        int pwrcount, cadcount, hrcount, spdcount, lodcount, grdcount; // for NZ average calc
         int status;
-        int displaymode;
 
         QString codeWorkoutKey;     // traindb-key of the workout in the case of a code-workout; empty otherwise
         QString codeWorkoutTitle;   // title of the workout in the case of a code-workout; empty otherwise

--- a/src/Train/TrainSidebar.h
+++ b/src/Train/TrainSidebar.h
@@ -55,8 +55,6 @@
 #include "PhysicsUtility.h"
 #include "BicycleSim.h"
 
-#include <queue>
-
 // Status settings
 #define RT_MODE_ERGO        0x0001        // load generation modes
 #define RT_MODE_SPIN        0x0002        // spinscan like modes
@@ -91,51 +89,6 @@ class RealtimeData;
 class MultiDeviceDialog;
 class TrainBottom;
 class DeviceTreeView;
-
-// Class implements queue for tracking altitude across time for
-// past minute. This is used to derive a vertical meters per minute
-// value that is retuned by each push.
-// A route location change of more than 50 meters in a second is
-// considered a 'skip' and clears the vam queue.
-// New data is accepted only every second.
-class Vaminator {
-    std::deque<std::tuple<double, double, double>> q;
-
-public:
-    Vaminator() {}
-    double Push(double altitude, double sessionMS, double routeLocationKM) {
-
-        bool fDoPush = true;
-        if (!q.empty()) {
-            // a seek is more than 50 meters in a second
-            double routeDelta = routeLocationKM - std::get<2>(q.back());
-            if (fabs(routeDelta) > (50. / 1000.)) {
-                q.clear(); // make empty
-            } else {
-                // Pop elements more than 1 minute back
-                double startTimeMS = std::get<1>(q.front());
-                while ((sessionMS - startTimeMS) > (60. * 1000.)) {
-                    q.pop_front();
-                    if (q.empty())
-                        break;
-                    startTimeMS = std::get<1>(q.front());
-                }
-
-                fDoPush = q.empty() || sessionMS - 1000. >= std::get<1>(q.back());
-            }
-        }
-
-        // Push element if its > 1 second ahead of newest
-        if (fDoPush)
-            q.push_back(std::make_tuple( altitude, sessionMS, routeLocationKM ));
-
-        double vertDeltaM = std::get<0>(q.back()) - std::get<0>(q.front());
-        double timeDeltaHour = (std::get<1>(q.back()) - std::get<1>(q.front())) / (1000. * 60. * 60);
-
-        // Require 1 second of time data before posting non-zero value.
-        return (timeDeltaHour > (1./3600.)) ? vertDeltaM / timeDeltaHour : 0.;
-    }
-};
 
 class TrainSidebar : public GcWindow
 {
@@ -329,7 +282,7 @@ class TrainSidebar : public GcWindow
 
         void maintainLapDistanceState();
 
-        Vaminator vaminator;
+        RealtimeDataSession rtData;
 
         // for non-zero average calcs
         int pwrcount, cadcount, hrcount, spdcount, lodcount, grdcount; // for NZ average calc
@@ -386,7 +339,6 @@ class TrainSidebar : public GcWindow
         QCheckBox   *recordSelector;
         QSharedPointer<QFileSystemWatcher> watcher;
         bool calibrating;
-        double wbalr, wbal;
 };
 
 class MultiDeviceDialog : public QDialog


### PR DESCRIPTION
Started with W'bal and VAM moved from TrainSideBar to a new RealtimeDataSession class derived from RealtimeData with an updateDerived method inteded to do the computation before telemetry update is generated and start/stop/newLap methods for the necessary resets of accumulation members.
This is still WIP, the next step would be to move (copy then remove after testing) Coggan/Skiba metrics, Joules, HeatLoad and averages/lap averages from DialWindow so they become available for the new HTML Chart and Overlay Widgets too.