### PR TITLE
Support for Kettler Golf E and other old Kettler trainers requiring uppercase serial commands

### DIFF
--- a/src/Train/Kettler.cpp
+++ b/src/Train/Kettler.cpp
@@ -85,6 +85,8 @@ bool Kettler::discover(QString portName)
     QSerialPort sp;
 
     sp.setPortName(portName);
+    
+    // qDebug() << "Kettler::discover(" << portName << ") open";
 
     if (sp.open(QSerialPort::ReadWrite))
     {
@@ -97,17 +99,26 @@ bool Kettler::discover(QString portName)
         sp.write("ID\r\n");
         sp.waitForBytesWritten(500);
 
-        QByteArray reply = sp.readAll();
-
+        QByteArray reply;
+        int i;
+        for (i=0; i<6; i++)
+        {
+            if (!sp.waitForReadyRead(i?50:500)) break;
+            reply.append(sp.readAll());
+        }
         reply.append('\0');
+        // qDebug() << "Kettler::discover, i " << i << ", reply " << reply; 
 
         QString replyString(reply);
-        if (replyString.startsWith("ACK") || replyString.startsWith("RUN"))
+        if (replyString.startsWith("ACK") || replyString.startsWith("RUN")
+                || replyString.startsWith("HT1P\r\n")) /* HT1P: Kettler Golf E 7961-600 with computer M9816 */
         {
             found = true;
         }
     }
 
+    // qDebug() << "Kettler::discover close";
+    
     sp.close();
 
     return found;

--- a/src/Train/Kettler.cpp
+++ b/src/Train/Kettler.cpp
@@ -86,38 +86,31 @@ bool Kettler::discover(QString portName)
 
     sp.setPortName(portName);
     
-    // qDebug() << "Kettler::discover(" << portName << ") open";
+    qDebug() << "Kettler::discover(" << portName << ") open";
 
     if (sp.open(QSerialPort::ReadWrite))
     {
         m_kettlerConnection.configurePort(&sp);
 
-        // Discard any existing data
-        QByteArray data = sp.readAll();
-
         // Read id from bike
-        sp.write("ID\r\n");
-        sp.waitForBytesWritten(500);
-
-        QByteArray reply;
-        int i;
-        for (i=0; i<6; i++)
-        {
-            if (!sp.waitForReadyRead(i?50:500)) break;
-            reply.append(sp.readAll());
-        }
-        reply.append('\0');
-        // qDebug() << "Kettler::discover, i " << i << ", reply " << reply; 
+        QByteArray reply = KettlerConnection::sendCmdReadReply(&sp,"ID\r\n");
 
         QString replyString(reply);
-        if (replyString.startsWith("ACK") || replyString.startsWith("RUN")
-                || replyString.startsWith("HT1P\r\n")) /* HT1P: Kettler Golf E 7961-600 with computer M9816 */
+        if (replyString.startsWith("ACK") || replyString.startsWith("RUN"))
         {
             found = true;
         }
+        else if (replyString.size()>2 && replyString.endsWith("\r\n"))
+        {
+            reply = KettlerConnection::sendCmdReadReply(&sp,"RS\r\n");
+            if (reply=="ACK\r\n" || reply=="RUN\r\n")
+            {
+                found = true;
+            }
+        }
     }
 
-    // qDebug() << "Kettler::discover close";
+    qDebug() << "Kettler::discover close";
     
     sp.close();
 

--- a/src/Train/KettlerConnection.cpp
+++ b/src/Train/KettlerConnection.cpp
@@ -23,6 +23,7 @@
 #include <QFile>
 #include <QTextStream>
 #include <QRegularExpression>
+#include <QElapsedTimer>
 
 KettlerConnection::KettlerConnection() :
     m_serial(0),
@@ -203,29 +204,15 @@ void KettlerConnection::initializePcConnection()
         keepTrying = (--maxRetries != 0);
 
         // Set kettler into PC-mode, reply should be ACK or RUN
-        m_serial->write(m_needsUppercase?"CD\r\n":"cd\r\n");
-
-        if (!m_serial->waitForBytesWritten(500))
+        QByteArray data = sendCmdReadReply(m_serial,m_needsUppercase?"CD\r\n":"cd\r\n");
+        if (data.contains("ACK") || data.contains("RUN"))
         {
-            // failure to write to device, bail out
-            this->exit(-1);
+            keepTrying = false;
         }
-
-        QByteArray data;
-
-        if (m_serial->waitForReadyRead(500))
+        else if (!m_needsUppercase && data=="ERROR\r\n")
         {
-            data = m_serial->readAll();
-            if (QString(data).contains("ACK") || QString(data).contains("RUN"))
-            {
-                keepTrying = false;
-            }
-            else if (!m_needsUppercase && QString(data).startsWith("ERROR\r\n"))
-            {
-                m_needsUppercase = true;
-            }
+            m_needsUppercase = true;
         }
-        // qDebug() << "KettlerConnection::initializePcConnection, data " << data << ", m_needsUpperCase " << m_needsUppercase << ", keepTrying " << keepTrying;
 
     } while (keepTrying);
 
