### PR TITLE
Global Named Searches file

### DIFF
--- a/src/Core/Athlete.cpp
+++ b/src/Core/Athlete.cpp
@@ -147,9 +147,6 @@ Athlete::Athlete(Context *context, const QDir &homeDir)
     autoImportConfig = new RideAutoImportConfig(home->config());
     autoImport = NULL;
 
-    // Search / filter
-    namedSearches = new NamedSearches(this); // must be before navigator
-
     // Metadata
     rideCache = NULL; // let metadata know we don't have a ridecache yet
 
@@ -253,7 +250,6 @@ Athlete::~Athlete()
     delete davCalendar;
 #endif
 
-    delete namedSearches;
     delete routes;
     delete seasons;
     delete measures;

--- a/src/Core/Athlete.h
+++ b/src/Core/Athlete.h
@@ -42,7 +42,6 @@ class ICalendar;
 class CalDAV;
 class Seasons;
 class RideNavigator;
-class NamedSearches;
 class RideFileCache;
 class RideItem;
 class IntervalItem;
@@ -134,9 +133,6 @@ class Athlete : public QObject
         void loadCharts(); // load charts.xml
         void translateDefaultCharts(QList<LTMSettings>&charts);
 
-        // named filters / queries
-        NamedSearches *namedSearches;
-
         // DataFilter global storage/cache
         QMap<QString,Result> dfcache;
 
@@ -150,7 +146,6 @@ class Athlete : public QObject
         // zones etc
         void notifyZonesChanged() { zonesChanged(); }
         void notifySeasonsChanged() { seasonsChanged(); }
-        void notifyNamedSearchesChanged() { namedSearchesChanged(); }
 
         // import rides from athlete specific directory
         void importFilesWhenOpeningAthlete();
@@ -158,7 +153,6 @@ class Athlete : public QObject
     signals:
         void zonesChanged();
         void seasonsChanged();
-        void namedSearchesChanged();
 
     public slots:
         void checkCPX(RideItem*ride);

--- a/src/Core/Context.h
+++ b/src/Core/Context.h
@@ -84,6 +84,7 @@ class GlobalContext : public QObject
 
         static GlobalContext *context();
 
+        void notifyNamedSearchesChanged() { namedSearchesChanged(); }
         void notifyConfigChanged(qint32);
 
         // metadata etc
@@ -106,6 +107,8 @@ class GlobalContext : public QObject
         // realtime signals global widgets that aren't athlete specific
         void start();
         void stop();
+
+        void namedSearchesChanged();
 
     private:
         // singleton pattern

--- a/src/Core/NamedSearch.cpp
+++ b/src/Core/NamedSearch.cpp
@@ -93,7 +93,8 @@ NamedSearches::read()
 
     } else {
 
-        // Read the individual athlete namedsearches.xml files
+        // Read the individual athlete namedsearches.xml files, this should only ever
+        // occur once to create the combined single namedsearches.xml file.
         QStringListIterator i(QDir(gcroot).entryList(QDir::Dirs | QDir::NoDotAndDotDot));
         while (i.hasNext()) {
             QString name = i.next();
@@ -112,8 +113,10 @@ NamedSearches::read()
                 xmlReader.setErrorHandler(&handler);
                 xmlReader.parse(source);
 
-                // go read them!
-                list += handler.getResults();
+                // skip any duplicates
+                for (const NamedSearch& ns : handler.getResults()) {
+                    if (list.indexOf(ns) == -1) list.append(ns);
+                }
             }
         }
     }

--- a/src/Core/NamedSearch.cpp
+++ b/src/Core/NamedSearch.cpp
@@ -72,21 +72,53 @@ static QString unprotect(const QString string)
 
     return s;
 }
