### PR TITLE
Realtime data - Compute derived metrics

### DIFF
--- a/src/Core/Settings.h
+++ b/src/Core/Settings.h
@@ -352,6 +352,10 @@
 #define GC_SIM_BICYCLE_Tk                     "<athlete-preferences>sim_bicycle/Tk"
 #define GC_SIM_BICYCLE_ACTUALTRAINERALTITUDEM "<athlete-preferences>sim_bicycle/ActualTrainerAltitudeM"
 
+#define GC_REALTIMEDATA_HEATLOAD              "<athlete-preferences>RealtimeData/HeatLoad"
+#define GC_REALTIMEDATA_HEATLOAD_MSEC         "<athlete-preferences>RealtimeData/HeatLoadMSec"
+#define GC_REALTIMEDATA_HEATLOAD_LOCALDATE    "<athlete-preferences>RealtimeData/HeatLoadLocalDate"
+
 #define GC_RWGPSUSER                    "<athlete-private>rwgps/user"
 #define GC_RWGPSPASS                    "<athlete-private>rwgps/pass"
 #define GC_RWGPS_AUTH_TOKEN             "<athlete-private>rwgps/auth_token"

--- a/src/Train/DialWindow.cpp
+++ b/src/Train/DialWindow.cpp
@@ -111,13 +111,6 @@ DialWindow::DialWindow(Context *context) :
 
     // set to zero
     resetValues();
-
-
-    //do this on init, but not in resetValues as we want to preserve the heat load across sessions, resetting if local midnight passes while not running
-    heatLoadMSec = 0;
-    heatLoad = 0;
-    heatLoadLocalDate = QDateTime::currentDateTime();
-    isRunning = false;
 }
 
 void
@@ -131,14 +124,12 @@ void
 DialWindow::start()
 {
     resetValues();
-    isRunning = true;
 }
 
 void
 DialWindow::stop()
 {
     resetValues();
-    isRunning = false;
 }
 
 void
@@ -334,168 +325,30 @@ DialWindow::telemetryUpdate(const RealtimeData &rtData)
 
     // COGGAN Metrics
     case RealtimeData::IsoPower:
+        valueLabel->setText(QString("%1").arg(round(rtData.getIsoPower())));
+        break;
     case RealtimeData::IF:
+        valueLabel->setText(QString("%1").arg(rtData.getIF(), 0, 'f', 3));
+        break;
     case RealtimeData::BikeStress:
+        valueLabel->setText(QString("%1").arg(rtData.getBikeStress(), 0, 'f', 1));
+        break;
     case RealtimeData::VI:
-        {
-
-        // Update sum of watts for last 30 seconds
-        sum += rtData.value(RealtimeData::Watts);
-        sum -= rolling[index];
-        rolling[index] = rtData.value(RealtimeData::Watts);
-
-        // raise average to the 4th power
-        rollingSum += pow(sum/150,4); // raise rolling average to 4th power
-        count ++;
-
-        // move index on/round
-        index = (index >= 149) ? 0 : index+1;
-
-        // calculate IsoPower
-        double np = pow(rollingSum / (count), 0.25);
-
-        if (series == RealtimeData::IsoPower) {
-            // We only wanted IsoPower so thats it
-            valueLabel->setText(QString("%1").arg(round(np)));
-
-        } else {
-
-            double rif, cp;
-            // carry on and calculate IF
-            if (context->athlete->zones("Bike")) {
-
-                // get cp for today
-                int zonerange = context->athlete->zones("Bike")->whichRange(QDateTime::currentDateTime().date());
-                if (zonerange >= 0) cp = context->athlete->zones("Bike")->getCP(zonerange);
-                else cp = 0;
-
-            } else {
-                cp = 0;
-            }
-
-            if (cp) rif = np / cp;
-            else rif = 0;
-
-            if (series == RealtimeData::IF) {
-
-                // we wanted IF so thats it
-                valueLabel->setText(QString("%1").arg(rif, 0, 'f', 3));
-
-            } else {
-
-                double normWork = np * (rtData.value(RealtimeData::Time) / 1000); // msecs
-                double rawTSS = normWork * rif;
-                double workInAnHourAtCP = cp * 3600;
-                double tss = rawTSS / workInAnHourAtCP * 100.0;
-
-                if (series == RealtimeData::BikeStress) {
-
-                    valueLabel->setText(QString("%1").arg(tss, 0, 'f', 1));
-
-                } else {
-
-                    // track average power for VI
-                    apsum += rtData.value(RealtimeData::Watts);
-                    apcount++;
-
-                    double ap = apsum ? apsum / apcount : 0;
-
-                    // VI is all that is left!
-                    valueLabel->setText(QString("%1").arg(ap ? np / ap : 0, 0, 'f', 3));
-
-                }
-
-            }
-
-        }
-
-        }
+        valueLabel->setText(QString("%1").arg(rtData.getVI(), 0, 'f', 3));
         break;
 
     // SKIBA Metrics
     case RealtimeData::XPower:
+        valueLabel->setText(QString("%1").arg(round(rtData.getXPower())));
+        break;
     case RealtimeData::RI:
+        valueLabel->setText(QString("%1").arg(rtData.getRI(), 0, 'f', 3));
+        break;
     case RealtimeData::BikeScore:
+        valueLabel->setText(QString("%1").arg(rtData.getBikeScore(), 0, 'f', 1));
+        break;
     case RealtimeData::SkibaVI:
-        {
-
-        static const double exp = 2.0f / ((25.0f / 0.2f) + 1.0f);
-        static const double rem = 1.0f - exp;
-
-        count++;
-
-        if (count < 125) {
-
-            // get up to speed
-            rsum += rtData.value(RealtimeData::Watts);
-            ewma = rsum / count;
-
-        } else {
-
-            // we're up to speed
-            ewma = (rtData.value(RealtimeData::Watts) * exp) + (ewma * rem);
-        }
-
-        sum += pow(ewma, 4.0f);
-        double xpower = pow(sum / count, 0.25f);
-
-        if (series == RealtimeData::XPower) {
-
-            // We wanted XPower!
-            valueLabel->setText(QString("%1").arg(round(xpower)));
-
-        } else {
-
-            double rif, cp;
-            // carry on and calculate IF
-            if (context->athlete->zones("Bike")) {
-
-                // get cp for today
-                int zonerange = context->athlete->zones("Bike")->whichRange(QDateTime::currentDateTime().date());
-                if (zonerange >= 0) cp = context->athlete->zones("Bike")->getCP(zonerange);
-                else cp = 0;
-
-            } else {
-                cp = 0;
-            }
-
-            if (cp) rif = xpower / cp;
-            else rif = 0;
-
-            if (series == RealtimeData::RI) {
-
-                // we wanted IF so thats it
-                valueLabel->setText(QString("%1").arg(rif, 0, 'f', 3));
-
-            } else {
-
-                double normWork = xpower * (rtData.value(RealtimeData::Time) / 1000); // msecs
-                double rawTSS = normWork * rif;
-                double workInAnHourAtCP = cp * 3600;
-                double tss = rawTSS / workInAnHourAtCP * 100.0;
-
-                if (series == RealtimeData::BikeScore) {
-
-                    valueLabel->setText(QString("%1").arg(tss, 0, 'f', 1));
-
-                } else {
-
-                    // track average power for Relative Intensity
-                    apsum += rtData.value(RealtimeData::Watts);
-                    apcount++;
-
-                    double ap = apsum ? apsum / apcount : 0;
-
-                    // RI is all that is left!
-                    valueLabel->setText(QString("%1").arg(ap ? xpower / ap : 0, 0, 'f', 3));
-
-                }
-
-            }
-
-        }
-
-        }
+        valueLabel->setText(QString("%1").arg(rtData.getSkibaVI(), 0, 'f', 3));
         break;
 
     case RealtimeData::Load:
