### PR TITLE
elevProfile distance on Train Html chart corrected

### DIFF
--- a/src/Train/HtmlTrainingBridge.cpp
+++ b/src/Train/HtmlTrainingBridge.cpp
@@ -70,11 +70,6 @@ static QJsonArray toJsonArrayD(const QList<double> &xs)
     return a;
 }
 
-static double deg2rad(double deg)
-{
-    return deg * M_PI / 180.0;
-}
-
 HtmlTrainingBridge::HtmlTrainingBridge(Context *context, QObject *parent)
     : QObject(parent),
       m_context(context),
@@ -440,8 +435,8 @@ void HtmlTrainingBridge::onErgFileSelected(ErgFile *file)
             const ErgFilePoint &p1 = points[i - 1];
             const ErgFilePoint &p2 = points[i];
 
-            cumulativeDistanceMeters = std::max(0.0, p2.x - routeStartMeters);
-            double segAccumulatedM = std::max(0.0, p2.x - segStartDist);
+            cumulativeDistanceMeters = (p2.x > routeStartMeters) ? (p2.x - routeStartMeters) : 0.0;
+            double segAccumulatedM = (p2.x > segStartDist) ? (p2.x - segStartDist) : 0.0;
 
             QJsonArray pointCoord;
             pointCoord.append(p2.lon);

--- a/src/Train/HtmlTrainingBridge.cpp
+++ b/src/Train/HtmlTrainingBridge.cpp
@@ -75,22 +75,6 @@ static double deg2rad(double deg)
     return deg * M_PI / 180.0;
 }
 
-static double haversineDistance(double lat1, double lon1, double lat2, double lon2)
-{
-    if (lat1 == lat2 && lon1 == lon2) return 0.0;
-
-    double dLat = deg2rad(lat2 - lat1);
-    double dLon = deg2rad(lon2 - lon1);
-    double lat1_rad = deg2rad(lat1);
-    double lat2_rad = deg2rad(lat2);
-
-    double a = sin(dLat / 2) * sin(dLat / 2) +
-               cos(lat1_rad) * cos(lat2_rad) *
-               sin(dLon / 2) * sin(dLon / 2);
-
-    return 6371.0 * 2.0 * atan2(sqrt(a), sqrt(1.0 - a));
-}
-
 HtmlTrainingBridge::HtmlTrainingBridge(Context *context, QObject *parent)
     : QObject(parent),
       m_context(context),
@@ -425,6 +409,7 @@ void HtmlTrainingBridge::onErgFileSelected(ErgFile *file)
             return;
         }
 
+        const double routeStartMeters = points[0].x;
         double cumulativeDistanceMeters = 0.0;
         double markerIntervalMeters = 5000.0;
         double nextMarkerMeters = markerIntervalMeters;
@@ -442,7 +427,7 @@ void HtmlTrainingBridge::onErgFileSelected(ErgFile *file)
         // huge slope spikes caused by near-zero distance pairs.
         const double MIN_SEGMENT_METERS = 5.0;
         double segStartEle = points[0].y;
-        double segAccumulatedM = 0.0;
+        double segStartDist = points[0].x;
 
         QJsonArray currentLineCoords;
         QJsonArray startCoord;
@@ -455,10 +440,8 @@ void HtmlTrainingBridge::onErgFileSelected(ErgFile *file)
             const ErgFilePoint &p1 = points[i - 1];
             const ErgFilePoint &p2 = points[i];
 
-            const double distKm = haversineDistance(p1.lat, p1.lon, p2.lat, p2.lon);
-            const double distM = distKm * 1000.0;
-            cumulativeDistanceMeters += distM;
-            segAccumulatedM += distM;
+            cumulativeDistanceMeters = std::max(0.0, p2.x - routeStartMeters);
+            double segAccumulatedM = std::max(0.0, p2.x - segStartDist);
 
             QJsonArray pointCoord;
             pointCoord.append(p2.lon);
@@ -500,7 +483,7 @@ void HtmlTrainingBridge::onErgFileSelected(ErgFile *file)
                 features.append(lineFeature);
 
                 segStartEle = p2.y;
-                segAccumulatedM = 0.0;
+                segStartDist = p2.x;
 
                 currentLineCoords = QJsonArray();
                 currentLineCoords.append(pointCoord);
@@ -508,6 +491,7 @@ void HtmlTrainingBridge::onErgFileSelected(ErgFile *file)
 
             while (cumulativeDistanceMeters >= nextMarkerMeters) {
                 double ratio = 1.0;
+                const double distM = p2.x - p1.x;
                 if (distM > 0.0) {
                     ratio = (nextMarkerMeters - (cumulativeDistanceMeters - distM)) / distM;
                 }


### PR DESCRIPTION
The distances in the route elevation profile (elevProfile within the planned route JSON payload returned by getPlannedRoute() and plannedRouteChanged()) were incorrect because they  were calculated using the _Haversine algorithm_. _Haversine_ calculates 2D straight-line distances between GPS coordinates on a sphere, without accounting for road curvature between sample points or elevation changes. As a result, the profile distance accumulated faster or slower than the actual route distance, placing the rider in an incorrect position on the profile chart.

Consequently, on workouts with winding roads or variable terrain, these distances diverged significantly.
With these changes, the elevation profile now directly uses the cumulative route distances stored in the ErgFile points (pt.x). This ensures the elevation profile distance aligns perfectly with the Route Distance telemetry without any distortion.

In the image, it can be noticed: the marker 34.4 km on the map is the 'calculated' position according to the elevation profile (marked with the mouse exactly on the athlete position on the elevation profile), whereas the red point on the map is the real position (its real time coordinates).

<img width="820" height="567" alt="Screenshot" src="https://github.com/user-attachments/assets/b11c8e10-fbcc-43c5-ba26-35ae24cbd74b" />


With tha assistance of Gemini IA to detect the source of the problem.