+
 void
 NamedSearches::read()
 {
-    QFile namedSearchFile(home.canonicalPath() + "/namedsearches.xml");
-    QXmlInputSource source( &namedSearchFile );
-    QXmlSimpleReader xmlReader;
-    NamedSearchParser handler;
-    xmlReader.setContentHandler(&handler);
-    xmlReader.setErrorHandler(&handler);
-    xmlReader.parse(source);
+    QFile globalNamedSearchFile(QDir(gcroot).canonicalPath()+"/namedsearches.xml");
 
-    // go read them!
-    list = handler.getResults();
+    // Read the global namedsearches.xml file if it exists
+    if (globalNamedSearchFile.exists()) {
 
-    // If there is no filters yet, add some for multisport use.
+        QXmlInputSource source( &globalNamedSearchFile );
+        QXmlSimpleReader xmlReader;
+        NamedSearchParser handler;
+        xmlReader.setContentHandler(&handler);
+        xmlReader.setErrorHandler(&handler);
+        xmlReader.parse(source);
+
+        // go read them!
+        list = handler.getResults();
+
+    } else {
+
+        // Read the individual athlete namedsearches.xml files
+        QStringListIterator i(QDir(gcroot).entryList(QDir::Dirs | QDir::NoDotAndDotDot));
+        while (i.hasNext()) {
+            QString name = i.next();
+            SKIP_QTWE_CACHE  // skip Folder Names created by QTWebEngine on Windows
+
+            // ignore dot folders
+            if (name.startsWith(".")) continue;
+
+            QFile namedSearchFile(QDir(gcroot).canonicalPath()+"/" + name + "/config/namedsearches.xml");
+            if (namedSearchFile.exists()) {
+
+                QXmlInputSource source( &namedSearchFile );
+                QXmlSimpleReader xmlReader;
+                NamedSearchParser handler;
+                xmlReader.setContentHandler(&handler);
+                xmlReader.setErrorHandler(&handler);
+                xmlReader.parse(source);
+
+                // go read them!
+                list += handler.getResults();
+            }
+        }
+    }
+
+    // If there are no filters yet, add some for multisport use.
     if (list.isEmpty()) {
         NamedSearch namedSearch;
         namedSearch.type = NamedSearch::filter;
@@ -107,42 +139,83 @@ NamedSearches::read()
         list.append(namedSearch);
     }
 
-    // let everyone know they have changed
-    changed();
+    // write the filters to the global namedsearches.xml file
+    write();
 }
 
-
-NamedSearch NamedSearches::get(QString name)
+NamedSearch NamedSearches::get(const QString& name) const
 {
-    NamedSearch returning;
     foreach (NamedSearch x, list) {
         if (x.name == name) {
-            returning = x;
-            break;
+            return x;
         }
     }
-    return returning;
+    return NamedSearch();
 }
 
-NamedSearch NamedSearches::get(int index)
+NamedSearch NamedSearches::get(int index) const
 {
-    return list[index];
+    if ((index >= 0) && (index < list.size())) {
+        return list[index];
+    }
+    return NamedSearch();
 }
 
 void
 NamedSearches::write()
 {
-    // update namedSearchs.xml
-    QString file = QString(home.canonicalPath() + "/namedsearches.xml");
+    // update namedsearches.xml
+    QString file = QString(QDir(gcroot).canonicalPath()+"/namedsearches.xml");
     NamedSearchParser::serialize(file, list);
-    athlete->notifyNamedSearchesChanged();
+
+    // let everyone know the searches have changed
+    GlobalContext::context()->notifyNamedSearchesChanged();
+}
+
+bool
+NamedSearches::deleteNamedSearch(int index)
+{
+    if ((index >= 0) && (index < list.size())) {
+        list.removeAt(index);
+        write();
+        return true;
+    }
+    return false;
 }
 
 void
-NamedSearches::deleteNamedSearch(int index)
+NamedSearches::appendNamedSearch(const NamedSearch& x)
 {
-    list.removeAt(index);
+    list.append(x);
     write();
+}
+
+bool
+NamedSearches::updateNamedSearch(int index, const NamedSearch& x)
+{
+    if ((index >= 0) && (index < list.size())) {
+        list[index] = x;
+        write();
+        return true;
+    }
+    return false;
+}
+
+bool
+NamedSearches::swapNamedSearch(int newIndex, int index)
+{
+    if ((newIndex != index) && (newIndex >= 0) && (newIndex < list.size()) && (index >= 0) && (index < list.size())) {
+        list.swapItemsAt(newIndex, index);
+
+        // defer writing to the file, to prevent numerous writes as a search is moved, as
+        // closing the edit dialog, or appending, deleting or updating a search will cause a write.
+
+        // let everyone know the searches have changed
+        GlobalContext::context()->notifyNamedSearchesChanged();
+
+        return true;
+    }
+    return false;
 }
 
 bool NamedSearchParser::startDocument()