@@ -573,41 +426,7 @@ DialWindow::telemetryUpdate(const RealtimeData &rtData)
         break;
 
     case RealtimeData::HeatLoad:
-        {
-            double heatStrain = rtData.getHeatStrain();
-            QDateTime currentTime = QDateTime::currentDateTimeUtc();
-            qint64 msecEpoc = currentTime.toMSecsSinceEpoch();
-
-            //qDebug()<<"reset check time isRunning" << isRunning << "at" << QDateTime::currentDateTime() << "heatLoadLocalDate" << heatLoadLocalDate << "DOY" << heatLoadLocalDate.date().dayOfYear();
-            if(!isRunning && heatLoadLocalDate.date().dayOfYear() != QDateTime::currentDateTime().date().dayOfYear())
-            {
-                qDebug()<<"resetting heat load at " << QDateTime::currentDateTime() << "heatLoadLocalDate" << heatLoadLocalDate;
-                heatLoadMSec = 0;
-                heatLoad = 0;
-                heatLoadLocalDate = QDateTime::currentDateTime();
-            }
-
-            if(heatLoadMSec != 0 && heatStrain > HEATLOAD_OFFSET) //don't try to calculate a negative effective heat strain
-            {
-                //(HSI-AOC_Off)^AOC_EXP*TIME/AOC_Mult
-
-                qint64 deltaMSec = msecEpoc - heatLoadMSec;
-                double deltamin = deltaMSec / (1000.0 * 60.0); //msec to minutes
-
-                double newLoad = pow(heatStrain-HEATLOAD_OFFSET, HEATLOAD_EXP) * deltamin / HEATLOAD_MULT;
-
-                if(newLoad > 0)
-                    heatLoad += newLoad;
-
-                //qDebug()<<"newLoad is "<< newLoad << "a" << a << "b" << b << "heatStrain" << heatStrain << "c" << c << "deltamin" << deltamin << "heatLoad" << heatLoad;
-
-                if(heatLoad >= 10.0)
-                    heatLoad = 10.0;
-            }
-            heatLoadMSec = msecEpoc;
-
-            valueLabel->setText(QString("%1").arg(heatLoad, 0, 'f', 3)); //HACK, three DP for extra details
-        }
+        valueLabel->setText(QString("%1").arg(rtData.getHeatLoad(), 0, 'f', 3)); //HACK, three DP for extra details
         break;
 
     default:

--- a/src/Train/DialWindow.h
+++ b/src/Train/DialWindow.h
@@ -116,33 +116,16 @@ class DialWindow : public GcChartWindow
         bool isNewLap;
 
         // for keeping track of rolling averages (max 30s at 5hz)
-        // used by IsoPower and XPower
         QVector<double> rolling;
         double rollingSum;
         int index; // index into rolling (circular buffer)
 
-
-        // VI/RI makes us track AP too
-        int apcount;
-        int apsum;
-
-        // used by XPower algorithm
-        double rsum, ewma;
-
-        //heat load estimate (don't reset in resetValues, but preserve between sessions, and reset when local date changes)
-        //note: each athelete has it's own set of DialWindows if more than one athlete is loaded at the same time
-        double heatLoad;
-        qint64 heatLoadMSec;
-        QDateTime heatLoadLocalDate;
-        bool isRunning = false;
-
         void resetValues() {
 
             rolling.fill(0.00);
-            rsum = ewma = 0.0f;
             rollingSum = index = 0;
-            apcount = count = sum = instantValue = avg30 =
-            apsum = avgLap = avgTotal = lapNumber = 0;
+            count = sum = instantValue = avg30 =
+            avgLap = avgTotal = lapNumber = 0;
             telemetryUpdate(RealtimeData());
         }
 

--- a/src/Train/RealtimeData.cpp
+++ b/src/Train/RealtimeData.cpp
@@ -1095,3 +1095,42 @@ double RealtimeData::getTemp() const { return temp; }
 double RealtimeData::getCoreTemp() const { return coreTemp; }
 double RealtimeData::getSkinTemp() const { return skinTemp; }
 double RealtimeData::getHeatStrain() const { return heatStrain; }
+
+//
+// RealtimeDataSession
+//
+RealtimeDataSession::RealtimeDataSession(double CP, double WPRIME, double TAU) : CP(CP), WPRIME(WPRIME), TAU(TAU)
+{
+    // Initialize derived series data for the session
+    wbalr = 0;
+    wbal = WPRIME;
+}
+
+void RealtimeDataSession::newLap()
+{
+    // Initialize derived series data for the lap
+}
+
+void RealtimeDataSession::updateDerived()
+{
+    // Update derived series data for session and lap
+
+    //
+    // W'bal on the fly using Dave Waterworth's reformulation
+    //
+
+    // any watts expended in last 200msec?
+    double joules = double(getWatts() - CP) / 5.00f;
+    if (joules < 0) joules = 0;
+
+    // running total of replenishment
+    wbalr += joules * exp((getMsecs()/1000.00f) / TAU);
+    wbal = WPRIME - (wbalr * exp((-getMsecs()/1000.00f) / TAU));
+
+    setWbal(wbal);
+
+    //
+    // VAM
+    //
+    setVAM(vaminator.Push(getAltitude(), getMsecs(), getRouteDistance()));
+}

--- a/src/Train/RealtimeData.cpp
+++ b/src/Train/RealtimeData.cpp
@@ -19,6 +19,9 @@
 
 #include "RealtimeData.h"
 #include "RideFile.h"
+#include "Settings.h"
+#include "Context.h"
+#include "Athlete.h"
 
 #include <QtDebug>
 
@@ -40,7 +43,7 @@ RealtimeData::RealtimeData()
     rppb = rppe = rpppb = rpppe = 0.0;
     lppb = lppe = lpppb = lpppe = 0.0;
     coreTemp = skinTemp = 0.0;
-    heatStrain = 0.0;
+    heatStrain = heatLoad = 0.0;
     latitude = longitude = altitude = 0.0;
     rf = rmv = vo2 = vco2 = tv = feo2 = 0.0;
     routeDistance = distanceRemaining = VAMValue = 0.0;
