### PR TITLE
Always adding workouts-directory to gcplan bundles

### DIFF
--- a/src/Planning/PlanBundle.cpp
+++ b/src/Planning/PlanBundle.cpp
@@ -1033,7 +1033,6 @@ packDir
                                      QFileDevice::ReadGroup | QFileDevice::ExeGroup |
                                      QFileDevice::ReadOther | QFileDevice::ExeOther);
     zipWriter.addDirectory(dirName + "/");
-    qDebug() << __PRETTY_FUNCTION__ << "Added directory" << dirName;
     for (const QString &fileName : fileNames) {
         QString fullPath = workDir.filePath(fileName);
         QFile file(fullPath);

--- a/src/Planning/PlanBundle.cpp
+++ b/src/Planning/PlanBundle.cpp
@@ -821,11 +821,9 @@ PlanBundle::exportBundle
             zipWriter.close();
             return false;
         }
-        if (copied.second > 0) {
-            if (! packDir(workoutDir, "workouts", zipWriter)) {
-                zipWriter.close();
-                return false;
-            }
+        if (! packDir(workoutDir, "workouts", zipWriter)) {
+            zipWriter.close();
+            return false;
         }
 
         QList<QString> savedFiles = metadata.save(baseDir);
@@ -1030,23 +1028,22 @@ packDir
 (const QDir &workDir, const QString &dirName, ZipWriter &zipWriter)
 {
     QStringList fileNames = workDir.entryList(QDir::Files);
-    bool ret = fileNames.count() > 0;
-    if (ret) {
-        zipWriter.setCreationPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner |
-                                         QFileDevice::ReadGroup | QFileDevice::ExeGroup |
-                                         QFileDevice::ReadOther | QFileDevice::ExeOther);
-        zipWriter.addDirectory(dirName + "/");
-        for (const QString &fileName : fileNames) {
-            QString fullPath = workDir.filePath(fileName);
-            QFile file(fullPath);
-            zipWriter.setCreationPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner |
-                                             QFileDevice::ReadGroup |
-                                             QFileDevice::ReadOther);
-            zipWriter.addFile(dirName + "/" + fileName, &file);
-        }
-        if (zipWriter.status() != ZipWriter::NoError) {
-            ret = false;
-        }
+    bool ret = true;
+    zipWriter.setCreationPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner |
+                                     QFileDevice::ReadGroup | QFileDevice::ExeGroup |
+                                     QFileDevice::ReadOther | QFileDevice::ExeOther);
+    zipWriter.addDirectory(dirName + "/");
+    qDebug() << __PRETTY_FUNCTION__ << "Added directory" << dirName;
+    for (const QString &fileName : fileNames) {
+        QString fullPath = workDir.filePath(fileName);
+        QFile file(fullPath);
+        zipWriter.setCreationPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner |
+                                         QFileDevice::ReadGroup |
+                                         QFileDevice::ReadOther);
+        zipWriter.addFile(dirName + "/" + fileName, &file);
+    }
+    if (zipWriter.status() != ZipWriter::NoError) {
+        ret = false;
     }
     return ret;
 }


### PR DESCRIPTION
Before: Import always required both planned and workouts directories to be present while export skipped workouts if empty.
Now: Export always adds a workouts directory, even if empty

See issue reported in https://groups.google.com/g/golden-cheetah-users/c/aYpDrwkO1eo