@@ -155,8 +228,6 @@ bool NamedSearchParser::endElement( const QString&, const QString&, const QStrin
 {
     if(qName == "name")
         namedSearch.name = unprotect(buffer.trimmed());
-    else if (qName == "count")
-        namedSearch.count = unprotect(buffer.trimmed()).toInt();
     else if (qName == "type")
         namedSearch.type = unprotect(buffer.trimmed()).toInt();
     else if (qName == "text")
@@ -309,7 +380,7 @@ EditNamedSearches::EditNamedSearches(QWidget *parent, Context *context) : QDialo
     row4->addWidget(closeButton);
 
     // Populate the list of named searches
-    foreach(NamedSearch x, context->athlete->namedSearches->getList()) {
+    foreach(NamedSearch x, NamedSearches::getInstance().getList()) {
         QTreeWidgetItem *add = new QTreeWidgetItem(searchList->invisibleRootItem(), 0);
         add->setIcon(0, x.type == NamedSearch::search ? searchIcon : filterIcon);
         add->setText(1, x.name);
@@ -318,7 +389,7 @@ EditNamedSearches::EditNamedSearches(QWidget *parent, Context *context) : QDialo
     connect(searchList, SIGNAL(itemSelectionChanged()), this, SLOT(selectionChanged()));
 
     // and select the first one
-    if (context->athlete->namedSearches->getList().count()) {
+    if (NamedSearches::getInstance().getList().count()) {
         searchList->setCurrentItem(searchList->invisibleRootItem()->child(0));
     }
 
@@ -337,7 +408,7 @@ EditNamedSearches::selectionChanged()
     if (active || searchList->currentItem() == NULL) return;
 
     int index = searchList->invisibleRootItem()->indexOfChild(searchList->currentItem());
-    NamedSearch x = context->athlete->namedSearches->getList().at(index);
+    NamedSearch x = NamedSearches::getInstance().get(index);
 
     editName->setText(x.name);
     editSearch->setText(x.text);
@@ -354,7 +425,7 @@ EditNamedSearches::addClicked()
     x.text = editSearch->text();
     x.name = editName->text();
     x.type = editSearch->getMode();
-    context->athlete->namedSearches->getList().append(x);
+    NamedSearches::getInstance().appendNamedSearch(x);
 
     QTreeWidgetItem *add = new QTreeWidgetItem(searchList->invisibleRootItem(), 0);
     add->setIcon(0, x.type == NamedSearch::search ? searchIcon : filterIcon);
@@ -375,9 +446,12 @@ EditNamedSearches::updateClicked()
     int index = searchList->invisibleRootItem()->indexOfChild(searchList->currentItem());
 
     // update the text
-    context->athlete->namedSearches->getList()[index].name = editName->text();
-    context->athlete->namedSearches->getList()[index].type = editSearch->getMode();
-    context->athlete->namedSearches->getList()[index].text = editSearch->text();
+
+    NamedSearch x;
+    x.text = editSearch->text();
+    x.name = editName->text();
+    x.type = editSearch->getMode();
+    NamedSearches::getInstance().updateNamedSearch(index, x);
 
     QTreeWidgetItem *here = searchList->invisibleRootItem()->child(index);
     here->setIcon(0, editSearch->getMode() == 0 ? searchIcon : filterIcon);
@@ -398,7 +472,7 @@ EditNamedSearches::upClicked()
     int newIndex = index - 1;
 
     if (index > 0) {
-        context->athlete->namedSearches->getList().swapItemsAt(newIndex, index);
+        NamedSearches::getInstance().swapNamedSearch(newIndex, index);
         QTreeWidgetItem* child = searchList->invisibleRootItem()->takeChild(index);
         searchList->invisibleRootItem()->insertChild(newIndex, child);
         searchList->setCurrentItem(child);
@@ -417,8 +491,8 @@ EditNamedSearches::downClicked()
     int index = searchList->invisibleRootItem()->indexOfChild(searchList->currentItem());
     int newIndex = index + 1;
 
-    if (index < (context->athlete->namedSearches->getList().size() - 1)) {
-        context->athlete->namedSearches->getList().swapItemsAt(newIndex, index);
+    if (index < (NamedSearches::getInstance().getList().size() - 1)) {
+        NamedSearches::getInstance().swapNamedSearch(newIndex, index);
         QTreeWidgetItem* child = searchList->invisibleRootItem()->takeChild(index);
         searchList->invisibleRootItem()->insertChild(newIndex, child);
         searchList->setCurrentItem(child);
@@ -435,7 +509,7 @@ EditNamedSearches::deleteClicked()
     active = true;
 
     int index = searchList->invisibleRootItem()->indexOfChild(searchList->currentItem());
-    context->athlete->namedSearches->getList().removeAt(index);
+    NamedSearches::getInstance().deleteNamedSearch(index);
     delete searchList->invisibleRootItem()->takeChild(index);
 
     active = false;
@@ -443,12 +517,7 @@ EditNamedSearches::deleteClicked()
 }
 
 // trap close dialog and update named searches in mainwindow/on disk
-void EditNamedSearches::closeEvent(QCloseEvent*) { writeSearches(); }
-void EditNamedSearches::reject() { writeSearches(); }
+void EditNamedSearches::closeEvent(QCloseEvent*) { NamedSearches::getInstance().write(); }
+void EditNamedSearches::reject() { NamedSearches::getInstance().write(); }
 
-void
-EditNamedSearches::writeSearches()
-{
-    context->athlete->namedSearches->write();
-}
 

--- a/src/Core/NamedSearch.h
+++ b/src/Core/NamedSearch.h
@@ -34,11 +34,10 @@ class NamedSearch
 {
 	public:
         enum Type { search=0, filter=1 };
-        NamedSearch() : type(search), count(0) {}
+        NamedSearch() : type(search) {}
 
         QString name; // name, typically users name them by year e.g. "2011 Season"
         int type;
-        int count;   // how many times has it been used (not counting in charts) ?
         QString text;
 };
 
@@ -47,25 +46,33 @@ class NamedSearches : public QObject {
     Q_OBJECT;
 
     public:
-        NamedSearches(Athlete *athlete) : athlete(athlete) { 
-            home = athlete->home->config();
-            read();
+
+        // Singleton pattern
+        static NamedSearches& getInstance() {
+            static NamedSearches instance;
+            return instance;
         }
-        void read();
+        ~NamedSearches() {}
+        NamedSearches(NamedSearches const&) = delete;
+        void operator=(NamedSearches const&) = delete;
+
         void write();
 
-        QList<NamedSearch> &getList() { return list; }
-        NamedSearch get(QString name);
-        NamedSearch get(int index);
-        void deleteNamedSearch(int index);
+        const QList<NamedSearch> &getList() const { return list; }
+        NamedSearch get(const QString& name) const;
+        NamedSearch get(int index) const;
+        bool deleteNamedSearch(int index);
+        void appendNamedSearch(const NamedSearch& x);
+        bool updateNamedSearch(int index, const NamedSearch& x);
+        bool swapNamedSearch(int newIndex, int index);
 
-    signals:
-        void changed();
 
 
     private:
-        Athlete *athlete;
-        QDir home;
+
+        NamedSearches() { read(); }
+        void read();
+
         QList<NamedSearch> list;
 };
 
@@ -88,8 +95,6 @@ protected:
     QString buffer;
     NamedSearch namedSearch;
     QList<NamedSearch> result;
-    int loadcount;
-
 };
 
 class EditNamedSearches : public QDialog
@@ -100,7 +105,6 @@ class EditNamedSearches : public QDialog
     public:
         EditNamedSearches(QWidget *parent, Context *context);
         void closeEvent(QCloseEvent* event); // write away on save
-        void writeSearches();
 
     public slots:
         void reject(); // write away on close

--- a/src/Core/NamedSearch.h
+++ b/src/Core/NamedSearch.h
@@ -36,6 +36,12 @@ class NamedSearch
         enum Type { search=0, filter=1 };
         NamedSearch() : type(search) {}
 
+        // we need to check the searches are functionally the same, so strip the whitespace for the search text before comparison
+        bool operator==(const NamedSearch& ns) const {
+            return (name == ns.name && type == ns.type &&
+                text.simplified().remove(' ') == ns.text.simplified().remove(' '));
+        }
+
         QString name; // name, typically users name them by year e.g. "2011 Season"
         int type;
         QString text;

--- a/src/Gui/LTMSidebar.cpp
+++ b/src/Gui/LTMSidebar.cpp
@@ -249,7 +249,7 @@ LTMSidebar::LTMSidebar(Context *context) : QWidget(context->mainWindow), context
     // GC signal
     connect(context, SIGNAL(configChanged(qint32)), this, SLOT(configChanged(qint32)));
     connect(seasons, SIGNAL(seasonsChanged()), this, SLOT(resetSeasons()));
-    connect(context->athlete, SIGNAL(namedSearchesChanged()), this, SLOT(resetFilters()));
+    connect(GlobalContext::context(), &GlobalContext::namedSearchesChanged, this, &LTMSidebar::resetFilters);
     connect(context, SIGNAL(presetsChanged()), this, SLOT(presetsChanged()));
     connect(context, SIGNAL(presetSelected(int)), this, SLOT(presetSelected(int)));
 
@@ -841,7 +841,7 @@ LTMSidebar::filterTreeWidgetSelectionChanged()
 
             int index = filterTree->invisibleRootItem()->indexOfChild(item);
 
-            NamedSearch ns = context->athlete->namedSearches->get(index);
+            NamedSearch ns = NamedSearches::getInstance().get(index);
             QStringList errors, results;
 
             switch(ns.type) {
@@ -1033,7 +1033,7 @@ LTMSidebar::resetFilters()
         delete allFilters->takeChild(0);
     }
 
-    foreach(NamedSearch ns, context->athlete->namedSearches->getList()) {
+    foreach(NamedSearch ns, NamedSearches::getInstance().getList()) {
         
         QTreeWidgetItem *add = new QTreeWidgetItem(allFilters, 0);
 
@@ -1085,7 +1085,7 @@ LTMSidebar::deleteFilter()
 
         // now delete!
         delete allFilters->takeChild(index);
-        context->athlete->namedSearches->deleteNamedSearch(index);
+        NamedSearches::getInstance().deleteNamedSearch(index);
     }
     active = false;
 }

--- a/src/Gui/MainWindow.cpp
+++ b/src/Gui/MainWindow.cpp
@@ -2153,9 +2153,6 @@ MainWindow::removeAthleteTab(AthleteTab *tab)
     // cancel ridecache refresh if its in progress
     tab->context->athlete->rideCache->cancel();
 
-    // save the named searches
-    tab->context->athlete->namedSearches->write();
-
     // clear the clipboard if neccessary
     QApplication::clipboard()->setText("");
 

--- a/src/Gui/SearchBox.cpp
+++ b/src/Gui/SearchBox.cpp
@@ -247,7 +247,7 @@ void SearchBox::clearClicked()
 
 void SearchBox::checkMenu()
 {
-    if (context->athlete->namedSearches->getList().count() || text() != "") toolButton->show();
+    if (NamedSearches::getInstance().getList().count() || text() != "") toolButton->show();
     else toolButton->hide();
 }
 
@@ -255,9 +255,9 @@ void SearchBox::setMenu()
 {
     dropMenu->clear();
     if (text() != "") dropMenu->addAction(tr("Add to Named Filters"));
-    if (context->athlete->namedSearches->getList().count()) {
+    if (NamedSearches::getInstance().getList().count()) {
         if (text() != "") dropMenu->addSeparator();
-        foreach(NamedSearch x, context->athlete->namedSearches->getList()) {
+        foreach(NamedSearch x, NamedSearches::getInstance().getList()) {
             dropMenu->addAction(x.name);
         }
         dropMenu->addSeparator();
@@ -284,7 +284,7 @@ void SearchBox::runMenu(QAction *x)
         selector->show();
 
     } else {
-        NamedSearch get = context->athlete->namedSearches->get(x->text());
+        NamedSearch get = NamedSearches::getInstance().get(x->text());
         if (get.name == x->text()) {
             setMode(static_cast<SearchBox::SearchBoxMode>(get.type));
             setText(get.text);
@@ -363,9 +363,7 @@ SearchBox::addNamed()
         x.name = text;
         x.text = this->text();
         x.type = mode;
-        x.count = 0;
-        context->athlete->namedSearches->getList().append(x);
-        context->athlete->namedSearches->write();
+        NamedSearches::getInstance().appendNamedSearch(x);
     }
 }
 


### PR DESCRIPTION
Currently named searches (filters) are defined per athlete (<athlete>/config/namedsearches.xml), but working with multiple athletes this means that searches have to be entered or amended multiple times to keep them consistent across all athletes.

This PR creates a single global named searches definitions that can be used by all athletes (in the same way as metadata).

To aid transition, at first start-up all the athlete's current filters are merged into the new single global definition file, and from this point only the global namedSearches.xml file is used. It is an easy one off activity for the user to prune out any duplicates using the manage filters dialog, if you have a single athlete there is nothing to do.

**Changes:**

- removed NamedSearches from the Athlete class, and related slots and signals
- NamedSearches is now a singleton
- namedsearches.xml file is now in gcroot directory, all existing athlete <athlete>/config/namedsearches.xml are left in place and unmodified.
- Adds a new signal to GlobalContext ( void namedSearchesChanged() ) to notify interested components the searches have changed.
- The NamedSearches class now manages writing and updating of the namedSearches.xml file as each change occurs.


**Remove unused items:**

removed unused _count_ from NamedSearch, as it was never written out to the namedsearches.xml file.
removed unused _loadcount_ in NamedSearchParser, as it never present in the namedsearches.xml file, so never parsed.