@@ -264,6 +267,9 @@ void RealtimeData::setCoreTemp(double core, double skin, double heatStrain) {
     this->coreTemp = core;
     this->skinTemp = skin;
     this->heatStrain = heatStrain;
+}
+void RealtimeData::setHeatLoad(double heatLoad) {
+    this->heatLoad = heatLoad;
 }
 
 const char *
@@ -755,6 +761,8 @@ double RealtimeData::value(DataSeries series) const
         break;
     case HeatStrain: return heatStrain;
         break;
+    case HeatLoad: return heatLoad;
+        break;
 
     case None:
     default:
@@ -1242,6 +1250,8 @@ QString RealtimeData::seriesSymbol(DataSeries series)
         break;
     case HeatStrain: return QString("Heat Strain");
         break;
+    case HeatLoad: return QString("Estimated Heat Load");
+        break;
 
     case RightPCO: return QString("Right PCO");
         break;
@@ -1341,11 +1351,13 @@ double RealtimeData::getTemp() const { return temp; }
 double RealtimeData::getCoreTemp() const { return coreTemp; }
 double RealtimeData::getSkinTemp() const { return skinTemp; }
 double RealtimeData::getHeatStrain() const { return heatStrain; }
+double RealtimeData::getHeatLoad() const { return heatLoad; }
 
 //
 // RealtimeDataSession
 //
-RealtimeDataSession::RealtimeDataSession(double CP, double WPRIME, double TAU) : CP(CP), WPRIME(WPRIME), TAU(TAU)
+RealtimeDataSession::RealtimeDataSession(Context* context, double CP, double WPRIME, double TAU) :
+                                         context(context), CP(CP), WPRIME(WPRIME), TAU(TAU)
 {
     // Initialize derived series data for the session
 
@@ -1371,6 +1383,27 @@ RealtimeDataSession::RealtimeDataSession(double CP, double WPRIME, double TAU) :
     // Skiba Metrics
     rsum = ewma = xsum = 0.0;
     rcount = 0;
+
+    // Heat Load Estimation - we want to preserve the heat load across sessions,
+    // resetting if local midnight passes while not running
+    setHeatLoad(appsettings->cvalue(context->athlete->cyclist, GC_REALTIMEDATA_HEATLOAD, "").toDouble());
+    heatLoadMSec = appsettings->cvalue(context->athlete->cyclist, GC_REALTIMEDATA_HEATLOAD_MSEC, "").toULongLong();
+    heatLoadLocalDate = QDateTime::fromString(appsettings->cvalue(context->athlete->cyclist, GC_REALTIMEDATA_HEATLOAD_LOCALDATE, "").toString(), Qt::ISODate);
+    if(heatLoadLocalDate.date().dayOfYear() != QDateTime::currentDateTime().date().dayOfYear()) {
+        qDebug()<<"resetting heat load at " << QDateTime::currentDateTime() << "heatLoadLocalDate" << heatLoadLocalDate;
+        setHeatLoad(0.0);
+        heatLoadMSec = 0;
+        heatLoadLocalDate = QDateTime::currentDateTime();
+    }
+}
+
+RealtimeDataSession::~RealtimeDataSession()
+{
+    // Heat Load Estimation - we want to preserve the heat load across sessions,
+    // resetting if local midnight passes while not running
+    appsettings->setCValue(context->athlete->cyclist, GC_REALTIMEDATA_HEATLOAD, getHeatLoad());
+    appsettings->cvalue(context->athlete->cyclist, GC_REALTIMEDATA_HEATLOAD_MSEC, heatLoadMSec);
+    appsettings->cvalue(context->athlete->cyclist, GC_REALTIMEDATA_HEATLOAD_LOCALDATE, heatLoadLocalDate.toString(Qt::ISODate));
 }
 
 void RealtimeDataSession::newLap()
@@ -1379,6 +1412,10 @@ void RealtimeDataSession::newLap()
     sumAvgWattsLap = sumAvgSpeedLap = sumAvgCadenceLap = sumAvgHeartRateLap = 0.0;
     nAvgWattsLap = nAvgSpeedLap = nAvgCadenceLap = nAvgHeartRateLap = 0;
 }
+
+#define HEATLOAD_OFFSET 0.9596
+#define HEATLOAD_MULT 35.92
+#define HEATLOAD_EXP 1.324
 
 void RealtimeDataSession::updateDerived()
 {
@@ -1502,4 +1539,28 @@ void RealtimeDataSession::updateDerived()
     // VI is all that is left!
     double svi = ap ? xpower / ap : 0.0;
     setSkibaVI(svi);
+
+    // Heat Load Estimate
+    double heatStrain = getHeatStrain();
+    QDateTime currentTime = QDateTime::currentDateTimeUtc();
+    qint64 msecEpoc = currentTime.toMSecsSinceEpoch();
+
+    if(heatLoadMSec != 0 && heatStrain > HEATLOAD_OFFSET) //don't try to calculate a negative effective heat strain
+    {
+        //(HSI-AOC_Off)^AOC_EXP*TIME/AOC_Mult
+
+        qint64 deltaMSec = msecEpoc - heatLoadMSec;
+        double deltamin = deltaMSec / (1000.0 * 60.0); //msec to minutes
+
+        double newLoad = pow(heatStrain-HEATLOAD_OFFSET, HEATLOAD_EXP) * deltamin / HEATLOAD_MULT;
+
+        if(newLoad > 0)
+            setHeatLoad(getHeatLoad() + newLoad);
+
+        //qDebug()<<"newLoad is "<< newLoad << "a" << a << "b" << b << "heatStrain" << heatStrain << "c" << c << "deltamin" << deltamin << "heatLoad" << getHeatLoad();
+
+        if(getHeatLoad() >= 10.0)
+            setHeatLoad(10.0);
+    }
+    heatLoadMSec = msecEpoc;
 }

--- a/src/Train/RealtimeData.cpp
+++ b/src/Train/RealtimeData.cpp
@@ -91,6 +91,38 @@ void RealtimeData::setWbal(double wbal)
 {
     this->wbal = wbal;
 }