@@ -251,4 +238,48 @@ void KettlerConnection::configurePort(QSerialPort *serialPort)
     serialPort->setDataBits(QSerialPort::Data8);
     serialPort->setFlowControl(QSerialPort::NoFlowControl);
     serialPort->setParity(QSerialPort::NoParity);
+}
+
+QByteArray KettlerConnection::sendCmdReadReply (QSerialPort * serialPort, QByteArray cmd, int timeoutMs)
+{
+    QByteArray data;
+
+    if (!serialPort)
+    {
+        qWarning() << "KettlerConnection::sendCmdReadReply" << cmd << "serial port null";
+        return data;
+    }
+
+    // Discard any existing data
+    serialPort->readAll();
+
+    // Start timer. Note that timeoutMs is the maximum allocated time for the entire communication, including the sending of the command.
+    QElapsedTimer timer;
+    timer.start();
+
+    // Send command string to bike
+    serialPort->write(cmd);
+    if (!serialPort->waitForBytesWritten(timeoutMs))
+    {
+        qWarning() << "KettlerConnection::sendCmdReadReply" << cmd << "write failed";
+        return data;
+    }
+
+    int nrReads = 0;
+    for (;;)
+    {
+        int elapsed = static_cast<int>(timer.elapsed());
+        int wait = timeoutMs - elapsed;
+        if (wait <= 0)
+            break;
+        if (!serialPort->waitForReadyRead(wait))
+            break;
+
+        data.append(serialPort->readAll());
+        nrReads++;
+        if (data.endsWith("\r\n"))
+            break;
+    }
+    qDebug() << "KettlerConnection::sendCmdReadReply" << cmd << nrReads << data;
+    return data;
 }

--- a/src/Train/KettlerConnection.cpp
+++ b/src/Train/KettlerConnection.cpp
@@ -30,7 +30,7 @@ KettlerConnection::KettlerConnection() :
     m_timer(0),
     m_load(0),
     m_loadToWrite(0),
-    m_shouldWriteLoad(false)
+    m_needsUppercase(false)
 {
 }
 
@@ -175,7 +175,7 @@ void KettlerConnection::requestAll()
 
     if ((m_loadToWrite != m_load))
     {
-        QString cmd = QString("pw %1\r\n").arg(m_loadToWrite);
+        QString cmd = QString(m_needsUppercase?"PW %1\r\n":"pw %1\r\n").arg(m_loadToWrite);
         m_serial->write(cmd.toStdString().c_str());
         if (!m_serial->waitForBytesWritten(500))
         {
@@ -203,7 +203,7 @@ void KettlerConnection::initializePcConnection()
         keepTrying = (--maxRetries != 0);
 
         // Set kettler into PC-mode, reply should be ACK or RUN
-        m_serial->write("cd\r\n");
+        m_serial->write(m_needsUppercase?"CD\r\n":"cd\r\n");
 
         if (!m_serial->waitForBytesWritten(500))
         {
@@ -220,8 +220,12 @@ void KettlerConnection::initializePcConnection()
             {
                 keepTrying = false;
             }
+            else if (!m_needsUppercase && QString(data).startsWith("ERROR\r\n"))
+            {
+                m_needsUppercase = true;
+            }
         }
-
+        // qDebug() << "KettlerConnection::initializePcConnection, data " << data << ", m_needsUpperCase " << m_needsUppercase << ", keepTrying " << keepTrying;
 
     } while (keepTrying);
 
@@ -231,7 +235,6 @@ void KettlerConnection::initializePcConnection()
 void KettlerConnection::setLoad(unsigned int load)
 {
     m_loadToWrite = load;
-    m_shouldWriteLoad = true;
 }
 
 /*

--- a/src/Train/KettlerConnection.h
+++ b/src/Train/KettlerConnection.h
@@ -56,6 +56,9 @@ signals:
     void cadence(quint32);
     void power(quint32);
     void speed(double);
+
+public:
+    static QByteArray sendCmdReadReply(QSerialPort * serialPort, QByteArray cmd, int timeoutMs = 500);
 };
 
 #endif // _GC_KettlerConnection_h

--- a/src/Train/KettlerConnection.h
+++ b/src/Train/KettlerConnection.h
@@ -49,7 +49,7 @@ private:
     QMutex m_mutex;
     unsigned int m_load;
     unsigned int m_loadToWrite;
-    bool m_shouldWriteLoad;
+    bool m_needsUppercase;
 
 signals:
     void pulse(quint32);


### PR DESCRIPTION
This pull request adds support for Kettler Golf E and other old Kettler trainers requiring uppercase serial commands. In order not to break the existing trainer base, it does so by sending the original commands and determining from the reply whether to keep or change the approach. It also robustifies the serial communication with the Kettler trainers during discovery and initialization in general.

The changes were discussed with the maintenance crew in https://groups.google.com/g/golden-cheetah-users/c/Hhsd5_bMPYE.