+void RealtimeData::setBikeScore(double bikeScore)
+{
+    this->bikeScore = bikeScore;
+}
+void RealtimeData::setBikeStress(double bikeStress)
+{
+    this->bikeStress = bikeStress;
+}
+void RealtimeData::setXPower(double xPower)
+{
+    this->xPower = xPower;
+}
+void RealtimeData::setIsoPower(double isoPower)
+{
+    this->isoPower = isoPower;
+}
+void RealtimeData::setRI(double rI)
+{
+    this->rI = rI;
+}
+void RealtimeData::setIF(double iF)
+{
+    this->iF = iF;
+}
+void RealtimeData::setSkibaVI(double skibaVI)
+{
+    this->skibaVI = skibaVI;
+}
+void RealtimeData::setVI(double vI)
+{
+    this->vI = vI;
+}
 void RealtimeData::setVirtualSpeed(double speed)
 {
     this->virtualSpeed = speed;
@@ -268,6 +300,38 @@ double RealtimeData::getJoules() const
 double RealtimeData::getWbal() const
 {
     return wbal;
+}
+double RealtimeData::getBikeScore() const
+{
+    return bikeScore;
+}
+double RealtimeData::getBikeStress() const
+{
+    return bikeStress;
+}
+double RealtimeData::getXPower() const
+{
+    return xPower;
+}
+double RealtimeData::getIsoPower() const
+{
+    return isoPower;
+}
+double RealtimeData::getRI() const
+{
+    return rI;
+}
+double RealtimeData::getIF() const
+{
+    return iF;
+}
+double RealtimeData::getSkibaVI() const
+{
+    return skibaVI;
+}
+double RealtimeData::getVI() const
+{
+    return vI;
 }
 double RealtimeData::getVirtualSpeed() const
 {
@@ -539,6 +603,30 @@ double RealtimeData::value(DataSeries series) const
         break;
 
     case Wbal: return wbal;
+        break;
+
+    case BikeScore: return bikeScore;
+        break;
+
+    case BikeStress: return bikeStress;
+        break;
+
+    case IsoPower: return isoPower;
+        break;
+
+    case XPower: return xPower;
+        break;
+
+    case RI: return rI;
+        break;
+
+    case IF: return iF;
+        break;
+
+    case SkibaVI: return skibaVI;
+        break;
+
+    case VI: return vI;
         break;
 
     case Speed: return speed;
@@ -986,6 +1074,30 @@ QString RealtimeData::seriesSymbol(DataSeries series)
     case Wbal: return QString("W' bal");
         break;
 
+    case BikeStress: return QString("BikeStress");
+        break;
+
+    case BikeScore: return QString("BikeScore");
+        break;
+
+    case XPower: return QString("XPower");
+        break;
+
+    case IsoPower: return QString("Iso Power");
+        break;
+
+    case IF: return QString("Intensity Factor");
+        break;
+
+    case RI: return QString("Relative Intensity");
+        break;
+
+    case SkibaVI: return QString("Skiba Variability Index");
+        break;
+
+    case VI: return QString("Variability Index");
+        break;
+
     case Distance: return QString("Distance");
         break;
 
@@ -1249,6 +1361,16 @@ RealtimeDataSession::RealtimeDataSession(double CP, double WPRIME, double TAU) :
     // W'bal
     wbalr = 0;
     wbal = WPRIME;
+
+    // Coggan Metrics
+    rolling.resize(150); // enough for 30 seconds at 5hz
+    rolling.fill(0.00);
+    sum = rollingSum = 0.0;
+    count = index = 0;
+
+    // Skiba Metrics
+    rsum = ewma = xsum = 0.0;
+    rcount = 0;
 }
 
 void RealtimeDataSession::newLap()
@@ -1305,4 +1427,79 @@ void RealtimeDataSession::updateDerived()
     // VAM
     //
     setVAM(vaminator.Push(getAltitude(), getMsecs(), getRouteDistance()));
+
+    //
+    // Coggan Metrics
+    //
+
+    // Update sum of watts for last 30 seconds
+    sum += value(RealtimeData::Watts);
+    sum -= rolling[index];
+    rolling[index] = value(RealtimeData::Watts);
+
+    // raise average to the 4th power
+    rollingSum += pow(sum/150,4); // raise rolling average to 4th power
+    count ++;
+
+    // move index on/round
+    index = (index >= 149) ? 0 : index+1;
+
+    // calculate IsoPower
+    double np = pow(rollingSum / (count), 0.25);
+    setIsoPower(np);
+
+    // carry on and calculate IF
+    double rif = CP ? np / CP : 0.0;
+    setIF(rif);
+
+    // now TSS
+    double normWork = np * (value(RealtimeData::Time) / 1000); // msecs
+    double rawTSS = normWork * rif;
+    double workInAnHourAtCP = CP * 3600;
+    double tss = rawTSS / workInAnHourAtCP * 100.0;
+    setBikeStress(tss);
+
+    // VI is all that is left!
+    double ap = value(RealtimeData::AvgWatts);
+    double vi = ap ? np / ap : 0.0;
+    setVI(vi);
+
+    //
+    // Skiba Metrics
+    //
+
+    static const double exp = 2.0f / ((25.0f / 0.2f) + 1.0f);
+    static const double rem = 1.0f - exp;
+
+    rcount++;
+
+    if (rcount < 125) {
+
+        // get up to speed
+        rsum += value(RealtimeData::Watts);
+        ewma = rsum / rcount;
+
+    } else {
+
+        // we're up to speed
+        ewma = (value(RealtimeData::Watts) * exp) + (ewma * rem);
+    }
+
+    xsum += pow(ewma, 4.0f);
+    double xpower = pow(xsum / rcount, 0.25f);
+    setXPower(xpower);
+
+    // carry on and calculate RI
+    double ri = CP ? xpower / CP : 0.0;
+    setRI(ri);
+
+    // now BikeScore
+    double normWorkBS = xpower * (value(RealtimeData::Time) / 1000); // msecs
+    double rawBS = normWorkBS * ri;
+    double bikescore = rawBS / workInAnHourAtCP * 100.0;
+    setBikeScore(bikescore);
+
+    // VI is all that is left!
+    double svi = ap ? xpower / ap : 0.0;
+    setSkibaVI(svi);
 }

--- a/src/Train/RealtimeData.cpp
+++ b/src/Train/RealtimeData.cpp
@@ -83,6 +83,10 @@ void RealtimeData::setSpeed(double speed)
 {
     this->speed = speed;
 }
+void RealtimeData::setJoules(double joules)
+{
+    this->joules = joules;
+}
 void RealtimeData::setWbal(double wbal)
 {
     this->wbal = wbal;
@@ -216,6 +220,10 @@ double RealtimeData::getHr() const
 double RealtimeData::getSpeed() const
 {
     return speed;
+}
+double RealtimeData::getJoules() const
+{
+    return joules;
 }
 double RealtimeData::getWbal() const
 {
@@ -453,6 +461,9 @@ double RealtimeData::value(DataSeries series) const
         break;
 
     case Watts: return watts;
+        break;
+
+    case Joules: return joules;
         break;
 
     case Wbal: return wbal;
@@ -873,6 +884,9 @@ QString RealtimeData::seriesSymbol(DataSeries series)
     case ErgTimeRemaining: return QString("Section Time Remaining");
         break;
 
+    case Joules: return QString("kJoules");
+        break;
+
     case Wbal: return QString("W' bal");
         break;
 
@@ -1102,6 +1116,11 @@ double RealtimeData::getHeatStrain() const { return heatStrain; }
 RealtimeDataSession::RealtimeDataSession(double CP, double WPRIME, double TAU) : CP(CP), WPRIME(WPRIME), TAU(TAU)
 {
     // Initialize derived series data for the session
+
+    // Joules
+    setJoules(0.0);
+
+    // W'bal
     wbalr = 0;
     wbal = WPRIME;
 }
@@ -1113,7 +1132,12 @@ void RealtimeDataSession::newLap()
 
 void RealtimeDataSession::updateDerived()
 {
-    // Update derived series data for session and lap
+    // Update derived series data for session and lap (each 200msec)
+
+    //
+    // Joules
+    //
+    setJoules(getJoules() + getWatts()/5000.0);
 
     //
     // W'bal on the fly using Dave Waterworth's reformulation

--- a/src/Train/RealtimeData.cpp
+++ b/src/Train/RealtimeData.cpp
@@ -162,6 +162,46 @@ void RealtimeData::setLapDistanceRemaining(double x)
     this->lapDistanceRemaining = x;
 }
 
+void RealtimeData::setAvgWatts(double x)
+{
+    this->avgWatts = x;
+}
+
+void RealtimeData::setAvgSpeed(double x)
+{
+    this->avgSpeed = x;
+}
+
+void RealtimeData::setAvgCadence(double x)
+{
+    this->avgCadence = x;
+}
+
+void RealtimeData::setAvgHeartRate(double x)
+{
+    this->avgHeartRate = x;
+}
+
+void RealtimeData::setAvgWattsLap(double x)
+{
+    this->avgWattsLap = x;
+}
+
+void RealtimeData::setAvgSpeedLap(double x)
+{
+    this->avgSpeedLap = x;
+}
+
+void RealtimeData::setAvgCadenceLap(double x)
+{
+    this->avgCadenceLap = x;
+}
+
+void RealtimeData::setAvgHeartRateLap(double x)
+{
+    this->avgHeartRateLap = x;
+}
+
 void RealtimeData::setLRBalance(double x)
 {
     this->lrbalance = x;
@@ -284,6 +324,38 @@ double RealtimeData::getLapDistance() const
 double RealtimeData::getLapDistanceRemaining() const
 {
     return lapDistanceRemaining;
+}
+double RealtimeData::getAvgWatts() const
+{
+    return avgWatts;
+}
+double RealtimeData::getAvgSpeed() const
+{
+    return avgSpeed;
+}
+double RealtimeData::getAvgCadence() const
+{
+    return avgCadence;
+}
+double RealtimeData::getAvgHeartRate() const
+{
+    return avgHeartRate;
+}
+double RealtimeData::getAvgWattsLap() const
+{
+    return avgWattsLap;
+}
+double RealtimeData::getAvgSpeedLap() const
+{
+    return avgSpeedLap;
+}
+double RealtimeData::getAvgCadenceLap() const
+{
+    return avgCadenceLap;
+}
+double RealtimeData::getAvgHeartRateLap() const
+{
+    return avgHeartRateLap;
 }
 double RealtimeData::getLRBalance() const
 {
@@ -494,6 +566,30 @@ double RealtimeData::value(DataSeries series) const
         break;
 
     case O2Hb: return o2hb;
+        break;
+
+    case AvgWatts: return avgWatts;
+        break;
+
+    case AvgSpeed: return avgSpeed;
+        break;
+
+    case AvgCadence: return avgCadence;
+        break;
+
+    case AvgHeartRate: return avgHeartRate;
+        break;
+
+    case AvgWattsLap: return avgWattsLap;
+        break;
+
+    case AvgSpeedLap: return avgSpeedLap;
+        break;
+
+    case AvgCadenceLap: return avgCadenceLap;
+        break;
+
+    case AvgHeartRateLap: return avgHeartRateLap;
         break;
 
     case LRBalance: return lrbalance;
@@ -923,6 +1019,30 @@ QString RealtimeData::seriesSymbol(DataSeries series)
     case Load: return QString("Target Power");
         break;
 
+    case AvgWatts: return QString("Average Power");
+        break;
+
+    case AvgSpeed: return QString("Average Speed");
+        break;
+
+    case AvgHeartRate: return QString("Average Heartrate");
+        break;
+
+    case AvgCadence: return QString("Average Cadence");
+        break;
+
+    case AvgWattsLap: return QString("Lap Power");
+        break;
+
+    case AvgSpeedLap: return QString("Lap Speed");
+        break;
+
+    case AvgHeartRateLap: return QString("Lap Heartrate");
+        break;
+
+    case AvgCadenceLap: return QString("Lap Cadence");
+        break;
+
     case LRBalance: return QString("Left/Right Balance");
         break;
 
@@ -1120,6 +1240,12 @@ RealtimeDataSession::RealtimeDataSession(double CP, double WPRIME, double TAU) :
     // Joules
     setJoules(0.0);
 
+    // Averages
+    sumAvgWatts = sumAvgSpeed = sumAvgCadence = sumAvgHeartRate = 0.0;
+    nAvgWatts = nAvgSpeed = nAvgCadence = nAvgHeartRate = 0;
+    sumAvgWattsLap = sumAvgSpeedLap = sumAvgCadenceLap = sumAvgHeartRateLap = 0.0;
+    nAvgWattsLap = nAvgSpeedLap = nAvgCadenceLap = nAvgHeartRateLap = 0;
+
     // W'bal
     wbalr = 0;
     wbal = WPRIME;
@@ -1128,6 +1254,8 @@ RealtimeDataSession::RealtimeDataSession(double CP, double WPRIME, double TAU) :
 void RealtimeDataSession::newLap()
 {
     // Initialize derived series data for the lap
+    sumAvgWattsLap = sumAvgSpeedLap = sumAvgCadenceLap = sumAvgHeartRateLap = 0.0;
+    nAvgWattsLap = nAvgSpeedLap = nAvgCadenceLap = nAvgHeartRateLap = 0;
 }
 
 void RealtimeDataSession::updateDerived()
@@ -1138,6 +1266,26 @@ void RealtimeDataSession::updateDerived()
     // Joules
     //
     setJoules(getJoules() + getWatts()/5000.0);
+
+    //
+    // Averages
+    //
+    sumAvgWatts += getWatts();
+    setAvgWatts(sumAvgWatts/nAvgWatts++);
+    sumAvgSpeed += getSpeed();
+    setAvgSpeed(sumAvgSpeed/nAvgSpeed++);
+    sumAvgCadence += getCadence();
+    setAvgCadence(sumAvgCadence/nAvgCadence++);
+    sumAvgHeartRate += getHr();
+    setAvgHeartRate(sumAvgHeartRate/nAvgHeartRate++);
+    sumAvgWattsLap += getWatts();
+    setAvgWattsLap(sumAvgWattsLap/nAvgWattsLap++);
+    sumAvgSpeedLap += getSpeed();
+    setAvgSpeedLap(sumAvgSpeedLap/nAvgSpeedLap++);
+    sumAvgCadenceLap += getCadence();
+    setAvgCadenceLap(sumAvgCadenceLap/nAvgCadenceLap++);
+    sumAvgHeartRateLap += getHr();
+    setAvgHeartRateLap(sumAvgHeartRateLap/nAvgHeartRateLap++);
 
     //
     // W'bal on the fly using Dave Waterworth's reformulation

--- a/src/Train/RealtimeData.h
+++ b/src/Train/RealtimeData.h
@@ -123,6 +123,16 @@ public:
     void setLatitude(double);
     void setLongitude(double);
     void setAltitude(double);
+
+    void setAvgWatts(double);
+    void setAvgSpeed(double);
+    void setAvgCadence(double);
+    void setAvgHeartRate(double);
+    void setAvgWattsLap(double);
+    void setAvgSpeedLap(double);
+    void setAvgCadenceLap(double);
+    void setAvgHeartRateLap(double);
+
     void setCoreTemp(double,double,double);
     const char *getName() const;
 
@@ -194,6 +204,15 @@ public:
     double getLongitude() const;
     double getAltitude() const;
 
+    double getAvgWatts() const;
+    double getAvgSpeed() const;
+    double getAvgCadence() const;
+    double getAvgHeartRate() const;
+    double getAvgWattsLap() const;
+    double getAvgSpeedLap() const;
+    double getAvgCadenceLap() const;
+    double getAvgHeartRateLap() const;
+
     void setTrainerStatusAvailable(bool status);
     bool getTrainerStatusAvailable() const;
     void setTrainerReady(bool status);
@@ -251,6 +270,8 @@ private:
     long lapMsecs;
     long lapMsecsRemaining;
     long ergMsecsRemaining;
+    double avgWatts, avgSpeed, avgCadence, avgHeartRate;
+    double avgWattsLap, avgSpeedLap, avgCadenceLap, avgHeartRateLap;
 
     bool trainerStatusAvailable;
     bool trainerReady;
@@ -317,8 +338,15 @@ public:
 
 private:
     double CP, WPRIME, TAU;
+
     Vaminator vaminator;
+
     double wbalr, wbal;
+
+    double sumAvgWatts, sumAvgSpeed, sumAvgCadence, sumAvgHeartRate;
+    int nAvgWatts, nAvgSpeed, nAvgCadence, nAvgHeartRate;
+    double sumAvgWattsLap, sumAvgSpeedLap, sumAvgCadenceLap, sumAvgHeartRateLap;
+    int nAvgWattsLap, nAvgSpeedLap, nAvgCadenceLap, nAvgHeartRateLap;
 };
 
 #endif

--- a/src/Train/RealtimeData.h
+++ b/src/Train/RealtimeData.h
@@ -95,9 +95,15 @@ public:
     void setRouteDistance(double);
     void setDistanceRemaining(double);
     void setVAM(double);
-    void setBikeScore(long);
+    void setXPower(double);
+    void setBikeScore(double);
+    void setRI(double);
+    void setSkibaVI(double);
+    void setIsoPower(double);
+    void setBikeStress(double);
+    void setIF(double);
+    void setVI(double);
     void setJoules(double);
-    void setXPower(long);
     void setLap(long);
     void setLapDistance(double distance);
     void setLapDistanceRemaining(double distance);
@@ -180,6 +186,14 @@ public:
     double getRouteDistance() const;
     double getDistanceRemaining() const;
     double getVAM() const;
+    double getXPower() const;
+    double getBikeScore() const;
+    double getRI() const;
+    double getSkibaVI() const;
+    double getIsoPower() const;
+    double getBikeStress() const;
+    double getIF() const;
+    double getVI() const;
     long getLap() const;
     double getLapDistance() const;
     double getLapDistanceRemaining() const;
@@ -263,6 +277,8 @@ private:
     double virtualSpeed;
     double wbal;
     double joules;
+    double xPower, bikeScore, rI, skibaVI;
+    double isoPower, bikeStress, iF, vI;
     double hhb, o2hb;
     double rer;
     long lap;
@@ -347,6 +363,15 @@ private:
     int nAvgWatts, nAvgSpeed, nAvgCadence, nAvgHeartRate;
     double sumAvgWattsLap, sumAvgSpeedLap, sumAvgCadenceLap, sumAvgHeartRateLap;
     int nAvgWattsLap, nAvgSpeedLap, nAvgCadenceLap, nAvgHeartRateLap;
+
+    // for keeping track of rolling averages (max 30s at 5hz)
+    // used by IsoPower and XPower
+    QVector<double> rolling;
+    double sum, rollingSum;
+    int count, index; // index into rolling (circular buffer)
+    // used by XPower algorithm
+    double rsum, ewma, xsum;
+    int rcount;
 };
 
 #endif

--- a/src/Train/RealtimeData.h
+++ b/src/Train/RealtimeData.h
@@ -140,6 +140,7 @@ public:
     void setAvgHeartRateLap(double);
 
     void setCoreTemp(double,double,double);
+    void setHeatLoad(double);
     const char *getName() const;
 
     // new muscle oxygen stuff
@@ -165,6 +166,7 @@ public:
     double getCoreTemp() const;
     double getSkinTemp() const;
     double getHeatStrain() const;
+    double getHeatLoad() const;
 
     double getWatts() const;
     double getAltWatts() const;
@@ -264,6 +266,7 @@ private:
     double temp;
     double skinTemp, coreTemp;
     double heatStrain;
+    double heatLoad;
 
     std::chrono::high_resolution_clock::time_point wheelRpmSampleTime;
 
@@ -345,14 +348,18 @@ public:
     }
 };
 
+class Context;
+
 class RealtimeDataSession : public RealtimeData
 {
 public:
-    RealtimeDataSession(double CP, double WPRIME, double TAU);
+    RealtimeDataSession(Context* context, double CP, double WPRIME, double TAU);
+    ~RealtimeDataSession();
     void newLap();
     void updateDerived();
 
 private:
+    Context* context;
     double CP, WPRIME, TAU;
 
     Vaminator vaminator;
@@ -372,6 +379,10 @@ private:
     // used by XPower algorithm
     double rsum, ewma, xsum;
     int rcount;
+
+    // Heat Load Estimate for the athlete, preserve between sessions, and reset when local date changes
+    qint64 heatLoadMSec;
+    QDateTime heatLoadLocalDate;
 };
 
 #endif

--- a/src/Train/RealtimeData.h
+++ b/src/Train/RealtimeData.h
@@ -258,4 +258,65 @@ private:
     bool trainerBrakeFault;
 };
 
+// Class implements queue for tracking altitude across time for
+// past minute. This is used to derive a vertical meters per minute
+// value that is retuned by each push.
+// A route location change of more than 50 meters in a second is
+// considered a 'skip' and clears the vam queue.
+// New data is accepted only every second.
+
+#include <queue>
+
+class Vaminator {
+    std::deque<std::tuple<double, double, double>> q;
+
+public:
+    Vaminator() {}
+    double Push(double altitude, double sessionMS, double routeLocationKM) {
+
+        bool fDoPush = true;
+        if (!q.empty()) {
+            // a seek is more than 50 meters in a second
+            double routeDelta = routeLocationKM - std::get<2>(q.back());
+            if (fabs(routeDelta) > (50. / 1000.)) {
+                q.clear(); // make empty
+            } else {
+                // Pop elements more than 1 minute back
+                double startTimeMS = std::get<1>(q.front());
+                while ((sessionMS - startTimeMS) > (60. * 1000.)) {
+                    q.pop_front();
+                    if (q.empty())
+                        break;
+                    startTimeMS = std::get<1>(q.front());
+                }
+
+                fDoPush = q.empty() || sessionMS - 1000. >= std::get<1>(q.back());
+            }
+        }
+
+        // Push element if its > 1 second ahead of newest
+        if (fDoPush)
+            q.push_back(std::make_tuple( altitude, sessionMS, routeLocationKM ));
+
+        double vertDeltaM = std::get<0>(q.back()) - std::get<0>(q.front());
+        double timeDeltaHour = (std::get<1>(q.back()) - std::get<1>(q.front())) / (1000. * 60. * 60);
+
+        // Require 1 second of time data before posting non-zero value.
+        return (timeDeltaHour > (1./3600.)) ? vertDeltaM / timeDeltaHour : 0.;
+    }
+};
+
+class RealtimeDataSession : public RealtimeData
+{
+public:
+    RealtimeDataSession(double CP, double WPRIME, double TAU);
+    void newLap();
+    void updateDerived();
+
+private:
+    double CP, WPRIME, TAU;
+    Vaminator vaminator;
+    double wbalr, wbal;
+};
+
 #endif

--- a/src/Train/RealtimeData.h
+++ b/src/Train/RealtimeData.h
@@ -96,7 +96,7 @@ public:
     void setDistanceRemaining(double);
     void setVAM(double);
     void setBikeScore(long);
-    void setJoules(long);
+    void setJoules(double);
     void setXPower(long);
     void setLap(long);
     void setLapDistance(double distance);
@@ -157,6 +157,7 @@ public:
     long getTime() const;
     double getSpeed() const;
     double getWbal() const;
+    double getJoules() const;
     double getVirtualSpeed() const;
     double getWheelRpm() const;
     std::chrono::high_resolution_clock::time_point getWheelRpmSampleTime() const;
@@ -242,6 +243,7 @@ private:
     double lapDistanceRemaining;
     double virtualSpeed;
     double wbal;
+    double joules;
     double hhb, o2hb;
     double rer;
     long lap;

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -80,7 +80,7 @@
 #endif
 
 TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(context),
-    bicycle(context)
+    bicycle(context), rtData(0, 0, 0)
 {
     // Athlete
     FTP=285; // default to 285 if zones are not set
@@ -91,6 +91,10 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
         FTP = context->athlete->zones("Bike")->getCP(range);
         WPRIME = context->athlete->zones("Bike")->getWprime(range);
     }
+
+    TAU = appsettings->cvalue(context->athlete->cyclist, GC_WBALTAU, 300).toInt();
+
+    rtData = RealtimeDataSession(FTP, WPRIME, TAU);
 
     QWidget *c = new QWidget;
     //c->setContentsMargins(0,0,0,0); // bit of space is useful
@@ -395,7 +399,6 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
     hrcount = 0;
     spdcount = 0;
     lodcount = 0;
-    wbalr = wbal = 0;
     load_msecs = total_msecs = lap_msecs = 0;
     displayWorkoutDistance = displayDistance = displayPower = displayHeartRate =
     displaySpeed = displayCadence = slope = load = 0;
@@ -796,6 +799,8 @@ TrainSidebar::configChanged(qint32 why)
         FTP = context->athlete->zones("Bike")->getCP(range);
         WPRIME = context->athlete->zones("Bike")->getWprime(range);
     }
+
+    TAU = appsettings->cvalue(context->athlete->cyclist, GC_WBALTAU, 300).toInt();
 
     if (why & CONFIG_ZONES) {
         Library::refreshWorkouts(context);
@@ -1416,8 +1421,7 @@ void TrainSidebar::Start()       // when start button is pressed
         session_elapsed_msec = 0;
         lap_time.start();
         lap_elapsed_msec = 0;
-        wbalr = 0;
-        wbal = WPRIME;
+        rtData = RealtimeDataSession(FTP, WPRIME, TAU);
         
         resetTextAudioEmitTracking();
 
@@ -1669,12 +1673,11 @@ void TrainSidebar::Stop(int deviceStatus)        // when stop button is pressed
     lodcount = 0;
     displayTemp = 0;
     displayWorkoutLap = 0;
-    wbalr = 0;
-    wbal = WPRIME;
     session_elapsed_msec = 0;
     session_time.restart();
     lap_elapsed_msec = 0;
     lap_time.restart();
+    rtData = RealtimeDataSession(FTP, WPRIME, TAU);
     displayWorkoutDistance = displayDistance = 0;
     displayLapDistance = 0;
     displayLapDistanceRemaining = -1;
@@ -1808,7 +1811,6 @@ void TrainSidebar::Disconnect()
 
 void TrainSidebar::guiUpdate()           // refreshes the telemetry
 {
-    RealtimeData rtData;
     rtData.setLap(displayWorkoutLap);
     rtData.mode = mode;
 
@@ -2178,24 +2180,8 @@ void TrainSidebar::guiUpdate()           // refreshes the telemetry
 
             rtData.setVirtualSpeed(vs);
 
-            // W'bal on the fly
-            // using Dave Waterworth's reformulation
-            double TAU = appsettings->cvalue(context->athlete->cyclist, GC_WBALTAU, 300).toInt();
-
-            // any watts expended in last 200msec?
-            double JOULES = double(rtData.getWatts() - FTP) / 5.00f;
-            if (JOULES < 0) JOULES = 0;
-
-            // running total of replenishment
-            wbalr += JOULES * exp((total_msecs/1000.00f) / TAU);
-            wbal = WPRIME - (wbalr * exp((-total_msecs/1000.00f) / TAU));
-
-            rtData.setWbal(wbal);
-
-            // VAMinator
-            displayVAM = vaminator.Push(displayAltitude, session_time.elapsed(), displayWorkoutDistance);
-            if (!GlobalContext::context()->useMetricUnits) displayVAM *= (1. / 0.3048);
-            rtData.setVAM(displayVAM);
+            // Update Derived data series
+            rtData.updateDerived();
 
             // go update the displays...
             context->notifyTelemetryUpdate(rtData); // signal everyone to update telemetry

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -80,7 +80,7 @@
 #endif
 
 TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(context),
-    bicycle(context), rtData(0, 0, 0)
+    bicycle(context), rtData(context, 0, 0, 0)
 {
     // Athlete
     FTP=285; // default to 285 if zones are not set
@@ -94,7 +94,7 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
 
     TAU = appsettings->cvalue(context->athlete->cyclist, GC_WBALTAU, 300).toInt();
 
-    rtData = RealtimeDataSession(FTP, WPRIME, TAU);
+    rtData = RealtimeDataSession(context, FTP, WPRIME, TAU);
 
     QWidget *c = new QWidget;
     //c->setContentsMargins(0,0,0,0); // bit of space is useful
@@ -1416,7 +1416,7 @@ void TrainSidebar::Start()       // when start button is pressed
         session_elapsed_msec = 0;
         lap_time.start();
         lap_elapsed_msec = 0;
-        rtData = RealtimeDataSession(FTP, WPRIME, TAU);
+        rtData = RealtimeDataSession(context, FTP, WPRIME, TAU);
         
         resetTextAudioEmitTracking();
 
@@ -1667,7 +1667,7 @@ void TrainSidebar::Stop(int deviceStatus)        // when stop button is pressed
     session_time.restart();
     lap_elapsed_msec = 0;
     lap_time.restart();
-    rtData = RealtimeDataSession(FTP, WPRIME, TAU);
+    rtData = RealtimeDataSession(context, FTP, WPRIME, TAU);
     displayWorkoutDistance = displayDistance = 0;
     displayLapDistance = 0;
     displayLapDistanceRemaining = -1;

--- a/src/Train/TrainSidebar.cpp
+++ b/src/Train/TrainSidebar.cpp
@@ -394,11 +394,6 @@ TrainSidebar::TrainSidebar(Context *context) : GcWindow(context), context(contex
 
     displayTemp = 0;
     displayWorkoutLap = 0;
-    pwrcount = 0;
-    cadcount = 0;
-    hrcount = 0;
-    spdcount = 0;
-    lodcount = 0;
     load_msecs = total_msecs = lap_msecs = 0;
     displayWorkoutDistance = displayDistance = displayPower = displayHeartRate =
     displaySpeed = displayCadence = slope = load = 0;
@@ -1666,11 +1661,6 @@ void TrainSidebar::Stop(int deviceStatus)        // when stop button is pressed
 
     // Re-enable gui elements
     // reset counters etc
-    pwrcount = 0;
-    cadcount = 0;
-    hrcount = 0;
-    spdcount = 0;
-    lodcount = 0;
     displayTemp = 0;
     displayWorkoutLap = 0;
     session_elapsed_msec = 0;
@@ -2216,10 +2206,6 @@ void TrainSidebar::resetLapTimer()
     lap_time.restart();
     lap_elapsed_msec = 0;
     displayLapDistance = 0;
-    pwrcount  = 0;
-    cadcount  = 0;
-    hrcount   = 0;
-    spdcount  = 0;
     this->resetTextAudioEmitTracking();
     this->maintainLapDistanceState();
 }

--- a/src/Train/TrainSidebar.h
+++ b/src/Train/TrainSidebar.h
@@ -285,10 +285,7 @@ class TrainSidebar : public GcWindow
 
         RealtimeDataSession rtData;
 
-        // for non-zero average calcs
-        int pwrcount, cadcount, hrcount, spdcount, lodcount, grdcount; // for NZ average calc
         int status;
-        int displaymode;
 
         QString codeWorkoutKey;     // traindb-key of the workout in the case of a code-workout; empty otherwise
         QString codeWorkoutTitle;   // title of the workout in the case of a code-workout; empty otherwise

--- a/src/Train/TrainSidebar.h
+++ b/src/Train/TrainSidebar.h
@@ -55,8 +55,6 @@
 #include "PhysicsUtility.h"
 #include "BicycleSim.h"
 
-#include <queue>
-
 // Status settings
 #define RT_MODE_ERGO        0x0001        // load generation modes
 #define RT_MODE_SPIN        0x0002        // spinscan like modes
@@ -91,51 +89,6 @@ class RealtimeData;
 class MultiDeviceDialog;
 class TrainBottom;
 class DeviceTreeView;
-
-// Class implements queue for tracking altitude across time for
-// past minute. This is used to derive a vertical meters per minute
-// value that is retuned by each push.
-// A route location change of more than 50 meters in a second is
-// considered a 'skip' and clears the vam queue.
-// New data is accepted only every second.
-class Vaminator {
-    std::deque<std::tuple<double, double, double>> q;
-
-public:
-    Vaminator() {}
-    double Push(double altitude, double sessionMS, double routeLocationKM) {
-
-        bool fDoPush = true;
-        if (!q.empty()) {
-            // a seek is more than 50 meters in a second
-            double routeDelta = routeLocationKM - std::get<2>(q.back());
-            if (fabs(routeDelta) > (50. / 1000.)) {
-                q.clear(); // make empty
-            } else {
-                // Pop elements more than 1 minute back
-                double startTimeMS = std::get<1>(q.front());
-                while ((sessionMS - startTimeMS) > (60. * 1000.)) {
-                    q.pop_front();
-                    if (q.empty())
-                        break;
-                    startTimeMS = std::get<1>(q.front());
-                }
-
-                fDoPush = q.empty() || sessionMS - 1000. >= std::get<1>(q.back());
-            }
-        }
-
-        // Push element if its > 1 second ahead of newest
-        if (fDoPush)
-            q.push_back(std::make_tuple( altitude, sessionMS, routeLocationKM ));
-
-        double vertDeltaM = std::get<0>(q.back()) - std::get<0>(q.front());
-        double timeDeltaHour = (std::get<1>(q.back()) - std::get<1>(q.front())) / (1000. * 60. * 60);
-
-        // Require 1 second of time data before posting non-zero value.
-        return (timeDeltaHour > (1./3600.)) ? vertDeltaM / timeDeltaHour : 0.;
-    }
-};
 
 class TrainSidebar : public GcWindow
 {
@@ -300,6 +253,7 @@ class TrainSidebar : public GcWindow
 
         int FTP; // current FTP / CP
         int WPRIME; // current W'
+        int TAU; // current W'bal Tau
 
         QList<DeviceConfiguration> Devices;
         QList<int> activeDevices;
@@ -329,7 +283,7 @@ class TrainSidebar : public GcWindow
 
         void maintainLapDistanceState();
 
-        Vaminator vaminator;
+        RealtimeDataSession rtData;
 
         // for non-zero average calcs
         int pwrcount, cadcount, hrcount, spdcount, lodcount, grdcount; // for NZ average calc
@@ -386,7 +340,6 @@ class TrainSidebar : public GcWindow
         QCheckBox   *recordSelector;
         QSharedPointer<QFileSystemWatcher> watcher;
         bool calibrating;
-        double wbalr, wbal;
 };
 
 class MultiDeviceDialog : public QDialog


### PR DESCRIPTION
Refactor derived metrics out of TrainSidebar to a new RealtimeDataSession class derived from RealTime with updateDerived method inteded to do the computation before telemetry update is generated, and newLap method for lap data reset.
Compute incrementally Joules, Session and Lap averages for Watts/Speed/Cadence/HR, Skiba (BikeScore/XPower/RI/VI), Coggan (BikeStress/IsoPower/IF/VI) and HeatLoad metrics so they can be used in the new HTML chart, and Overlay Widgets eventually. Remove now redundant code from DialWindow.